### PR TITLE
add REFUSED_STREAM retry policy

### DIFF
--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -68,7 +68,7 @@ using a ',' delimited list. The supported policies are:
 
 5xx
   Envoy will attempt a retry if the upstream server responds with any 5xx response code, or does not
-  respond at all (disconnect/reset/etc.). (Includes *connect-failure*)
+  respond at all (disconnect/reset/etc.). (Includes *connect-failure* and *refused-stream*)
 
   * **NOTE:** Envoy will not retry when a request times out (resulting in a 504 error code). This is
     by design. The request timeout is an outer time limit for a request, including any retries that
@@ -91,6 +91,10 @@ retriable-4xx
     that an optimistic locking revision needs to be updated. Thus, the caller should not retry and
     needs to read then attempt another write. If a retry happens in this type of case it will always
     fail with another 409.
+
+refused-stream
+  Envoy will attempt a retry if the upstream server resets the stream with a REFUSED_STREAM error
+  code. This reset type indicates that a request is safe to retry. (Included in *5xx*)
 
 The number of retries can be controlled via the
 :ref:`config_http_filters_router_x-envoy-max-retries` header or via the :ref:`route

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -77,11 +77,11 @@ public:
 enum class StreamResetReason {
   // If a local codec level reset was sent on the stream.
   LocalReset,
-  // FIXFIX
+  // If a local codec level refused stream reset was sent on the stream (allowing for retry).
   LocalRefusedStreamReset,
   // If a remote codec level reset was received on the stream.
   RemoteReset,
-  // FIXFIX
+  // If a remove codec level refused stream reset was received on the stream (allowing for retry).
   RemoteRefusedStreamReset,
   // If the stream was locally reset by a connection pool due to an initial connection failure.
   ConnectionFailure,

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -81,7 +81,7 @@ enum class StreamResetReason {
   LocalRefusedStreamReset,
   // If a remote codec level reset was received on the stream.
   RemoteReset,
-  // If a remove codec level refused stream reset was received on the stream (allowing for retry).
+  // If a remote codec level refused stream reset was received on the stream (allowing for retry).
   RemoteRefusedStreamReset,
   // If the stream was locally reset by a connection pool due to an initial connection failure.
   ConnectionFailure,

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -77,8 +77,12 @@ public:
 enum class StreamResetReason {
   // If a local codec level reset was sent on the stream.
   LocalReset,
+  // FIXFIX
+  LocalRefusedStreamReset,
   // If a remote codec level reset was received on the stream.
   RemoteReset,
+  // FIXFIX
+  RemoteRefusedStreamReset,
   // If the stream was locally reset by a connection pool due to an initial connection failure.
   ConnectionFailure,
   // If the stream was locally reset due to connection termination.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -31,6 +31,7 @@ public:
   static const uint32_t RETRY_ON_5XX             = 0x1;
   static const uint32_t RETRY_ON_CONNECT_FAILURE = 0x2;
   static const uint32_t RETRY_ON_RETRIABLE_4XX   = 0x4;
+  static const uint32_t RETRY_ON_REFUSED_STREAM  = 0x8;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -63,6 +63,7 @@ public:
   struct {
     const std::string _5xx{"5xx"};
     const std::string ConnectFailure{"connect-failure"};
+    const std::string RefusedStream{"refused-stream"};
     const std::string Retriable4xx{"retriable-4xx"};
   } EnvoyRetryOnValues;
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -358,10 +358,12 @@ Filter::streamResetReasonToFailureReason(Http::StreamResetReason reset_reason) {
   case Http::StreamResetReason::ConnectionTermination:
     return Http::AccessLog::FailureReason::UpstreamConnectionTermination;
   case Http::StreamResetReason::LocalReset:
+  case Http::StreamResetReason::LocalRefusedStreamReset:
     return Http::AccessLog::FailureReason::LocalReset;
   case Http::StreamResetReason::Overflow:
     return Http::AccessLog::FailureReason::UpstreamOverflow;
   case Http::StreamResetReason::RemoteReset:
+  case Http::StreamResetReason::RemoteRefusedStreamReset:
     return Http::AccessLog::FailureReason::UpstreamRemoteReset;
   }
 


### PR DESCRIPTION
This also requires wiring up REFUSED_STREAM handling in the HTTP/2 codec.