### PR TITLE
mongo proxy: 3.2 support

### DIFF
--- a/include/envoy/mongo/bson.h
+++ b/include/envoy/mongo/bson.h
@@ -25,6 +25,7 @@ public:
     STRING = 0x02,
     DOCUMENT = 0x03,
     ARRAY = 0x04,
+    BINARY = 0x05,
     OBJECT_ID = 0x07,
     BOOLEAN = 0x08,
     DATETIME = 0x09,
@@ -58,6 +59,7 @@ public:
   virtual const std::string& asString() const PURE;
   virtual const Document& asDocument() const PURE;
   virtual const Document& asArray() const PURE;
+  virtual const std::string& asBinary() const PURE;
   virtual const ObjectId& asObjectId() const PURE;
   virtual bool asBoolean() const PURE;
   virtual int64_t asDatetime() const PURE;
@@ -87,6 +89,7 @@ public:
   virtual DocumentPtr addString(const std::string& key, std::string&& value) PURE;
   virtual DocumentPtr addDocument(const std::string& key, DocumentPtr value) PURE;
   virtual DocumentPtr addArray(const std::string& key, DocumentPtr value) PURE;
+  virtual DocumentPtr addBinary(const std::string& key, std::string&& value) PURE;
   virtual DocumentPtr addObjectId(const std::string& key, Field::ObjectId&& value) PURE;
   virtual DocumentPtr addBoolean(const std::string& key, bool value) PURE;
   virtual DocumentPtr addDatetime(const std::string& key, int64_t value) PURE;

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -124,7 +124,7 @@ void BufferHelper::writeString(Buffer::Instance& data, const std::string& value)
 }
 
 void BufferHelper::writeBinary(Buffer::Instance& data, const std::string& value) {
-  // Write now we do not actually store the binary subtype and always use zero.
+  // Right now we do not actually store the binary subtype and always use zero.
   writeInt32(data, value.size());
   uint8_t subtype = 0;
   data.add(&subtype, sizeof(subtype));

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -88,6 +88,16 @@ std::string BufferHelper::removeString(Buffer::Instance& data) {
   return ret;
 }
 
+std::string BufferHelper::removeBinary(Buffer::Instance& data) {
+  // Read out the subtype but do not store it for now.
+  int32_t length = removeInt32(data);
+  removeByte(data);
+  char* start = reinterpret_cast<char*>(data.linearize(length));
+  std::string ret(start, length);
+  data.drain(length);
+  return ret;
+}
+
 void BufferHelper::writeCString(Buffer::Instance& data, const std::string& value) {
   data.add(value.c_str(), value.size() + 1);
 }
@@ -113,6 +123,14 @@ void BufferHelper::writeString(Buffer::Instance& data, const std::string& value)
   data.add(value.c_str(), value.size() + 1);
 }
 
+void BufferHelper::writeBinary(Buffer::Instance& data, const std::string& value) {
+  // Write now we do not actually store the binary subtype and always use zero.
+  writeInt32(data, value.size());
+  uint8_t subtype = 0;
+  data.add(&subtype, sizeof(subtype));
+  data.add(value.c_str(), value.size());
+}
+
 int32_t FieldImpl::byteSize() const {
   // 1 byte type, cstring key, field.
   int32_t total = 1 + key_.size() + 1;
@@ -132,6 +150,10 @@ int32_t FieldImpl::byteSize() const {
   case Type::DOCUMENT:
   case Type::ARRAY: {
     return total + value_.document_value_->byteSize();
+  }
+
+  case Type::BINARY: {
+    return total + 5 + value_.string_value_.size();
   }
 
   case Type::OBJECT_ID: {
@@ -174,6 +196,10 @@ void FieldImpl::encode(Buffer::Instance& output) const {
   case Type::DOCUMENT:
   case Type::ARRAY: {
     return value_.document_value_->encode(output);
+  }
+
+  case Type::BINARY: {
+    return BufferHelper::writeBinary(output, value_.string_value_);
   }
 
   case Type::OBJECT_ID: {
@@ -229,6 +255,10 @@ bool FieldImpl::operator==(const Field& rhs) const {
     return asArray() == rhs.asArray();
   }
 
+  case Type::BINARY: {
+    return asBinary() == rhs.asBinary();
+  }
+
   case Type::OBJECT_ID: {
     return asObjectId() == rhs.asObjectId();
   }
@@ -271,7 +301,8 @@ std::string FieldImpl::toString() const {
     return std::to_string(value_.double_value_);
   }
 
-  case Type::STRING: {
+  case Type::STRING:
+  case Type::BINARY: {
     return fmt::format("'{}'", value_.string_value_);
   }
 
@@ -358,6 +389,13 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
     case Field::Type::ARRAY: {
       log_trace("BSON array");
       addArray(key, DocumentImpl::create(data));
+      break;
+    }
+
+    case Field::Type::BINARY: {
+      std::string value = BufferHelper::removeBinary(data);
+      log_trace("BSON binary: {}", value);
+      addBinary(key, std::move(value));
       break;
     }
 

--- a/source/common/mongo/bson_impl.h
+++ b/source/common/mongo/bson_impl.h
@@ -21,11 +21,13 @@ public:
   static int32_t removeInt32(Buffer::Instance& data);
   static int64_t removeInt64(Buffer::Instance& data);
   static std::string removeString(Buffer::Instance& data);
+  static std::string removeBinary(Buffer::Instance& data);
   static void writeCString(Buffer::Instance& data, const std::string& value);
   static void writeInt32(Buffer::Instance& data, int32_t value);
   static void writeInt64(Buffer::Instance& data, int64_t value);
   static void writeDouble(Buffer::Instance& data, double value);
   static void writeString(Buffer::Instance& data, const std::string& value);
+  static void writeBinary(Buffer::Instance& data, const std::string& value);
 };
 
 class FieldImpl : public Field {
@@ -34,7 +36,8 @@ public:
     value_.double_value_ = value;
   }
 
-  explicit FieldImpl(const std::string& key, std::string&& value) : type_(Type::STRING), key_(key) {
+  explicit FieldImpl(Type type, const std::string& key, std::string&& value)
+      : type_(type), key_(key) {
     value_.string_value_ = std::move(value);
   }
 
@@ -84,6 +87,11 @@ public:
   const Document& asArray() const override {
     checkType(Type::ARRAY);
     return *value_.document_value_;
+  }
+
+  const std::string& asBinary() const override {
+    checkType(Type::BINARY);
+    return value_.string_value_;
   }
 
   const ObjectId& asObjectId() const override {
@@ -173,7 +181,7 @@ public:
   }
 
   DocumentPtr addString(const std::string& key, std::string&& value) override {
-    fields_.emplace_back(new FieldImpl(key, std::move(value)));
+    fields_.emplace_back(new FieldImpl(Field::Type::STRING, key, std::move(value)));
     return shared_from_this();
   }
 
@@ -184,6 +192,11 @@ public:
 
   DocumentPtr addArray(const std::string& key, DocumentPtr value) override {
     fields_.emplace_back(new FieldImpl(Field::Type::ARRAY, key, value));
+    return shared_from_this();
+  }
+
+  DocumentPtr addBinary(const std::string& key, std::string&& value) override {
+    fields_.emplace_back(new FieldImpl(Field::Type::BINARY, key, std::move(value)));
     return shared_from_this();
   }
 

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -107,15 +107,15 @@ public:
 
 private:
   struct ActiveQuery {
-    ActiveQuery(ProxyFilter& parent, QueryMessagePtr&& query)
-        : parent_(parent), query_(std::move(query)), start_time_(std::chrono::system_clock::now()) {
+    ActiveQuery(ProxyFilter& parent, const QueryMessage& query)
+        : parent_(parent), query_info_(query), start_time_(std::chrono::system_clock::now()) {
       parent_.stats_.op_query_active_.inc();
     }
 
     ~ActiveQuery() { parent_.stats_.op_query_active_.dec(); }
 
     ProxyFilter& parent_;
-    QueryMessagePtr query_;
+    QueryMessageInfo query_info_;
     SystemTime start_time_;
   };
 
@@ -127,7 +127,7 @@ private:
                                                  POOL_TIMER_PREFIX(store, prefix))};
   }
 
-  void chargeQueryStats(const std::string& prefix, MessageUtility::QueryType query_type);
+  void chargeQueryStats(const std::string& prefix, QueryMessageInfo::QueryType query_type);
   void chargeReplyStats(ActiveQuery& active_query, const std::string& prefix,
                         const ReplyMessage& message);
   void doDecode(Buffer::Instance& buffer);

--- a/test/common/mongo/codec_impl_test.cc
+++ b/test/common/mongo/codec_impl_test.cc
@@ -76,6 +76,7 @@ TEST_F(MongoCodecImplTest, Query) {
                   ->addString("string", "string_value")
                   ->addDocument("document", Bson::DocumentImpl::create())
                   ->addArray("array", Bson::DocumentImpl::create())
+                  ->addBinary("binary", "binary_value")
                   ->addObjectId("object_id", Bson::Field::ObjectId())
                   ->addBoolean("true", true)
                   ->addBoolean("false", false)


### PR DESCRIPTION
- BSON binary type (0x5) parsing
- 3.2 'find' command stats
- Save query info for use during reply stats