### PR TITLE
http conn man: do not eat data and trailers if response has started

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -416,11 +416,6 @@ void ConnectionManagerImpl::ActiveStream::decodeData(const Buffer::Instance& dat
 
 void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* filter,
                                                      Buffer::Instance& data, bool end_stream) {
-  // If a response has been started, filters do not care about further body data. Just drop it.
-  if (state_.local_started_) {
-    return;
-  }
-
   std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
   if (!filter) {
     entry = decoder_filters_.begin();
@@ -447,11 +442,6 @@ void ConnectionManagerImpl::ActiveStream::decodeTrailers(HeaderMapPtr&& trailers
 
 void ConnectionManagerImpl::ActiveStream::decodeTrailers(ActiveStreamDecoderFilter* filter,
                                                          HeaderMap& trailers) {
-  // If a response has been started, filters do not care about trailers. Just drop it.
-  if (state_.local_started_) {
-    return;
-  }
-
   std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
   if (!filter) {
     entry = decoder_filters_.begin();

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -304,8 +304,8 @@ TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
       }));
   filter->callbacks_->encodeHeaders(std::move(response_headers), false);
 
-  // Finish the request. Since we already started, we expect the data to get eaten.
-  EXPECT_CALL(*filter, decodeData(_, _)).Times(0);
+  // Finish the request.
+  EXPECT_CALL(*filter, decodeData(_, true));
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance& data) -> void { decoder->decodeData(data, true); }));
 
@@ -461,7 +461,7 @@ TEST_F(HttpConnectionManagerImplTest, IntermediateBufferingEarlyResponse) {
         return Http::FilterHeadersStatus::StopIteration;
       }));
 
-  EXPECT_CALL(*decoder_filter2, decodeData(_, _)).Times(0);
+  EXPECT_CALL(*decoder_filter2, decodeData(_, true));
   decoder_filter1->callbacks_->continueDecoding();
 }
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -26,9 +26,11 @@ public:
   void encodeData(uint64_t size, bool end_stream);
   void encodeData(Buffer::Instance& data, bool end_stream);
   void encodeTrailers(Http::HeaderMapImpl trailers);
+  void encodeResetStream();
   const Http::HeaderMap& headers() { return *headers_; }
   const Http::HeaderMapPtr& trailers() { return trailers_; }
   void waitForHeadersComplete();
+  void waitForData(Event::Dispatcher& client_dispatcher, uint64_t body_length);
   void waitForEndStream(Event::Dispatcher& client_dispatcher);
   void waitForReset();
 


### PR DESCRIPTION
Previously we assumed that if an upstream response started, the upstream
server no longer cares about further request data. This is not the case in
bidirectional streaming scenarios such as gRPC streaming requests and responses.
We need to relax this requirement. I believe the only change required here beyond
dropping the restriction is to fix retry state handling in the router, however
this is a scary change so there might be follow on fixes.

Note that both the HTTP/1.1 and HTTP/2 codecs should not raise any further data
frames if a stream is reset which should make this handling safe.