### PR TITLE
async client: set xff and charge internal stats

### DIFF
--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -66,8 +66,7 @@ typedef std::shared_ptr<AllowedPrincipals> AllowedPrincipalsPtr;
 class Config : public Http::AsyncClient::Callbacks {
 public:
   Config(const Json::Object& config, ThreadLocal::Instance& tls, Upstream::ClusterManager& cm,
-         Event::Dispatcher& dispatcher, Stats::Store& stats_store, Runtime::Loader& runtime,
-         const std::string& local_address);
+         Event::Dispatcher& dispatcher, Stats::Store& stats_store, Runtime::Loader& runtime);
 
   const AllowedPrincipals& allowedPrincipals();
   const Network::IpWhiteList& ipWhiteList() { return ip_white_list_; }
@@ -91,7 +90,6 @@ private:
   Network::IpWhiteList ip_white_list_;
   GlobalStats stats_;
   Runtime::Loader& runtime_;
-  const std::string local_address_;
 };
 
 typedef std::shared_ptr<Config> ConfigPtr;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -24,7 +24,8 @@ public:
   AsyncClientImpl(const Upstream::Cluster& cluster, Stats::Store& stats_store,
                   Event::Dispatcher& dispatcher, const std::string& local_zone_name,
                   Upstream::ClusterManager& cm, Runtime::Loader& runtime,
-                  Runtime::RandomGenerator& random, Router::ShadowWriterPtr&& shadow_writer);
+                  Runtime::RandomGenerator& random, Router::ShadowWriterPtr&& shadow_writer,
+                  const std::string& local_address);
   ~AsyncClientImpl();
 
   // Http::AsyncClient
@@ -36,6 +37,7 @@ private:
   Router::FilterConfig config_;
   Event::Dispatcher& dispatcher_;
   std::list<std::unique_ptr<AsyncRequestImpl>> active_requests_;
+  std::string local_address_;
 
   friend class AsyncRequestImpl;
 };

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -37,7 +37,7 @@ private:
   Router::FilterConfig config_;
   Event::Dispatcher& dispatcher_;
   std::list<std::unique_ptr<AsyncRequestImpl>> active_requests_;
-  std::string local_address_;
+  const std::string local_address_;
 
   friend class AsyncRequestImpl;
 };

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -21,7 +21,7 @@ public:
   ClusterManagerImpl(const Json::Object& config, Stats::Store& stats, ThreadLocal::Instance& tls,
                      Network::DnsResolver& dns_resolver, Ssl::ContextManager& ssl_context_manager,
                      Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                     const std::string& local_zone_name);
+                     const std::string& local_zone_name, const std::string& local_address);
 
   // Upstream::ClusterManager
   void setInitializedCb(std::function<void()> callback) override {
@@ -74,7 +74,7 @@ private:
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, const Cluster& cluster,
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Stats::Store& stats_store, Event::Dispatcher& dispatcher,
-                   const std::string& local_zone_name);
+                   const std::string& local_zone_name, const std::string& local_address);
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 
@@ -89,7 +89,8 @@ private:
 
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
                                   Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                                  const std::string& local_zone_name);
+                                  const std::string& local_zone_name,
+                                  const std::string& local_address);
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,
                                         ConstHostVectorPtr healthy_hosts,

--- a/source/server/config/network/client_ssl_auth.cc
+++ b/source/server/config/network/client_ssl_auth.cc
@@ -22,7 +22,7 @@ public:
 
     Filter::Auth::ClientSsl::ConfigPtr config(new Filter::Auth::ClientSsl::Config(
         json_config, server.threadLocal(), server.clusterManager(), server.dispatcher(),
-        server.stats(), server.runtime(), server.getLocalAddress()));
+        server.stats(), server.runtime()));
     return [config](Network::Connection& connection) -> void {
       connection.addReadFilter(
           Network::ReadFilterPtr{new Filter::Auth::ClientSsl::Instance(config)});

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -21,7 +21,7 @@ void MainImpl::initialize(const std::string& file_path) {
   cluster_manager_.reset(new Upstream::ProdClusterManagerImpl(
       loader.getObject("cluster_manager"), server_.stats(), server_.threadLocal(),
       server_.dnsResolver(), server_.sslContextManager(), server_.runtime(), server_.random(),
-      server_.options().serviceZone()));
+      server_.options().serviceZone(), server_.getLocalAddress()));
 
   std::vector<Json::Object> listeners = loader.getObjectArray("listeners");
   log().notice("loading {} listener(s)", listeners.size());

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -42,7 +42,7 @@ public:
     Json::StringLoader loader(json);
     EXPECT_CALL(cm_, get("vpn"));
     setupRequest();
-    config_.reset(new Config(loader, tls_, cm_, dispatcher_, stats_store_, runtime_, "127.0.0.1"));
+    config_.reset(new Config(loader, tls_, cm_, dispatcher_, stats_store_, runtime_));
 
     createAuthFilter();
   }
@@ -56,9 +56,8 @@ public:
     EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(
-            Invoke([this](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+            Invoke([this](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                           Optional<std::chrono::milliseconds>) -> Http::AsyncClient::Request* {
-              EXPECT_EQ("127.0.0.1", request->headers().get("x-forwarded-for"));
               callbacks_ = &callbacks;
               return &request_;
             }));
@@ -88,8 +87,7 @@ TEST_F(ClientSslAuthFilterTest, NoCluster) {
 
   Json::StringLoader loader(json);
   EXPECT_CALL(cm_, get("bad_cluster")).WillOnce(Return(nullptr));
-  EXPECT_THROW(new Config(loader, tls_, cm_, dispatcher_, stats_store_, runtime_, "127.0.0.1"),
-               EnvoyException);
+  EXPECT_THROW(new Config(loader, tls_, cm_, dispatcher_, stats_store_, runtime_), EnvoyException);
 }
 
 TEST_F(ClientSslAuthFilterTest, Basic) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -34,7 +34,7 @@ public:
   void create(const Json::Object& config) {
     cluster_manager_.reset(new ClusterManagerImplForTest(config, stats_, tls_, dns_resolver_,
                                                          ssl_context_manager_, runtime_, random_,
-                                                         "us-east-1d"));
+                                                         "us-east-1d", "local_address"));
   }
 
   Stats::IsolatedStoreImpl stats_;


### PR DESCRIPTION
The previous refactor broke charging internal stats for local origin
calls. Also set XFF on local origin calls and remove duplication from
callers.