### PR TITLE
http/2 graceful drain support

### DIFF
--- a/docs/configuration/http_conn_man/http_conn_man.rst
+++ b/docs/configuration/http_conn_man/http_conn_man.rst
@@ -102,9 +102,9 @@ idle_timeout_s
   manager. The idle timeout is defined as the period in which there are no active requests. If not
   set, there is no idle timeout. When the idle timeout is reached the connection will be closed. If
   the connection is an HTTP/2 connection a drain sequence will occur prior to closing the
-  connection. See :ref:`drain_timeout_s <config_http_conn_man_drain_timeout_s>`.
+  connection. See :ref:`drain_timeout_s <config_http_conn_man_drain_timeout_ms>`.
 
-.. _config_http_conn_man_drain_timeout_s:
+.. _config_http_conn_man_drain_timeout_ms:
 
 drain_timeout_ms
   *(optional, integer)* The time in milliseconds that Envoy will wait between sending an HTTP/2

--- a/docs/configuration/http_conn_man/http_conn_man.rst
+++ b/docs/configuration/http_conn_man/http_conn_man.rst
@@ -21,6 +21,7 @@ HTTP connection manager
       "http_codec_options": "...",
       "server_name": "...",
       "idle_timeout_s": "...",
+      "drain_timeout_ms": "...",
       "access_log": [],
       "use_remote_address": "..."
     }
@@ -100,8 +101,19 @@ idle_timeout_s
   *(optional, integer)* The idle timeout in seconds for connections managed by the connection
   manager. The idle timeout is defined as the period in which there are no active requests. If not
   set, there is no idle timeout. When the idle timeout is reached the connection will be closed. If
-  the connection is an HTTP/2 connection a GOAWAY frame will be sent prior to closing
-  the connection.
+  the connection is an HTTP/2 connection a drain sequence will occur prior to closing the
+  connection. See :ref:`drain_timeout_s <config_http_conn_man_drain_timeout_s>`.
+
+.. _config_http_conn_man_drain_timeout_s:
+
+drain_timeout_ms
+  *(optional, integer)* The time in milliseconds that Envoy will wait between sending an HTTP/2
+  "shutdown notification" (GOAWAY frame with max stream ID) and a final GOAWAY frame. This is used
+  so that Envoy provides a grace period for new streams that race with the final GOAWAY frame.
+  During this grace period, Envoy will continue to accept new streams. After the grace period, a
+  final GOAWAY frame is sent and Envoy will start refusing new streams. Draining occurs both
+  when a connection hits the idle timeout or during general server draining. The default grace
+  period is 5000 milliseconds (5 seconds) if this option is not specified.
 
 :ref:`access_log <config_http_conn_man_access_log>`
   *(optional, array)* Configuration for :ref:`HTTP access logs <arch_overview_http_access_logs>`
@@ -111,7 +123,7 @@ idle_timeout_s
 
 use_remote_address
   *(optional, boolean)* If set to true, the connection manager will use the real remote address
-  of the client connection when determining internal versus external origin and manipulating 
+  of the client connection when determining internal versus external origin and manipulating
   various headers. If set to false or absent, the connection manager will use the
   :ref:`config_http_conn_man_headers_x-forwarded-for` HTTP header. See the documentation for
   :ref:`config_http_conn_man_headers_x-forwarded-for`,

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -189,6 +189,12 @@ public:
   virtual const std::string& protocolString() PURE;
 
   /**
+   * Indicate a "shutdown notice" to the remote. This is a hint that the remote should not send
+   * any new streams, but if streams do arrive that will not be reset.
+   */
+  virtual void shutdownNotice() PURE;
+
+  /**
    * @return bool whether the codec has data that it wants to write but cannot due to protocol
    *              reasons (e.g, needing window updates).
    */

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -79,7 +79,6 @@ ConnectionManagerImpl::~ConnectionManagerImpl() {
 
 void ConnectionManagerImpl::checkForDeferredClose() {
   if (drain_state_ == DrainState::Closing && streams_.empty() && !codec_->wantsToWrite()) {
-    codec_->goAway();
     read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
   }
 }
@@ -249,7 +248,8 @@ void ConnectionManagerImpl::onIdleTimeout() {
 }
 
 void ConnectionManagerImpl::onDrainTimeout() {
-  ASSERT(drain_state_ != DrainState::NotDraining)
+  ASSERT(drain_state_ != DrainState::NotDraining);
+  codec_->goAway();
   drain_state_ = DrainState::Closing;
   checkForDeferredClose();
 }

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -127,6 +127,7 @@ public:
   uint64_t features() override { return 0; }
   void goAway() override {} // Called during connection manager drain flow
   const std::string& protocolString() override { return Http1::PROTOCOL_STRING; }
+  void shutdownNotice() override {} // Called during connection manager drain flow
   bool wantsToWrite() override { return false; }
 
 protected:

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -66,6 +66,7 @@ public:
   uint64_t features() override { return CodecFeatures::Multiplexing; }
   void goAway() override;
   const std::string& protocolString() override { return PROTOCOL_STRING; }
+  void shutdownNotice() override;
   bool wantsToWrite() override { return nghttp2_session_want_write(session_); }
 
   static const uint64_t MAX_CONCURRENT_STREAMS = 1024;
@@ -190,6 +191,7 @@ private:
 
   Network::Connection& connection_;
   bool dispatching_{};
+  bool raised_goaway_{};
 };
 
 /**

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -74,7 +74,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
       stats_(Http::ConnectionManagerImpl::generateStats(stats_prefix_, server.stats())),
       codec_options_(Http::Utility::parseCodecOptions(config)),
       route_config_(new Router::ConfigImpl(config.getObject("route_config"), server.runtime(),
-                                           server.clusterManager())) {
+                                           server.clusterManager())),
+      drain_timeout_(config.getInteger("drain_timeout_ms", 5000)) {
 
   if (config.hasObject("use_remote_address")) {
     use_remote_address_ = config.getBoolean("use_remote_address");

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -62,6 +62,7 @@ public:
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
+  std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }
   const Optional<std::chrono::milliseconds>& idleTimeout() override { return idle_timeout_; }
   const Router::Config& routeConfig() override { return *route_config_; }
@@ -101,6 +102,7 @@ private:
   Optional<std::string> user_agent_;
   Optional<std::chrono::milliseconds> idle_timeout_;
   Router::ConfigPtr route_config_;
+  std::chrono::milliseconds drain_timeout_;
 };
 
 /**

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -42,6 +42,7 @@ public:
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
+  std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }
   const Optional<std::chrono::milliseconds>& idleTimeout() override { return idle_timeout_; }
   const Router::Config& routeConfig() override { return *route_config_; }

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -21,6 +21,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",
@@ -101,6 +102,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -14,6 +14,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",
@@ -83,6 +84,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",

--- a/test/config/integration/server_http2_upstream.json
+++ b/test/config/integration/server_http2_upstream.json
@@ -8,6 +8,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",
@@ -77,6 +78,7 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
+        "drain_timeout_ms": 10,
         "access_log": [
         {
           "path": "/dev/null",

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -63,7 +63,7 @@ public:
   MOCK_METHOD0(accessLogs, const std::list<AccessLog::InstancePtr>&());
   MOCK_METHOD3(createCodec_, ServerConnection*(Network::Connection&, const Buffer::Instance&,
                                                ServerConnectionCallbacks&));
-
+  MOCK_METHOD0(drainTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(filterFactory, FilterChainFactory&());
   MOCK_METHOD0(idleTimeout, const Optional<std::chrono::milliseconds>&());
   MOCK_METHOD0(routeConfig, Router::Config&());
@@ -158,6 +158,7 @@ public:
   MOCK_METHOD0(features, uint64_t());
   MOCK_METHOD0(goAway, void());
   MOCK_METHOD0(protocolString, const std::string&());
+  MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
 
   const std::string protocol_{"HTTP/1.1"};
@@ -173,6 +174,7 @@ public:
   MOCK_METHOD0(features, uint64_t());
   MOCK_METHOD0(goAway, void());
   MOCK_METHOD0(protocolString, const std::string&());
+  MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
 
   // Http::ClientConnection


### PR DESCRIPTION
The connection manager goes into a drain sequence where we issue a shutdown
notice, wait 5s, then do a full shutdown.