### PR TITLE
split host health check failure types

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -22,6 +22,11 @@ public:
     HostDescriptionPtr host_description_;
   };
 
+  enum class HealthFlag {
+    // The host is currently failing active health checks.
+    FAILED_ACTIVE_HC = 0x1
+  };
+
   /**
    * @return host specific counters.
    */
@@ -44,14 +49,25 @@ public:
   virtual std::list<std::reference_wrapper<Stats::Gauge>> gauges() const PURE;
 
   /**
-   * @return bool whether the host is currently healthy and routable.
+   * Atomically clear a health flag for a host. Flags are specified in HealthFlags.
    */
-  virtual bool healthy() const PURE;
+  virtual void healthFlagClear(HealthFlag flag) PURE;
 
   /**
-   * Set whether the host is currently healthy and routable.
+   * Atomically get whether a health flag is set for a host. Flags are specified in HealthFlags.
    */
-  virtual void healthy(bool is_healthy) PURE;
+  virtual bool healthFlagGet(HealthFlag flag) const PURE;
+
+  /**
+   * Atomically set a health flag for a host. Flags are specified in HealthFlags.
+   */
+  virtual void healthFlagSet(HealthFlag flag) PURE;
+
+  /**
+   * @return whether in aggregate a host is healthy and routable. Multiple health flags and other
+   *         information may be considered.
+   */
+  virtual bool healthy() const PURE;
 
   /**
    * @return the current load balancing weight of the host, in the range 1-100.

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(
   tracing/http_tracer_impl.cc
   upstream/cluster_manager_impl.cc
   upstream/health_checker_impl.cc
+  upstream/host_utility.cc
   upstream/load_balancer_impl.cc
   upstream/logical_dns_cluster.cc
   upstream/sds.cc

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -1,0 +1,18 @@
+#include "host_utility.h"
+
+namespace Upstream {
+
+std::string HostUtility::healthFlagsToString(const Host& host) {
+  if (host.healthy()) {
+    return "healthy";
+  }
+
+  std::string ret;
+  if (host.healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
+    ret += "/failed_active_hc";
+  }
+
+  return ret;
+}
+
+} // Upstream

--- a/source/common/upstream/host_utility.h
+++ b/source/common/upstream/host_utility.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "envoy/upstream/upstream.h"
+
+namespace Upstream {
+
+/**
+ * Utility functions for hosts.
+ */
+class HostUtility {
+public:
+  /**
+   * Convert a host's health flags into a debug string.
+   */
+  static std::string healthFlagsToString(const Host& host);
+};
+
+} // Upstream

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -219,14 +219,16 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostPtr>& n
       hosts_added.push_back(host);
 
       // If we are depending on a health checker, we initialize to unhealthy.
-      hosts_added.back()->healthy(!depend_on_hc);
+      if (depend_on_hc) {
+        hosts_added.back()->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
+      }
     }
   }
 
   // If there are removed hosts, check to see if we should only delete if unhealthy.
   if (!current_hosts.empty() && depend_on_hc) {
     for (auto i = current_hosts.begin(); i != current_hosts.end();) {
-      if ((*i)->healthy()) {
+      if (!(*i)->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
         if ((*i)->weight() > max_host_weight) {
           max_host_weight = (*i)->weight();
         }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -22,6 +22,7 @@
 #include "common/network/listen_socket_impl.h"
 #include "common/profiler/profiler.h"
 #include "common/router/config_impl.h"
+#include "common/upstream/host_utility.h"
 
 namespace Server {
 
@@ -117,8 +118,8 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
                                  stat.first, stat.second));
       }
 
-      response.add(fmt::format("{}::{}::healthy::{}\n", cluster.second->name(), host->url(),
-                               host->healthy()));
+      response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second->name(), host->url(),
+                               Upstream::HostUtility::healthFlagsToString(*host)));
       response.add(
           fmt::format("{}::{}::weight::{}\n", cluster.second->name(), host->url(), host->weight()));
       response.add(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(envoy-test
   common/tracing/http_tracer_impl_test.cc
   common/upstream/cluster_manager_impl_test.cc
   common/upstream/health_checker_impl_test.cc
+  common/upstream/host_utility_test.cc
   common/upstream/load_balancer_impl_test.cc
   common/upstream/logical_dns_cluster_test.cc
   common/upstream/resource_manager_impl_test.cc

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -1,0 +1,16 @@
+#include "common/upstream/host_utility.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "test/mocks/upstream/mocks.h"
+
+namespace Upstream {
+
+TEST(HostUtilityTest, All) {
+  MockCluster cluster;
+  HostImpl host(cluster, "tcp://127.0.0.1:80", false, 1, "");
+  EXPECT_EQ("healthy", HostUtility::healthFlagsToString(host));
+  host.healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
+  EXPECT_EQ("/failed_active_hc", HostUtility::healthFlagsToString(host));
+}
+
+} // Upstream

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -203,7 +203,7 @@ TEST_F(SdsTest, HealthChecker) {
 
   // Now run through and make all the hosts healthy except for the first one.
   for (size_t i = 1; i < cluster_->hosts().size(); i++) {
-    cluster_->hosts()[i]->healthy(true);
+    cluster_->hosts()[i]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
     health_checker->runCallbacks(cluster_->hosts()[i], true);
   }
 
@@ -213,7 +213,7 @@ TEST_F(SdsTest, HealthChecker) {
 
   // Do the last one now which should fire the initialized event.
   EXPECT_CALL(membership_updated_, ready());
-  cluster_->hosts()[0]->healthy(true);
+  cluster_->hosts()[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker->runCallbacks(cluster_->hosts()[0], true);
   EXPECT_EQ(13UL, cluster_->healthyHosts().size());
   EXPECT_EQ(4UL, cluster_->localZoneHosts().size());
@@ -237,7 +237,7 @@ TEST_F(SdsTest, HealthChecker) {
 
   // Now set one of the removed hosts to unhealthy, and return the same query again, this should
   // remove it.
-  findHost("10.0.5.0")->healthy(false);
+  findHost("10.0.5.0")->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   setupRequest();
   timer_->callback_();
   EXPECT_CALL(*timer_, enableTimer(_));


### PR DESCRIPTION
This is a prerequisite for outlier detection.