### PR TITLE
Remove unnecessary call to ERR_load_crypto_strings().

### DIFF
--- a/source/common/ssl/openssl.cc
+++ b/source/common/ssl/openssl.cc
@@ -10,7 +10,6 @@ namespace Ssl {
 std::unique_ptr<std::mutex[]> OpenSsl::locks_;
 
 void OpenSsl::initialize() {
-  ERR_load_CRYPTO_strings();
   SSL_load_error_strings();
 
   if (!SSL_library_init()) {


### PR DESCRIPTION
It's already called as part of SSL_load_error_strings(),
and it's deprecated in BoringSSL and OpenSSL-1.1.0+.