### PR TITLE
Make cluster manager know about local cluster (optional)

### DIFF
--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -75,7 +75,7 @@ private:
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Stats::Store& stats_store, Event::Dispatcher& dispatcher,
                    const std::string& local_zone_name, const std::string& local_address,
-                   const ClusterEntry* local_cluster);
+                   const HostSet* local_host_set);
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -74,7 +74,8 @@ private:
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, const Cluster& cluster,
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Stats::Store& stats_store, Event::Dispatcher& dispatcher,
-                   const std::string& local_zone_name, const std::string& local_address);
+                   const std::string& local_zone_name, const std::string& local_address,
+                   const Optional<std::string>& local_cluster_name);
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 
@@ -90,7 +91,8 @@ private:
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
                                   Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                                   const std::string& local_zone_name,
-                                  const std::string& local_address);
+                                  const std::string& local_address,
+                                  const Optional<std::string>& local_cluster_name);
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,
                                         ConstHostVectorPtr healthy_hosts,
@@ -98,7 +100,7 @@ private:
                                         ConstHostVectorPtr local_zone_healthy_hosts,
                                         const std::vector<HostPtr>& hosts_added,
                                         const std::vector<HostPtr>& hosts_removed,
-                                        ThreadLocal::Instance& tls, uint32_t thead_local_slot);
+                                        ThreadLocal::Instance& tls, uint32_t thread_local_slot);
 
     // ThreadLocal::ThreadLocalObject
     void shutdown() override;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -75,7 +75,7 @@ private:
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Stats::Store& stats_store, Event::Dispatcher& dispatcher,
                    const std::string& local_zone_name, const std::string& local_address,
-                   const Optional<std::string>& local_cluster_name);
+                   const ClusterEntry* local_cluster);
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -79,10 +79,11 @@ ConstHostPtr RoundRobinLoadBalancer::chooseHost() {
   return hosts_to_use[rr_index_++ % hosts_to_use.size()];
 }
 
-LeastRequestLoadBalancer::LeastRequestLoadBalancer(const HostSet& host_set, ClusterStats& stats,
-                                                   Runtime::Loader& runtime,
+LeastRequestLoadBalancer::LeastRequestLoadBalancer(const HostSet& host_set,
+                                                   const HostSet* local_host_set,
+                                                   ClusterStats& stats, Runtime::Loader& runtime,
                                                    Runtime::RandomGenerator& random)
-    : LoadBalancerBase(host_set, stats, runtime, random) {
+    : LoadBalancerBase(host_set, local_host_set, stats, runtime, random) {
   host_set.addMemberUpdateCb(
       [this](const std::vector<HostPtr>&, const std::vector<HostPtr>& hosts_removed) -> void {
         if (last_host_) {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -11,9 +11,10 @@ namespace Upstream {
  */
 class LoadBalancerBase {
 protected:
-  LoadBalancerBase(const HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
-                   Runtime::RandomGenerator& random)
-      : stats_(stats), runtime_(runtime), random_(random), host_set_(host_set) {}
+  LoadBalancerBase(const HostSet& host_set, const HostSet* local_host_set, ClusterStats& stats,
+                   Runtime::Loader& runtime, Runtime::RandomGenerator& random)
+      : stats_(stats), runtime_(runtime), random_(random), host_set_(host_set),
+        local_host_set_(local_host_set) {}
 
   /**
    * Pick the host list to use (healthy or all depending on how many in the set are not healthy).
@@ -26,6 +27,7 @@ protected:
 
 private:
   const HostSet& host_set_;
+  const HostSet* local_host_set_;
 };
 
 /**
@@ -33,9 +35,10 @@ private:
  */
 class RoundRobinLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  RoundRobinLoadBalancer(const HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
+  RoundRobinLoadBalancer(const HostSet& host_set, const HostSet* local_host_set_,
+                         ClusterStats& stats, Runtime::Loader& runtime,
                          Runtime::RandomGenerator& random)
-      : LoadBalancerBase(host_set, stats, runtime, random) {}
+      : LoadBalancerBase(host_set, local_host_set_, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
   ConstHostPtr chooseHost() override;
@@ -59,7 +62,8 @@ private:
  */
 class LeastRequestLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  LeastRequestLoadBalancer(const HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
+  LeastRequestLoadBalancer(const HostSet& host_set, const HostSet* local_host_set_,
+                           ClusterStats& stats, Runtime::Loader& runtime,
                            Runtime::RandomGenerator& random);
 
   // Upstream::LoadBalancer
@@ -75,9 +79,9 @@ private:
  */
 class RandomLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  RandomLoadBalancer(const HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
-                     Runtime::RandomGenerator& random)
-      : LoadBalancerBase(host_set, stats, runtime, random) {}
+  RandomLoadBalancer(const HostSet& host_set, const HostSet* local_host_set, ClusterStats& stats,
+                     Runtime::Loader& runtime, Runtime::RandomGenerator& random)
+      : LoadBalancerBase(host_set, local_host_set, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
   ConstHostPtr chooseHost() override;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -83,9 +83,7 @@ TEST_F(ClusterManagerImplTest, UnknownClusterType) {
 TEST_F(ClusterManagerImplTest, LocalClusterNotDefined) {
   std::string json = R"EOF(
   {
-    "local_cluster": {
-      "name": "new_cluster"
-    },
+    "local_cluster_name": "new_cluster",
     "clusters": [
     {
       "name": "cluster_1",
@@ -111,9 +109,7 @@ TEST_F(ClusterManagerImplTest, LocalClusterNotDefined) {
 TEST_F(ClusterManagerImplTest, LocalClusterDefined) {
   std::string json = R"EOF(
   {
-    "local_cluster": {
-      "name": "new_cluster"
-    },
+    "local_cluster_name": "new_cluster",
     "clusters": [
     {
       "name": "cluster_1",

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -80,6 +80,69 @@ TEST_F(ClusterManagerImplTest, UnknownClusterType) {
   EXPECT_THROW(create(loader), EnvoyException);
 }
 
+TEST_F(ClusterManagerImplTest, LocalClusterNotDefined) {
+  std::string json = R"EOF(
+  {
+    "local_cluster": {
+      "name": "new_cluster"
+    },
+    "clusters": [
+    {
+      "name": "cluster_1",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:11001"}]
+    },
+    {
+      "name": "cluster_2",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:11002"}]
+    }]
+  }
+  )EOF";
+
+  Json::StringLoader loader(json);
+  EXPECT_THROW(create(loader), EnvoyException);
+}
+
+TEST_F(ClusterManagerImplTest, LocalClusterDefined) {
+  std::string json = R"EOF(
+  {
+    "local_cluster": {
+      "name": "new_cluster"
+    },
+    "clusters": [
+    {
+      "name": "cluster_1",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:11001"}]
+    },
+    {
+      "name": "cluster_2",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:11002"}]
+    },
+    {
+      "name": "new_cluster",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:11002"}]
+    }]
+  }
+  )EOF";
+
+  Json::StringLoader loader(json);
+  create(loader);
+}
+
 TEST_F(ClusterManagerImplTest, DuplicateCluster) {
   std::string json = R"EOF(
   {

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -23,7 +23,7 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
-  RoundRobinLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+  RoundRobinLoadBalancer lb_{cluster_, nullptr, stats_, runtime_, random_};
 };
 
 TEST_F(RoundRobinLoadBalancerTest, NoHosts) { EXPECT_EQ(nullptr, lb_.chooseHost()); }
@@ -196,7 +196,7 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
-  LeastRequestLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+  LeastRequestLoadBalancer lb_{cluster_, nullptr, stats_, runtime_, random_};
 };
 
 TEST_F(LeastRequestLoadBalancerTest, NoHosts) { EXPECT_EQ(nullptr, lb_.chooseHost()); }
@@ -354,7 +354,7 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
-  RandomLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+  RandomLoadBalancer lb_{cluster_, nullptr, stats_, runtime_, random_};
 };
 
 TEST_F(RandomLoadBalancerTest, NoHosts) { EXPECT_EQ(nullptr, lb_.chooseHost()); }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -119,7 +119,7 @@ public:
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
   // TODO: make per originating host load balancer.
-  RandomLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+  RandomLoadBalancer lb_{cluster_, nullptr, stats_, runtime_, random_};
 };
 
 TEST_F(DISABLED_SimulationTest, strictlyEqualDistribution) {


### PR DESCRIPTION
Allow to specify local cluster on a cluster manager configuration.
If local cluster is specified make load balancer aware of current cluster (required for next step in advanced zone aware routing)