### PR TITLE
less buffer copying

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -65,6 +65,19 @@ public:
   virtual void* linearize(uint32_t size) PURE;
 
   /**
+   * Move a buffer into this buffer. As little copying is done as possible.
+   * @param rhs supplies the buffer to move.
+   */
+  virtual void move(Instance& rhs) PURE;
+
+  /**
+   * Move a portion of a buffer into this buffer. As little copying is done as possible.
+   * @param rhs supplies the buffer to move.
+   * @param length supplies the amount of data to move.
+   */
+  virtual void move(Instance& rhs, uint64_t length) PURE;
+
+  /**
    * Search for an occurence of a buffer within the larger buffer.
    * @param data supplies the data to search for.
    * @param size supplies the length of the data to search for.

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -25,10 +25,10 @@ public:
 
   /**
    * Encode a data frame.
-   * @param data supplies the data to encode.
+   * @param data supplies the data to encode. The data may be moved by the encoder.
    * @param end_stream supplies whether this is the last data frame.
    */
-  virtual void encodeData(const Buffer::Instance& data, bool end_stream) PURE;
+  virtual void encodeData(Buffer::Instance& data, bool end_stream) PURE;
 
   /**
    * Encode trailers. This implicitly ends the stream.
@@ -62,7 +62,7 @@ public:
    * @param data supplies the decoded data.
    * @param end_stream supplies whether this is the last data frame.
    */
-  virtual void decodeData(const Buffer::Instance& data, bool end_stream) PURE;
+  virtual void decodeData(Buffer::Instance& data, bool end_stream) PURE;
 
   /**
    * Called with a decoded trailers frame. This implicitly ends the stream.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -19,6 +19,8 @@ public:
   uint64_t getRawSlices(RawSlice* out, uint64_t out_size) const override;
   uint64_t length() const override;
   void* linearize(uint32_t size) override;
+  void move(Instance& rhs) override;
+  void move(Instance& rhs, uint64_t length) override;
   ssize_t search(const void* data, uint64_t size, size_t start) const override;
 
 private:

--- a/source/common/filter/echo.cc
+++ b/source/common/filter/echo.cc
@@ -10,7 +10,7 @@ namespace Filter {
 Network::FilterStatus Echo::onData(Buffer::Instance& data) {
   conn_log_trace("echo: got {} bytes", read_callbacks_->connection(), data.length());
   read_callbacks_->connection().write(data);
-  data.drain(data.length());
+  ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;
 }
 

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -107,7 +107,7 @@ Network::FilterStatus TcpProxy::onData(Buffer::Instance& data) {
 
   conn_log_trace("received {} bytes", read_callbacks_->connection(), data.length());
   upstream_connection_->write(data);
-  data.drain(data.length());
+  ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;
 }
 
@@ -147,7 +147,7 @@ void TcpProxy::onUpstreamBufferChange(Network::ConnectionBufferType type, uint64
 
 void TcpProxy::onUpstreamData(Buffer::Instance& data) {
   read_callbacks_->connection().write(data);
-  data.drain(data.length());
+  ASSERT(0 == data.length());
 }
 
 void TcpProxy::onUpstreamEvent(uint32_t event) {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -70,10 +70,9 @@ void AsyncRequestImpl::encodeData(Buffer::Instance& data, bool end_stream) {
   log_trace("async http request response data (length={} end_stream={})", data.length(),
             end_stream);
   if (!response_->body()) {
-    response_->body(Buffer::InstancePtr{new Buffer::OwnedImpl(data)});
-  } else {
-    response_->body()->add(data);
+    response_->body(Buffer::InstancePtr{new Buffer::OwnedImpl()});
   }
+  response_->body()->move(data);
 
   if (end_stream) {
     onComplete();

--- a/source/common/http/codec_wrappers.h
+++ b/source/common/http/codec_wrappers.h
@@ -22,7 +22,7 @@ public:
     }
   }
 
-  void decodeData(const Buffer::Instance& data, bool end_stream) override {
+  void decodeData(Buffer::Instance& data, bool end_stream) override {
     if (end_stream) {
       onPreDecodeComplete();
     }
@@ -66,7 +66,7 @@ public:
     }
   }
 
-  void encodeData(const Buffer::Instance& data, bool end_stream) override {
+  void encodeData(Buffer::Instance& data, bool end_stream) override {
     inner_.encodeData(data, end_stream);
     if (end_stream) {
       onEncodeComplete();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -420,8 +420,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilte
   }
 }
 
-void ConnectionManagerImpl::ActiveStream::decodeData(const Buffer::Instance& data,
-                                                     bool end_stream) {
+void ConnectionManagerImpl::ActiveStream::decodeData(Buffer::Instance& data, bool end_stream) {
   request_info_.bytes_received_ += data.length();
   ASSERT(!state_.remote_complete_);
   state_.remote_complete_ = end_stream;
@@ -429,10 +428,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(const Buffer::Instance& dat
     stream_log_debug("request end stream", *this);
   }
 
-  // We are fed data directly from codec buffers. Perform a single copy here so that filters can
-  // modify the data and potentially take ownership of it.
-  Buffer::OwnedImpl data_copy(data);
-  decodeData(nullptr, data_copy, end_stream);
+  decodeData(nullptr, data, end_stream);
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* filter,
@@ -702,7 +698,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleBufferData(
     if (!bufferedData()) {
       bufferedData().reset(new Buffer::OwnedImpl());
     }
-    bufferedData()->add(provided_data);
+    bufferedData()->move(provided_data);
   }
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -341,7 +341,7 @@ private:
 
     // Http::StreamDecoder
     void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeData(const Buffer::Instance& data, bool end_stream) override;
+    void decodeData(Buffer::Instance& data, bool end_stream) override;
     void decodeTrailers(HeaderMapPtr&& trailers) override;
 
     // Http::FilterChainFactoryCallbacks

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -28,7 +28,7 @@ public:
 
   // Http::StreamEncoder
   void encodeHeaders(const HeaderMap& headers, bool end_stream) override;
-  void encodeData(const Buffer::Instance& data, bool end_stream) override;
+  void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(const HeaderMap& trailers) override;
   Stream& getStream() override { return *this; }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -110,7 +110,7 @@ protected:
 
     // Http::StreamEncoder
     void encodeHeaders(const HeaderMap& headers, bool end_stream) override;
-    void encodeData(const Buffer::Instance& data, bool end_stream) override;
+    void encodeData(Buffer::Instance& data, bool end_stream) override;
     void encodeTrailers(const HeaderMap& trailers) override;
     Stream& getStream() override { return *this; }
 

--- a/source/common/http/pooled_stream_encoder.cc
+++ b/source/common/http/pooled_stream_encoder.cc
@@ -42,11 +42,11 @@ void PooledStreamEncoder::encodeHeaders(const HeaderMap& headers, bool end_strea
   }
 }
 
-void PooledStreamEncoder::encodeData(const Buffer::Instance& data, bool end_stream) {
+void PooledStreamEncoder::encodeData(Buffer::Instance& data, bool end_stream) {
   commonEncodePrefix(end_stream);
   if (!request_encoder_) {
     stream_log_trace("buffering {} bytes", *this, data.length());
-    buffered_request_body_.add(data);
+    buffered_request_body_.move(data);
   } else {
     stream_log_trace("proxying {} bytes", *this, data.length());
     request_encoder_->encodeData(data, end_stream);

--- a/source/common/http/pooled_stream_encoder.h
+++ b/source/common/http/pooled_stream_encoder.h
@@ -38,7 +38,7 @@ public:
                       PooledStreamEncoderCallbacks& callbacks);
 
   void encodeHeaders(const HeaderMap& headers, bool end_stream);
-  void encodeData(const Buffer::Instance& data, bool end_stream);
+  void encodeData(Buffer::Instance& data, bool end_stream);
   void encodeTrailers(const HeaderMap& trailers);
   void resetStream();
   uint64_t connectionId() { return connection_id_; }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -108,6 +108,7 @@ private:
   void fakeBufferDrain(ConnectionBufferType type, evbuffer* buffer);
 
   Buffer::WrappedImpl read_buffer_;
+  Buffer::WrappedImpl write_buffer_;
   Buffer::Instance* current_write_buffer_{};
 };
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -118,7 +118,7 @@ private:
 
     // Http::StreamDecoder
     void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeData(const Buffer::Instance& data, bool end_stream) override;
+    void decodeData(Buffer::Instance& data, bool end_stream) override;
     void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
 
     // Http::StreamCallbacks
@@ -159,7 +159,7 @@ private:
   void onResetStream();
   void onResponseTimeout();
   void onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream);
-  void onUpstreamData(const Buffer::Instance& data, bool end_stream);
+  void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);
   void onUpstreamComplete();
   void onUpstreamReset(UpstreamResetType type,

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -125,7 +125,7 @@ private:
 
     // Http::StreamDecoder
     void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-    void decodeData(const Buffer::Instance&, bool end_stream) override {
+    void decodeData(Buffer::Instance&, bool end_stream) override {
       if (end_stream) {
         onResponseComplete();
       }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -515,7 +515,10 @@ TEST_F(HttpConnectionManagerImplTest, DoubleBuffering) {
 
   NiceMock<Http::MockStreamEncoder> encoder;
   Http::StreamDecoder* decoder = nullptr;
+
+  // The data will get moved so we need to have a copy to compare against.
   Buffer::OwnedImpl fake_data("hello");
+  Buffer::OwnedImpl fake_data_copy("hello");
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
@@ -540,7 +543,7 @@ TEST_F(HttpConnectionManagerImplTest, DoubleBuffering) {
   // data to have been kept inline as it moves through.
   EXPECT_CALL(*decoder_filter3, decodeHeaders(_, false))
       .WillOnce(Return(Http::FilterHeadersStatus::StopIteration));
-  EXPECT_CALL(*decoder_filter3, decodeData(BufferEqual(&fake_data), true))
+  EXPECT_CALL(*decoder_filter3, decodeData(BufferEqual(&fake_data_copy), true))
       .WillOnce(Return(Http::FilterDataStatus::StopIterationNoBuffer));
   decoder_filter2->callbacks_->continueDecoding();
 }

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -145,7 +145,8 @@ TEST_P(Http2CodecImplTest, TrailingHeaders) {
   EXPECT_CALL(request_decoder, decodeHeaders_(_, false));
   request_encoder.encodeHeaders(request_headers, false);
   EXPECT_CALL(request_decoder, decodeData(_, false));
-  request_encoder.encodeData(Buffer::OwnedImpl("hello"), false);
+  Buffer::OwnedImpl hello("hello");
+  request_encoder.encodeData(hello, false);
   EXPECT_CALL(request_decoder, decodeTrailers_(_));
   request_encoder.encodeTrailers(HeaderMapImpl{{"trailing", "header"}});
 
@@ -153,7 +154,8 @@ TEST_P(Http2CodecImplTest, TrailingHeaders) {
   EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
   response_encoder->encodeHeaders(response_headers, false);
   EXPECT_CALL(response_decoder, decodeData(_, false));
-  response_encoder->encodeData(Buffer::OwnedImpl("world"), false);
+  Buffer::OwnedImpl world("world");
+  response_encoder->encodeData(world, false);
   EXPECT_CALL(response_decoder, decodeTrailers_(_));
   response_encoder->encodeTrailers(HeaderMapImpl{{"trailing", "header"}});
 }
@@ -180,7 +182,8 @@ TEST_P(Http2CodecImplTest, TrailingHeadersLargeBody) {
   EXPECT_CALL(request_decoder, decodeHeaders_(_, false));
   request_encoder.encodeHeaders(request_headers, false);
   EXPECT_CALL(request_decoder, decodeData(_, false)).Times(AtLeast(1));
-  request_encoder.encodeData(Buffer::OwnedImpl(std::string(1024 * 1024, 'a')), false);
+  Buffer::OwnedImpl body(std::string(1024 * 1024, 'a'));
+  request_encoder.encodeData(body, false);
   EXPECT_CALL(request_decoder, decodeTrailers_(_));
   request_encoder.encodeTrailers(HeaderMapImpl{{"trailing", "header"}});
 
@@ -192,7 +195,8 @@ TEST_P(Http2CodecImplTest, TrailingHeadersLargeBody) {
   EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
   response_encoder->encodeHeaders(response_headers, false);
   EXPECT_CALL(response_decoder, decodeData(_, false));
-  response_encoder->encodeData(Buffer::OwnedImpl("world"), false);
+  Buffer::OwnedImpl world("world");
+  response_encoder->encodeData(world, false);
   EXPECT_CALL(response_decoder, decodeTrailers_(_));
   response_encoder->encodeTrailers(HeaderMapImpl{{"trailing", "header"}});
 }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -22,7 +22,7 @@ void FakeStream::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   decoder_event_.notify_one();
 }
 
-void FakeStream::decodeData(const Buffer::Instance& data, bool end_stream) {
+void FakeStream::decodeData(Buffer::Instance& data, bool end_stream) {
   std::unique_lock<std::mutex> lock(lock_);
   end_stream_ = end_stream;
   body_length_ += data.length();

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -36,7 +36,7 @@ public:
 
   // Http::StreamDecoder
   void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-  void decodeData(const Buffer::Instance& data, bool end_stream) override;
+  void decodeData(Buffer::Instance& data, bool end_stream) override;
   void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
 
   // Http::StreamCallbacks

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -43,7 +43,7 @@ void IntegrationStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool 
   }
 }
 
-void IntegrationStreamDecoder::decodeData(const Buffer::Instance& data, bool end_stream) {
+void IntegrationStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream) {
   saw_end_stream_ = end_stream;
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   Buffer::RawSlice slices[num_slices];

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -24,7 +24,7 @@ public:
 
   // Http::StreamDecoder
   void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-  void decodeData(const Buffer::Instance& data, bool end_stream) override;
+  void decodeData(Buffer::Instance& data, bool end_stream) override;
   void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
 
   // Http::StreamCallbacks

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -21,7 +21,7 @@ void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool en
   }
 }
 
-void BufferingStreamDecoder::decodeData(const Buffer::Instance& data, bool end_stream) {
+void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!complete_);
   complete_ = end_stream;
   body_.append(TestUtility::bufferToString(data));
@@ -61,7 +61,8 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
   headers.addViaMoveValue(Http::Headers::get().Scheme, "http");
   encoder.encodeHeaders(headers, body.empty());
   if (!body.empty()) {
-    encoder.encodeData(Buffer::OwnedImpl(body), true);
+    Buffer::OwnedImpl body_buffer(body);
+    encoder.encodeData(body_buffer, true);
   }
 
   dispatcher->run(Event::Dispatcher::RunType::Block);

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -20,7 +20,7 @@ public:
 
   // Http::StreamDecoder
   void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-  void decodeData(const Buffer::Instance&, bool end_stream) override;
+  void decodeData(Buffer::Instance&, bool end_stream) override;
   void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
 
   // Http::StreamCallbacks

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -109,7 +109,7 @@ public:
 
   // Http::StreamDecoder
   MOCK_METHOD2(decodeHeaders_, void(HeaderMapPtr& headers, bool end_stream));
-  MOCK_METHOD2(decodeData, void(const Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD2(decodeData, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(decodeTrailers_, void(HeaderMapPtr& trailers));
 };
 
@@ -142,7 +142,7 @@ public:
 
   // Http::StreamEncoder
   MOCK_METHOD2(encodeHeaders, void(const HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(encodeData, void(const Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD2(encodeData, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(encodeTrailers, void(const HeaderMap& trailers));
   MOCK_METHOD0(getStream, Stream&());
 

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -44,6 +44,11 @@ template <class T> static void initializeMockConnection(T& connection) {
   ON_CALL(connection, remoteAddress()).WillByDefault(ReturnRef(connection.remote_address_));
   ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
   ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
+
+  // The real implementation will move the buffer data into the socket.
+  ON_CALL(connection, write(_))
+      .WillByDefault(
+          Invoke([](Buffer::Instance& buffer) -> void { buffer.drain(buffer.length()); }));
 }
 
 MockConnection::MockConnection() { initializeMockConnection(*this); }


### PR DESCRIPTION
This change removes many of the buffer copies in the code base
in the fast paths (no retry, etc.).