### PR TITLE
Make x-request-id part of the trace span. Cleanup of example configs.

### DIFF
--- a/configs/envoy_double_proxy.template.json
+++ b/configs/envoy_double_proxy.template.json
@@ -18,7 +18,9 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
-        "tracing_enabled": true,
+        "tracing": {
+          "operation_name": "ingress"
+        },
         "idle_timeout_s": 840,
         "access_log": [
         {

--- a/configs/envoy_front_proxy.template.json
+++ b/configs/envoy_front_proxy.template.json
@@ -27,7 +27,9 @@
       "config": {
         "codec_type": "auto",
         "add_user_agent": true,
-        "tracing_enabled": true,
+        "tracing": {
+          "operation_name": "ingress"
+        },
         "idle_timeout_s": 840,
         "access_log": [
         {

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -11,7 +11,9 @@
     "config": {
       "codec_type": "auto",
       "http_codec_options": "no_compression",
-      "tracing_enabled": true,
+      "tracing": {
+        "operation_name": "ingress"
+      },
       "idle_timeout_s": 840,
       "access_log": [
       {
@@ -97,6 +99,10 @@
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
+        "tracing": {
+          "operation_name": "egress",
+          "type": "upstream_error"
+        }
         "add_user_agent": true,
         "idle_timeout_s": 840,
         "access_log": [

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -101,7 +101,7 @@
         "codec_type": "auto",
         "tracing": {
           "operation_name": "egress",
-          "type": "upstream_error"
+          "type": "upstream_failure"
         },
         "add_user_agent": true,
         "idle_timeout_s": 840,

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -102,7 +102,7 @@
         "tracing": {
           "operation_name": "egress",
           "type": "upstream_error"
-        }
+        },
         "add_user_agent": true,
         "idle_timeout_s": 840,
         "access_log": [

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -244,7 +244,8 @@ void LightStepSink::flushTrace(const Http::HeaderMap& request_headers, const Htt
        lightstep::SetTag(
            "user agent",
            StringUtil::valueOrDefault(request_headers.get(Http::Headers::get().UserAgent), "-")),
-       lightstep::SetTag("node id", service_node_)});
+       lightstep::SetTag("node id", service_node_),
+       lightstep::SetTag("x-request-id", request_headers.get(Http::Headers::get().RequestId))});
 
   if (request_info.responseCode().valid() &&
       Http::CodeUtility::is5xx(request_info.responseCode().value())) {


### PR DESCRIPTION
I'm seeing joined traces, which looks strange. Add x-request-id to the span data to help debugging.