### PR TITLE
Expose per zone hosts as part of host set

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -130,7 +130,7 @@ public:
 
   /**
    * @return hosts per zone, index 0 is dedicated to local zone hosts.
-   * If there is no hosts in local zone for upstream cluster hostPerZone() will @return
+   * If there are no hosts in local zone for upstream cluster hostPerZone() will @return
    * empty vector.
    *
    * Note, that we sort zones in alphabetical order starting from index 1.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -127,13 +127,20 @@ public:
    *         set on the command line and to use a cluster type that supports population such as
    *         the SDS cluster type.
    */
-  virtual const std::vector<HostPtr>& localZoneHosts() const PURE;
 
   /**
-   * @return all healthy hosts that are in the zone local to this node. See healthyHosts() and
-   *         localZoneHosts() for more information.
+   * @return hosts per zone, index 0 is dedicated to local zone hosts.
+   * If there is no hosts in local zone for upstream cluster hostPerZone() will @return
+   * empty vector.
+   *
+   * Note, that we sort zones in alphabetical order starting from index 1.
    */
-  virtual const std::vector<HostPtr>& localZoneHealthyHosts() const PURE;
+  virtual const std::vector<std::vector<HostPtr>>& hostsPerZone() const PURE;
+
+  /**
+   * @return same as hostsPerZone but only contains healthy hosts.
+   */
+  virtual const std::vector<std::vector<HostPtr>>& healthyHostsPerZone() const PURE;
 };
 
 /**
@@ -188,8 +195,7 @@ public:
   COUNTER(zone_over_percentage)                                                                    \
   COUNTER(zone_routing_sampled)                                                                    \
   COUNTER(zone_routing_no_sampled)                                                                 \
-  GAUGE  (max_host_weight)                                                                         \
-  GAUGE  (upstream_zone_count)
+  GAUGE  (max_host_weight)
 // clang-format on
 
 /**

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -96,8 +96,8 @@ private:
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,
                                         ConstHostVectorPtr healthy_hosts,
-                                        ConstHostVectorPtr local_zone_hosts,
-                                        ConstHostVectorPtr local_zone_healthy_hosts,
+                                        ConstHostListsPtr hosts_per_zone,
+                                        ConstHostListsPtr healthy_hosts_per_zone,
                                         const std::vector<HostPtr>& hosts_added,
                                         const std::vector<HostPtr>& hosts_removed,
                                         ThreadLocal::Instance& tls, uint32_t thread_local_slot);

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -26,6 +26,9 @@ protected:
   Runtime::RandomGenerator& random_;
 
 private:
+  bool earlyExitNonZoneRouting();
+  bool isGlobalPanic();
+
   const HostSet& host_set_;
   const HostSet* local_host_set_;
 };

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -53,8 +53,8 @@ void LogicalDnsCluster::startResolve() {
             logical_host_.reset(new LogicalHost(*this, dns_url_, *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());
             new_hosts->emplace_back(logical_host_);
-            updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_list_,
-                        empty_host_list_, *new_hosts, {});
+            updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
+                        empty_host_lists_, *new_hosts, {});
           }
         }
 

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -55,7 +55,6 @@ public:
       std::vector<std::vector<HostPtr>> per_zone_upstream;
       per_zone_upstream.push_back(per_zone_hosts[from_zone]);
       for (size_t pos = 0; pos < per_zone_hosts.size(); ++pos) {
-        // make compiler happy for now.
         if (pos == from_zone) {
           continue;
         }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -39,12 +39,9 @@ public:
    */
   void run(std::vector<uint32_t> originating_cluster, std::vector<uint32_t> all_destination_cluster,
            std::vector<uint32_t> healthy_destination_cluster) {
-    stats_.upstream_zone_count_.set(all_destination_cluster.size());
 
-    std::unordered_map<std::string, std::vector<HostPtr>> healthy_map =
+    std::vector<std::vector<HostPtr>> per_zone_hosts =
         generateHostsPerZone(healthy_destination_cluster);
-    std::unordered_map<std::string, std::vector<HostPtr>> all_map =
-        generateHostsPerZone(all_destination_cluster);
 
     std::vector<HostPtr> originating_hosts = generateHostList(originating_cluster);
     cluster_.healthy_hosts_ = generateHostList(healthy_destination_cluster);
@@ -53,9 +50,20 @@ public:
     std::map<std::string, uint32_t> hits;
     for (uint32_t i = 0; i < total_number_of_requests; ++i) {
       HostPtr from_host = selectOriginatingHost(originating_hosts);
+      uint32_t from_zone = atoi(from_host->zone().c_str());
 
-      cluster_.local_zone_hosts_ = all_map[from_host->zone()];
-      cluster_.local_zone_healthy_hosts_ = healthy_map[from_host->zone()];
+      std::vector<std::vector<HostPtr>> per_zone_upstream;
+      per_zone_upstream.push_back(per_zone_hosts[from_zone]);
+      for (size_t pos = 0; pos < per_zone_hosts.size(); ++pos) {
+        // make compiler happy for now.
+        if (pos == from_zone) {
+          continue;
+        }
+
+        per_zone_upstream.push_back(per_zone_hosts[pos]);
+      }
+
+      cluster_.healthy_hosts_per_zone_ = std::move(per_zone_upstream);
 
       ConstHostPtr selected = lb_.chooseHost();
       hits[selected->url()]++;
@@ -93,9 +101,8 @@ public:
    * Generate hosts by zone.
    * @param hosts number of hosts per zone.
    */
-  std::unordered_map<std::string, std::vector<HostPtr>>
-  generateHostsPerZone(const std::vector<uint32_t>& hosts) {
-    std::unordered_map<std::string, std::vector<HostPtr>> ret;
+  std::vector<std::vector<HostPtr>> generateHostsPerZone(const std::vector<uint32_t>& hosts) {
+    std::vector<std::vector<HostPtr>> ret;
     for (size_t i = 0; i < hosts.size(); ++i) {
       const std::string zone = std::to_string(i);
       std::vector<HostPtr> zone_hosts;
@@ -105,7 +112,7 @@ public:
         zone_hosts.push_back(newTestHost(cluster_, url, 1, zone));
       }
 
-      ret.insert({zone, std::move(zone_hosts)});
+      ret.push_back(std::move(zone_hosts));
     }
 
     return ret;

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -78,8 +78,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
 
   EXPECT_EQ(1UL, cluster_->hosts().size());
   EXPECT_EQ(1UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->localZoneHosts().size());
-  EXPECT_EQ(0UL, cluster_->localZoneHealthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(cluster_->hosts()[0], cluster_->healthyHosts()[0]);
   HostPtr logical_host = cluster_->hosts()[0];
 

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -78,6 +78,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
 
   EXPECT_EQ(1UL, cluster_->hosts().size());
   EXPECT_EQ(1UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
   EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(cluster_->hosts()[0], cluster_->healthyHosts()[0]);
   HostPtr logical_host = cluster_->hosts()[0];

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -132,8 +132,8 @@ TEST(StrictDnsClusterImplTest, Basic) {
               ContainerEq(hostListToURLs(cluster.hosts())));
 
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
-  EXPECT_EQ(0UL, cluster.localZoneHosts().size());
-  EXPECT_EQ(0UL, cluster.localZoneHealthyHosts().size());
+  // check for local zone hosts also.
+  EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());
 
   for (const HostPtr& host : cluster.hosts()) {
     EXPECT_EQ(&cluster, &host->cluster());
@@ -255,8 +255,8 @@ TEST(StaticClusterImplTest, UrlConfig) {
   EXPECT_THAT(std::list<std::string>({"tcp://10.0.0.1:11001", "tcp://10.0.0.2:11002"}),
               ContainerEq(hostListToURLs(cluster.hosts())));
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
-  EXPECT_EQ(0UL, cluster.localZoneHosts().size());
-  EXPECT_EQ(0UL, cluster.localZoneHealthyHosts().size());
+  // check for local zone hosts number.
+  EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());
 }
 
 TEST(StaticClusterImplTest, UnsupportedLBType) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -132,7 +132,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
               ContainerEq(hostListToURLs(cluster.hosts())));
 
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
-  // check for local zone hosts also.
+  EXPECT_EQ(0UL, cluster.hostsPerZone().size());
   EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());
 
   for (const HostPtr& host : cluster.hosts()) {
@@ -255,7 +255,7 @@ TEST(StaticClusterImplTest, UrlConfig) {
   EXPECT_THAT(std::list<std::string>({"tcp://10.0.0.1:11001", "tcp://10.0.0.2:11002"}),
               ContainerEq(hostListToURLs(cluster.hosts())));
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
-  // check for local zone hosts number.
+  EXPECT_EQ(0UL, cluster.hostsPerZone().size());
   EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());
 }
 

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -38,8 +38,8 @@ MockCluster::MockCluster()
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, hosts()).WillByDefault(ReturnRef(hosts_));
   ON_CALL(*this, healthyHosts()).WillByDefault(ReturnRef(healthy_hosts_));
-  ON_CALL(*this, localZoneHosts()).WillByDefault(ReturnRef(local_zone_hosts_));
-  ON_CALL(*this, localZoneHealthyHosts()).WillByDefault(ReturnRef(local_zone_healthy_hosts_));
+  ON_CALL(*this, hostsPerZone()).WillByDefault(ReturnRef(hosts_per_zone_));
+  ON_CALL(*this, healthyHostsPerZone()).WillByDefault(ReturnRef(healthy_hosts_per_zone_));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, altStatName()).WillByDefault(ReturnRef(alt_stat_name_));
   ON_CALL(*this, lbType()).WillByDefault(Return(Upstream::LoadBalancerType::RoundRobin));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -29,8 +29,8 @@ public:
   MOCK_CONST_METHOD1(addMemberUpdateCb, void(MemberUpdateCb callback));
   MOCK_CONST_METHOD0(hosts, const std::vector<HostPtr>&());
   MOCK_CONST_METHOD0(healthyHosts, const std::vector<HostPtr>&());
-  MOCK_CONST_METHOD0(localZoneHosts, const std::vector<HostPtr>&());
-  MOCK_CONST_METHOD0(localZoneHealthyHosts, const std::vector<HostPtr>&());
+  MOCK_CONST_METHOD0(hostsPerZone, const std::vector<std::vector<HostPtr>>&());
+  MOCK_CONST_METHOD0(healthyHostsPerZone, const std::vector<std::vector<HostPtr>>&());
 
   // Upstream::Cluster
   MOCK_CONST_METHOD0(altStatName, const std::string&());
@@ -48,8 +48,8 @@ public:
 
   std::vector<HostPtr> hosts_;
   std::vector<HostPtr> healthy_hosts_;
-  std::vector<HostPtr> local_zone_hosts_;
-  std::vector<HostPtr> local_zone_healthy_hosts_;
+  std::vector<std::vector<HostPtr>> hosts_per_zone_;
+  std::vector<std::vector<HostPtr>> healthy_hosts_per_zone_;
   std::string name_{"fake_cluster"};
   std::string alt_stat_name_{"fake_alt_cluster"};
   std::list<MemberUpdateCb> callbacks_;


### PR DESCRIPTION
This will be required for advanced load balancing when consider local cluster (This is going to be separate change).

At this point I'd like to get proof of concept for routing and then we can optimize it further (e.g., precompute % of the healthy zone hosts to all hosts).