### PR TITLE
Allow non intersecting spans matching in a trace

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -233,9 +233,11 @@ void LightStepSink::flushTrace(const Http::HeaderMap& request_headers, const Htt
   lightstep::Span span = tls_.getTyped<TlsLightStepTracer>(tls_slot_).tracer_.StartSpan(
       tracing_context.operationName(),
       {lightstep::StartTimestamp(request_info.startTime()),
-       lightstep::SetTag("join:x-request-id", request_headers.get(Http::Headers::get().RequestId)),
+       lightstep::SetTag("guid:x-request-id", request_headers.get(Http::Headers::get().RequestId)),
        lightstep::SetTag("request line", buildRequestLine(request_headers, request_info)),
        lightstep::SetTag("response code", buildResponseCode(request_info)),
+       lightstep::SetTag("request size", request_info.bytesReceived()),
+       lightstep::SetTag("response size", request_info.bytesSent()),
        lightstep::SetTag("host header", request_headers.get(Http::Headers::get().Host)),
        lightstep::SetTag(
            "downstream cluster",

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -470,6 +470,8 @@ TEST_F(LightStepSinkTest, FlushSpansTimer) {
   EXPECT_CALL(request_info, startTime()).WillOnce(Return(start_time));
   Optional<uint32_t> code(200);
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(code));
+  EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10UL));
+  EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(100UL));
 
   const std::string protocol = "http/1";
   EXPECT_CALL(request_info, protocol()).WillOnce(ReturnRef(protocol));


### PR DESCRIPTION
Additional data to span (bytes send and received) and matching on x-request-id as guid matching,
guid matching make non intersecting spans assemble as well.