### PR TITLE
remove use of bufferevent for both plain and ssl connections

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -57,12 +57,9 @@ public:
    * Create a file event that will signal when a file is readable or writable. On UNIX systems this
    * can be used for any file like interface (files, sockets, etc.).
    * @param fd supplies the fd to watch.
-   * @param read_cb supplies the callback to fire when the file is readable. Can be nullptr if no
-   *                callback is desired.
-   * @param write_cb supplies the callback to fire when the file is writable. Can be nullptr if no
-   *                 callback is desired.
+   * @param cb supplies the callback to fire when the file is ready.
    */
-  virtual FileEventPtr createFileEvent(int fd, FileReadyCb read_cb, FileReadyCb write_cb) PURE;
+  virtual FileEventPtr createFileEvent(int fd, FileReadyCb cb) PURE;
 
   /**
    * @return Filesystem::WatcherPtr a filesystem watcher owned by the caller.

--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -22,7 +22,7 @@ public:
   virtual ~FileEvent() {}
 
   /**
-   * Active the file event explicitly for a set of events. Should be a logical OR of FileReadyType
+   * Activate the file event explicitly for a set of events. Should be a logical OR of FileReadyType
    * events.
    */
   virtual void activate(uint32_t events) PURE;

--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include "envoy/common/pure.h"
+
 namespace Event {
+
+struct FileReadyType {
+  static const uint32_t Read = 0x1;
+  static const uint32_t Write = 0x2;
+};
 
 /**
  * Callback invoked when a FileEvent is ready for reading or writing.
  */
-typedef std::function<void()> FileReadyCb;
+typedef std::function<void(uint32_t events)> FileReadyCb;
 
 /**
  * Wrapper for file based (read/write) event notifications.
@@ -13,6 +20,12 @@ typedef std::function<void()> FileReadyCb;
 class FileEvent {
 public:
   virtual ~FileEvent() {}
+
+  /**
+   * Active the file event explicitly for a set of events. Should be a logical OR of FileReadyType
+   * events.
+   */
+  virtual void activate(uint32_t events) PURE;
 };
 
 typedef std::unique_ptr<FileEvent> FileEventPtr;

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -6,11 +6,17 @@
 
 namespace Buffer {
 
-void ImplBase::add(const void* data, uint64_t size) { evbuffer_add(&buffer(), data, size); }
+const evbuffer_cb_func OwnedImpl::buffer_cb_ =
+    [](evbuffer*, const evbuffer_cb_info* info, void* arg)
+        -> void { static_cast<OwnedImpl*>(arg)->onBufferChange(*info); };
 
-void ImplBase::add(const std::string& data) { evbuffer_add(&buffer(), data.c_str(), data.size()); }
+void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(), data, size); }
 
-void ImplBase::add(const Instance& data) {
+void OwnedImpl::add(const std::string& data) {
+  evbuffer_add(buffer_.get(), data.c_str(), data.size());
+}
+
+void OwnedImpl::add(const Instance& data) {
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   RawSlice slices[num_slices];
   data.getRawSlices(slices, num_slices);
@@ -19,16 +25,27 @@ void ImplBase::add(const Instance& data) {
   }
 }
 
-void ImplBase::drain(uint64_t size) {
-  ASSERT(size <= length());
-  int rc = evbuffer_drain(&buffer(), size);
+void OwnedImpl::commit(RawSlice* iovecs, uint64_t num_iovecs) {
+  evbuffer_iovec local_iovecs[num_iovecs];
+  for (uint64_t i = 0; i < num_iovecs; i++) {
+    local_iovecs[i].iov_len = iovecs[i].len_;
+    local_iovecs[i].iov_base = iovecs[i].mem_;
+  }
+  int rc = evbuffer_commit_space(buffer_.get(), local_iovecs, num_iovecs);
   ASSERT(rc == 0);
   UNREFERENCED_PARAMETER(rc);
 }
 
-uint64_t ImplBase::getRawSlices(RawSlice* out, uint64_t out_size) const {
+void OwnedImpl::drain(uint64_t size) {
+  ASSERT(size <= length());
+  int rc = evbuffer_drain(buffer_.get(), size);
+  ASSERT(rc == 0);
+  UNREFERENCED_PARAMETER(rc);
+}
+
+uint64_t OwnedImpl::getRawSlices(RawSlice* out, uint64_t out_size) const {
   evbuffer_iovec iovecs[out_size];
-  uint64_t needed_size = evbuffer_peek(&buffer(), -1, nullptr, iovecs, out_size);
+  uint64_t needed_size = evbuffer_peek(buffer_.get(), -1, nullptr, iovecs, out_size);
   for (uint64_t i = 0; i < std::min(out_size, needed_size); i++) {
     out[i].mem_ = iovecs[i].iov_base;
     out[i].len_ = iovecs[i].iov_len;
@@ -36,40 +53,73 @@ uint64_t ImplBase::getRawSlices(RawSlice* out, uint64_t out_size) const {
   return needed_size;
 }
 
-uint64_t ImplBase::length() const { return evbuffer_get_length(&buffer()); }
+uint64_t OwnedImpl::length() const { return evbuffer_get_length(buffer_.get()); }
 
-void* ImplBase::linearize(uint32_t size) {
+void* OwnedImpl::linearize(uint32_t size) {
   ASSERT(size <= length());
-  return evbuffer_pullup(&buffer(), size);
+  return evbuffer_pullup(buffer_.get(), size);
 }
 
-void ImplBase::move(Instance& rhs) {
+void OwnedImpl::move(Instance& rhs) {
   // We do the static cast here because in practice we only have one buffer implementation right
   // now and this is safe. Using the evbuffer move routines require having access to both evbuffers.
   // This is a reasonable compromise in a high performance path where we want to maintain an
   // abstraction in case we get rid of evbuffer later.
-  int rc = evbuffer_add_buffer(&buffer(), &static_cast<ImplBase&>(rhs).buffer());
+  int rc = evbuffer_add_buffer(buffer_.get(), static_cast<OwnedImpl&>(rhs).buffer_.get());
   ASSERT(rc == 0);
   UNREFERENCED_PARAMETER(rc);
 }
 
-void ImplBase::move(Instance& rhs, uint64_t length) {
+void OwnedImpl::move(Instance& rhs, uint64_t length) {
   // See move() above for why we do the static cast.
-  int rc = evbuffer_remove_buffer(&static_cast<ImplBase&>(rhs).buffer(), &buffer(), length);
+  int rc =
+      evbuffer_remove_buffer(static_cast<OwnedImpl&>(rhs).buffer_.get(), buffer_.get(), length);
   ASSERT(static_cast<uint64_t>(rc) == length);
   UNREFERENCED_PARAMETER(rc);
 }
 
-ssize_t ImplBase::search(const void* data, uint64_t size, size_t start) const {
+void OwnedImpl::onBufferChange(const evbuffer_cb_info& info) {
+  cb_(info.orig_size, info.n_added - info.n_deleted);
+}
+
+int OwnedImpl::read(int fd, uint64_t max_length) {
+  return evbuffer_read(buffer_.get(), fd, max_length);
+}
+
+uint64_t OwnedImpl::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) {
+  evbuffer_iovec local_iovecs[num_iovecs];
+  uint64_t ret = evbuffer_reserve_space(buffer_.get(), length, local_iovecs, num_iovecs);
+  ASSERT(ret >= 1);
+  for (uint64_t i = 0; i < ret; i++) {
+    iovecs[i].len_ = local_iovecs[i].iov_len;
+    iovecs[i].mem_ = local_iovecs[i].iov_base;
+  }
+  return ret;
+}
+
+ssize_t OwnedImpl::search(const void* data, uint64_t size, size_t start) const {
   evbuffer_ptr start_ptr;
-  if (-1 == evbuffer_ptr_set(&buffer(), &start_ptr, start, EVBUFFER_PTR_SET)) {
+  if (-1 == evbuffer_ptr_set(buffer_.get(), &start_ptr, start, EVBUFFER_PTR_SET)) {
     return -1;
   }
 
   evbuffer_ptr result_ptr =
-      evbuffer_search(&buffer(), static_cast<const char*>(data), size, &start_ptr);
+      evbuffer_search(buffer_.get(), static_cast<const char*>(data), size, &start_ptr);
   return result_ptr.pos;
 }
+
+void OwnedImpl::setCallback(Callback callback) {
+  ASSERT(!callback || !cb_);
+  if (callback) {
+    evbuffer_add_cb(buffer_.get(), buffer_cb_, this);
+    cb_ = callback;
+  } else {
+    evbuffer_remove_cb(buffer_.get(), buffer_cb_, this);
+    cb_ = nullptr;
+  }
+}
+
+int OwnedImpl::write(int fd) { return evbuffer_write(buffer_.get(), fd); }
 
 OwnedImpl::OwnedImpl() : buffer_(evbuffer_new()) {}
 

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -4,7 +4,7 @@
 
 #include "common/event/libevent.h"
 
-// Forward decls to avoid leaking libevent headers to reset of program.
+// Forward decls to avoid leaking libevent headers to rest of program.
 struct evbuffer_cb_info;
 typedef void (*evbuffer_cb_func)(evbuffer* buffer, const evbuffer_cb_info* info, void* arg);
 
@@ -40,10 +40,11 @@ public:
 private:
   void onBufferChange(const evbuffer_cb_info& info);
 
-  static const evbuffer_cb_func buffer_cb_;
+  static const evbuffer_cb_func buffer_cb_; // Static callback used for all evbuffer callbacks.
+                                            // This allows us to add/remove by value.
 
   Event::Libevent::BufferPtr buffer_;
-  Callback cb_;
+  Callback cb_; // The per buffer callback. Invoked via the buffer_cb_ static thunk.
 };
 
 } // Buffer

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -4,61 +4,46 @@
 
 #include "common/event/libevent.h"
 
+// Forward decls to avoid leaking libevent headers to reset of program.
+struct evbuffer_cb_info;
+typedef void (*evbuffer_cb_func)(evbuffer* buffer, const evbuffer_cb_info* info, void* arg);
+
 namespace Buffer {
-
-/**
- * Base implementation for libevent backed buffers.
- */
-class ImplBase : public Instance {
-public:
-  // Instance
-  void add(const void* data, uint64_t size) override;
-  void add(const std::string& data) override;
-  void add(const Instance& data) override;
-  void drain(uint64_t size) override;
-  uint64_t getRawSlices(RawSlice* out, uint64_t out_size) const override;
-  uint64_t length() const override;
-  void* linearize(uint32_t size) override;
-  void move(Instance& rhs) override;
-  void move(Instance& rhs, uint64_t length) override;
-  ssize_t search(const void* data, uint64_t size, size_t start) const override;
-
-private:
-  /**
-   * @return evbuffer& the backing evbuffer.
-   */
-  virtual evbuffer& buffer() const PURE;
-};
-
-/**
- * Wraps a non-owned evbuffer.
- */
-class WrappedImpl : public ImplBase {
-public:
-  WrappedImpl(evbuffer* buffer) : buffer_(buffer) {}
-
-private:
-  // ImplBase
-  evbuffer& buffer() const override { return *buffer_; }
-
-  evbuffer* buffer_;
-};
 
 /**
  * Wraps an allocated and owned evbuffer.
  */
-class OwnedImpl : public ImplBase {
+class OwnedImpl : public Instance {
 public:
   OwnedImpl();
   OwnedImpl(const std::string& data);
   OwnedImpl(const Instance& data);
   OwnedImpl(const void* data, uint64_t size);
 
+  // Instance
+  void add(const void* data, uint64_t size) override;
+  void add(const std::string& data) override;
+  void add(const Instance& data) override;
+  void commit(RawSlice* iovecs, uint64_t num_iovecs) override;
+  void drain(uint64_t size) override;
+  uint64_t getRawSlices(RawSlice* out, uint64_t out_size) const override;
+  uint64_t length() const override;
+  void* linearize(uint32_t size) override;
+  void move(Instance& rhs) override;
+  void move(Instance& rhs, uint64_t length) override;
+  int read(int fd, uint64_t max_length) override;
+  uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
+  ssize_t search(const void* data, uint64_t size, size_t start) const override;
+  void setCallback(Callback callback) override;
+  int write(int fd) override;
+
 private:
-  // ImplBase
-  evbuffer& buffer() const override { return *buffer_; }
+  void onBufferChange(const evbuffer_cb_info& info);
+
+  static const evbuffer_cb_func buffer_cb_;
 
   Event::Libevent::BufferPtr buffer_;
+  Callback cb_;
 };
 
 } // Buffer

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -28,7 +28,7 @@ public:
   Network::ClientConnectionPtr createSslClientConnection(Ssl::ClientContext& ssl_ctx,
                                                          const std::string& url) override;
   Network::DnsResolverPtr createDnsResolver() override;
-  FileEventPtr createFileEvent(int fd, FileReadyCb read_cb, FileReadyCb write_cb) override;
+  FileEventPtr createFileEvent(int fd, FileReadyCb cb) override;
   Filesystem::WatcherPtr createFilesystemWatcher() override;
   Network::ListenerPtr createListener(Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
                                       Stats::Store& stats_store, bool use_proxy_proto) override;

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -3,33 +3,43 @@
 
 #include "event2/event.h"
 
+#include "common/common/assert.h"
+
 namespace Event {
 
-FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb read_cb,
-                             FileReadyCb write_cb)
-    : read_cb_(read_cb), write_cb_(write_cb) {
-  short what = EV_PERSIST | EV_ET;
-  if (read_cb) {
-    what |= EV_READ;
-  }
-
-  if (write_cb) {
-    what |= EV_WRITE;
-  }
-
-  event_assign(&raw_event_, &dispatcher.base(), fd,
-               what, [](evutil_socket_t, short what, void* arg) -> void {
+FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb cb) : cb_(cb) {
+  event_assign(&raw_event_, &dispatcher.base(), fd, EV_PERSIST | EV_ET | EV_READ | EV_WRITE,
+               [](evutil_socket_t, short what, void* arg) -> void {
                  FileEventImpl* event = static_cast<FileEventImpl*>(arg);
+                 uint32_t events = 0;
                  if (what & EV_READ) {
-                   event->read_cb_();
+                   events |= FileReadyType::Read;
                  }
 
                  if (what & EV_WRITE) {
-                   event->write_cb_();
+                   events |= FileReadyType::Write;
                  }
-               }, this);
+
+                 ASSERT(events);
+                 event->cb_(events);
+               },
+               this);
 
   event_add(&raw_event_, nullptr);
+}
+
+void FileEventImpl::activate(uint32_t events) {
+  int libevent_events = 0;
+  if (events & FileReadyType::Read) {
+    libevent_events |= EV_READ;
+  }
+
+  if (events & FileReadyType::Write) {
+    libevent_events |= EV_WRITE;
+  }
+
+  ASSERT(libevent_events);
+  event_active(&raw_event_, libevent_events, 0);
 }
 
 } // Event

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -12,11 +12,13 @@ namespace Event {
  */
 class FileEventImpl : public FileEvent, ImplBase {
 public:
-  FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb read_cb, FileReadyCb write_cb);
+  FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb cb);
+
+  // Event::FileEvent
+  void activate(uint32_t events) override;
 
 private:
-  FileReadyCb read_cb_;
-  FileReadyCb write_cb_;
+  FileReadyCb cb_;
 };
 
 } // Event

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -17,11 +17,15 @@ TimerImpl::TimerImpl(DispatcherImpl& dispatcher, TimerCb cb) : cb_(cb) {
 void TimerImpl::disableTimer() { event_del(&raw_event_); }
 
 void TimerImpl::enableTimer(const std::chrono::milliseconds& d) {
-  std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(d);
-  timeval tv;
-  tv.tv_sec = us.count() / 1000000;
-  tv.tv_usec = us.count() % 1000000;
-  event_add(&raw_event_, &tv);
+  if (d.count() == 0) {
+    event_active(&raw_event_, EV_TIMEOUT, 0);
+  } else {
+    std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(d);
+    timeval tv;
+    tv.tv_sec = us.count() / 1000000;
+    tv.tv_usec = us.count() % 1000000;
+    event_add(&raw_event_, &tv);
+  }
 }
 
 } // Event

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -13,8 +13,11 @@ namespace Filesystem {
 
 WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher)
     : dispatcher_(dispatcher), inotify_fd_(inotify_init1(IN_NONBLOCK)),
-      inotify_event_(dispatcher.createFileEvent(inotify_fd_, [this]() -> void { onInotifyEvent(); },
-                                                nullptr)) {}
+      inotify_event_(dispatcher.createFileEvent(inotify_fd_, [this](uint32_t events) -> void {
+        if (events & Event::FileReadyType::Read) {
+          onInotifyEvent();
+        }
+      })) {}
 
 WatcherImpl::~WatcherImpl() { close(inotify_fd_); }
 

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -154,10 +154,7 @@ void TcpProxy::onUpstreamEvent(uint32_t event) {
       read_callbacks_->upstreamHost()->stats().cx_connect_fail_.inc();
     }
 
-    // TODO: If we close without flushing here we may drop some data. For flushing to work
-    //       downstream we need to drop any received data while we are waiting to flush and also
-    //       setup a flush timer.
-    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
   } else if (event & Network::ConnectionEvent::Connected) {
     connect_timespan_->complete();
   }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -6,49 +6,36 @@
 
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
+#include "common/common/enum_to_int.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/network/utility.h"
-
-#include "event2/buffer.h"
-#include "event2/bufferevent.h"
-#include "event2/event.h"
 
 namespace Network {
 
 std::atomic<uint64_t> ConnectionImpl::next_global_id_;
-const evbuffer_cb_func ConnectionImpl::read_buffer_cb_ =
-    [](evbuffer*, const evbuffer_cb_info* info, void* arg) -> void {
-      static_cast<ConnectionImpl*>(arg)->onBufferChange(ConnectionBufferType::Read, info);
-    };
 
-const evbuffer_cb_func ConnectionImpl::write_buffer_cb_ =
-    [](evbuffer*, const evbuffer_cb_info* info, void* arg) -> void {
-      static_cast<ConnectionImpl*>(arg)->onBufferChange(ConnectionBufferType::Write, info);
-    };
-
-ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher)
-    : ConnectionImpl(dispatcher,
-                     bufferevent_socket_new(&dispatcher.base(), -1,
-                                            BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS),
-                     "") {}
-
-ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher,
-                               Event::Libevent::BufferEventPtr&& bev,
+ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                const std::string& remote_address)
-    : dispatcher_(dispatcher), bev_(std::move(bev)), remote_address_(remote_address),
-      id_(++next_global_id_), filter_manager_(*this, *this),
-      redispatch_read_event_(dispatcher.createTimer([this]() -> void { onRead(); })),
-      read_buffer_(bufferevent_get_input(bev_.get())),
-      write_buffer_(bufferevent_get_output(bev_.get())) {
+    : filter_manager_(*this, *this), remote_address_(remote_address), dispatcher_(dispatcher),
+      fd_(fd), id_(++next_global_id_) {
 
-  enableCallbacks(true, false, true);
-  bufferevent_enable(bev_.get(), EV_READ | EV_WRITE);
+  file_event_ =
+      dispatcher_.createFileEvent(fd, [this](uint32_t events) -> void { onFileEvent(events); });
+  if (fd_ == -1) {
+    // Can't obtain a socket.
+    state_ |= InternalState::ImmediateConnectionError;
+    file_event_->activate(Event::FileReadyType::Write);
+  }
 
-  evbuffer_add_cb(bufferevent_get_input(bev_.get()), read_buffer_cb_, this);
-  evbuffer_add_cb(bufferevent_get_output(bev_.get()), write_buffer_cb_, this);
+  read_buffer_.setCallback([this](uint64_t old_size, int64_t delta) -> void {
+    onBufferChange(ConnectionBufferType::Read, old_size, delta);
+  });
+  write_buffer_.setCallback([this](uint64_t old_size, int64_t delta) -> void {
+    onBufferChange(ConnectionBufferType::Write, old_size, delta);
+  });
 }
 
-ConnectionImpl::~ConnectionImpl() { ASSERT(!bev_); }
+ConnectionImpl::~ConnectionImpl() { ASSERT(fd_ == -1); }
 
 void ConnectionImpl::addWriteFilter(WriteFilterPtr filter) {
   filter_manager_.addWriteFilter(filter);
@@ -59,50 +46,64 @@ void ConnectionImpl::addFilter(FilterPtr filter) { filter_manager_.addFilter(fil
 void ConnectionImpl::addReadFilter(ReadFilterPtr filter) { filter_manager_.addReadFilter(filter); }
 
 void ConnectionImpl::close(ConnectionCloseType type) {
-  if (!bev_) {
+  if (fd_ == -1) {
     return;
   }
 
-  uint64_t data_to_write = evbuffer_get_length(bufferevent_get_output(bev_.get()));
-  conn_log_debug("closing data_to_write={}", *this, data_to_write);
+  uint64_t data_to_write = write_buffer_.length();
+  conn_log_debug("closing data_to_write={} type={}", *this, data_to_write, enumToInt(type));
   if (data_to_write == 0 || type == ConnectionCloseType::NoFlush) {
-    closeNow();
+    if (data_to_write > 0) {
+      // We aren't going to wait to flush, but try to write as much as we can if there is pending
+      // data.
+      doWriteToSocket();
+    }
+
+    doLocalClose();
   } else {
     ASSERT(type == ConnectionCloseType::FlushWrite);
-    closing_with_flush_ = true;
-    enableCallbacks(false, true, true);
+    state_ |= InternalState::CloseWithFlush;
+    state_ &= ~InternalState::ReadEnabled;
   }
 }
 
 Connection::State ConnectionImpl::state() {
-  if (!bev_) {
+  if (fd_ == -1) {
     return State::Closed;
-  } else if (closing_with_flush_) {
+  } else if (state_ & InternalState::CloseWithFlush) {
     return State::Closing;
   } else {
     return State::Open;
   }
 }
 
-void ConnectionImpl::closeBev() {
-  ASSERT(bev_);
-  conn_log_debug("destroying bev", *this);
+void ConnectionImpl::closeSocket() {
+  ASSERT(fd_ != -1 || (state_ & InternalState::ImmediateConnectionError));
+  conn_log_debug("closing socket", *this);
 
   // Drain input and output buffers so that callbacks get fired. This does not happen automatically
   // as part of destruction.
-  fakeBufferDrain(ConnectionBufferType::Read, bufferevent_get_input(bev_.get()));
-  evbuffer_remove_cb(bufferevent_get_input(bev_.get()), read_buffer_cb_, this);
+  uint64_t current_read_buffer_length = read_buffer_.length();
+  read_buffer_.setCallback(nullptr);
+  if (current_read_buffer_length > 0) {
+    onBufferChange(ConnectionBufferType::Read, current_read_buffer_length,
+                   -current_read_buffer_length);
+  }
+  uint64_t current_write_buffer_length = write_buffer_.length();
+  write_buffer_.setCallback(nullptr);
+  if (current_write_buffer_length > 0) {
+    onBufferChange(ConnectionBufferType::Write, current_write_buffer_length,
+                   -current_write_buffer_length);
+  }
 
-  fakeBufferDrain(ConnectionBufferType::Write, bufferevent_get_output(bev_.get()));
-  evbuffer_remove_cb(bufferevent_get_output(bev_.get()), write_buffer_cb_, this);
-
-  bev_.reset();
-  redispatch_read_event_->disableTimer();
+  file_event_.reset();
+  ::close(fd_);
+  fd_ = -1;
 }
 
-void ConnectionImpl::closeNow() {
-  conn_log_debug("closing now", *this);
-  closeBev();
+void ConnectionImpl::doLocalClose() {
+  conn_log_debug("doing local close", *this);
+  closeSocket();
 
   // We expect our owner to deal with freeing us in whatever way makes sense. We raise an event
   // to kick that off.
@@ -111,44 +112,7 @@ void ConnectionImpl::closeNow() {
 
 Event::Dispatcher& ConnectionImpl::dispatcher() { return dispatcher_; }
 
-void ConnectionImpl::enableCallbacks(bool read, bool write, bool event) {
-  read_enabled_ = false;
-  bufferevent_data_cb read_cb = nullptr;
-  bufferevent_data_cb write_cb = nullptr;
-  bufferevent_event_cb event_cb = nullptr;
-
-  if (read) {
-    read_enabled_ = true;
-    read_cb = [](bufferevent*, void* ctx) -> void { static_cast<ConnectionImpl*>(ctx)->onRead(); };
-  }
-
-  if (write) {
-    write_cb =
-        [](bufferevent*, void* ctx) -> void { static_cast<ConnectionImpl*>(ctx)->onWrite(); };
-  }
-
-  if (event) {
-    event_cb = [](bufferevent*, short events, void* ctx)
-                   -> void { static_cast<ConnectionImpl*>(ctx)->onEvent(events); };
-  }
-
-  bufferevent_setcb(bev_.get(), read_cb, write_cb, event_cb, this);
-}
-
-void ConnectionImpl::fakeBufferDrain(ConnectionBufferType type, evbuffer* buffer) {
-  if (evbuffer_get_length(buffer) > 0) {
-    evbuffer_cb_info info;
-    info.n_added = 0;
-    info.n_deleted = evbuffer_get_length(buffer);
-    info.orig_size = evbuffer_get_length(buffer);
-
-    onBufferChange(type, &info);
-  }
-}
-
 void ConnectionImpl::noDelay(bool enable) {
-  int fd = bufferevent_getfd(bev_.get());
-
   // There are cases where a connection to localhost can immediately fail (e.g., if the other end
   // does not have enough fds, reaches a backlog limit, etc.). Because we run with deferred error
   // events, the calling code may not yet know that the connection has failed. This is one call
@@ -156,14 +120,14 @@ void ConnectionImpl::noDelay(bool enable) {
   // invalid. For this call instead of plumbing through logic that will immediately indicate that a
   // connect failed, we will just ignore the noDelay() call if the socket is invalid since error is
   // going to be raised shortly anyway and it makes the calling code simpler.
-  if (fd == -1) {
+  if (fd_ == -1) {
     return;
   }
 
   // Don't set NODELAY for unix domain sockets
   sockaddr addr;
   socklen_t len = sizeof(addr);
-  int rc = getsockname(fd, &addr, &len);
+  int rc = getsockname(fd_, &addr, &len);
   RELEASE_ASSERT(rc == 0);
 
   if (addr.sa_family == AF_UNIX) {
@@ -172,50 +136,29 @@ void ConnectionImpl::noDelay(bool enable) {
 
   // Set NODELAY
   int new_value = enable;
-  rc = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &new_value, sizeof(new_value));
+  rc = setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &new_value, sizeof(new_value));
   RELEASE_ASSERT(0 == rc);
   UNREFERENCED_PARAMETER(rc);
 }
 
 uint64_t ConnectionImpl::id() { return id_; }
 
-void ConnectionImpl::onBufferChange(ConnectionBufferType type, const evbuffer_cb_info* info) {
-  // We don't run callbacks deferred so we should only get deleted or added.
-  ASSERT(info->n_deleted ^ info->n_added);
+void ConnectionImpl::onBufferChange(ConnectionBufferType type, uint64_t old_size, int64_t delta) {
   for (ConnectionCallbacks* callbacks : callbacks_) {
-    callbacks->onBufferChange(type, info->orig_size, info->n_added - info->n_deleted);
+    callbacks->onBufferChange(type, old_size, delta);
   }
-}
-
-void ConnectionImpl::onEvent(short events) {
-  uint32_t normalized_events = 0;
-  if ((events & BEV_EVENT_EOF) || (events & BEV_EVENT_ERROR)) {
-    normalized_events |= ConnectionEvent::RemoteClose;
-    closeBev();
-  }
-
-  if (events & BEV_EVENT_CONNECTED) {
-    normalized_events |= ConnectionEvent::Connected;
-  }
-
-  ASSERT(normalized_events != 0);
-  conn_log_debug("event: {}", *this, normalized_events);
-  raiseEvents(normalized_events);
 }
 
 void ConnectionImpl::onRead() {
-  // Cancel the redispatch event in case we raced with a network event.
-  redispatch_read_event_->disableTimer();
+  if (!(state_ & InternalState::ReadEnabled)) {
+    return;
+  }
+
   if (read_buffer_.length() == 0) {
     return;
   }
 
   filter_manager_.onRead();
-}
-
-void ConnectionImpl::onWrite() {
-  conn_log_debug("write flush complete", *this);
-  closeNow();
 }
 
 void ConnectionImpl::readDisable(bool disable) {
@@ -231,11 +174,13 @@ void ConnectionImpl::readDisable(bool disable) {
   //       applies back pressure to bad HTTP/1.1 clients.
   if (disable) {
     ASSERT(read_enabled);
-    enableCallbacks(false, false, true);
+    state_ &= ~InternalState::ReadEnabled;
   } else {
     ASSERT(!read_enabled);
-    enableCallbacks(true, false, true);
-    redispatch_read_event_->enableTimer(std::chrono::milliseconds::zero());
+    state_ |= InternalState::ReadEnabled;
+    if (read_buffer_.length() > 0) {
+      file_event_->activate(Event::FileReadyType::Read);
+    }
   }
 }
 
@@ -245,7 +190,7 @@ void ConnectionImpl::raiseEvents(uint32_t events) {
   }
 }
 
-bool ConnectionImpl::readEnabled() { return read_enabled_; }
+bool ConnectionImpl::readEnabled() { return state_ & InternalState::ReadEnabled; }
 
 void ConnectionImpl::addConnectionCallbacks(ConnectionCallbacks& cb) { callbacks_.push_back(&cb); }
 
@@ -264,47 +209,172 @@ void ConnectionImpl::write(Buffer::Instance& data) {
   if (data.length() > 0) {
     conn_log_trace("writing {} bytes", *this, data.length());
     write_buffer_.move(data);
+    if (!(state_ & InternalState::Connecting)) {
+      file_event_->activate(Event::FileReadyType::Write);
+    }
   }
 }
 
-ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher,
-                                           Event::Libevent::BufferEventPtr&& bev,
+void ConnectionImpl::onFileEvent(uint32_t events) {
+  conn_log_trace("socket event: {}", *this, events);
+
+  if (state_ & InternalState::ImmediateConnectionError) {
+    conn_log_debug("raising immediate connect error", *this);
+    closeSocket();
+    raiseEvents(ConnectionEvent::RemoteClose);
+    return;
+  }
+
+  // Read may become ready if there is an error connecting. If still connecting, skip straight
+  // to write ready which is where the connection logic is.
+  if (!(state_ & InternalState::Connecting) && (events & Event::FileReadyType::Read)) {
+    onReadReady();
+  }
+
+  // Possible for a read event close the socket.
+  if (fd_ != -1 && (events & Event::FileReadyType::Write)) {
+    onWriteReady();
+  }
+}
+
+ConnectionImpl::PostIoAction ConnectionImpl::doReadFromSocket() {
+  do {
+    int rc = read_buffer_.read(fd_, 16384);
+    conn_log_trace("read returns: {}", *this, rc);
+
+    // Remote close. Might need to raise data before raising close.
+    if (rc == 0) {
+      return PostIoAction::Close;
+    }
+
+    // Remote error (might be no data).
+    if (rc == -1) {
+      conn_log_trace("read error: {}", *this, errno);
+      if (errno == EAGAIN) {
+        return PostIoAction::KeepOpen;
+      } else {
+        return PostIoAction::Close;
+      }
+    }
+  } while (true);
+}
+
+void ConnectionImpl::onReadReady() {
+  ASSERT(!(state_ & InternalState::Connecting));
+
+  PostIoAction action = doReadFromSocket();
+  onRead();
+
+  // The read callback may have already closed the connection.
+  if (fd_ != -1 && action == PostIoAction::Close) {
+    conn_log_debug("remote close", *this);
+    closeSocket();
+    raiseEvents(ConnectionEvent::RemoteClose);
+  }
+}
+
+ConnectionImpl::PostIoAction ConnectionImpl::doWriteToSocket() {
+  do {
+    if (write_buffer_.length() == 0) {
+      return PostIoAction::KeepOpen;
+    }
+
+    int rc = write_buffer_.write(fd_);
+    conn_log_trace("write returns: {}", *this, rc);
+    if (rc == -1) {
+      conn_log_trace("write error: {}", *this, errno);
+      if (errno == EAGAIN) {
+        return PostIoAction::KeepOpen;
+      } else {
+        return PostIoAction::Close;
+      }
+    }
+  } while (true);
+}
+
+void ConnectionImpl::onConnected() { raiseEvents(ConnectionEvent::Connected); }
+
+void ConnectionImpl::onWriteReady() {
+  conn_log_trace("write ready", *this);
+
+  if (state_ & InternalState::Connecting) {
+    int error;
+    socklen_t error_size = sizeof(error);
+    int rc = getsockopt(fd_, SOL_SOCKET, SO_ERROR, &error, &error_size);
+    ASSERT(0 == rc);
+    UNREFERENCED_PARAMETER(rc);
+
+    if (error == 0) {
+      conn_log_debug("connected", *this);
+      state_ &= ~InternalState::Connecting;
+      onConnected();
+    } else {
+      conn_log_debug("delayed connection error: {}", *this, error);
+      closeSocket();
+      raiseEvents(ConnectionEvent::RemoteClose);
+      return;
+    }
+  }
+
+  if (doWriteToSocket() == PostIoAction::Close) {
+    closeSocket();
+    raiseEvents(ConnectionEvent::RemoteClose);
+  } else if ((state_ & InternalState::CloseWithFlush) && write_buffer_.length() == 0) {
+    conn_log_debug("write flush complete", *this);
+    doLocalClose();
+  }
+}
+
+void ConnectionImpl::doConnect(const sockaddr* addr, socklen_t addrlen) {
+  int rc = ::connect(fd_, addr, addrlen);
+  if (rc == 0) {
+    // write will become ready.
+    state_ |= InternalState::Connecting;
+  } else {
+    ASSERT(rc == -1);
+    if (errno == EINPROGRESS) {
+      state_ |= InternalState::Connecting;
+      conn_log_debug("connection in progress", *this);
+    } else {
+      // read/write will become ready.
+      state_ |= InternalState::ImmediateConnectionError;
+      conn_log_debug("immediate connection error: {}", *this, errno);
+    }
+  }
+}
+
+ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                            const std::string& url)
-    : ConnectionImpl(dispatcher, std::move(bev), url) {}
+    : ConnectionImpl(dispatcher, fd, url) {}
 
 Network::ClientConnectionPtr ClientConnectionImpl::create(Event::DispatcherImpl& dispatcher,
-                                                          Event::Libevent::BufferEventPtr&& bev,
                                                           const std::string& url) {
   if (url.find(Network::Utility::TCP_SCHEME) == 0) {
-    return Network::ClientConnectionPtr{
-        new Network::TcpClientConnectionImpl(dispatcher, std::move(bev), url)};
+    return Network::ClientConnectionPtr{new Network::TcpClientConnectionImpl(dispatcher, url)};
   } else if (url.find(Network::Utility::UNIX_SCHEME) == 0) {
-    return Network::ClientConnectionPtr{
-        new Network::UdsClientConnectionImpl(dispatcher, std::move(bev), url)};
+    return Network::ClientConnectionPtr{new Network::UdsClientConnectionImpl(dispatcher, url)};
   } else {
     throw EnvoyException(fmt::format("malformed url: {}", url));
   }
 }
 
 TcpClientConnectionImpl::TcpClientConnectionImpl(Event::DispatcherImpl& dispatcher,
-                                                 Event::Libevent::BufferEventPtr&& bev,
                                                  const std::string& url)
-    : ClientConnectionImpl(dispatcher, std::move(bev), url) {}
+    : ClientConnectionImpl(dispatcher, socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0), url) {}
 
 void TcpClientConnectionImpl::connect() {
   AddrInfoPtr addr_info = Utility::resolveTCP(Utility::hostFromUrl(remote_address_),
                                               Utility::portFromUrl(remote_address_));
-  bufferevent_socket_connect(bev_.get(), addr_info->ai_addr, addr_info->ai_addrlen);
+  doConnect(addr_info->ai_addr, addr_info->ai_addrlen);
 }
 
 UdsClientConnectionImpl::UdsClientConnectionImpl(Event::DispatcherImpl& dispatcher,
-                                                 Event::Libevent::BufferEventPtr&& bev,
                                                  const std::string& url)
-    : ClientConnectionImpl(dispatcher, std::move(bev), url) {}
+    : ClientConnectionImpl(dispatcher, socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0), url) {}
 
 void UdsClientConnectionImpl::connect() {
   sockaddr_un addr = Utility::resolveUnixDomainSocket(Utility::pathFromUrl(remote_address_));
-  bufferevent_socket_connect(bev_.get(), reinterpret_cast<sockaddr*>(&addr), sizeof(sockaddr_un));
+  doConnect(reinterpret_cast<sockaddr*>(&addr), sizeof(sockaddr_un));
 }
 
 } // Network

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -9,7 +9,6 @@
 #include "common/network/connection_impl.h"
 #include "common/ssl/connection_impl.h"
 
-#include "event2/bufferevent_ssl.h"
 #include "event2/listener.h"
 
 namespace Network {
@@ -30,6 +29,7 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, ListenSocket& sock
 }
 
 void ListenerImpl::newConnection(int fd, sockaddr* addr) {
+  evutil_make_socket_nonblocking(fd);
   if (use_proxy_proto_) {
     proxy_protocol_.newConnection(dispatcher_, fd, *this);
   } else {
@@ -38,9 +38,7 @@ void ListenerImpl::newConnection(int fd, sockaddr* addr) {
 }
 
 void ListenerImpl::newConnection(int fd, const std::string& remote_address) {
-  Event::Libevent::BufferEventPtr bev{bufferevent_socket_new(
-      &dispatcher_.base(), fd, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS)};
-  ConnectionPtr new_connection(new ConnectionImpl(dispatcher_, std::move(bev), remote_address));
+  ConnectionPtr new_connection(new ConnectionImpl(dispatcher_, fd, remote_address));
   cb_.onNewConnection(std::move(new_connection));
 }
 
@@ -53,15 +51,8 @@ void SslListenerImpl::newConnection(int fd, sockaddr* addr) {
 }
 
 void SslListenerImpl::newConnection(int fd, const std::string& remote_address) {
-  // The dynamic_cast is necessary here in order to avoid exposing the SSL_CTX directly from
-  // Ssl::Context.
-  Ssl::ContextImpl* ctx = dynamic_cast<Ssl::ContextImpl*>(&ssl_ctx_);
-
-  Event::Libevent::BufferEventPtr bev{bufferevent_openssl_socket_new(
-      &dispatcher_.base(), fd, ctx->newSsl(), BUFFEREVENT_SSL_ACCEPTING,
-      BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS)};
-  ConnectionPtr new_connection(
-      new Ssl::ConnectionImpl(dispatcher_, std::move(bev), remote_address, *ctx));
+  ConnectionPtr new_connection(new Ssl::ConnectionImpl(dispatcher_, fd, remote_address, ssl_ctx_,
+                                                       Ssl::ConnectionImpl::InitialState::Server));
   cb_.onNewConnection(std::move(new_connection));
 }
 

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -22,7 +22,11 @@ ProxyProtocol::ActiveConnection::ActiveConnection(ProxyProtocol& parent,
                                                   Event::Dispatcher& dispatcher, int fd,
                                                   ListenerImpl& listener)
     : parent_(parent), fd_(fd), listener_(listener), search_index_(1) {
-  file_event_ = dispatcher.createFileEvent(fd, [this]() { onRead(); }, nullptr);
+  file_event_ = dispatcher.createFileEvent(fd, [this](uint32_t events) {
+    if (events & Event::FileReadyType::Read) {
+      onRead();
+    }
+  });
 }
 
 ProxyProtocol::ActiveConnection::~ActiveConnection() {

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -43,6 +43,8 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doReadFromSocket() {
   bool keep_reading = true;
   PostIoAction action = PostIoAction::KeepOpen;
   while (keep_reading) {
+    // We use 2 slices here so that we can use the remainder of an existing buffer chain element
+    // if there is extra space. 16K read is arbitrary and can be tuned later.
     Buffer::RawSlice slices[2];
     uint64_t slices_to_commit = 0;
     uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -5,15 +5,25 @@
 #include "common/common/hex.h"
 #include "common/network/utility.h"
 
-#include "event2/bufferevent_ssl.h"
 #include "openssl/err.h"
 
 namespace Ssl {
 
-ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher,
-                               Event::Libevent::BufferEventPtr&& bev,
-                               const std::string& remote_address, ContextImpl& ctx)
-    : Network::ConnectionImpl(dispatcher, std::move(bev), remote_address), ctx_(ctx) {}
+ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
+                               const std::string& remote_address, Context& ctx, InitialState state)
+    : Network::ConnectionImpl(dispatcher, fd, remote_address),
+      ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
+  BIO* bio = BIO_new_socket(fd, 0);
+  SSL_set_bio(ssl_.get(), bio, bio);
+
+  SSL_set_mode(ssl_.get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+  if (state == InitialState::Client) {
+    SSL_set_connect_state(ssl_.get());
+  } else {
+    ASSERT(state == InitialState::Server);
+    SSL_set_accept_state(ssl_.get());
+  }
+}
 
 ConnectionImpl::~ConnectionImpl() {
   // Filters may care about whether this connection is an SSL connection or not in their
@@ -22,36 +32,142 @@ ConnectionImpl::~ConnectionImpl() {
   filter_manager_.destroyFilters();
 }
 
-void ConnectionImpl::onEvent(short events) {
-  if (events & BEV_EVENT_ERROR) {
-    long error;
-    do {
-      error = bufferevent_get_openssl_error(bev_.get());
-      if (error != 0) {
-        ctx_.stats().connection_error_.inc();
-        conn_log_debug("SSL error: {}:{}:{}", *this, ERR_lib_error_string(error),
-                       ERR_func_error_string(error), ERR_reason_error_string(error));
-      }
-    } while (error != 0);
+Network::ConnectionImpl::PostIoAction ConnectionImpl::doReadFromSocket() {
+  if (!handshake_complete_) {
+    PostIoAction action = doHandshake();
+    if (action == PostIoAction::Close || !handshake_complete_) {
+      return action;
+    }
   }
 
-  if (events & BEV_EVENT_CONNECTED) {
-    // Handshake complete
-    SSL* ssl = bufferevent_openssl_get_ssl(bev_.get());
-    if (!ctx_.verifyPeer(ssl)) {
+  bool keep_reading = true;
+  PostIoAction action = PostIoAction::KeepOpen;
+  while (keep_reading) {
+    Buffer::RawSlice slices[2];
+    uint64_t slices_to_commit = 0;
+    uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);
+    for (uint64_t i = 0; i < num_slices; i++) {
+      int rc = SSL_read(ssl_.get(), slices[i].mem_, slices[i].len_);
+      conn_log_trace("ssl read returns: {}", *this, rc);
+      if (rc > 0) {
+        slices[i].len_ = rc;
+        slices_to_commit++;
+      } else {
+        keep_reading = false;
+        int err = SSL_get_error(ssl_.get(), rc);
+        switch (err) {
+        case SSL_ERROR_WANT_READ:
+          break;
+        case SSL_ERROR_WANT_WRITE:
+        // Renegotiation has started. We don't handle renegotiation so just fall through.
+        default:
+          drainErrorQueue();
+          action = PostIoAction::Close;
+          break;
+        }
+
+        break;
+      }
+    }
+
+    if (slices_to_commit > 0) {
+      read_buffer_.commit(slices, slices_to_commit);
+    }
+  }
+
+  return action;
+}
+
+Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
+  ASSERT(!handshake_complete_);
+  int rc = SSL_do_handshake(ssl_.get());
+  if (rc == 1) {
+    conn_log_debug("handshake complete", *this);
+    if (!ctx_.verifyPeer(ssl_.get())) {
       conn_log_debug("SSL peer verification failed", *this);
-      close(Network::ConnectionCloseType::NoFlush);
-      return;
+      return PostIoAction::Close;
     }
 
     handshake_complete_ = true;
+    raiseEvents(Network::ConnectionEvent::Connected);
+    return PostIoAction::KeepOpen;
+  } else {
+    int err = SSL_get_error(ssl_.get(), rc);
+    conn_log_debug("handshake error: {}", *this, err);
+    switch (err) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+      return PostIoAction::KeepOpen;
+    default:
+      drainErrorQueue();
+      return PostIoAction::Close;
+    }
   }
-
-  Network::ConnectionImpl::onEvent(events);
 }
 
+void ConnectionImpl::drainErrorQueue() {
+  while (uint64_t err = ERR_get_error()) {
+    conn_log_debug("SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
+                   ERR_func_error_string(err), ERR_reason_error_string(err));
+    UNREFERENCED_PARAMETER(err);
+  }
+}
+
+Network::ConnectionImpl::PostIoAction ConnectionImpl::doWriteToSocket() {
+  if (!handshake_complete_) {
+    PostIoAction action = doHandshake();
+    if (action == PostIoAction::Close || !handshake_complete_) {
+      return action;
+    }
+  }
+
+  if (write_buffer_.length() == 0) {
+    return PostIoAction::KeepOpen;
+  }
+
+  uint64_t num_slices = write_buffer_.getRawSlices(nullptr, 0);
+  Buffer::RawSlice slices[num_slices];
+  write_buffer_.getRawSlices(slices, num_slices);
+
+  uint64_t bytes_written = 0;
+  for (uint64_t i = 0; i < num_slices; i++) {
+    // SSL_write() requires that if a previous call returns SSL_ERROR_WANT_WRITE, we need to call
+    // it again with the same parameters. Most implementations keep track of the last write size.
+    // In our case we don't need to do that because: a) SSL_write() will not write partial buffers.
+    // b) We only move() into the write buffer, which means that it's impossible for a particular
+    // chain to increase in size. So as long as we start writing where we left off we are guaranteed
+    // to call SSL_write() with the same parameters.
+    int rc = SSL_write(ssl_.get(), slices[i].mem_, slices[i].len_);
+    conn_log_trace("ssl write returns: {}", *this, rc);
+    if (rc > 0) {
+      bytes_written += rc;
+    } else {
+      int err = SSL_get_error(ssl_.get(), rc);
+      switch (err) {
+      case SSL_ERROR_WANT_WRITE:
+        break;
+      case SSL_ERROR_WANT_READ:
+      // Renegotiation has started. We don't handle renegotiation so just fall through.
+      default:
+        drainErrorQueue();
+        return PostIoAction::Close;
+      }
+
+      break;
+    }
+  }
+
+  if (bytes_written > 0) {
+    write_buffer_.drain(bytes_written);
+  }
+
+  return PostIoAction::KeepOpen;
+}
+
+void ConnectionImpl::onConnected() { ASSERT(!handshake_complete_); }
+
 std::string ConnectionImpl::sha256PeerCertificateDigest() {
-  X509Ptr cert = X509Ptr(SSL_get_peer_certificate(bufferevent_openssl_get_ssl(bev_.get())));
+  X509Ptr cert = X509Ptr(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";
   }
@@ -63,43 +179,36 @@ std::string ConnectionImpl::sha256PeerCertificateDigest() {
   return Hex::encode(computed_hash);
 }
 
-ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher,
-                                           Event::Libevent::BufferEventPtr&& bev, ContextImpl& ctx,
+ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Context& ctx,
                                            const std::string& url)
-    : ConnectionImpl(dispatcher, std::move(bev), url, ctx) {}
+    : ConnectionImpl(dispatcher, socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0), url, ctx,
+                     InitialState::Client) {}
 
 void ClientConnectionImpl::connect() {
   Network::AddrInfoPtr addr_info =
       Network::Utility::resolveTCP(Network::Utility::hostFromUrl(remote_address_),
                                    Network::Utility::portFromUrl(remote_address_));
-  bufferevent_socket_connect(bev_.get(), addr_info->ai_addr, addr_info->ai_addrlen);
+  doConnect(addr_info->ai_addr, addr_info->ai_addrlen);
 }
 
-void ConnectionImpl::closeBev() {
+void ConnectionImpl::closeSocket() {
   if (handshake_complete_) {
-    // SSL_RECEIVED_SHUTDOWN tells SSL_shutdown to act as if we had already received a close notify
-    // from the other end.  SSL_shutdown will then send the final close notify in reply.  The other
-    // end will receive the close notify and send theirs.  By this time, we will have already closed
-    // the socket and the other end's real close notify will never be received.  In effect, both
-    // sides will think that they have completed a clean shutdown and keep their sessions valid.
-    // This strategy will fail if the socket is not ready for writing, in which case this hack will
-    // lead to an unclean shutdown and lost session on the other end.
-    SSL* ssl = bufferevent_openssl_get_ssl(bev_.get());
-    SSL_set_shutdown(ssl, SSL_RECEIVED_SHUTDOWN);
-    SSL_shutdown(ssl);
-
-    // These calls can now alter the error stack. Make sure we clear it so that libevent does not
-    // accidently pick an error up.
-    ERR_clear_error();
+    // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
+    // there is no room on the socket. We can extend the state machine to handle this at some point
+    // if needed.
+    int rc = SSL_shutdown(ssl_.get());
+    conn_log_debug("SSL shutdown: rc={}", *this, rc);
+    UNREFERENCED_PARAMETER(rc);
+    drainErrorQueue();
   }
 
-  Network::ConnectionImpl::closeBev();
+  Network::ConnectionImpl::closeSocket();
 }
 
 std::string ConnectionImpl::nextProtocol() {
   const unsigned char* proto;
   unsigned int proto_len;
-  SSL_get0_alpn_selected(bufferevent_openssl_get_ssl(bev_.get()), &proto, &proto_len);
+  SSL_get0_alpn_selected(ssl_.get(), &proto, &proto_len);
   return std::string(reinterpret_cast<const char*>(proto), proto_len);
 }
 

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -203,7 +203,7 @@ std::vector<uint8_t> ContextImpl::parseAlpnProtocols(const std::string& alpn_pro
   return out;
 }
 
-SSL* ContextImpl::newSsl() const { return SSL_new(ctx_.get()); }
+SslConPtr ContextImpl::newSsl() const { return SSL_new(ctx_.get()); }
 
 bool ContextImpl::verifyPeer(SSL* ssl) const {
   bool verified = true;
@@ -370,7 +370,7 @@ ClientContextImpl::ClientContextImpl(const std::string& name, Stats::Store& stat
   server_name_indication_ = config.serverNameIndication();
 }
 
-SSL* ClientContextImpl::newSsl() const {
+SslConPtr ClientContextImpl::newSsl() const {
   SslConPtr ssl_con = SslConPtr(ContextImpl::newSsl());
 
   if (!server_name_indication_.empty()) {
@@ -380,7 +380,7 @@ SSL* ClientContextImpl::newSsl() const {
     UNREFERENCED_PARAMETER(rc);
   }
 
-  return ssl_con.release();
+  return ssl_con;
 }
 
 ServerContextImpl::ServerContextImpl(const std::string& name, Stats::Store& stats,

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -27,9 +27,11 @@ struct SslStats {
   ALL_SSL_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_TIMER_STRUCT)
 };
 
+typedef CSmartPtr<SSL, SSL_free> SslConPtr;
+
 class ContextImpl : public virtual Context {
 public:
-  virtual SSL* newSsl() const;
+  virtual SslConPtr newSsl() const;
 
   /**
    * Performs all configured cert verifications on the connection
@@ -64,7 +66,6 @@ protected:
   static const unsigned char SERVER_SESSION_ID_CONTEXT;
 
   typedef CSmartPtr<SSL_CTX, SSL_CTX_free> SslCtxPtr;
-  typedef CSmartPtr<SSL, SSL_free> SslConPtr;
 
   /**
    * Performs subjectAltName verification
@@ -111,7 +112,7 @@ class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
   ClientContextImpl(const std::string& name, Stats::Store& stats, ContextConfig& config);
 
-  SSL* newSsl() const override;
+  SslConPtr newSsl() const override;
 
 private:
   std::string server_name_indication_;

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -163,8 +163,11 @@ void HotRestartImpl::getParentStats(GetParentStatsInfo& info) {
 }
 
 void HotRestartImpl::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {
-  socket_event_ =
-      dispatcher.createFileEvent(my_domain_socket_, [this]() -> void { onSocketEvent(); }, nullptr);
+  socket_event_ = dispatcher.createFileEvent(my_domain_socket_, [this](uint32_t events) -> void {
+    if (events & Event::FileReadyType::Read) {
+      onSocketEvent();
+    }
+  });
   server_ = &server;
 }
 

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -92,7 +92,7 @@ TEST_F(TcpProxyTest, UpstreamDisconnect) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
   upstream_read_filter_->onData(response);
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
 }
 
@@ -148,7 +148,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
   EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*connect_timer_, disableTimer());
   upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
   EXPECT_EQ(1U, cluster_manager_.cluster_.stats_store_

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -116,7 +116,7 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
         server_connection->addConnectionCallbacks(server_connection_callbacks);
       }));
 
-  EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose))
+  EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose))
       .WillOnce(Invoke([&](uint32_t) -> void {
         client_connection->close(Network::ConnectionCloseType::NoFlush);
         dispatcher.exit();

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -133,6 +133,10 @@ void FakeConnectionBase::close() {
   }
 }
 
+void FakeConnectionBase::readDisable(bool disable) {
+  connection_.dispatcher().post([this, disable]() -> void { connection_.readDisable(disable); });
+}
+
 Http::StreamDecoder& FakeHttpConnection::newStream(Http::StreamEncoder& encoder) {
   std::unique_lock<std::mutex> lock(lock_);
   new_streams_.emplace_back(new FakeStream(*this, encoder));
@@ -234,7 +238,7 @@ FakeHttpConnectionPtr FakeUpstream::waitForHttpConnection(Event::Dispatcher& cli
   ASSERT(!new_connections_.empty());
   FakeHttpConnectionPtr connection(
       new FakeHttpConnection(*new_connections_.front(), stats_store_, http_type_));
-  new_connections_.front()->readDisable(false);
+  connection->readDisable(false);
   new_connections_.pop_front();
   return connection;
 }
@@ -248,7 +252,7 @@ FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
 
   ASSERT(!new_connections_.empty());
   FakeRawConnectionPtr connection(new FakeRawConnection(*new_connections_.front()));
-  new_connections_.front()->readDisable(false);
+  connection->readDisable(false);
   new_connections_.pop_front();
   return connection;
 }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -62,6 +62,7 @@ typedef std::unique_ptr<FakeStream> FakeStreamPtr;
 class FakeConnectionBase : public Network::ConnectionCallbacks {
 public:
   void close();
+  void readDisable(bool disable);
   void waitForDisconnect();
 
   // Network::ConnectionCallbacks

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -186,6 +186,7 @@ void IntegrationTcpClient::write(const std::string& data) {
 
 Network::FilterStatus IntegrationTcpClient::ConnectionCallbacks::onData(Buffer::Instance& data) {
   parent_.data_.append(TestUtility::bufferToString(data));
+  data.drain(data.length());
   if (!parent_.data_to_wait_for_.empty() && parent_.data_.find(parent_.data_to_wait_for_) == 0) {
     parent_.data_to_wait_for_.clear();
     parent_.connection_->dispatcher().exit();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -133,6 +133,12 @@ TEST_F(IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
                                        Http::CodecClient::Type::HTTP1, 1024, 512);
 }
 
+TEST_F(IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
+                                       Http::CodecClient::Type::HTTP1, 4 * 1024 * 1024,
+                                       4 * 1024 * 1024);
+}
+
 void BaseIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
     Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
 

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -62,6 +62,13 @@ void SslIntegrationTest::checkStats() {
   counter.reset();
 }
 
+TEST_F(SslIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
+  testRouterRequestAndResponseWithBody(makeSslClientConnection(false),
+                                       Http::CodecClient::Type::HTTP1, 16 * 1024 * 1024,
+                                       16 * 1024 * 1024);
+  checkStats();
+}
+
 TEST_F(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeSslClientConnection(false),
                                        Http::CodecClient::Type::HTTP1, 1024, 512);

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -57,6 +57,7 @@ private:
     // Network::ReadFilter
     Network::FilterStatus onData(Buffer::Instance& data) override {
       data_callback_(*parent_.client_, data);
+      data.drain(data.length());
       return Network::FilterStatus::StopIteration;
     }
 

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -30,8 +30,8 @@ public:
     return Network::DnsResolverPtr{createDnsResolver_()};
   }
 
-  FileEventPtr createFileEvent(int fd, FileReadyCb read_cb, FileReadyCb write_cb) override {
-    return FileEventPtr{createFileEvent_(fd, read_cb, write_cb)};
+  FileEventPtr createFileEvent(int fd, FileReadyCb cb) override {
+    return FileEventPtr{createFileEvent_(fd, cb)};
   }
 
   Filesystem::WatcherPtr createFilesystemWatcher() override {
@@ -69,7 +69,7 @@ public:
   MOCK_METHOD2(createSslClientConnection_,
                Network::ClientConnection*(Ssl::ClientContext& ssl_ctx, const std::string& url));
   MOCK_METHOD0(createDnsResolver_, Network::DnsResolver*());
-  MOCK_METHOD3(createFileEvent_, FileEvent*(int fd, FileReadyCb read_cb, FileReadyCb write_cb));
+  MOCK_METHOD2(createFileEvent_, FileEvent*(int fd, FileReadyCb cb));
   MOCK_METHOD0(createFilesystemWatcher_, Filesystem::Watcher*());
   MOCK_METHOD4(createListener_,
                Network::Listener*(Network::ListenSocket& socket, Network::ListenerCallbacks& cb,


### PR DESCRIPTION
From perf investigations, a big slow down at high throughput is inside
libevent. bufferevent does not use edge triggered events, so it ends up
calling epoll_ctl on very write.

This change implements our own version of bufferevent inside of
ConnectionImpl. We need to do this for both plain and ssl connections.

This is an incredibly scary change. I've already run this on a prod box
for a while but will do more smoke testing before we merge and do a full
canary.