### PR TITLE
perf: do not allocate stat prefix and maintenance mode strings

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -258,6 +258,14 @@ public:
   virtual LoadBalancerType lbType() const PURE;
 
   /**
+   * @return Whether the cluster is currently in maintenance mode and should not be routed to.
+   *         Different filters may handle this situation in different ways. The implementation
+   *         of this routine is typically based on randomness and may not return the same answer
+   *         on each call.
+   */
+  virtual bool maintenanceMode() const PURE;
+
+  /**
    * @return uint64_t the maximum number of outbound requests that a connection pool will make on
    *         each upstream connection. This can be used to increase spread if the backends cannot
    *         tolerate imbalance. 0 indicates no maximum.
@@ -279,6 +287,11 @@ public:
    * Shutdown the cluster prior to destroying connection pools and other thread local data.
    */
   virtual void shutdown() PURE;
+
+  /**
+   * @return the stat prefix to use for cluster specific stats.
+   */
+  virtual const std::string& statPrefix() const PURE;
 
   /**
    * @return ClusterStats& strongly named stats for this cluster.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -171,7 +171,7 @@ private:
   FilterConfig& config_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   const RouteEntry* route_;
-  std::string stat_prefix_;
+  const Upstream::Cluster* cluster_;
   std::list<std::string> alt_stat_prefixes_;
   const VirtualCluster* request_vcluster_;
   bool downstream_response_started_{};

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -49,8 +49,8 @@ DH* get_dh2048() {
 const unsigned char ContextImpl::SERVER_SESSION_ID_CONTEXT = 1;
 
 ContextImpl::ContextImpl(const std::string& name, Stats::Store& store, ContextConfig& config)
-    : ctx_(SSL_CTX_new(SSLv23_method())), store_(store),
-      stats_prefix_(fmt::format("{}.ssl.", name)), stats_(generateStats(stats_prefix_, store)) {
+    : ctx_(SSL_CTX_new(SSLv23_method())), store_(store), stats_prefix_(fmt::format("{}ssl.", name)),
+      stats_(generateStats(stats_prefix_, store)) {
   RELEASE_ASSERT(ctx_);
   // the list of ciphers that will be supported
   if (!config.cipherSuites().empty()) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -159,7 +159,7 @@ class ClusterImplBase : public Cluster,
                         protected Logger::Loggable<Logger::Id::upstream> {
 
 public:
-  static ClusterStats generateStats(const std::string& name, Stats::Store& stats);
+  static ClusterStats generateStats(const std::string& prefix, Stats::Store& stats);
 
   /**
    * Optionally set the health checker for the primary cluster. This is done after cluster
@@ -181,9 +181,11 @@ public:
   uint64_t httpCodecOptions() const override { return http_codec_options_; }
   Ssl::ClientContext* sslContext() const override { return ssl_ctx_; }
   LoadBalancerType lbType() const override { return lb_type_; }
+  bool maintenanceMode() const override;
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
   const std::string& name() const override { return name_; }
   ResourceManager& resourceManager(ResourcePriority priority) const override;
+  const std::string& statPrefix() const override { return stat_prefix_; }
   ClusterStats& stats() const override { return stats_; }
 
 protected:
@@ -197,15 +199,17 @@ protected:
 
   static const ConstHostListsPtr empty_host_lists_;
 
+  Runtime::Loader& runtime_;
   Ssl::ClientContext* ssl_ctx_;
-  std::string name_;
+  const std::string name_;
   LoadBalancerType lb_type_;
-  uint64_t max_requests_per_connection_;
-  std::chrono::milliseconds connect_timeout_;
+  const uint64_t max_requests_per_connection_;
+  const std::chrono::milliseconds connect_timeout_;
+  const std::string stat_prefix_;
   mutable ClusterStats stats_;
   HealthCheckerPtr health_checker_;
-  std::string alt_stat_name_;
-  uint64_t features_;
+  const std::string alt_stat_name_;
+  const uint64_t features_;
   OutlierDetectorPtr outlier_detector_;
 
 private:
@@ -224,6 +228,7 @@ private:
 
   const uint64_t http_codec_options_;
   mutable ResourceManagers resource_managers_;
+  const std::string maintenance_mode_runtime_key_;
 };
 
 typedef std::shared_ptr<ClusterImplBase> ClusterImplBasePtr;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -123,7 +123,7 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json)
   if (json.hasObject("ssl_context")) {
     Ssl::ContextConfigImpl context_config(json.getObject("ssl_context"));
     ssl_context_ = &parent_.server_.sslContextManager().createSslServerContext(
-        fmt::format("listener.{}", port_), parent_.server_.stats(), context_config);
+        fmt::format("listener.{}.", port_), parent_.server_.stats(), context_config);
   }
 
   if (json.hasObject("use_proxy_proto")) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -142,8 +142,7 @@ TEST_F(RouterTest, NoHost) {
 }
 
 TEST_F(RouterTest, MaintenanceMode) {
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.maintenance_mode.fake_cluster", 0))
-      .WillOnce(Return(true));
+  EXPECT_CALL(cm_.cluster_, maintenanceMode()).WillOnce(Return(true));
 
   Http::HeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "16"}, {"content-type", "text/plain"}};

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -93,6 +93,11 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_EQ(4U, cluster.resourceManager(ResourcePriority::High).retries().max());
   EXPECT_EQ(3U, cluster.maxRequestsPerConnection());
   EXPECT_EQ(Http::CodecOptions::NoCompression, cluster.httpCodecOptions());
+  EXPECT_EQ("cluster.name.", cluster.statPrefix());
+
+  EXPECT_CALL(runtime.snapshot_, featureEnabled("upstream.maintenance_mode.name", 0));
+  EXPECT_FALSE(cluster.maintenanceMode());
+
   ReadyWatcher membership_updated;
   cluster.addMemberUpdateCb([&](const std::vector<HostPtr>&, const std::vector<HostPtr>&)
                                 -> void { membership_updated.ready(); });

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -33,7 +33,7 @@ MockHost::MockHost() {}
 MockHost::~MockHost() {}
 
 MockCluster::MockCluster()
-    : stats_(ClusterImplBase::generateStats(name_, stats_store_)),
+    : stats_(ClusterImplBase::generateStats(stat_prefix_, stats_store_)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1)) {
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, hosts()).WillByDefault(ReturnRef(hosts_));
@@ -47,6 +47,7 @@ MockCluster::MockCluster()
       .WillByDefault(Invoke([this](MemberUpdateCb cb) -> void { callbacks_.push_back(cb); }));
   ON_CALL(*this, maxRequestsPerConnection())
       .WillByDefault(ReturnPointee(&max_requests_per_connection_));
+  ON_CALL(*this, statPrefix()).WillByDefault(ReturnRef(stat_prefix_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke([this](ResourcePriority)

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -40,21 +40,24 @@ public:
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
   MOCK_CONST_METHOD0(lbType, LoadBalancerType());
+  MOCK_CONST_METHOD0(maintenanceMode, bool());
   MOCK_CONST_METHOD0(maxRequestsPerConnection, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
   MOCK_METHOD0(shutdown, void());
+  MOCK_CONST_METHOD0(statPrefix, const std::string&());
   MOCK_CONST_METHOD0(stats, ClusterStats&());
 
   std::vector<HostPtr> hosts_;
   std::vector<HostPtr> healthy_hosts_;
   std::vector<std::vector<HostPtr>> hosts_per_zone_;
   std::vector<std::vector<HostPtr>> healthy_hosts_per_zone_;
-  std::string name_{"fake_cluster"};
-  std::string alt_stat_name_{"fake_alt_cluster"};
+  const std::string name_{"fake_cluster"};
+  const std::string alt_stat_name_{"fake_alt_cluster"};
   std::list<MemberUpdateCb> callbacks_;
   uint64_t max_requests_per_connection_{};
   Stats::IsolatedStoreImpl stats_store_;
+  const std::string stat_prefix_{"cluster.fake_cluster."};
   ClusterStats stats_;
   std::unique_ptr<Upstream::ResourceManager> resource_manager_;
   NiceMock<Runtime::MockLoader> runtime_;


### PR DESCRIPTION
Refactor a little bit to avoid needless string allocation in the common
hot path.