### PR TITLE
perf: use vector for dispatcher deferred deletion

### DIFF
--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -24,13 +24,14 @@ DispatcherImpl::DispatcherImpl()
 DispatcherImpl::~DispatcherImpl() {}
 
 void DispatcherImpl::clearDeferredDeleteList() {
-  while (!to_delete_.empty()) {
+  size_t index = 0;
+  while (index != to_delete_.size()) {
     // The destructor of a deferred deletion item can yield more deferred deletion. Loop
     // and destroy all of them until there is nothing left.
-    std::list<DeferredDeletablePtr> copy(std::move(to_delete_));
-    log_trace("clearing deferred deletion list (size={})", copy.size());
-    copy.clear();
+    log_trace("clearing deferred deletion list (index={})", index);
+    to_delete_[index++].reset();
   }
+  to_delete_.clear();
 }
 
 Network::ClientConnectionPtr DispatcherImpl::createClientConnection(const std::string& url) {

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -47,7 +47,7 @@ private:
 
   Libevent::BasePtr base_;
   TimerPtr deferred_delete_timer_;
-  std::list<DeferredDeletablePtr> to_delete_;
+  std::vector<DeferredDeletablePtr> to_delete_;
   std::mutex post_lock_;
   std::list<std::function<void()>> post_callbacks_;
 };


### PR DESCRIPTION
Using a linked list leads to repeated allocations for no reason.
A vector once large enough is stable and will not allocate anything.