### PR TITLE
perf: network utility functions should operate on c strings

### DIFF
--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -26,7 +26,7 @@ void ConnectionManagerUtility::mutateRequestHeaders(Http::HeaderMap& request_hea
   // peer. Cases where we don't "use remote address" include trusted double proxy where we expect
   // our peer to have already properly set XFF, etc.
   if (config.useRemoteAddress()) {
-    if (Network::Utility::isLoopbackAddress(connection.remoteAddress())) {
+    if (Network::Utility::isLoopbackAddress(connection.remoteAddress().c_str())) {
       Utility::appendXff(request_headers, config.localAddress());
     } else {
       Utility::appendXff(request_headers, connection.remoteAddress());

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -87,7 +87,7 @@ bool Utility::isInternalRequest(const HeaderMap& headers) {
     return false;
   }
 
-  return Network::Utility::isInternalAddress(forwarded_for);
+  return Network::Utility::isInternalAddress(forwarded_for.c_str());
 }
 
 uint64_t Utility::parseCodecOptions(const Json::Object& config) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -214,9 +214,9 @@ std::string Utility::getAddressName(sockaddr_in* addr) {
   return std::string(str);
 }
 
-bool Utility::isInternalAddress(const std::string& address) {
+bool Utility::isInternalAddress(const char* address) {
   in_addr addr;
-  int rc = inet_pton(AF_INET, address.c_str(), &addr);
+  int rc = inet_pton(AF_INET, address, &addr);
   if (1 != rc) {
     return false;
   }
@@ -232,9 +232,9 @@ bool Utility::isInternalAddress(const std::string& address) {
   return false;
 }
 
-bool Utility::isLoopbackAddress(const std::string& address) {
+bool Utility::isLoopbackAddress(const char* address) {
   in_addr addr;
-  int rc = inet_pton(AF_INET, address.c_str(), &addr);
+  int rc = inet_pton(AF_INET, address, &addr);
   if (1 != rc) {
     return false;
   }

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -112,13 +112,13 @@ public:
    * Determine whether this is an internal (RFC1918) address.
    * @return bool the address is an RFC1918 address.
    */
-  static bool isInternalAddress(const std::string& address);
+  static bool isInternalAddress(const char* address);
 
   /**
    * Check if address is loopback address.
    * @return true if so, otherwise false
    */
-  static bool isLoopbackAddress(const std::string& address);
+  static bool isLoopbackAddress(const char* address);
 };
 
 } // Network

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -108,11 +108,11 @@ TEST(NetworkUtility, GetLocalAddress) {
 TEST(NetworkUtility, loopbackAddress) {
   {
     std::string address = "127.0.0.1";
-    EXPECT_TRUE(Utility::isLoopbackAddress(address));
+    EXPECT_TRUE(Utility::isLoopbackAddress(address.c_str()));
   }
   {
     std::string address = "10.0.0.1";
-    EXPECT_FALSE(Utility::isLoopbackAddress(address));
+    EXPECT_FALSE(Utility::isLoopbackAddress(address.c_str()));
   }
 }
 


### PR DESCRIPTION
By itself this doesn't do anything but this is part of a larger change I am
breaking apart into discrete changes.