### PR TITLE
fix deferred deletion using vector

### DIFF
--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -50,6 +50,7 @@ private:
   std::vector<DeferredDeletablePtr> to_delete_;
   std::mutex post_lock_;
   std::list<std::function<void()>> post_callbacks_;
+  bool deferred_deleting_{};
 };
 
 } // Event


### PR DESCRIPTION
This is a regression from 83c421. We can to deferred deletion in a nested
manner which breaks the code from that commit. This fixes that but also
makes the logic simpler overall. Now, if we are currently doing deferred
deletion we just delete immediately.