### PR TITLE
perf: store reference to stats in connection manager

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -423,6 +423,8 @@ private:
   enum class DrainState { NotDraining, Draining, Closing };
 
   ConnectionManagerConfig& config_;
+  ConnectionManagerStats& stats_; // We store a reference here to avoid an extra stats() call on the
+                                  // config in the hot path.
   ServerConnectionPtr codec_;
   std::list<ActiveStreamPtr> streams_;
   Stats::TimespanPtr conn_length_;


### PR DESCRIPTION
We end up making needless virtual function calls in the hot path
(especially when doing buffer updates).