### PR TITLE
fix dispatcher deferred deletion (again)

### DIFF
--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -47,7 +47,9 @@ private:
 
   Libevent::BasePtr base_;
   TimerPtr deferred_delete_timer_;
-  std::vector<DeferredDeletablePtr> to_delete_;
+  std::vector<DeferredDeletablePtr> to_delete_1_;
+  std::vector<DeferredDeletablePtr> to_delete_2_;
+  std::vector<DeferredDeletablePtr>* current_to_delete_;
   std::mutex post_lock_;
   std::list<std::function<void()>> post_callbacks_;
   bool deferred_deleting_{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(envoy-test
   common/common/hex_test.cc
   common/common/optional_test.cc
   common/common/utility_test.cc
+  common/event/dispatcher_impl_test.cc
   common/event/file_event_impl_test.cc
   common/filesystem/filesystem_impl_test.cc
   common/filesystem/watcher_impl_test.cc

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1,0 +1,48 @@
+#include "common/event/dispatcher_impl.h"
+
+#include "test/mocks/common.h"
+
+using testing::InSequence;
+
+namespace Event {
+
+class TestDeferredDeletable : public DeferredDeletable {
+public:
+  TestDeferredDeletable(std::function<void()> on_destroy) : on_destroy_(on_destroy) {}
+  ~TestDeferredDeletable() { on_destroy_(); }
+
+private:
+  std::function<void()> on_destroy_;
+};
+
+TEST(DispatcherImplTest, DeferredDelete) {
+  InSequence s;
+  DispatcherImpl dispatcher;
+  ReadyWatcher watcher1;
+
+  dispatcher.deferredDelete(
+      DeferredDeletablePtr{new TestDeferredDeletable([&]() -> void { watcher1.ready(); })});
+
+  // The first one will get deleted inline.
+  EXPECT_CALL(watcher1, ready());
+  dispatcher.clearDeferredDeleteList();
+
+  // This one does a nested deferred delete. We should need two clear calls to actually get
+  // rid of it with the vector swapping. We also test that inline clear() call does nothing.
+  ReadyWatcher watcher2;
+  ReadyWatcher watcher3;
+  dispatcher.deferredDelete(DeferredDeletablePtr{new TestDeferredDeletable([&]() -> void {
+    watcher2.ready();
+    dispatcher.deferredDelete(
+        DeferredDeletablePtr{new TestDeferredDeletable([&]() -> void { watcher3.ready(); })});
+    dispatcher.clearDeferredDeleteList();
+  })});
+
+  EXPECT_CALL(watcher2, ready());
+  dispatcher.clearDeferredDeleteList();
+
+  EXPECT_CALL(watcher3, ready());
+  dispatcher.clearDeferredDeleteList();
+}
+
+} // Event


### PR DESCRIPTION
Try again at fixing deferred deletion with vectors. We need to handle
the old behavior of nested deferred deletion. Now we do this with
swapping vectors.