### PR TITLE
perf: pre-buffer http/1 encoding

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -43,7 +43,8 @@ int StringUtil::caseInsensitiveCompare(const std::string& lhs, const std::string
 }
 
 uint32_t StringUtil::itoa(char* out, size_t buffer_size, uint64_t i) {
-  if (buffer_size < 32) {
+  // The maximum size required for an unsigned 64-bit integer is 21 chars (including null).
+  if (buffer_size < 21) {
     throw std::invalid_argument("itoa buffer too small");
   }
 

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -42,6 +42,27 @@ int StringUtil::caseInsensitiveCompare(const std::string& lhs, const std::string
   return strcasecmp(lhs.c_str(), rhs.c_str());
 }
 
+uint32_t StringUtil::itoa(char* out, size_t buffer_size, uint64_t i) {
+  if (buffer_size < 32) {
+    throw std::invalid_argument("itoa buffer too small");
+  }
+
+  char* current = out;
+  do {
+    *current++ = "0123456789"[i % 10];
+    i /= 10;
+  } while (i > 0);
+
+  for (uint64_t i = 0, j = current - out - 1; i < j; i++, j--) {
+    char c = out[i];
+    out[i] = out[j];
+    out[j] = c;
+  }
+
+  *current = 0;
+  return current - out;
+}
+
 void StringUtil::rtrim(std::string& source) {
   std::size_t pos = source.find_last_not_of(" \t\f\v\n\r");
   if (pos != std::string::npos) {

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -64,6 +64,15 @@ public:
   static int caseInsensitiveCompare(const std::string& lhs, const std::string& rhs);
 
   /**
+   * Convert an unsigned integer to a base 10 string as fast as possible.
+   * @param out supplies the string to fill.
+   * @param out_len supplies the length of the output buffer. Must be >= 32.
+   * @param i supplies the number to convert.
+   * @return the size of the string, not including the null termination.
+   */
+  static uint32_t itoa(char* out, size_t out_len, uint64_t i);
+
+  /**
    * Trim trailing whitespace from a string in place.
    */
   static void rtrim(std::string& source);

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -37,7 +37,7 @@ TEST(StringUtil, itoa) {
   EXPECT_EQ(2UL, StringUtil::itoa(buf, sizeof(buf), 10));
   EXPECT_STREQ("10", buf);
 
-  EXPECT_EQ(10UL, StringUtil::itoa(buf, sizeof(buf), 10));
+  EXPECT_EQ(10UL, StringUtil::itoa(buf, sizeof(buf), 1234567890));
   EXPECT_STREQ("1234567890", buf);
 
   EXPECT_EQ(20UL, StringUtil::itoa(buf, sizeof(buf), std::numeric_limits<uint64_t>::max()));

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -29,13 +29,16 @@ TEST(StringUtil, caseInsensitiveCompare) {
 
 TEST(StringUtil, itoa) {
   char buf[32];
-  EXPECT_THROW(StringUtil::itoa(buf, 31, 1), std::invalid_argument);
+  EXPECT_THROW(StringUtil::itoa(buf, 20, 1), std::invalid_argument);
 
   EXPECT_EQ(1UL, StringUtil::itoa(buf, sizeof(buf), 0));
   EXPECT_STREQ("0", buf);
 
   EXPECT_EQ(2UL, StringUtil::itoa(buf, sizeof(buf), 10));
   EXPECT_STREQ("10", buf);
+
+  EXPECT_EQ(10UL, StringUtil::itoa(buf, sizeof(buf), 10));
+  EXPECT_STREQ("1234567890", buf);
 
   EXPECT_EQ(20UL, StringUtil::itoa(buf, sizeof(buf), std::numeric_limits<uint64_t>::max()));
   EXPECT_STREQ("18446744073709551615", buf);

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -27,6 +27,20 @@ TEST(StringUtil, caseInsensitiveCompare) {
   EXPECT_GT(0, StringUtil::caseInsensitiveCompare("CONTENT-LENGTH", "hello"));
 }
 
+TEST(StringUtil, itoa) {
+  char buf[32];
+  EXPECT_THROW(StringUtil::itoa(buf, 31, 1), std::invalid_argument);
+
+  EXPECT_EQ(1UL, StringUtil::itoa(buf, sizeof(buf), 0));
+  EXPECT_STREQ("0", buf);
+
+  EXPECT_EQ(2UL, StringUtil::itoa(buf, sizeof(buf), 10));
+  EXPECT_STREQ("10", buf);
+
+  EXPECT_EQ(20UL, StringUtil::itoa(buf, sizeof(buf), std::numeric_limits<uint64_t>::max()));
+  EXPECT_STREQ("18446744073709551615", buf);
+}
+
 TEST(StringUtil, rtrim) {
   {
     std::string test("   ");

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -15,4 +15,5 @@ MATCHER_P(BufferStringEqual, rhs, rhs) {
 
 ACTION_P(AddBufferToString, target_string) {
   target_string->append(TestUtility::bufferToString(arg0));
+  arg0.drain(arg0.length());
 }


### PR DESCRIPTION
Allocate a buffer during encoding and fill it before flushing. This
is a portion of the larger headers change that I am splitting apart.