### PR TITLE
perf: new header map implementation

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -187,7 +187,6 @@ private:
   HEADER_FUNC(EnvoyExpectedRequestTimeoutMs)                                                       \
   HEADER_FUNC(EnvoyExternalAddress)                                                                \
   HEADER_FUNC(EnvoyForceTrace)                                                                     \
-  HEADER_FUNC(EnvoyUpstreamHealthCheckedCluster)                                                   \
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
@@ -195,14 +194,15 @@ private:
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
   HEADER_FUNC(EnvoyUpstreamCanary)                                                                 \
+  HEADER_FUNC(EnvoyUpstreamHealthCheckedCluster)                                                   \
   HEADER_FUNC(EnvoyUpstreamRequestPerTryTimeoutMs)                                                 \
   HEADER_FUNC(EnvoyUpstreamRequestTimeoutMs)                                                       \
   HEADER_FUNC(EnvoyUpstreamServiceTime)                                                            \
   HEADER_FUNC(Expect)                                                                              \
   HEADER_FUNC(ForwardedFor)                                                                        \
   HEADER_FUNC(ForwardedProto)                                                                      \
-  HEADER_FUNC(GrpcStatus)                                                                          \
   HEADER_FUNC(GrpcMessage)                                                                         \
+  HEADER_FUNC(GrpcStatus)                                                                          \
   HEADER_FUNC(Host)                                                                                \
   HEADER_FUNC(KeepAlive)                                                                           \
   HEADER_FUNC(Method)                                                                              \
@@ -273,7 +273,7 @@ public:
   /**
    * Callback when calling iterate() over a const header map.
    * @param header supplies the header entry.
-   * @param context supplies the context passd to iterate().
+   * @param context supplies the context passed to iterate().
    */
   typedef void (*ConstIterateCb)(const HeaderEntry& header, void* context);
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -121,9 +121,12 @@ private:
     const char* static_;
   } buffer_;
 
-  char inline_buffer_[128];
+  union {
+    char inline_buffer_[128];
+    uint32_t dynamic_capacity_;
+  };
+
   uint32_t string_length_;
-  uint32_t dynamic_capacity_;
   Type type_;
 };
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -10,8 +10,8 @@ namespace Http {
  */
 class LowerCaseString {
 public:
-  explicit LowerCaseString(LowerCaseString&& rhs) : string_(std::move(rhs.string_)) {}
-  explicit LowerCaseString(const LowerCaseString& rhs) : string_(rhs.string_) {}
+  LowerCaseString(LowerCaseString&& rhs) : string_(std::move(rhs.string_)) {}
+  LowerCaseString(const LowerCaseString& rhs) : string_(rhs.string_) {}
   explicit LowerCaseString(const std::string& new_string) : string_(new_string) { lower(); }
   explicit LowerCaseString(std::string&& new_string, bool convert = true)
       : string_(std::move(new_string)) {
@@ -19,8 +19,6 @@ public:
       lower();
     }
   }
-
-  LowerCaseString(const char* new_string) : string_(new_string) { lower(); }
 
   const std::string& get() const { return string_; }
   bool operator==(const LowerCaseString& rhs) const { return string_ == rhs.string_; }
@@ -32,32 +30,230 @@ private:
 };
 
 /**
+ * This is a string implementation for use in header processing. It is heavily optimized for
+ * performance. It supports 3 different types of storage and can switch between them:
+ * 1) A static reference.
+ * 2) Interned string.
+ * 3) Heap allocated storage.
+ */
+class HeaderString {
+public:
+  enum class Type { Inline, Static, Dynamic };
+
+  /**
+   * Default constructor. Sets up for inline storage.
+   */
+  HeaderString();
+
+  /**
+   * Constructor for a static string reference.
+   * @param static_value MUST point to static data.
+   */
+  explicit HeaderString(const LowerCaseString& static_value);
+
+  /**
+   * Constructor for a static string reference.
+   * @param static_value MUST point to static data.
+   */
+  explicit HeaderString(const std::string& static_value);
+
+  HeaderString(HeaderString&& move_value);
+  ~HeaderString();
+
+  /**
+   * Append data to an existing string. If the string is a static string the static data is not
+   * copied.
+   */
+  void append(const char* data, uint32_t size);
+
+  /**
+   * @return the modifiable backing buffer (either inline or heap allocated).
+   */
+  char* buffer() { return buffer_.dynamic_; }
+
+  /**
+   * @return a null terminated C string.
+   */
+  const char* c_str() const { return buffer_.static_; }
+
+  /**
+   * Return the string to a default state. Static strings are not touched. Both inline/dynamic
+   * strings are reset to zero size.
+   */
+  void clear();
+
+  /**
+   * @return whether the string is empty or not.
+   */
+  bool empty() const { return string_length_ == 0; }
+
+  /**
+   * @return whether a substring exists in the string.
+   */
+  bool find(const char* str) const { return strstr(c_str(), str); }
+
+  /**
+   * Set the value of the string by copying data into it. This overwrites any existing string.
+   */
+  void setCopy(const char* data, uint32_t size);
+
+  /**
+   * Set the value of the string to an integer. This overwrites any existing string.
+   */
+  void setInteger(uint64_t value);
+
+  /**
+   * @return the size of the string, not including the null terminator.
+   */
+  uint32_t size() const { return string_length_; }
+
+  /**
+   * @return the type of backing storage for the string.
+   */
+  Type type() const { return type_; }
+
+  bool operator==(const char* rhs) const { return 0 == strcmp(c_str(), rhs); }
+  bool operator!=(const char* rhs) const { return 0 != strcmp(c_str(), rhs); }
+
+private:
+  union {
+    char* dynamic_;
+    const char* static_;
+  } buffer_;
+
+  char inline_buffer_[128];
+  uint32_t string_length_;
+  uint32_t dynamic_capacity_;
+  Type type_;
+};
+
+/**
+ * Encapsulates an individual header entry (including both key and value).
+ */
+class HeaderEntry {
+public:
+  virtual ~HeaderEntry() {}
+
+  /**
+   * @return the header key.
+   */
+  virtual const HeaderString& key() const PURE;
+
+  /**
+   * Set the header value by copying data into it.
+   */
+  virtual void value(const char* value, uint32_t size) PURE;
+
+  /**
+   * Set the header value by copying data into it.
+   */
+  virtual void value(const std::string& value) PURE;
+
+  /**
+   * Set the header value by copying an integer into it.
+   */
+  virtual void value(uint64_t value) PURE;
+
+  /**
+   * Set the header value by copying the value in another header entry.
+   */
+  virtual void value(const HeaderEntry& header) PURE;
+
+  /**
+   * @return the header value.
+   */
+  virtual const HeaderString& value() const PURE;
+
+private:
+  void value(const char*); // Do not allow auto conversion to std::string
+};
+
+/**
+ * The following defines all headers that Envoy allows direct access to inside of the header map.
+ * In practice, these are all headers used during normal Envoy request flow processing. This allows
+ * O(1) access to these headers without even a hash lookup.
+ */
+#define ALL_INLINE_HEADERS(HEADER_FUNC)                                                            \
+  HEADER_FUNC(Authorization)                                                                       \
+  HEADER_FUNC(ClientTraceId)                                                                       \
+  HEADER_FUNC(Connection)                                                                          \
+  HEADER_FUNC(ContentLength)                                                                       \
+  HEADER_FUNC(ContentType)                                                                         \
+  HEADER_FUNC(Date)                                                                                \
+  HEADER_FUNC(EnvoyDownstreamServiceCluster)                                                       \
+  HEADER_FUNC(EnvoyExpectedRequestTimeoutMs)                                                       \
+  HEADER_FUNC(EnvoyExternalAddress)                                                                \
+  HEADER_FUNC(EnvoyForceTrace)                                                                     \
+  HEADER_FUNC(EnvoyUpstreamHealthCheckedCluster)                                                   \
+  HEADER_FUNC(EnvoyInternalRequest)                                                                \
+  HEADER_FUNC(EnvoyMaxRetries)                                                                     \
+  HEADER_FUNC(EnvoyOriginalPath)                                                                   \
+  HEADER_FUNC(EnvoyProtocolVersion)                                                                \
+  HEADER_FUNC(EnvoyRetryOn)                                                                        \
+  HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
+  HEADER_FUNC(EnvoyUpstreamCanary)                                                                 \
+  HEADER_FUNC(EnvoyUpstreamRequestPerTryTimeoutMs)                                                 \
+  HEADER_FUNC(EnvoyUpstreamRequestTimeoutMs)                                                       \
+  HEADER_FUNC(EnvoyUpstreamServiceTime)                                                            \
+  HEADER_FUNC(Expect)                                                                              \
+  HEADER_FUNC(ForwardedFor)                                                                        \
+  HEADER_FUNC(ForwardedProto)                                                                      \
+  HEADER_FUNC(GrpcStatus)                                                                          \
+  HEADER_FUNC(GrpcMessage)                                                                         \
+  HEADER_FUNC(Host)                                                                                \
+  HEADER_FUNC(KeepAlive)                                                                           \
+  HEADER_FUNC(Method)                                                                              \
+  HEADER_FUNC(Path)                                                                                \
+  HEADER_FUNC(ProxyConnection)                                                                     \
+  HEADER_FUNC(RequestId)                                                                           \
+  HEADER_FUNC(Scheme)                                                                              \
+  HEADER_FUNC(Server)                                                                              \
+  HEADER_FUNC(Status)                                                                              \
+  HEADER_FUNC(TransferEncoding)                                                                    \
+  HEADER_FUNC(Upgrade)                                                                             \
+  HEADER_FUNC(UserAgent)                                                                           \
+  HEADER_FUNC(Version)
+
+/**
+ * The following functions are defined for each inline header above. E.g., for ContentLength we
+ * have:
+ *
+ * ContentLength() -> returns the header entry if it exists or nullptr.
+ * insertContentLength() -> inserts the header if it does not exist, and returns a reference to it.
+ * removeContentLength() -> removes the header if it exists.
+ */
+#define DEFINE_INLINE_HEADER(name)                                                                 \
+  virtual const HeaderEntry* name() const PURE;                                                    \
+  virtual HeaderEntry* name() PURE;                                                                \
+  virtual HeaderEntry& insert##name() PURE;                                                        \
+  virtual void remove##name() PURE;
+
+/**
  * Wraps a set of HTTP headers.
  */
 class HeaderMap {
 public:
   virtual ~HeaderMap() {}
 
-  /**
-   * Copy a key/value into the map.
-   * @param key supplies the key to copy in.
-   * @param value supplies the value to copy in.
-   */
-  virtual void addViaCopy(const LowerCaseString& key, const std::string& value) PURE;
+  ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER)
 
   /**
-   * Move a key/value into the map.
-   * @param key supplies the key to move in.
-   * @param value supplies the value to move in.
+   * Add a fully static header to the map. Both key and value MUST point to fully static data.
+   * Nothing will be copied.
    */
-  virtual void addViaMove(LowerCaseString&& key, std::string&& value) PURE;
+  virtual void addStatic(const LowerCaseString& key, const std::string& value) PURE;
 
   /**
-   * Copy a key and move a value into the map.
-   * @param key supplies the key to copy in.
-   * @param value supplies the value to move in.
+   * Add a header with a static key to the map. The key MUST point to fully static data. The value
+   * will be copied.
    */
-  virtual void addViaMoveValue(const LowerCaseString& key, std::string&& value) PURE;
+  virtual void addStaticKey(const LowerCaseString& key, uint64_t value) PURE;
+
+  /**
+   * Add a header with a static key to the map. The key MUST point to fully static data. The value
+   * will be copied.
+   */
+  virtual void addStaticKey(const LowerCaseString& key, const std::string& value) PURE;
 
   /**
    * @return uint64_t the approximate size of the header map in bytes.
@@ -65,61 +261,36 @@ public:
   virtual uint64_t byteSize() const PURE;
 
   /**
-   * Get a header value by key.
+   * Get a header by key.
    * @param key supplies the header key.
-   * @return the header value or the empty string if the header has no value or does not exist.
+   * @return the header entry if it exsits otherwise nullptr.
    */
-  virtual const std::string& get(const LowerCaseString& key) const PURE;
-
-  /**
-   * @return whether the map has a specific header (even if it contains an empty value).
-   */
-  virtual bool has(const LowerCaseString& key) const PURE;
+  virtual const HeaderEntry* get(const LowerCaseString& key) const PURE;
 
   /**
    * Callback when calling iterate() over a const header map.
-   * @param key supplies the header key.
-   * @param value supplies header value.
+   * @param header supplies the header entry.
+   * @param context supplies the context passd to iterate().
    */
-  typedef std::function<void(const LowerCaseString& key, const std::string& value)> ConstIterateCb;
+  typedef void (*ConstIterateCb)(const HeaderEntry& header, void* context);
 
   /**
    * Iterate over a constant header map.
    * @param cb supplies the iteration callback.
+   * @param context supplies the context that will be passed to the callback.
    */
-  virtual void iterate(ConstIterateCb cb) const PURE;
-
-  /**
-   * Replace all instances of a header key with a single copied key/value pair.
-   * @param key supplies the header key to replace via copy.
-   * @param value supplies the value to replace via copy.
-   */
-  virtual void replaceViaCopy(const LowerCaseString& key, const std::string& value) PURE;
-
-  /**
-   * Replace all instances of a header key with a single moved key/value pair.
-   * @param key supplies the header key to replace via move.
-   * @param value supplies the header value to replace via move.
-   */
-  virtual void replaceViaMove(LowerCaseString&& key, std::string&& value) PURE;
-
-  /**
-   * Replace all instances of a header key with a single copied header key and a moved value.
-   * @param key supplies the header key to replace via copy.
-   * @param value supplies the header value to replace via move.
-   */
-  virtual void replaceViaMoveValue(const LowerCaseString& key, std::string&& value) PURE;
+  virtual void iterate(ConstIterateCb cb, void* context) const PURE;
 
   /**
    * Remove all instances of a header by key.
    * @param key supplies the header key to remove.
    */
-  virtual void remove(const LowerCaseString& remove_key) PURE;
+  virtual void remove(const LowerCaseString& key) PURE;
 
   /**
-   * @return uint64_t the number of headers currently in the map.
+   * @return the number of headers in the map.
    */
-  virtual uint64_t size() const PURE;
+  virtual size_t size() const PURE;
 };
 
 typedef std::unique_ptr<HeaderMap> HeaderMapPtr;

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -38,13 +38,8 @@ bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
   }
 }
 
-int StringUtil::caseInsensitiveCompare(const std::string& lhs, const std::string& rhs) {
-  return strcasecmp(lhs.c_str(), rhs.c_str());
-}
-
 uint32_t StringUtil::itoa(char* out, size_t buffer_size, uint64_t i) {
-  // The maximum size required for an unsigned 64-bit integer is 21 chars (including null).
-  if (buffer_size < 21) {
+  if (buffer_size < 32) {
     throw std::invalid_argument("itoa buffer too small");
   }
 
@@ -116,16 +111,10 @@ bool StringUtil::endsWith(const std::string& source, const std::string& end) {
   return std::equal(source.begin() + start_position, source.end(), end.begin());
 }
 
-bool StringUtil::startsWith(const std::string& source, const std::string& start,
-                            bool case_sensitive) {
+bool StringUtil::startsWith(const char* source, const std::string& start, bool case_sensitive) {
   if (case_sensitive) {
-    return strncmp(source.c_str(), start.c_str(), start.size()) == 0;
+    return strncmp(source, start.c_str(), start.size()) == 0;
   } else {
-    return strncasecmp(source.c_str(), start.c_str(), start.size()) == 0;
+    return strncasecmp(source, start.c_str(), start.size()) == 0;
   }
-}
-
-const std::string& StringUtil::valueOrDefault(const std::string& input,
-                                              const std::string& default_value) {
-  return input.empty() ? default_value : input;
 }

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -39,7 +39,8 @@ bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
 }
 
 uint32_t StringUtil::itoa(char* out, size_t buffer_size, uint64_t i) {
-  if (buffer_size < 32) {
+  // The maximum size required for an unsigned 64-bit integer is 21 chars (including null).
+  if (buffer_size < 21) {
     throw std::invalid_argument("itoa buffer too small");
   }
 

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -61,7 +61,9 @@ public:
    * @param rhs supplies string 2.
    * @return < 0, 0, > 0 depending on the comparison result.
    */
-  static int caseInsensitiveCompare(const std::string& lhs, const std::string& rhs);
+  static int caseInsensitiveCompare(const char* lhs, const char* rhs) {
+    return strcasecmp(lhs, rhs);
+  }
 
   /**
    * Convert an unsigned integer to a base 10 string as fast as possible.
@@ -99,12 +101,5 @@ public:
    * @param case_sensitive determines if the compare is case sensitive
    * @return true if @param source starts with @param start and ignores cases.
    */
-  static bool startsWith(const std::string& source, const std::string& start,
-                         bool case_sensitive = true);
-
-  /**
-   * @return original @param input string if it's not empty or @param default_value otherwise.
-   */
-  static const std::string& valueOrDefault(const std::string& input,
-                                           const std::string& default_value);
+  static bool startsWith(const char* source, const std::string& start, bool case_sensitive = true);
 };

--- a/source/common/dynamo/dynamo_request_parser.cc
+++ b/source/common/dynamo/dynamo_request_parser.cc
@@ -46,10 +46,11 @@ const std::vector<std::string> RequestParser::BATCH_OPERATIONS{"BatchGetItem", "
 std::string RequestParser::parseOperation(const Http::HeaderMap& headerMap) {
   std::string operation;
 
-  const std::string& x_amz_target = headerMap.get(X_AMZ_TARGET);
-  if (!x_amz_target.empty()) {
+  const Http::HeaderEntry* x_amz_target = headerMap.get(X_AMZ_TARGET);
+  if (x_amz_target) {
     // Normally x-amz-target contains Version.Operation, e.g., DynamoDB_20160101.GetItem
-    std::vector<std::string> version_and_operation = StringUtil::split(x_amz_target, '.');
+    std::vector<std::string> version_and_operation =
+        StringUtil::split(x_amz_target->value().c_str(), '.');
     if (version_and_operation.size() == 2) {
       operation = version_and_operation[1];
     }

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -81,11 +81,13 @@ void Config::onFailure(Http::AsyncClient::FailureReason) {
   requestComplete();
 }
 
+static const std::string Path = "/v1/certs/list/approved";
+
 void Config::refreshPrincipals() {
   Http::MessagePtr message(new Http::RequestMessageImpl());
-  message->headers().addViaMoveValue(Http::Headers::get().Method, "GET");
-  message->headers().addViaMoveValue(Http::Headers::get().Path, "/v1/certs/list/approved");
-  message->headers().addViaCopy(Http::Headers::get().Host, auth_api_cluster_);
+  message->headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
+  message->headers().insertPath().value(Path);
+  message->headers().insertHost().value(auth_api_cluster_);
   cm_.httpAsyncClientForCluster(auth_api_cluster_)
       .send(std::move(message), *this, Optional<std::chrono::milliseconds>());
 }

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "common/buffer/buffer_impl.h"
+#include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
 #include "common/http/headers.h"
@@ -10,8 +11,6 @@
 namespace Grpc {
 
 const std::string Common::GRPC_CONTENT_TYPE{"application/grpc"};
-const Http::LowerCaseString Common::GRPC_MESSAGE_HEADER{"grpc-message"};
-const Http::LowerCaseString Common::GRPC_STATUS_HEADER{"grpc-status"};
 
 void Common::chargeStat(Stats::Store& store, const std::string& cluster,
                         const std::string& grpc_service, const std::string& grpc_method,
@@ -37,30 +36,31 @@ Buffer::InstancePtr Common::serializeBody(const google::protobuf::Message& messa
 Http::MessagePtr Common::prepareHeaders(const std::string& upstream_cluster,
                                         const std::string& service_full_name,
                                         const std::string& method_name) {
+  // TODO PERF: Build path without fmt::format
   Http::MessagePtr message(new Http::RequestMessageImpl());
-  message->headers().addViaMoveValue(Http::Headers::get().Method, "POST");
-  message->headers().addViaMoveValue(Http::Headers::get().Path,
-                                     fmt::format("/{}/{}", service_full_name, method_name));
-  message->headers().addViaCopy(Http::Headers::get().Host, upstream_cluster);
-  message->headers().addViaCopy(Http::Headers::get().ContentType, Common::GRPC_CONTENT_TYPE);
+  message->headers().insertMethod().value(Http::Headers::get().MethodValues.Post);
+  message->headers().insertPath().value(fmt::format("/{}/{}", service_full_name, method_name));
+  message->headers().insertHost().value(upstream_cluster);
+  message->headers().insertContentType().value(Common::GRPC_CONTENT_TYPE);
 
   return message;
 }
 
 void Common::checkForHeaderOnlyError(Http::Message& http_response) {
   // First check for grpc-status in headers. If it is here, we have an error.
-  const std::string& grpc_status_header = http_response.headers().get(Common::GRPC_STATUS_HEADER);
-  if (grpc_status_header.empty()) {
+  const Http::HeaderEntry* grpc_status_header = http_response.headers().GrpcStatus();
+  if (!grpc_status_header) {
     return;
   }
 
   uint64_t grpc_status_code;
-  if (!StringUtil::atoul(grpc_status_header.c_str(), grpc_status_code)) {
+  if (!StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code)) {
     throw Exception(Optional<uint64_t>(), "bad grpc-status header");
   }
 
-  const std::string& grpc_status_message = http_response.headers().get(Common::GRPC_MESSAGE_HEADER);
-  throw Exception(grpc_status_code, grpc_status_message);
+  const Http::HeaderEntry* grpc_status_message = http_response.headers().GrpcMessage();
+  throw Exception(grpc_status_code,
+                  grpc_status_message ? grpc_status_message->value().c_str() : EMPTY_STRING);
 }
 
 void Common::validateResponse(Http::Message& http_response) {
@@ -75,16 +75,17 @@ void Common::validateResponse(Http::Message& http_response) {
     throw Exception(Optional<uint64_t>(), "no response trailers");
   }
 
-  const std::string& grpc_status_header = http_response.trailers()->get(Common::GRPC_STATUS_HEADER);
-  const std::string& grpc_status_message =
-      http_response.trailers()->get(Common::GRPC_MESSAGE_HEADER);
+  const Http::HeaderEntry* grpc_status_header = http_response.trailers()->GrpcStatus();
   uint64_t grpc_status_code;
-  if (!StringUtil::atoul(grpc_status_header.c_str(), grpc_status_code)) {
+  if (!grpc_status_header ||
+      !StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code)) {
     throw Exception(Optional<uint64_t>(), "bad grpc-status trailer");
   }
 
   if (grpc_status_code != 0) {
-    throw Exception(grpc_status_code, grpc_status_message);
+    const Http::HeaderEntry* grpc_status_message = http_response.trailers()->GrpcMessage();
+    throw Exception(grpc_status_code,
+                    grpc_status_message ? grpc_status_message->value().c_str() : EMPTY_STRING);
   }
 }
 

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -49,8 +49,6 @@ public:
   static void validateResponse(Http::Message& http_response);
 
   static const std::string GRPC_CONTENT_TYPE;
-  static const Http::LowerCaseString GRPC_MESSAGE_HEADER;
-  static const Http::LowerCaseString GRPC_STATUS_HEADER;
 
 private:
   static void checkForHeaderOnlyError(Http::Message& http_response);

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -223,21 +223,24 @@ HeaderFormatter::HeaderFormatter(const std::string& main_header,
     : main_header_(main_header), alternative_header_(alternative_header), max_length_(max_length) {}
 
 std::string HeaderFormatter::format(const HeaderMap& headers) const {
-  std::string header_value = headers.get(main_header_);
+  const HeaderEntry* header = headers.get(main_header_);
 
-  if (header_value.empty() && !alternative_header_.get().empty()) {
-    header_value = headers.get(alternative_header_);
+  if (!header && !alternative_header_.get().empty()) {
+    header = headers.get(alternative_header_);
   }
 
-  if (header_value.empty()) {
-    header_value = "-";
+  std::string header_value_string;
+  if (!header) {
+    header_value_string = "-";
+  } else {
+    header_value_string = header->value().c_str();
   }
 
-  if (max_length_.valid() && header_value.length() > max_length_.value()) {
-    return header_value.substr(0, max_length_.value());
+  if (max_length_.valid() && header_value_string.length() > max_length_.value()) {
+    return header_value_string.substr(0, max_length_.value());
   }
 
-  return header_value;
+  return header_value_string;
 }
 
 ResponseHeaderFormatter::ResponseHeaderFormatter(const std::string& main_header,

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -97,9 +97,9 @@ RuntimeFilter::RuntimeFilter(Json::Object& json, Runtime::Loader& runtime)
     : runtime_(runtime), runtime_key_(json.getString("key")) {}
 
 bool RuntimeFilter::evaluate(const RequestInfo&, const HeaderMap& request_header) {
-  std::string uuid = request_header.get(Http::Headers::get().RequestId);
+  const HeaderEntry* uuid = request_header.RequestId();
   uint16_t sampled_value;
-  if (UuidUtils::uuidModBy(uuid, sampled_value, 100)) {
+  if (uuid && UuidUtils::uuidModBy(uuid->value().c_str(), sampled_value, 100)) {
     uint64_t runtime_value = std::min(runtime_.snapshot().getInteger(runtime_key_, 0), 100UL);
 
     return sampled_value < static_cast<uint16_t>(runtime_value);

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -11,8 +11,8 @@
 namespace Http {
 namespace RateLimit {
 
-const Http::HeaderMapImpl Filter::TOO_MANY_REQUESTS_HEADER{
-    {Http::Headers::get().Status, std::to_string(enumToInt(Code::TooManyRequests))}};
+const Http::HeaderMapPtr Filter::TOO_MANY_REQUESTS_HEADER{new Http::HeaderMapImpl{
+    {Http::Headers::get().Status, std::to_string(enumToInt(Code::TooManyRequests))}}};
 
 void ServiceToServiceAction::populateDescriptors(const Router::RouteEntry& route,
                                                  std::vector<::RateLimit::Descriptor>& descriptors,
@@ -31,19 +31,20 @@ void RequestHeadersAction::populateDescriptors(const Router::RouteEntry& route,
                                                std::vector<::RateLimit::Descriptor>& descriptors,
                                                FilterConfig&, const HeaderMap& headers,
                                                StreamDecoderFilterCallbacks&) {
-  const std::string& header_value = headers.get(header_name_);
-  if (header_value.empty()) {
+  const HeaderEntry* header_value = headers.get(header_name_);
+  if (!header_value) {
     return;
   }
 
-  descriptors.push_back({{{descriptor_key_, header_value}}});
+  descriptors.push_back({{{descriptor_key_, header_value->value().c_str()}}});
 
   const std::string& route_key = route.rateLimitPolicy().routeKey();
   if (route_key.empty()) {
     return;
   }
 
-  descriptors.push_back({{{"route_key", route_key}, {descriptor_key_, header_value}}});
+  descriptors.push_back(
+      {{{"route_key", route_key}, {descriptor_key_, header_value->value().c_str()}}});
 }
 
 void RemoteAddressAction::populateDescriptors(const Router::RouteEntry& route,
@@ -110,7 +111,7 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
       state_ = State::Calling;
       initiating_call_ = true;
       client_->limit(*this, config_->domain(), descriptors,
-                     headers.get(Http::Headers::get().RequestId));
+                     headers.RequestId() ? headers.RequestId()->value().c_str() : EMPTY_STRING);
       initiating_call_ = false;
     }
   }
@@ -154,7 +155,7 @@ void Filter::complete(::RateLimit::LimitStatus status) {
   case ::RateLimit::LimitStatus::OverLimit:
     config_->stats().counter(cluster_ratelimit_stat_prefix_ + "over_limit").inc();
     Http::CodeUtility::ResponseStatInfo info{config_->stats(), cluster_stat_prefix_,
-                                             TOO_MANY_REQUESTS_HEADER, true, EMPTY_STRING,
+                                             *TOO_MANY_REQUESTS_HEADER, true, EMPTY_STRING,
                                              EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, false};
     Http::CodeUtility::chargeResponseStat(info);
     break;
@@ -163,7 +164,7 @@ void Filter::complete(::RateLimit::LimitStatus status) {
   if (status == ::RateLimit::LimitStatus::OverLimit &&
       config_->runtime().snapshot().featureEnabled("ratelimit.http_filter_enforcing", 100)) {
     state_ = State::Responded;
-    Http::HeaderMapPtr response_headers{new HeaderMapImpl(TOO_MANY_REQUESTS_HEADER)};
+    Http::HeaderMapPtr response_headers{new HeaderMapImpl(*TOO_MANY_REQUESTS_HEADER)};
     callbacks_->encodeHeaders(std::move(response_headers), true);
   } else if (!initiating_call_) {
     callbacks_->continueDecoding();

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -118,7 +118,7 @@ public:
 private:
   enum class State { NotStarted, Calling, Complete, Responded };
 
-  static const Http::HeaderMapImpl TOO_MANY_REQUESTS_HEADER;
+  static const Http::HeaderMapPtr TOO_MANY_REQUESTS_HEADER;
 
   FilterConfigPtr config_;
   ::RateLimit::ClientPtr client_;

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -56,7 +56,7 @@ HeaderString::~HeaderString() {
 void HeaderString::append(const char* data, uint32_t size) {
   switch (type_) {
   case Type::Static: {
-    // Switch back to inline and fall through. We do not actually pend to the static string
+    // Switch back to inline and fall through. We do not actually append to the static string
     // currently which would require a copy.
     type_ = Type::Inline;
     buffer_.dynamic_ = inline_buffer_;

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -31,6 +31,7 @@ HeaderString::HeaderString(HeaderString&& move_value) {
   }
   case Type::Dynamic: {
     buffer_.dynamic_ = move_value.buffer_.dynamic_;
+    dynamic_capacity_ = move_value.dynamic_capacity_;
     move_value.type_ = Type::Inline;
     move_value.buffer_.dynamic_ = move_value.inline_buffer_;
     move_value.clear();
@@ -74,10 +75,11 @@ void HeaderString::append(const char* data, uint32_t size) {
   case Type::Dynamic: {
     // We can get here either because we didn't fit in inline or we are already dynamic.
     if (type_ == Type::Inline) {
-      dynamic_capacity_ = (string_length_ + size) * 2;
-      buffer_.dynamic_ = static_cast<char*>(malloc(dynamic_capacity_));
-      type_ = Type::Dynamic;
+      uint32_t new_capacity = (string_length_ + size) * 2;
+      buffer_.dynamic_ = static_cast<char*>(malloc(new_capacity));
       memcpy(buffer_.dynamic_, inline_buffer_, string_length_);
+      dynamic_capacity_ = new_capacity;
+      type_ = Type::Dynamic;
     } else {
       if (size + 1 > dynamic_capacity_) {
         // Need to reallocate.

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -32,6 +32,7 @@ HeaderString::HeaderString(HeaderString&& move_value) {
   case Type::Dynamic: {
     buffer_.dynamic_ = move_value.buffer_.dynamic_;
     move_value.type_ = Type::Inline;
+    move_value.buffer_.dynamic_ = move_value.inline_buffer_;
     move_value.clear();
     break;
   }

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -81,7 +81,7 @@ void HeaderString::append(const char* data, uint32_t size) {
       dynamic_capacity_ = new_capacity;
       type_ = Type::Dynamic;
     } else {
-      if (size + 1 > dynamic_capacity_) {
+      if (size + 1 + string_length_ > dynamic_capacity_) {
         // Need to reallocate.
         dynamic_capacity_ = (string_length_ + size) * 2;
         buffer_.dynamic_ = static_cast<char*>(realloc(buffer_.dynamic_, dynamic_capacity_));

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -30,6 +30,7 @@ HeaderString::HeaderString(HeaderString&& move_value) {
     break;
   }
   case Type::Dynamic: {
+    // When we move a dynamic header, we switch the moved header back to its default state (inline).
     buffer_.dynamic_ = move_value.buffer_.dynamic_;
     dynamic_capacity_ = move_value.dynamic_capacity_;
     move_value.type_ = Type::Inline;
@@ -135,7 +136,7 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
       type_ = Type::Dynamic;
     } else {
       if (size + 1 > dynamic_capacity_) {
-        // Need to reallocate.
+        // Need to reallocate. Use free/malloc to avoid the copy since we are about to overwrite.
         dynamic_capacity_ = size * 2;
         free(buffer_.dynamic_);
         buffer_.dynamic_ = static_cast<char*>(malloc(dynamic_capacity_));

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -1,43 +1,127 @@
 #pragma once
 
+#include "headers.h"
+
 #include "envoy/http/header_map.h"
+
+#include "common/common/non_copyable.h"
 
 namespace Http {
 
 /**
- * Implementation of Http::HeaderMap. This implementation uses a linked list to keep the headers
- * in order. If it's proven that having fast lookup on top is helpful we can add a map referencing
- * capability as well.
+ * These are definitions of all of the inline header access functions described inside header_map.h
+ */
+#define DEFINE_INLINE_HEADER_FUNCS(name)                                                           \
+public:                                                                                            \
+  const HeaderEntry* name() const override { return inline_headers_.name##_; }                     \
+  HeaderEntry* name() override { return inline_headers_.name##_; }                                 \
+  HeaderEntry& insert##name() override {                                                           \
+    return maybeCreateInline(&inline_headers_.name##_, Headers::get().name);                       \
+  }                                                                                                \
+  void remove##name() override { removeInline(&inline_headers_.name##_); }
+
+#define DEFINE_INLINE_HEADER_STRUCT(name) HeaderEntryImpl* name##_;
+
+/**
+ * Implementation of Http::HeaderMap. This is heavily optimized for performance. Roughly, when
+ * headers are added to the map, we do a hash lookup to see if it's one of the O(1) headers.
+ * If it is, we store a reference to it that can be accessed later directly. Most high performance
+ * paths use O(1) direct access. In general, we try to copy as little as possible and allocate as
+ * little as possible in any of the paths.
  */
 class HeaderMapImpl : public HeaderMap {
 public:
-  typedef std::pair<LowerCaseString, std::string> HeaderEntry;
-
-  HeaderMapImpl() {}
-  HeaderMapImpl(const std::initializer_list<HeaderEntry>& values) : headers_(values) {}
+  HeaderMapImpl();
+  HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
   HeaderMapImpl(const HeaderMap& rhs);
+
+  /**
+   * Add a header via full move. This is the expected high performance paths for codecs populating
+   * a map when receiving.
+   */
+  void addViaMove(HeaderString&& key, HeaderString&& value);
 
   /**
    * For testing. Equality is based on equality of the backing list.
    */
-  bool operator==(const HeaderMapImpl& rhs) const { return headers_ == rhs.headers_; }
+  bool operator==(const HeaderMapImpl& rhs) const;
 
   // Http::HeaderMap
-  void addViaCopy(const LowerCaseString& key, const std::string& value) override;
-  void addViaMove(LowerCaseString&& key, std::string&& value) override;
-  void addViaMoveValue(const LowerCaseString& key, std::string&& value) override;
+  void addStatic(const LowerCaseString& key, const std::string& value) override;
+  void addStaticKey(const LowerCaseString& key, uint64_t value) override;
+  void addStaticKey(const LowerCaseString& key, const std::string& value) override;
   uint64_t byteSize() const override;
-  const std::string& get(const LowerCaseString& key) const override;
-  bool has(const LowerCaseString& key) const;
-  void iterate(ConstIterateCb cb) const override;
-  void replaceViaCopy(const LowerCaseString& key, const std::string& value) override;
-  void replaceViaMove(LowerCaseString&& key, std::string&& value) override;
-  void replaceViaMoveValue(const LowerCaseString& key, std::string&& value) override;
+  const HeaderEntry* get(const LowerCaseString& key) const override;
+  void iterate(ConstIterateCb cb, void* context) const override;
   void remove(const LowerCaseString& key) override;
-  uint64_t size() const override { return headers_.size(); }
+  size_t size() const override { return headers_.size(); }
 
-private:
-  std::list<HeaderEntry> headers_;
+protected:
+  struct HeaderEntryImpl : public HeaderEntry, NonCopyable {
+    HeaderEntryImpl(const LowerCaseString& key);
+    HeaderEntryImpl(const LowerCaseString& key, HeaderString&& value);
+    HeaderEntryImpl(HeaderString&& key, HeaderString&& value);
+
+    // HeaderEntry
+    const HeaderString& key() const override { return key_; }
+    void value(const char* value, uint32_t size) override;
+    void value(const std::string& value) override;
+    void value(uint64_t value) override;
+    void value(const HeaderEntry& header) override;
+    const HeaderString& value() const override { return value_; }
+
+    HeaderString key_;
+    HeaderString value_;
+    std::list<HeaderEntryImpl>::iterator entry_;
+  };
+
+  struct StaticLookupResponse {
+    HeaderEntryImpl** entry_;
+    const LowerCaseString* key_;
+  };
+
+  struct StaticLookupKey {
+    bool operator==(const StaticLookupKey& rhs) const { return 0 == strcmp(key_, rhs.key_); }
+
+    const char* key_;
+  };
+
+  struct StaticLookupKeyHasher {
+    size_t operator()(const StaticLookupKey&) const;
+  };
+
+  /**
+   * This is the static lookup table that is used to determine whether a header is one of the O(1)
+   * headers. Right now this is a basic hash table using a custom hash/equality function so we can
+   * work with C strings.
+   * TODO PERF: Right now we have to both hash and do a strcmp() for every incoming header. We can
+   *            avoid the hash step by building the O(1) headers into a trie and walking that.
+   */
+  struct StaticLookupTable {
+    StaticLookupTable();
+
+    typedef StaticLookupResponse (*EntryCb)(HeaderMapImpl&);
+    std::unordered_map<StaticLookupKey, EntryCb, StaticLookupKeyHasher> map_;
+  };
+
+  static const StaticLookupTable static_lookup_table_;
+
+  struct AllInlineHeaders {
+    ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_STRUCT)
+  };
+
+  void insertByKey(HeaderString&& key, HeaderString&& value);
+  HeaderEntryImpl& maybeCreateInline(HeaderEntryImpl** entry, const LowerCaseString& key);
+  HeaderEntryImpl& maybeCreateInline(HeaderEntryImpl** entry, const LowerCaseString& key,
+                                     HeaderString&& value);
+  void removeInline(HeaderEntryImpl** entry);
+
+  AllInlineHeaders inline_headers_;
+  std::list<HeaderEntryImpl> headers_;
+
+  ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_FUNCS)
 };
+
+typedef std::unique_ptr<HeaderMapImpl> HeaderMapImplPtr;
 
 } // Http

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -42,7 +42,8 @@ public:
   void addViaMove(HeaderString&& key, HeaderString&& value);
 
   /**
-   * For testing. Equality is based on equality of the backing list.
+   * For testing. Equality is based on equality of the backing list. This is an exact match
+   * comparison (order matters).
    */
   bool operator==(const HeaderMapImpl& rhs) const;
 

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -36,6 +36,8 @@ public:
   const LowerCaseString Expect{"expect"};
   const LowerCaseString ForwardedFor{"x-forwarded-for"};
   const LowerCaseString ForwardedProto{"x-forwarded-proto"};
+  const LowerCaseString GrpcMessage{"grpc-message"};
+  const LowerCaseString GrpcStatus{"grpc-status"};
   const LowerCaseString Host{":authority"};
   const LowerCaseString HostLegacy{"host"};
   const LowerCaseString KeepAlive{"keep-alive"};
@@ -61,6 +63,10 @@ public:
   } ContentTypeValues;
 
   struct {
+    const std::string True{"true"};
+  } EnvoyInternalRequestValues;
+
+  struct {
     const std::string _5xx{"5xx"};
     const std::string ConnectFailure{"connect-failure"};
     const std::string RefusedStream{"refused-stream"};
@@ -72,8 +78,15 @@ public:
   } ExpectValues;
 
   struct {
+    const std::string Get{"GET"};
     const std::string Head{"HEAD"};
+    const std::string Post{"POST"};
   } MethodValues;
+
+  struct {
+    const std::string Http{"http"};
+    const std::string Https{"https"};
+  } SchemeValues;
 
   struct {
     const std::string Chunked{"chunked"};

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -5,6 +5,7 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
+#include "common/http/header_map_impl.h"
 
 #include "http_parser.h"
 
@@ -196,7 +197,7 @@ private:
    * @return 0 if no error, 1 if there should be no body.
    */
   int onHeadersCompleteBase();
-  virtual int onHeadersComplete(HeaderMapPtr&& headers) PURE;
+  virtual int onHeadersComplete(HeaderMapImplPtr&& headers) PURE;
 
   /**
    * Called when body data is received.
@@ -222,10 +223,10 @@ private:
 
   static http_parser_settings settings_;
 
-  HeaderMapPtr current_header_map_;
+  HeaderMapImplPtr current_header_map_;
   HeaderParsingState header_parsing_state_{HeaderParsingState::Field};
-  std::string current_header_field_;
-  std::string current_header_value_;
+  HeaderString current_header_field_;
+  HeaderString current_header_value_;
   bool reset_stream_called_{};
   Buffer::OwnedImpl output_buffer_;
   Buffer::RawSlice reserved_iovec_;
@@ -246,7 +247,7 @@ private:
   struct ActiveRequest {
     ActiveRequest(ConnectionImpl& connection) : response_encoder_(connection) {}
 
-    std::string request_url_;
+    HeaderString request_url_;
     StreamDecoder* request_decoder_{};
     ResponseStreamEncoderImpl response_encoder_;
     bool remote_complete_{};
@@ -256,7 +257,7 @@ private:
   void onEncodeComplete() override;
   void onMessageBegin() override;
   void onUrl(const char* data, size_t length) override;
-  int onHeadersComplete(HeaderMapPtr&& headers) override;
+  int onHeadersComplete(HeaderMapImplPtr&& headers) override;
   void onBody(const char* data, size_t length) override;
   void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;
@@ -290,7 +291,7 @@ private:
   void onEncodeComplete() override;
   void onMessageBegin() {}
   void onUrl(const char*, size_t) override { NOT_IMPLEMENTED; }
-  int onHeadersComplete(HeaderMapPtr&& headers) override;
+  int onHeadersComplete(HeaderMapImplPtr&& headers) override;
   void onBody(const char* data, size_t length) override;
   void onMessageComplete() override;
   void onResetStream(StreamResetReason reason) override;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -229,8 +229,9 @@ ConnPoolImpl::ResponseDecoderWrapper::~ResponseDecoderWrapper() {
 }
 
 void ConnPoolImpl::ResponseDecoderWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
-  if (0 == StringUtil::caseInsensitiveCompare(headers->get(Headers::get().Connection),
-                                              Headers::get().ConnectionValues.Close)) {
+  if (headers->Connection() &&
+      0 == StringUtil::caseInsensitiveCompare(headers->Connection()->value().c_str(),
+                                              Headers::get().ConnectionValues.Close.c_str())) {
     saw_close_header_ = true;
     parent_.parent_.host_->cluster().stats().upstream_cx_close_header_.inc();
   }

--- a/source/common/http/pooled_stream_encoder.cc
+++ b/source/common/http/pooled_stream_encoder.cc
@@ -28,10 +28,10 @@ void PooledStreamEncoder::encodeHeaders(const HeaderMap& headers, bool end_strea
 
   // Do a common header check. We make sure that all outgoing requests have all HTTP/2 headers.
   // These get stripped by HTTP/1 codec where applicable.
-  ASSERT(headers.has(Headers::get().Scheme));
-  ASSERT(headers.has(Headers::get().Method));
-  ASSERT(headers.has(Headers::get().Host));
-  ASSERT(headers.has(Headers::get().Path));
+  ASSERT(headers.Scheme());
+  ASSERT(headers.Method());
+  ASSERT(headers.Host());
+  ASSERT(headers.Path());
 
   // It's possible for a reset to happen inline within the newStream() call. In this case, we might
   // get deleted inline as well. Only write the returned handle out if it is not nullptr to deal

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -22,16 +22,18 @@ void UserAgent::initializeFromHeaders(const HeaderMap& headers, const std::strin
     return;
   }
 
-  const std::string& user_agent = headers.get(Headers::get().UserAgent);
-  prefix_ = prefix;
-  if (user_agent.find("iOS") != std::string::npos) {
-    type_ = Type::iOS;
-    prefix_ += "user_agent.ios.";
-  } else if (user_agent.find("android") != std::string::npos) {
-    type_ = Type::Android;
-    prefix_ += "user_agent.android.";
-  } else {
-    type_ = Type::Unknown;
+  type_ = Type::Unknown;
+
+  const HeaderEntry* user_agent = headers.UserAgent();
+  if (user_agent) {
+    prefix_ = prefix;
+    if (user_agent->value().find("iOS")) {
+      type_ = Type::iOS;
+      prefix_ += "user_agent.ios.";
+    } else if (user_agent->value().find("android")) {
+      type_ = Type::Android;
+      prefix_ += "user_agent.android.";
+    }
   }
 
   if (type_ != Type::Unknown) {

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -47,7 +47,7 @@ void GrpcClientImpl::limit(RequestCallbacks& callbacks, const std::string& domai
 
 void GrpcClientImpl::onPreRequestCustomizeHeaders(Http::HeaderMap& headers) {
   if (!request_id_.empty()) {
-    headers.addViaCopy(Http::Headers::get().RequestId, request_id_);
+    headers.insertRequestId().value(request_id_);
   }
 }
 

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -14,29 +14,46 @@ const uint32_t RetryPolicy::RETRY_ON_5XX;
 const uint32_t RetryPolicy::RETRY_ON_CONNECT_FAILURE;
 const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_4XX;
 
+RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
+                                     Http::HeaderMap& request_headers,
+                                     const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                                     Runtime::RandomGenerator& random,
+                                     Event::Dispatcher& dispatcher,
+                                     Upstream::ResourcePriority priority) {
+  RetryStatePtr ret;
+
+  // We short circuit here and do not both with an allocation if there is no chance we will retry.
+  if (request_headers.EnvoyRetryOn() || route_policy.retryOn()) {
+    ret.reset(new RetryStateImpl(route_policy, request_headers, cluster, runtime, random,
+                                 dispatcher, priority));
+  }
+
+  request_headers.removeEnvoyRetryOn();
+  request_headers.removeEnvoyMaxRetries();
+  return ret;
+}
+
 RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
                                const Upstream::Cluster& cluster, Runtime::Loader& runtime,
                                Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                Upstream::ResourcePriority priority)
     : cluster_(cluster), runtime_(runtime), random_(random), dispatcher_(dispatcher),
       priority_(priority) {
-  retry_on_ = parseRetryOn(request_headers.get(Http::Headers::get().EnvoyRetryOn));
-  if (retry_on_ != 0) {
-    const std::string& max_retries = request_headers.get(Http::Headers::get().EnvoyMaxRetries);
-    uint64_t temp;
-    if (!StringUtil::atoul(max_retries.c_str(), temp)) {
-      retries_remaining_ = 1;
-    } else {
-      retries_remaining_ = temp;
+
+  if (request_headers.EnvoyRetryOn()) {
+    retry_on_ = parseRetryOn(request_headers.EnvoyRetryOn()->value().c_str());
+    if (retry_on_ != 0 && request_headers.EnvoyMaxRetries()) {
+      const char* max_retries = request_headers.EnvoyMaxRetries()->value().c_str();
+      uint64_t temp;
+      if (StringUtil::atoul(max_retries, temp)) {
+        retries_remaining_ = temp;
+      }
     }
   }
 
   // Merge in the route policy.
   retry_on_ |= route_policy.retryOn();
   retries_remaining_ = std::max(retries_remaining_, route_policy.numRetries());
-
-  request_headers.remove(Http::Headers::get().EnvoyRetryOn);
-  request_headers.remove(Http::Headers::get().EnvoyMaxRetries);
 }
 
 RetryStateImpl::~RetryStateImpl() { resetRetry(); }

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -15,10 +15,10 @@ namespace Router {
  */
 class RetryStateImpl : public RetryState {
 public:
-  RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
-                 const Upstream::Cluster& cluster, Runtime::Loader& runtime,
-                 Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
-                 Upstream::ResourcePriority priority);
+  static RetryStatePtr create(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
+                              const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                              Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
+                              Upstream::ResourcePriority priority);
   ~RetryStateImpl();
 
   static uint32_t parseRetryOn(const std::string& config);
@@ -30,6 +30,11 @@ public:
                    DoRetryCallback callback) override;
 
 private:
+  RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
+                 const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                 Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
+                 Upstream::ResourcePriority priority);
+
   void enableBackoffTimer();
   void resetRetry();
   bool wouldRetry(const Http::HeaderMap* response_headers,
@@ -40,7 +45,7 @@ private:
   Runtime::RandomGenerator& random_;
   Event::Dispatcher& dispatcher_;
   uint32_t retry_on_{};
-  uint32_t retries_remaining_{};
+  uint32_t retries_remaining_{1};
   uint32_t current_retry_{};
   DoRetryCallback callback_;
   Event::TimerPtr retry_timer_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -25,9 +25,9 @@ namespace Router {
 
 void FilterUtility::setUpstreamScheme(Http::HeaderMap& headers, const Upstream::Cluster& cluster) {
   if (cluster.sslContext()) {
-    headers.replaceViaMoveValue(Http::Headers::get().Scheme, "https");
+    headers.insertScheme().value(Http::Headers::get().SchemeValues.Https);
   } else {
-    headers.replaceViaMoveValue(Http::Headers::get().Scheme, "http");
+    headers.insertScheme().value(Http::Headers::get().SchemeValues.Http);
   }
 }
 
@@ -51,24 +51,22 @@ FilterUtility::TimeoutData FilterUtility::finalTimeout(const RouteEntry& route,
   // otherwise we use the default.
   TimeoutData timeout;
   timeout.global_timeout_ = route.timeout();
-  const std::string& header_timeout_string =
-      request_headers.get(Http::Headers::get().EnvoyUpstreamRequestTimeoutMs);
+  Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
   uint64_t header_timeout;
-  if (!header_timeout_string.empty()) {
-    if (StringUtil::atoul(header_timeout_string.c_str(), header_timeout)) {
+  if (header_timeout_entry) {
+    if (StringUtil::atoul(header_timeout_entry->value().c_str(), header_timeout)) {
       timeout.global_timeout_ = std::chrono::milliseconds(header_timeout);
     }
-    request_headers.remove(Http::Headers::get().EnvoyUpstreamRequestTimeoutMs);
+    request_headers.removeEnvoyUpstreamRequestTimeoutMs();
   }
 
   // See if there is a per try/retry timeout. If it's >= global we just ignore it.
-  const std::string& per_try_timeout_string =
-      request_headers.get(Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs);
-  if (!per_try_timeout_string.empty()) {
-    if (StringUtil::atoul(per_try_timeout_string.c_str(), header_timeout)) {
+  Http::HeaderEntry* per_try_timeout_entry = request_headers.EnvoyUpstreamRequestPerTryTimeoutMs();
+  if (per_try_timeout_entry) {
+    if (StringUtil::atoul(per_try_timeout_entry->value().c_str(), header_timeout)) {
       timeout.per_try_timeout_ = std::chrono::milliseconds(header_timeout);
     }
-    request_headers.remove(Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs);
+    request_headers.removeEnvoyUpstreamRequestPerTryTimeoutMs();
   }
 
   if (timeout.per_try_timeout_ >= timeout.global_timeout_) {
@@ -82,8 +80,7 @@ FilterUtility::TimeoutData FilterUtility::finalTimeout(const RouteEntry& route,
   }
 
   if (expected_timeout > 0) {
-    request_headers.replaceViaCopy(Http::Headers::get().EnvoyExpectedRequestTimeoutMs,
-                                   std::to_string(expected_timeout));
+    request_headers.insertEnvoyExpectedRequestTimeoutMs().value(expected_timeout);
   }
 
   return timeout;
@@ -103,8 +100,12 @@ const std::string& Filter::upstreamZone() {
 
 void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers) {
   if (config_.emit_dynamic_stats_ && !callbacks_->requestInfo().healthCheck()) {
-    bool is_canary = (response_headers.get(Http::Headers::get().EnvoyUpstreamCanary) == "true") ||
+    const Http::HeaderEntry* upstream_canary_header = response_headers.EnvoyUpstreamCanary();
+    const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
+
+    bool is_canary = (upstream_canary_header && upstream_canary_header->value() == "true") ||
                      (upstream_host_ ? upstream_host_->canary() : false);
+    bool internal_request = internal_request_header && internal_request_header->value() == "true";
 
     if (upstream_host_) {
       upstream_host_->outlierDetector().putHttpResponseCode(
@@ -112,18 +113,16 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers) {
     }
 
     Http::CodeUtility::ResponseStatInfo info{
-        config_.stats_store_, cluster_->statPrefix(), response_headers,
-        downstream_headers_->get(Http::Headers::get().EnvoyInternalRequest) == "true",
+        config_.stats_store_, cluster_->statPrefix(), response_headers, internal_request,
         route_->virtualHostName(), request_vcluster_ ? request_vcluster_->name() : "",
         config_.service_zone_, upstreamZone(), is_canary};
 
     Http::CodeUtility::chargeResponseStat(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
-      Http::CodeUtility::ResponseStatInfo info{
-          config_.stats_store_, alt_prefix, response_headers,
-          downstream_headers_->get(Http::Headers::get().EnvoyInternalRequest) == "true", "", "",
-          config_.service_zone_, upstreamZone(), is_canary};
+      Http::CodeUtility::ResponseStatInfo info{config_.stats_store_, alt_prefix, response_headers,
+                                               internal_request, "", "", config_.service_zone_,
+                                               upstreamZone(), is_canary};
 
       Http::CodeUtility::chargeResponseStat(info);
     }
@@ -155,8 +154,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   route_ = callbacks_->routeTable().routeForRequest(headers);
   if (!route_) {
     config_.stats_.no_route_.inc();
-    stream_log_debug("no cluster match for URL '{}'", *callbacks_,
-                     headers.get(Http::Headers::get().Path));
+    stream_log_debug("no cluster match for URL '{}'", *callbacks_, headers.Path()->value().c_str());
 
     callbacks_->requestInfo().onFailedResponse(Http::AccessLog::FailureReason::NoRouteFound);
     Http::HeaderMapPtr response_headers{new Http::HeaderMapImpl{
@@ -168,7 +166,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   // Set up stat prefixes, etc.
   request_vcluster_ = route_->virtualCluster(headers);
   stream_log_debug("cluster '{}' match for URL '{}'", *callbacks_, route_->clusterName(),
-                   headers.get(Http::Headers::get().Path));
+                   headers.Path()->value().c_str());
 
   cluster_ = config_.cm_.get(route_->clusterName());
   const std::string& cluster_alt_name = cluster_->altStatName();
@@ -176,12 +174,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     alt_stat_prefixes_.push_back(fmt::format("cluster.{}.", cluster_alt_name));
   }
 
-  const std::string& request_alt_name = headers.get(Http::Headers::get().EnvoyUpstreamAltStatName);
-  if (!request_alt_name.empty()) {
+  const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();
+  if (request_alt_name) {
     alt_stat_prefixes_.push_back(
-        fmt::format("cluster.{}.{}.", route_->clusterName(), request_alt_name));
+        fmt::format("cluster.{}.{}.", route_->clusterName(), request_alt_name->value().c_str()));
+    headers.removeEnvoyUpstreamAltStatName();
   }
-  headers.remove(Http::Headers::get().EnvoyUpstreamAltStatName);
 
   // See if we are supposed to immediately kill some percentage of this cluster's traffic.
   if (cluster_->maintenanceMode()) {
@@ -208,8 +206,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
       FilterUtility::shouldShadow(route_->shadowPolicy(), config_.runtime_, callbacks_->streamId());
 
 #ifndef NDEBUG
-  headers.iterate([this](const Http::LowerCaseString& key, const std::string& value)
-                      -> void { stream_log_debug("  '{}':'{}'", *callbacks_, key.get(), value); });
+  headers.iterate([](const Http::HeaderEntry& header, void* context) -> void {
+    stream_log_debug("  '{}':'{}'", *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
+                     header.key().c_str(), header.value().c_str());
+  }, callbacks_);
 #endif
 
   upstream_request_.reset(new UpstreamRequest(*this, *conn_pool));
@@ -396,7 +396,8 @@ Filter::streamResetReasonToFailureReason(Http::StreamResetReason reset_reason) {
 void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!downstream_response_started_);
 
-  if (retry_state_->shouldRetry(headers.get(), Optional<Http::StreamResetReason>(),
+  if (retry_state_ &&
+      retry_state_->shouldRetry(headers.get(), Optional<Http::StreamResetReason>(),
                                 [this]() -> void { doRetry(); }) &&
       setupRetry(end_stream)) {
     Http::CodeUtility::chargeBasicResponseStat(
@@ -415,12 +416,11 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now() -
         upstream_request_->upstream_encoder_->requestCompleteTime());
-    headers->replaceViaMoveValue(Http::Headers::get().EnvoyUpstreamServiceTime,
-                                 std::to_string(ms.count()));
+    headers->insertEnvoyUpstreamServiceTime().value(ms.count());
   }
 
   upstream_request_->upstream_canary_ =
-      (headers->get(Http::Headers::get().EnvoyUpstreamCanary) == "true") ||
+      (headers->EnvoyUpstreamCanary() && headers->EnvoyUpstreamCanary()->value() == "true") ||
       (upstream_host_ ? upstream_host_->canary() : false);
   chargeUpstreamCode(*headers);
 
@@ -458,20 +458,20 @@ void Filter::onUpstreamComplete() {
 
     upstream_host_->outlierDetector().putResponseTime(response_time);
 
+    const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
+    bool internal_request = internal_request_header && internal_request_header->value() == "true";
+
     Http::CodeUtility::ResponseTimingInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_time,
-        upstream_request_->upstream_canary_,
-        downstream_headers_->get(Http::Headers::get().EnvoyInternalRequest) == "true",
-        route_->virtualHostName(), request_vcluster_ ? request_vcluster_->name() : "",
-        config_.service_zone_, upstreamZone()};
+        upstream_request_->upstream_canary_, internal_request, route_->virtualHostName(),
+        request_vcluster_ ? request_vcluster_->name() : "", config_.service_zone_, upstreamZone()};
 
     Http::CodeUtility::chargeResponseTiming(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
       Http::CodeUtility::ResponseTimingInfo info{
           config_.stats_store_, alt_prefix, response_time, upstream_request_->upstream_canary_,
-          downstream_headers_->get(Http::Headers::get().EnvoyInternalRequest) == "true", "", "",
-          config_.service_zone_, upstreamZone()};
+          internal_request, "", "", config_.service_zone_, upstreamZone()};
 
       Http::CodeUtility::chargeResponseTiming(info);
     }
@@ -582,8 +582,8 @@ ProdFilter::createRetryState(const RetryPolicy& policy, Http::HeaderMap& request
                              const Upstream::Cluster& cluster, Runtime::Loader& runtime,
                              Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                              Upstream::ResourcePriority priority) {
-  return RetryStatePtr{
-      new RetryStateImpl(policy, request_headers, cluster, runtime, random, dispatcher, priority)};
+  return RetryStateImpl::create(policy, request_headers, cluster, runtime, random, dispatcher,
+                                priority);
 }
 
 } // Router

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -8,10 +8,11 @@ namespace Router {
 void ShadowWriterImpl::shadow(const std::string& cluster, Http::MessagePtr&& request,
                               std::chrono::milliseconds timeout) {
   // Switch authority to add a shadow postfix. This allows upstream logging to make a more sense.
-  std::string host = request->headers().get(Http::Headers::get().Host);
+  // TODO PERF: Avoid copy.
+  std::string host = request->headers().Host()->value().c_str();
   ASSERT(!host.empty());
   host += "-shadow";
-  request->headers().replaceViaMoveValue(Http::Headers::get().Host, std::move(host));
+  request->headers().Host()->value(host);
 
   // Configuration should guarantee that cluster exists before calling here. This is basically
   // fire and forget. We don't handle cancelling.

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -53,6 +53,10 @@ Decision HttpTracerUtility::isTracing(const Http::AccessLog::RequestInfo& reques
     return {Reason::HealthCheck, false};
   }
 
+  if (!request_headers.RequestId()) {
+    return {Reason::NotTraceableRequestId, false};
+  }
+
   // TODO PERF: Avoid copy.
   UuidTraceStatus trace_status =
       UuidUtils::isTraceableUuid(request_headers.RequestId()->value().c_str());

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -116,10 +116,9 @@ void SdsClusterImpl::refreshHosts() {
   stats_.update_attempt_.inc();
 
   Http::MessagePtr message(new Http::RequestMessageImpl());
-  message->headers().addViaMoveValue(Http::Headers::get().Method, "GET");
-  message->headers().addViaMoveValue(Http::Headers::get().Path,
-                                     "/v1/registration/" + service_name_);
-  message->headers().addViaMoveValue(Http::Headers::get().Host, "sds");
+  message->headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
+  message->headers().insertPath().value("/v1/registration/" + service_name_);
+  message->headers().insertHost().value(sds_config_.sds_cluster_name_);
   active_request_ = cm_.httpAsyncClientForCluster(sds_config_.sds_cluster_name_)
                         .send(std::move(message), *this,
                               Optional<std::chrono::milliseconds>(std::chrono::milliseconds(1000)));

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -25,8 +25,7 @@ public:
         json_config.getBoolean("dynamic_stats", true)));
 
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterPtr{new Router::ProdFilter(*config)});
+      callbacks.addStreamDecoderFilter(std::make_shared<Router::ProdFilter>(*config));
     };
   }
 };

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -274,7 +274,7 @@ Http::Code AdminImpl::handlerCerts(const std::string&, Buffer::Instance& respons
 }
 
 void AdminFilter::onComplete() {
-  const std::string& path = request_headers_->get(Http::Headers::get().Path);
+  std::string path = request_headers_->Path()->value().c_str();
   stream_log_info("request complete: path: {}", *callbacks_, path);
 
   Buffer::OwnedImpl response;

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -71,7 +71,7 @@ void HealthCheckCacheManager::onTimer() {
 
 Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& headers,
                                                            bool end_stream) {
-  if (headers.get(Http::Headers::get().Path) == endpoint_) {
+  if (headers.Path()->value() == endpoint_.c_str()) {
     health_check_request_ = true;
     callbacks_->requestInfo().healthCheck(true);
 
@@ -115,8 +115,7 @@ Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& head
           static_cast<Http::Code>(Http::Utility::getResponseStatus(headers)));
     }
 
-    headers.replaceViaCopy(Http::Headers::get().EnvoyUpstreamHealthCheckedCluster,
-                           server_.options().serviceClusterName());
+    headers.insertEnvoyUpstreamHealthCheckedCluster().value(server_.options().serviceClusterName());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/test/common/dynamo/dynamo_request_parser_test.cc
+++ b/test/common/dynamo/dynamo_request_parser_test.cc
@@ -2,30 +2,32 @@
 #include "common/json/json_loader.h"
 #include "common/http/header_map_impl.h"
 
+#include "test/test_common/utility.h"
+
 namespace Dynamo {
 
 TEST(DynamoRequestParser, parseOperation) {
   // Well formed x-amz-target header, in a format, Version.Operation
   {
-    Http::HeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X.Operation"}};
+    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X.Operation"}};
     EXPECT_EQ("Operation", RequestParser::parseOperation(headers));
   }
 
   // Not well formed x-amz-target header.
   {
-    Http::HeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X,Operation"}};
+    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X,Operation"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 
   // Too many entries in the Version.Operation.
   {
-    Http::HeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "NOT_VALID.NOT_VALID.NOT_VALID"}};
+    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "NOT_VALID.NOT_VALID.NOT_VALID"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 
   // Required header is not present in the headers
   {
-    Http::HeaderMapImpl headers{{"Z", "Z"}};
+    Http::TestHeaderMapImpl headers{{"Z", "Z"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 }

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::Invoke;
@@ -111,7 +112,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
   // Respond.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   Http::MessagePtr message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/filter/auth/test_data/vpn_response_1.json"))});
   callbacks_->onSuccess(std::move(message));
@@ -148,7 +149,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
   // Error response.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "503"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}}));
   callbacks_->onSuccess(std::move(message));
 
   // Interval timer fires.
@@ -158,7 +159,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
   // Parsing error
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl("bad_json")});
   callbacks_->onSuccess(std::move(message));
 
@@ -178,7 +179,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
           Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                      const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
             callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
-                Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "503"}}})});
+                Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
             return nullptr;
           }));
   interval_timer_->callback_();

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -24,10 +24,10 @@ TEST(CommonTest, chargeStats) {
 TEST(CommonTest, prepareHeaders) {
   Http::MessagePtr message = Common::prepareHeaders("cluster", "service_name", "method_name");
 
-  EXPECT_EQ("POST", message->headers().get(Http::Headers::get().Method));
-  EXPECT_EQ("/service_name/method_name", message->headers().get(Http::Headers::get().Path));
-  EXPECT_EQ("cluster", message->headers().get(Http::Headers::get().Host));
-  EXPECT_EQ("application/grpc", message->headers().get(Http::Headers::get().ContentType));
+  EXPECT_STREQ("POST", message->headers().Method()->value().c_str());
+  EXPECT_STREQ("/service_name/method_name", message->headers().Path()->value().c_str());
+  EXPECT_STREQ("cluster", message->headers().Host()->value().c_str());
+  EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 }
 
 } // Grpc

--- a/test/common/grpc/http1_bridge_filter_test.cc
+++ b/test/common/grpc/http1_bridge_filter_test.cc
@@ -4,6 +4,7 @@
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::NiceMock;
 using testing::ReturnRef;
@@ -28,12 +29,12 @@ public:
 TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2HeaderOnlyResponse) {
   protocol_ = "HTTP/2";
 
-  Http::HeaderMapImpl request_headers{{"content-type", "application/grpc"},
-                                      {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/grpc"},
+                                          {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, true));
   EXPECT_EQ(
       1UL,
@@ -50,16 +51,16 @@ TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2HeaderOnlyResponse) {
 TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2NormalResponse) {
   protocol_ = "HTTP/2";
 
-  Http::HeaderMapImpl request_headers{{"content-type", "application/grpc"},
-                                      {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/grpc"},
+                                          {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
-  Http::HeaderMapImpl response_trailers{{"grpc-status", "0"}};
+  Http::TestHeaderMapImpl response_trailers{{"grpc-status", "0"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
   EXPECT_EQ(
       1UL,
@@ -76,72 +77,74 @@ TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2NormalResponse) {
 TEST_F(GrpcHttp1BridgeFilterTest, NotHandlingHttp2) {
   protocol_ = "HTTP/2";
 
-  Http::HeaderMapImpl request_headers{{"content-type", "application/grpc"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/foo"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
-  Http::HeaderMapImpl request_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl request_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
-  Http::HeaderMapImpl response_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl response_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
-  EXPECT_EQ("200", response_headers.get(":status"));
+  EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, NotHandlingHttp1) {
-  Http::HeaderMapImpl request_headers{{"content-type", "application/foo"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/foo"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
-  Http::HeaderMapImpl request_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl request_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
-  Http::HeaderMapImpl response_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl response_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
-  EXPECT_EQ("200", response_headers.get(":status"));
+  EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, HandlingNormalResponse) {
-  Http::HeaderMapImpl request_headers{{"content-type", "application/grpc"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/grpc"},
+                                          {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
-  Http::HeaderMapImpl request_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl request_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.encodeData(data, false));
-  Http::HeaderMapImpl response_trailers{{"grpc-status", "0"}};
+  Http::TestHeaderMapImpl response_trailers{{"grpc-status", "0"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
-  EXPECT_EQ("200", response_headers.get(":status"));
-  EXPECT_EQ("0", response_headers.get("grpc-status"));
+  EXPECT_EQ("200", response_headers.get_(":status"));
+  EXPECT_EQ("0", response_headers.get_("grpc-status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, HandlingBadGrpcStatus) {
-  Http::HeaderMapImpl request_headers{{"content-type", "application/grpc"}};
+  Http::TestHeaderMapImpl request_headers{{"content-type", "application/grpc"},
+                                          {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
-  Http::HeaderMapImpl request_trailers{{"hello", "world"}};
+  Http::TestHeaderMapImpl request_trailers{{"hello", "world"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 
-  Http::HeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.encodeData(data, false));
-  Http::HeaderMapImpl response_trailers{{"grpc-status", "1"}, {"grpc-message", "foo"}};
+  Http::TestHeaderMapImpl response_trailers{{"grpc-status", "1"}, {"grpc-message", "foo"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
-  EXPECT_EQ("503", response_headers.get(":status"));
-  EXPECT_EQ("1", response_headers.get("grpc-status"));
-  EXPECT_EQ("foo", response_headers.get("grpc-message"));
+  EXPECT_EQ("503", response_headers.get_(":status"));
+  EXPECT_EQ("1", response_headers.get_("grpc-status"));
+  EXPECT_EQ("foo", response_headers.get_("grpc-message"));
 }
 
 } // Grpc

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -2,6 +2,7 @@
 #include "common/http/header_map_impl.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::Return;
 using testing::ReturnRef;
@@ -29,7 +30,7 @@ TEST(FailureReasonUtilsTest, toShortStringConversion) {
 
 TEST(AccessLogFormatterTest, plainStringFormatter) {
   PlainStringFormatter formatter("plain");
-  HeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
+  TestHeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
   MockRequestInfo request_info;
 
   EXPECT_EQ("plain", formatter.format(header, header, request_info));
@@ -39,7 +40,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   EXPECT_THROW(RequestInfoFormatter formatter("unknown_field"), EnvoyException);
 
   MockRequestInfo requestInfo;
-  HeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
+  TestHeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
 
   {
     RequestInfoFormatter start_time_format("START_TIME");
@@ -114,8 +115,8 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
 TEST(AccessLogFormatterTest, requestHeaderFormatter) {
   MockRequestInfo requestInfo;
-  HeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
-  HeaderMapImpl response_header{{":method", "PUT"}};
+  TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
+  TestHeaderMapImpl response_header{{":method", "PUT"}};
 
   {
     RequestHeaderFormatter formatter(":Method", "", Optional<size_t>());
@@ -140,8 +141,8 @@ TEST(AccessLogFormatterTest, requestHeaderFormatter) {
 
 TEST(AccessLogFormatterTest, responseHeaderFormatter) {
   MockRequestInfo requestInfo;
-  HeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
-  HeaderMapImpl response_header{{":method", "PUT"}, {"test", "test"}};
+  TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
+  TestHeaderMapImpl response_header{{":method", "PUT"}, {"test", "test"}};
 
   {
     ResponseHeaderFormatter formatter(":method", "", Optional<size_t>());
@@ -166,8 +167,8 @@ TEST(AccessLogFormatterTest, responseHeaderFormatter) {
 
 TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
   MockRequestInfo request_info;
-  HeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
-  HeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
+  TestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
+  TestHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
 
   {
     const std::string format = "{{%PROTOCOL%}}   %RESP(not exist)%++%RESP(test)% "

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::Invoke;
@@ -60,7 +61,7 @@ TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {
   Http::MockStreamDecoder outer_decoder;
   client_->newStream(outer_decoder);
 
-  Http::HeaderMapPtr response_headers{new HeaderMapImpl{{":status", "200"}}};
+  Http::HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(outer_decoder, decodeHeaders_(Pointee(Ref(*response_headers)), true));
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 }
@@ -77,7 +78,7 @@ TEST_F(CodecClientTest, BasicResponseWithBody) {
   Http::MockStreamDecoder outer_decoder;
   client_->newStream(outer_decoder);
 
-  Http::HeaderMapPtr response_headers{new HeaderMapImpl{{":status", "200"}}};
+  Http::HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(outer_decoder, decodeHeaders_(Pointee(Ref(*response_headers)), false));
   inner_decoder->decodeHeaders(std::move(response_headers), false);
 
@@ -121,7 +122,7 @@ TEST_F(CodecClientTest, ProtocolError) {
 TEST_F(CodecClientTest, 408Response) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([](Buffer::Instance&) -> void {
-        Http::HeaderMapPtr response_headers{new HeaderMapImpl{{":status", "408"}}};
+        Http::HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "408"}}};
         throw PrematureResponseException(std::move(response_headers));
       }));
 
@@ -136,7 +137,7 @@ TEST_F(CodecClientTest, 408Response) {
 TEST_F(CodecClientTest, PrematureResponse) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([](Buffer::Instance&) -> void {
-        Http::HeaderMapPtr response_headers{new HeaderMapImpl{{":status", "200"}}};
+        Http::HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
         throw PrematureResponseException(std::move(response_headers));
       }));
 

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -4,6 +4,7 @@
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 
@@ -16,7 +17,7 @@ public:
                    const std::string& request_vcluster_name = EMPTY_STRING,
                    const std::string& from_az = EMPTY_STRING,
                    const std::string& to_az = EMPTY_STRING) {
-    HeaderMapImpl headers{{":status", std::to_string(code)}};
+    TestHeaderMapImpl headers{{":status", std::to_string(code)}};
 
     CodeUtility::ResponseStatInfo info{store_, "prefix.", headers, internal_request,
                                        request_vhost_name, request_vcluster_name, from_az, to_az,

--- a/test/common/http/common.cc
+++ b/test/common/http/common.cc
@@ -3,8 +3,8 @@
 #include "envoy/http/header_map.h"
 
 void HttpTestUtility::addDefaultHeaders(Http::HeaderMap& headers) {
-  headers.addViaCopy(":scheme", "http");
-  headers.addViaCopy(":method", "GET");
-  headers.addViaCopy(":authority", "host");
-  headers.addViaCopy(":path", "/");
+  headers.insertScheme().value(std::string("http"));
+  headers.insertMethod().value(std::string("GET"));
+  headers.insertHost().value(std::string("host"));
+  headers.insertPath().value(std::string("/"));
 }

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::NiceMock;
@@ -64,11 +65,11 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddre
   EXPECT_CALL(connection_, remoteAddress())
       .WillRepeatedly(ReturnRef(not_local_host_remote_address));
 
-  HeaderMapImpl headers{};
+  TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(not_local_host_remote_address, headers.get(Headers::get().ForwardedFor));
+  EXPECT_EQ(not_local_host_remote_address, headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) {
@@ -79,11 +80,11 @@ TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(config_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
-  HeaderMapImpl headers{};
+  TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(local_address, headers.get(Headers::get().ForwardedFor));
+  EXPECT_EQ(local_address, headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
@@ -92,12 +93,12 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
-  HeaderMapImpl headers{{"user-agent", "foo"}};
+  TestHeaderMapImpl headers{{"user-agent", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
-  EXPECT_EQ("foo", headers.get(Headers::get().UserAgent));
+  EXPECT_EQ("foo", headers.get_(Headers::get().UserAgent));
   EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));
-  EXPECT_EQ("true", headers.get(Headers::get().EnvoyInternalRequest));
+  EXPECT_EQ("true", headers.get_(Headers::get().EnvoyInternalRequest));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
@@ -107,12 +108,12 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
-  HeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
+  TestHeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
-  EXPECT_EQ("bar", headers.get(Headers::get().UserAgent));
-  EXPECT_EQ("bar", headers.get(Headers::get().EnvoyDownstreamServiceCluster));
-  EXPECT_EQ("true", headers.get(Headers::get().EnvoyInternalRequest));
+  EXPECT_EQ("bar", headers.get_(Headers::get().UserAgent));
+  EXPECT_EQ("bar", headers.get_(Headers::get().EnvoyDownstreamServiceCluster));
+  EXPECT_EQ("true", headers.get_(Headers::get().EnvoyInternalRequest));
 }
 
 TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
@@ -125,27 +126,27 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 
   {
     // Internal request, make traceable
-    HeaderMapImpl headers{{"x-forwarded-for", internal_remote_address},
-                          {"x-request-id", uuid},
-                          {"x-envoy-force-trace", "true"}};
+    TestHeaderMapImpl headers{{"x-forwarded-for", internal_remote_address},
+                              {"x-request-id", uuid},
+                              {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
                                                    runtime_);
 
-    EXPECT_EQ("f4dca0a9-12c7-a307-8002-969403baf480", headers.get(Headers::get().RequestId));
+    EXPECT_EQ("f4dca0a9-12c7-a307-8002-969403baf480", headers.get_(Headers::get().RequestId));
   }
 
   {
     // Not internal request, force trace header should be cleaned.
-    HeaderMapImpl headers{{"x-forwarded-for", external_remote_address},
-                          {"x-request-id", uuid},
-                          {"x-envoy-force-trace", "true"}};
+    TestHeaderMapImpl headers{{"x-forwarded-for", external_remote_address},
+                              {"x-request-id", uuid},
+                              {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
                                                    runtime_);
-    EXPECT_EQ(uuid, headers.get(Headers::get().RequestId));
+    EXPECT_EQ(uuid, headers.get_(Headers::get().RequestId));
     EXPECT_FALSE(headers.has(Headers::get().EnvoyForceTrace));
   }
 }
@@ -161,8 +162,8 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
   ON_CALL(config_, tracingConfig()).WillByDefault(ReturnRef(set_tracing_all_));
 
   {
-    HeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                          {"x-request-id", "will_be_regenerated"}};
+    TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                              {"x-request-id", "will_be_regenerated"}};
     EXPECT_CALL(random_, uuid()).WillOnce(Return(generated_uuid));
 
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", _)).Times(0);
@@ -171,14 +172,14 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
 
     EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));
     // No changes to generated_uuid as x-client-trace-id is missing.
-    EXPECT_EQ(generated_uuid, headers.get(Headers::get().RequestId));
+    EXPECT_EQ(generated_uuid, headers.get_(Headers::get().RequestId));
   }
 
   {
     // Runtime does not allow to make request traceable even though x-client-request-id set
-    HeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                          {"x-request-id", "will_be_regenerated"},
-                          {"x-client-trace-id", "trace-id"}};
+    TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                              {"x-request-id", "will_be_regenerated"},
+                              {"x-client-trace-id", "trace-id"}};
     EXPECT_CALL(random_, uuid()).WillOnce(Return(generated_uuid));
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
         .WillOnce(Return(false));
@@ -187,15 +188,15 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                                                    runtime_);
 
     EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));
-    EXPECT_EQ("f4dca0a9-12c7-4307-8002-969403baf480", headers.get(Headers::get().RequestId));
+    EXPECT_EQ("f4dca0a9-12c7-4307-8002-969403baf480", headers.get_(Headers::get().RequestId));
   }
 
   {
     // Runtime is enabled for tracing and x-client-request-id set
 
-    HeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                          {"x-request-id", "will_be_regenerated"},
-                          {"x-client-trace-id", "trace-id"}};
+    TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                              {"x-request-id", "will_be_regenerated"},
+                              {"x-client-trace-id", "trace-id"}};
     EXPECT_CALL(random_, uuid()).WillOnce(Return(generated_uuid));
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", 100))
         .WillOnce(Return(true));
@@ -204,21 +205,21 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                                                    runtime_);
 
     EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));
-    EXPECT_EQ("f4dca0a9-12c7-b307-8002-969403baf480", headers.get(Headers::get().RequestId));
+    EXPECT_EQ("f4dca0a9-12c7-b307-8002-969403baf480", headers.get_(Headers::get().RequestId));
   }
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalRequestPreserveRequestIdAndDownstream) {
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(false));
   EXPECT_CALL(connection_, remoteAddress()).Times(0);
-  HeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                        {"x-request-id", "id"},
-                        {"x-forwarded-for", "34.0.0.1"}};
+  TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                            {"x-request-id", "id"},
+                            {"x-forwarded-for", "34.0.0.1"}};
 
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
-  EXPECT_EQ("foo", headers.get(Headers::get().EnvoyDownstreamServiceCluster));
-  EXPECT_EQ("id", headers.get(Headers::get().RequestId));
+  EXPECT_EQ("foo", headers.get_(Headers::get().EnvoyDownstreamServiceCluster));
+  EXPECT_EQ("id", headers.get_(Headers::get().RequestId));
   EXPECT_FALSE(headers.has(Headers::get().EnvoyInternalRequest));
 }
 
@@ -229,12 +230,12 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
-  HeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
+  TestHeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
-  EXPECT_EQ("foo", headers.get(Headers::get().UserAgent));
-  EXPECT_EQ("bar", headers.get(Headers::get().EnvoyDownstreamServiceCluster));
-  EXPECT_EQ("true", headers.get(Headers::get().EnvoyInternalRequest));
+  EXPECT_EQ("foo", headers.get_(Headers::get().UserAgent));
+  EXPECT_EQ("bar", headers.get_(Headers::get().EnvoyDownstreamServiceCluster));
+  EXPECT_EQ("true", headers.get_(Headers::get().EnvoyInternalRequest));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
@@ -244,28 +245,28 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
-  HeaderMapImpl headers{};
+  TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
   EXPECT_TRUE(headers.has(Headers::get().UserAgent));
-  EXPECT_EQ("bar", headers.get(Headers::get().UserAgent));
-  EXPECT_EQ("bar", headers.get(Headers::get().EnvoyDownstreamServiceCluster));
-  EXPECT_EQ("true", headers.get(Headers::get().EnvoyInternalRequest));
+  EXPECT_EQ("bar", headers.get_(Headers::get().UserAgent));
+  EXPECT_EQ("bar", headers.get_(Headers::get().EnvoyDownstreamServiceCluster));
+  EXPECT_EQ("true", headers.get_(Headers::get().EnvoyInternalRequest));
 }
 
 TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
   {
-    HeaderMapImpl headers{{":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}};
+    TestHeaderMapImpl headers{{":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}};
     EXPECT_CALL(random_, uuid()).WillOnce(Return("generated_uuid"));
 
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
                                                    runtime_);
-    EXPECT_EQ("generated_uuid", headers.get("x-request-id"));
+    EXPECT_EQ("generated_uuid", headers.get_("x-request-id"));
   }
 
   {
     Runtime::RandomGeneratorImpl rand;
-    HeaderMapImpl headers{{"x-client-trace-id", "trace-id"}};
+    TestHeaderMapImpl headers{{"x-client-trace-id", "trace-id"}};
     std::string uuid = rand.uuid();
 
     EXPECT_CALL(random_, uuid()).WillOnce(Return(uuid));
@@ -273,7 +274,7 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
                                                    runtime_);
     // x-request-id should not be set to be traceable as it's not edge request
-    EXPECT_EQ(uuid, headers.get("x-request-id"));
+    EXPECT_EQ(uuid, headers.get_("x-request-id"));
   }
 }
 
@@ -282,39 +283,39 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
   EXPECT_CALL(config_, useRemoteAddress()).WillOnce(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_remote_address));
 
-  HeaderMapImpl headers{{"x-request-id", "original_request_id"}};
+  TestHeaderMapImpl headers{{"x-request-id", "original_request_id"}};
   EXPECT_CALL(random_, uuid()).Times(0);
 
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
-  EXPECT_EQ("original_request_id", headers.get("x-request-id"));
+  EXPECT_EQ("original_request_id", headers.get_("x-request-id"));
 }
 
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
   std::string external_ip = "134.2.2.11";
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(external_ip));
-  HeaderMapImpl headers{{"x-request-id", "original"}};
+  TestHeaderMapImpl headers{{"x-request-id", "original"}};
 
   EXPECT_CALL(random_, uuid()).WillOnce(Return("override"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
-  EXPECT_EQ("override", headers.get("x-request-id"));
+  EXPECT_EQ("override", headers.get_("x-request-id"));
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRefOfCopy(std::string("50.0.0.1")));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
-  config_.route_config_.internal_only_headers_.push_back("custom_header");
+  config_.route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
 
-  HeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                        {"x-envoy-retry-on", "foo"},
-                        {"x-envoy-upstream-alt-stat-name", "foo"},
-                        {"x-envoy-upstream-rq-timeout-ms", "foo"},
-                        {"x-envoy-expected-rq-timeout-ms", "10"},
-                        {"custom_header", "foo"}};
+  TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                            {"x-envoy-retry-on", "foo"},
+                            {"x-envoy-upstream-alt-stat-name", "foo"},
+                            {"x-envoy-upstream-rq-timeout-ms", "foo"},
+                            {"x-envoy-expected-rq-timeout-ms", "10"},
+                            {"custom_header", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
-  EXPECT_EQ("50.0.0.1", headers.get("x-envoy-external-address"));
+  EXPECT_EQ("50.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_FALSE(headers.has("x-envoy-internal"));
   EXPECT_FALSE(headers.has("x-envoy-downstream-service-cluster"));
   EXPECT_FALSE(headers.has("x-envoy-retry-on"));
@@ -328,10 +329,11 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote
   ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRefOfCopy(std::string("50.0.0.1")));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
-  HeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"}, {"x-forwarded-for", "60.0.0.1"}};
+  TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
+                            {"x-forwarded-for", "60.0.0.1"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
-  EXPECT_EQ("60.0.0.1", headers.get("x-envoy-external-address"));
-  EXPECT_EQ("60.0.0.1", headers.get("x-forwarded-for"));
+  EXPECT_EQ("60.0.0.1", headers.get_("x-envoy-external-address"));
+  EXPECT_EQ("60.0.0.1", headers.get_("x-forwarded-for"));
   EXPECT_FALSE(headers.has("x-envoy-internal"));
 }
 
@@ -339,38 +341,39 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
   ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRefOfCopy(std::string("10.0.0.1")));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
-  HeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
-                        {"x-envoy-expected-rq-timeout-ms", "10"}};
+  TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
+                            {"x-envoy-expected-rq-timeout-ms", "10"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
-  EXPECT_EQ("60.0.0.1", headers.get("x-envoy-external-address"));
-  EXPECT_EQ("10.0.0.1", headers.get("x-forwarded-for"));
-  EXPECT_EQ("10", headers.get("x-envoy-expected-rq-timeout-ms"));
+  EXPECT_EQ("60.0.0.1", headers.get_("x-envoy-external-address"));
+  EXPECT_EQ("10.0.0.1", headers.get_("x-forwarded-for"));
+  EXPECT_EQ("10", headers.get_("x-envoy-expected-rq-timeout-ms"));
   EXPECT_TRUE(headers.has("x-envoy-internal"));
 }
 
 TEST_F(ConnectionManagerUtilityTest, MutateResponseHeaders) {
-  config_.route_config_.response_headers_to_remove_.push_back("custom_header");
-  config_.route_config_.response_headers_to_add_.push_back({"to_add", "foo"});
+  config_.route_config_.response_headers_to_remove_.push_back(LowerCaseString("custom_header"));
+  config_.route_config_.response_headers_to_add_.push_back({LowerCaseString("to_add"), "foo"});
 
-  HeaderMapImpl response_headers{{"connection", "foo"},
-                                 {"transfer-encoding", "foo"},
-                                 {":version", "foo"},
-                                 {"custom_header", "foo"}};
-  HeaderMapImpl request_headers{{"x-request-id", "request-id"}};
+  TestHeaderMapImpl response_headers{{"connection", "foo"},
+                                     {"transfer-encoding", "foo"},
+                                     {":version", "foo"},
+                                     {"custom_header", "foo"}};
+  TestHeaderMapImpl request_headers{{"x-request-id", "request-id"}};
 
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, config_);
 
   EXPECT_EQ(1UL, response_headers.size());
-  EXPECT_EQ("foo", response_headers.get("to_add"));
+  EXPECT_EQ("foo", response_headers.get_("to_add"));
   EXPECT_FALSE(response_headers.has("x-request-id"));
 }
 
 TEST_F(ConnectionManagerUtilityTest, MutateResponseHeadersReturnXRequestId) {
-  HeaderMapImpl response_headers;
-  HeaderMapImpl request_headers{{"x-request-id", "request-id"}, {"x-envoy-force-trace", "true"}};
+  TestHeaderMapImpl response_headers;
+  TestHeaderMapImpl request_headers{{"x-request-id", "request-id"},
+                                    {"x-envoy-force-trace", "true"}};
 
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, config_);
-  EXPECT_EQ("request-id", response_headers.get("x-request-id"));
+  EXPECT_EQ("request-id", response_headers.get_("x-request-id"));
 }
 
 } // Http

--- a/test/common/http/filter/buffer_filter_test.cc
+++ b/test/common/http/filter/buffer_filter_test.cc
@@ -35,7 +35,7 @@ public:
 };
 
 TEST_F(BufferFilterTest, HeaderOnlyRequest) {
-  HeaderMapImpl headers;
+  TestHeaderMapImpl headers;
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, true));
 }
 
@@ -44,7 +44,7 @@ TEST_F(BufferFilterTest, RequestWithData) {
 
   expectTimerCreate();
 
-  HeaderMapImpl headers;
+  TestHeaderMapImpl headers;
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
 
   Buffer::OwnedImpl data1("hello");
@@ -59,11 +59,11 @@ TEST_F(BufferFilterTest, RequestTimeout) {
 
   expectTimerCreate();
 
-  HeaderMapImpl headers;
+  TestHeaderMapImpl headers;
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
 
-  HeaderMapImpl response_headers{{":status", "408"}};
-  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(response_headers), true));
+  TestHeaderMapImpl response_headers{{":status", "408"}};
+  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
   timer_->callback_();
 
   callbacks_.reset_callback_();
@@ -75,7 +75,7 @@ TEST_F(BufferFilterTest, RequestTooLarge) {
 
   expectTimerCreate();
 
-  HeaderMapImpl headers;
+  TestHeaderMapImpl headers;
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
 
   Buffer::OwnedImpl buffered_data("buffered");
@@ -83,8 +83,8 @@ TEST_F(BufferFilterTest, RequestTooLarge) {
 
   Buffer::OwnedImpl data1("hello");
   config_->max_request_bytes_ = 1;
-  HeaderMapImpl response_headers{{":status", "413"}};
-  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(response_headers), true));
+  TestHeaderMapImpl response_headers{{":status", "413"}};
+  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
   EXPECT_EQ(FilterDataStatus::StopIterationAndBuffer, filter_.decodeData(data1, false));
 
   callbacks_.reset_callback_();
@@ -96,7 +96,7 @@ TEST_F(BufferFilterTest, TxResetAfterEndStream) {
 
   expectTimerCreate();
 
-  HeaderMapImpl headers;
+  TestHeaderMapImpl headers;
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
 
   Buffer::OwnedImpl data1("hello");

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -35,6 +35,39 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ(5U, string2.size());
   }
 
+  // Inline move constructor
+  {
+    HeaderString string;
+    string.setCopy("hello", 5);
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    HeaderString string2(std::move(string));
+    EXPECT_TRUE(string.empty());
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    EXPECT_EQ(HeaderString::Type::Inline, string2.type());
+    string.append("world", 5);
+    EXPECT_STREQ("world", string.c_str());
+    EXPECT_EQ(5UL, string.size());
+    EXPECT_STREQ("hello", string2.c_str());
+    EXPECT_EQ(5UL, string2.size());
+  }
+
+  // Dynamic move constructor
+  {
+    std::string large(4096, 'a');
+    HeaderString string;
+    string.setCopy(large.c_str(), large.size());
+    EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
+    HeaderString string2(std::move(string));
+    EXPECT_TRUE(string.empty());
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    EXPECT_EQ(HeaderString::Type::Dynamic, string2.type());
+    string.append("b", 1);
+    EXPECT_STREQ("b", string.c_str());
+    EXPECT_EQ(1UL, string.size());
+    EXPECT_STREQ(large.c_str(), string2.c_str());
+    EXPECT_EQ(4096UL, string2.size());
+  }
+
   // Static to inline number.
   {
     std::string static_string("HELLO");

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -1,12 +1,261 @@
 #include "common/http/header_map_impl.h"
 
+#include "test/test_common/utility.h"
+
 namespace Http {
 
+TEST(HeaderStringTest, All) {
+  // Static LowerCaseString constructor
+  {
+    LowerCaseString static_string("hello");
+    HeaderString string(static_string);
+    EXPECT_STREQ("hello", string.c_str());
+    EXPECT_EQ(static_string.get().c_str(), string.c_str());
+    EXPECT_EQ(5U, string.size());
+  }
+
+  // Static std::string constructor
+  {
+    std::string static_string("HELLO");
+    HeaderString string(static_string);
+    EXPECT_STREQ("HELLO", string.c_str());
+    EXPECT_EQ(static_string.c_str(), string.c_str());
+    EXPECT_EQ(5U, string.size());
+  }
+
+  // Static move contructor
+  {
+    std::string static_string("HELLO");
+    HeaderString string1(static_string);
+    HeaderString string2(std::move(string1));
+    EXPECT_STREQ("HELLO", string2.c_str());
+    EXPECT_EQ(static_string.c_str(), string1.c_str());
+    EXPECT_EQ(static_string.c_str(), string2.c_str());
+    EXPECT_EQ(5U, string1.size());
+    EXPECT_EQ(5U, string2.size());
+  }
+
+  // Static to inline number.
+  {
+    std::string static_string("HELLO");
+    HeaderString string(static_string);
+    string.setInteger(5);
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    EXPECT_STREQ("5", string.c_str());
+  }
+
+  // Static to inline string.
+  {
+    std::string static_string("HELLO");
+    HeaderString string(static_string);
+    string.setCopy(static_string.c_str(), static_string.size());
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    EXPECT_STREQ("HELLO", string.c_str());
+  }
+
+  // Static clear() does nothing.
+  {
+    std::string static_string("HELLO");
+    HeaderString string(static_string);
+    EXPECT_EQ(HeaderString::Type::Static, string.type());
+    string.clear();
+    EXPECT_EQ(HeaderString::Type::Static, string.type());
+    EXPECT_STREQ("HELLO", string.c_str());
+  }
+
+  // Static to append.
+  {
+    std::string static_string("HELLO");
+    HeaderString string(static_string);
+    EXPECT_EQ(HeaderString::Type::Static, string.type());
+    string.append("a", 1);
+    EXPECT_STREQ("a", string.c_str());
+  }
+
+  // Copy inline
+  {
+    HeaderString string;
+    string.setCopy("hello", 5);
+    EXPECT_STREQ("hello", string.c_str());
+    EXPECT_EQ(5U, string.size());
+  }
+
+  // Copy dynamic
+  {
+    HeaderString string;
+    std::string large_value(4096, 'a');
+    string.setCopy(large_value.c_str(), large_value.size());
+    EXPECT_STREQ(large_value.c_str(), string.c_str());
+    EXPECT_NE(large_value.c_str(), string.c_str());
+    EXPECT_EQ(4096U, string.size());
+  }
+
+  // Copy twice dynamic
+  {
+    HeaderString string;
+    std::string large_value1(4096, 'a');
+    string.setCopy(large_value1.c_str(), large_value1.size());
+    std::string large_value2(2048, 'b');
+    string.setCopy(large_value2.c_str(), large_value2.size());
+    EXPECT_STREQ(large_value2.c_str(), string.c_str());
+    EXPECT_NE(large_value2.c_str(), string.c_str());
+    EXPECT_EQ(2048U, string.size());
+  }
+
+  // Copy twice dynamic with reallocate
+  {
+    HeaderString string;
+    std::string large_value1(4096, 'a');
+    string.setCopy(large_value1.c_str(), large_value1.size());
+    std::string large_value2(16384, 'b');
+    string.setCopy(large_value2.c_str(), large_value2.size());
+    EXPECT_STREQ(large_value2.c_str(), string.c_str());
+    EXPECT_NE(large_value2.c_str(), string.c_str());
+    EXPECT_EQ(16384U, string.size());
+  }
+
+  // Copy twice inline to dynamic
+  {
+    HeaderString string;
+    std::string large_value1(16, 'a');
+    string.setCopy(large_value1.c_str(), large_value1.size());
+    std::string large_value2(16384, 'b');
+    string.setCopy(large_value2.c_str(), large_value2.size());
+    EXPECT_STREQ(large_value2.c_str(), string.c_str());
+    EXPECT_NE(large_value2.c_str(), string.c_str());
+    EXPECT_EQ(16384U, string.size());
+  }
+
+  // Append, small buffer to dynamic
+  {
+    HeaderString string;
+    std::string test(127, 'a');
+    string.append(test.c_str(), test.size());
+    EXPECT_EQ(HeaderString::Type::Inline, string.type());
+    string.append("a", 1);
+    EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
+    test += 'a';
+    EXPECT_STREQ(test.c_str(), string.c_str());
+  }
+
+  // Append into inline twice, then shift to dynamic.
+  {
+    HeaderString string;
+    string.append("hello", 5);
+    EXPECT_STREQ("hello", string.c_str());
+    EXPECT_EQ(5U, string.size());
+    string.append("world", 5);
+    EXPECT_STREQ("helloworld", string.c_str());
+    EXPECT_EQ(10U, string.size());
+    std::string large(4096, 'a');
+    string.append(large.c_str(), large.size());
+    large = "helloworld" + large;
+    EXPECT_STREQ(large.c_str(), string.c_str());
+    EXPECT_EQ(4106U, string.size());
+  }
+
+  // Append, realloc dynamic.
+  {
+    HeaderString string;
+    std::string large(128, 'a');
+    string.append(large.c_str(), large.size());
+    EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
+    std::string large2 = large + large;
+    string.append(large2.c_str(), large2.size());
+    large += large2;
+    EXPECT_STREQ(large.c_str(), string.c_str());
+    EXPECT_EQ(384U, string.size());
+  }
+
+  // Set integer, inline
+  {
+    HeaderString string;
+    string.setInteger(123456789);
+    EXPECT_STREQ("123456789", string.c_str());
+    EXPECT_EQ(9U, string.size());
+  }
+
+  // Set integer, dynamic
+  {
+    HeaderString string;
+    std::string large(128, 'a');
+    string.append(large.c_str(), large.size());
+    string.setInteger(123456789);
+    EXPECT_STREQ("123456789", string.c_str());
+    EXPECT_EQ(9U, string.size());
+    EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
+  }
+}
+
+TEST(HeaderMapImplTest, InlineInsert) {
+  HeaderMapImpl headers;
+  EXPECT_EQ(nullptr, headers.Host());
+  headers.insertHost().value(std::string("hello"));
+  EXPECT_STREQ(":authority", headers.Host()->key().c_str());
+  EXPECT_STREQ("hello", headers.Host()->value().c_str());
+  EXPECT_STREQ("hello", headers.get(Headers::get().Host)->value().c_str());
+}
+
+TEST(HeaderMapImplTest, MoveIntoInline) {
+  HeaderMapImpl headers;
+  HeaderString key;
+  key.setCopy(Headers::get().Host.get().c_str(), Headers::get().Host.get().size());
+  HeaderString value;
+  value.setCopy("hello", 5);
+  headers.addViaMove(std::move(key), std::move(value));
+  EXPECT_STREQ(":authority", headers.Host()->key().c_str());
+  EXPECT_STREQ("hello", headers.Host()->value().c_str());
+}
+
 TEST(HeaderMapImplTest, Remove) {
-  HeaderMapImpl headers{{"Expect", "100-continue"}};
-  EXPECT_EQ("100-continue", headers.get("expect"));
-  headers.remove("expect");
-  EXPECT_EQ("", headers.get("expect"));
+  HeaderMapImpl headers;
+
+  // Add random header and then remove by name.
+  LowerCaseString static_key("hello");
+  std::string static_value("value");
+  headers.addStatic(static_key, static_value);
+  EXPECT_STREQ("value", headers.get(static_key)->value().c_str());
+  EXPECT_EQ(HeaderString::Type::Static, headers.get(static_key)->value().type());
+  EXPECT_EQ(1UL, headers.size());
+  headers.remove(static_key);
+  EXPECT_EQ(nullptr, headers.get(static_key));
+  EXPECT_EQ(0UL, headers.size());
+
+  // Add and remove by inline.
+  headers.insertContentLength().value(5);
+  EXPECT_STREQ("5", headers.ContentLength()->value().c_str());
+  EXPECT_EQ(1UL, headers.size());
+  headers.removeContentLength();
+  EXPECT_EQ(nullptr, headers.ContentLength());
+  EXPECT_EQ(0UL, headers.size());
+
+  // Add inline and remove by name.
+  headers.insertContentLength().value(5);
+  EXPECT_STREQ("5", headers.ContentLength()->value().c_str());
+  EXPECT_EQ(1UL, headers.size());
+  headers.remove(Headers::get().ContentLength);
+  EXPECT_EQ(nullptr, headers.ContentLength());
+  EXPECT_EQ(0UL, headers.size());
+}
+
+TEST(HeaderMapImplTest, DoubleInlineAdd) {
+  HeaderMapImpl headers;
+  headers.addStaticKey(Headers::get().ContentLength, 5);
+  headers.addStaticKey(Headers::get().ContentLength, 6);
+  EXPECT_STREQ("5", headers.ContentLength()->value().c_str());
+  EXPECT_EQ(1UL, headers.size());
+}
+
+TEST(HeaderMapImplTest, Equality) {
+  TestHeaderMapImpl headers1;
+  TestHeaderMapImpl headers2;
+  EXPECT_EQ(headers1, headers2);
+
+  headers1.addViaCopy("hello", "world");
+  EXPECT_FALSE(headers1 == headers2);
+
+  headers2.addViaCopy("foo", "bar");
+  EXPECT_FALSE(headers1 == headers2);
 }
 
 } // Http

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -200,6 +200,20 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ(384U, string.size());
   }
 
+  // Append, realloc close to limit with small buffer.
+  {
+    HeaderString string;
+    std::string large(128, 'a');
+    string.append(large.c_str(), large.size());
+    EXPECT_EQ(HeaderString::Type::Dynamic, string.type());
+    std::string large2(120, 'b');
+    string.append(large2.c_str(), large2.size());
+    std::string large3(32, 'c');
+    string.append(large3.c_str(), large3.size());
+    EXPECT_STREQ((large + large2 + large3).c_str(), string.c_str());
+    EXPECT_EQ(280U, string.size());
+  }
+
   // Set integer, inline
   {
     HeaderString string;

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -2,6 +2,7 @@
 #include "common/http/user_agent.h"
 
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/utility.h"
 
 namespace Http {
 
@@ -17,8 +18,9 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(HeaderMapImpl{{"user-agent", "aaa iOS bbb"}}, "test.", stat_store);
-    ua.initializeFromHeaders(HeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa iOS bbb"}}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+                             stat_store);
     ua.completeConnectionLength(span);
   }
 
@@ -30,20 +32,22 @@ TEST(UserAgentTest, All) {
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(HeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+                             stat_store);
     ua.completeConnectionLength(span);
   }
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(HeaderMapImpl{{"user-agent", "aaa bbb"}}, "test.", stat_store);
-    ua.initializeFromHeaders(HeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa bbb"}}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{{"user-agent", "aaa android bbb"}}, "test.",
+                             stat_store);
     ua.completeConnectionLength(span);
   }
 
   {
     UserAgent ua;
-    ua.initializeFromHeaders(HeaderMapImpl{}, "test.", stat_store);
+    ua.initializeFromHeaders(TestHeaderMapImpl{}, "test.", stat_store);
     ua.completeConnectionLength(span);
   }
 }

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -51,7 +51,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     client_.limit(request_callbacks_, "foo", {{{{"foo", "bar"}}}}, "");
 
     client_.onPreRequestCustomizeHeaders(headers);
-    ASSERT_FALSE(headers.has(Http::Headers::get().RequestId));
+    EXPECT_EQ(nullptr, headers.RequestId());
 
     response->Clear();
     response->set_overall_code(pb::lyft::ratelimit::RateLimitResponse_Code_OVER_LIMIT);
@@ -71,7 +71,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     client_.limit(request_callbacks_, "foo", {{{{"foo", "bar"}, {"bar", "baz"}}}}, "requestid");
 
     client_.onPreRequestCustomizeHeaders(headers);
-    ASSERT_EQ(headers.get(Http::Headers::get().RequestId), "requestid");
+    EXPECT_EQ(headers.RequestId()->value(), "requestid");
 
     response->Clear();
     response->set_overall_code(pb::lyft::ratelimit::RateLimitResponse_Code_OK);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -201,6 +201,15 @@ TEST(HttpTracerUtilityTest, IsTracing) {
     EXPECT_EQ(Reason::ClientForced, result.reason);
     EXPECT_TRUE(result.is_tracing);
   }
+
+  // No request id.
+  {
+    Http::TestHeaderMapImpl headers;
+    EXPECT_CALL(request_info, healthCheck()).WillOnce(Return(false));
+    Decision result = HttpTracerUtility::isTracing(request_info, headers);
+    EXPECT_EQ(Reason::NotTraceableRequestId, result.reason);
+    EXPECT_FALSE(result.is_tracing);
+  }
 }
 
 TEST(HttpTracerImplTest, AllSinksTraceableRequest) {

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -10,6 +10,7 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::Invoke;
@@ -29,11 +30,12 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
-    Http::HeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::Sampled,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Sampling must not be done on client traced.
@@ -43,11 +45,12 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
-    Http::HeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::Forced,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Sampling, global off.
@@ -58,11 +61,12 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(false));
 
-    Http::HeaderMapImpl request_headers{{"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::NoTrace,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Client, client enabled, global on.
@@ -73,13 +77,13 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
-    Http::HeaderMapImpl request_headers{
+    Http::TestHeaderMapImpl request_headers{
         {"x-client-trace-id", "f4dca0a9-12c7-4307-8002-969403baf480"},
         {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::Client,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Client, client disabled, global on.
@@ -90,13 +94,13 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
-    Http::HeaderMapImpl request_headers{
+    Http::TestHeaderMapImpl request_headers{
         {"x-client-trace-id", "f4dca0a9-12c7-4307-8002-969403baf480"},
         {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::NoTrace,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Forced, global on.
@@ -105,12 +109,12 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
-    Http::HeaderMapImpl request_headers{{"x-envoy-force-trace", "true"},
-                                        {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-envoy-force-trace", "true"}, {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::Forced,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Forced, global off.
@@ -119,23 +123,24 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(false));
 
-    Http::HeaderMapImpl request_headers{{"x-envoy-force-trace", "true"},
-                                        {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
+    Http::TestHeaderMapImpl request_headers{
+        {"x-envoy-force-trace", "true"}, {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::NoTrace,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 
   // Forced, global on, broken uuid.
   {
     NiceMock<Runtime::MockLoader> runtime;
 
-    Http::HeaderMapImpl request_headers{{"x-envoy-force-trace", "true"}, {"x-request-id", "bb"}};
+    Http::TestHeaderMapImpl request_headers{{"x-envoy-force-trace", "true"},
+                                            {"x-request-id", "bb"}};
     HttpTracerUtility::mutateHeaders(request_headers, runtime);
 
     EXPECT_EQ(UuidTraceStatus::NoTrace,
-              UuidUtils::isTraceableUuid(request_headers.get("x-request-id")));
+              UuidUtils::isTraceableUuid(request_headers.get_("x-request-id")));
   }
 }
 
@@ -147,18 +152,18 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   std::string forced_guid = random.uuid();
   UuidUtils::setTraceableUuid(forced_guid, UuidTraceStatus::Forced);
-  Http::HeaderMapImpl forced_header{{"x-request-id", forced_guid}};
+  Http::TestHeaderMapImpl forced_header{{"x-request-id", forced_guid}};
 
   std::string sampled_guid = random.uuid();
   UuidUtils::setTraceableUuid(sampled_guid, UuidTraceStatus::Sampled);
-  Http::HeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
+  Http::TestHeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
 
   std::string client_guid = random.uuid();
   UuidUtils::setTraceableUuid(client_guid, UuidTraceStatus::Client);
-  Http::HeaderMapImpl client_header{{"x-request-id", client_guid}};
+  Http::TestHeaderMapImpl client_header{{"x-request-id", client_guid}};
 
-  Http::HeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
-  Http::HeaderMapImpl empty_header{};
+  Http::TestHeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
+  Http::TestHeaderMapImpl empty_header{};
 
   // Force traced.
   {
@@ -180,7 +185,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
   // HC request.
   {
-    Http::HeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
+    Http::TestHeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
     EXPECT_CALL(request_info, healthCheck()).WillOnce(Return(true));
 
     Decision result = HttpTracerUtility::isTracing(request_info, traceable_header_hc);
@@ -206,14 +211,14 @@ TEST(HttpTracerImplTest, AllSinksTraceableRequest) {
 
   std::string forced_guid = random.uuid();
   UuidUtils::setTraceableUuid(forced_guid, UuidTraceStatus::Forced);
-  Http::HeaderMapImpl forced_header{{"x-request-id", forced_guid}};
+  Http::TestHeaderMapImpl forced_header{{"x-request-id", forced_guid}};
 
   std::string sampled_guid = random.uuid();
   UuidUtils::setTraceableUuid(sampled_guid, UuidTraceStatus::Sampled);
-  Http::HeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
+  Http::TestHeaderMapImpl sampled_header{{"x-request-id", sampled_guid}};
 
-  Http::HeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
-  Http::HeaderMapImpl empty_header{};
+  Http::TestHeaderMapImpl not_traceable_header{{"x-request-id", not_traceable_guid}};
+  Http::TestHeaderMapImpl empty_header{};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
   NiceMock<MockTracingContext> context;
 
@@ -244,7 +249,7 @@ TEST(HttpTracerImplTest, AllSinksTraceableRequest) {
     EXPECT_CALL(*sink1, flushTrace(_, _, _, _)).Times(0);
     EXPECT_CALL(*sink2, flushTrace(_, _, _, _)).Times(0);
 
-    Http::HeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
+    Http::TestHeaderMapImpl traceable_header_hc{{"x-request-id", forced_guid}};
     NiceMock<Http::AccessLog::MockRequestInfo> request_info;
     EXPECT_CALL(request_info, healthCheck()).WillOnce(Return(true));
     tracer.trace(&traceable_header_hc, &empty_header, request_info, context);
@@ -266,7 +271,7 @@ TEST(HttpTracerImplTest, ZeroSinksRunsFine) {
   Runtime::RandomGeneratorImpl random;
   std::string not_traceable_guid = random.uuid();
 
-  Http::HeaderMapImpl not_traceable{{"x-request-id", not_traceable_guid}};
+  Http::TestHeaderMapImpl not_traceable{{"x-request-id", not_traceable_guid}};
 
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
   NiceMock<MockTracingContext> context;
@@ -280,7 +285,7 @@ TEST(HttpNullTracerTest, NoFailures) {
 
   tracer.addSink(HttpSinkPtr{sink});
 
-  Http::HeaderMapImpl empty_header{};
+  Http::TestHeaderMapImpl empty_header{};
   Http::AccessLog::MockRequestInfo request_info;
   NiceMock<MockTracingContext> context;
 
@@ -320,8 +325,9 @@ public:
   }
 
   const std::string operation_name_{"test"};
-  const Http::HeaderMapImpl empty_header_{};
-  const Http::HeaderMapImpl response_headers_{{":status", "500"}};
+  const Http::TestHeaderMapImpl request_headers_{
+      {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
+  const Http::TestHeaderMapImpl response_headers_{{":status", "500"}};
 
   std::unique_ptr<LightStepSink> sink_;
   NiceMock<Event::MockTimer>* timer_;
@@ -403,10 +409,10 @@ TEST_F(LightStepSinkTest, FlushSeveralSpans) {
                      const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
-            EXPECT_EQ("/lightstep.collector.CollectorService/Report",
-                      message->headers().get(Http::Headers::get().Path));
-            EXPECT_EQ("lightstep_saas", message->headers().get(Http::Headers::get().Host));
-            EXPECT_EQ("application/grpc", message->headers().get(Http::Headers::get().ContentType));
+            EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
+                         message->headers().Path()->value().c_str());
+            EXPECT_STREQ("lightstep_saas", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
           }));
@@ -425,13 +431,13 @@ TEST_F(LightStepSinkTest, FlushSeveralSpans) {
       .WillOnce(Return(5000U));
   EXPECT_CALL(context_, operationName()).Times(2).WillRepeatedly(ReturnRef(operation_name_));
 
-  sink_->flushTrace(empty_header_, response_headers_, request_info, context_);
-  sink_->flushTrace(empty_header_, response_headers_, request_info, context_);
+  sink_->flushTrace(request_headers_, response_headers_, request_info, context_);
+  sink_->flushTrace(request_headers_, response_headers_, request_info, context_);
 
   Http::MessagePtr msg(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
 
-  msg->trailers(std::move(Http::HeaderMapPtr{new Http::HeaderMapImpl{{"grpc-status", "0"}}}));
+  msg->trailers(std::move(Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{"grpc-status", "0"}}}));
 
   callback->onSuccess(std::move(msg));
 
@@ -479,7 +485,7 @@ TEST_F(LightStepSinkTest, FlushSpansTimer) {
       .WillOnce(Return(5));
   EXPECT_CALL(context_, operationName()).WillOnce(ReturnRef(operation_name_));
 
-  sink_->flushTrace(empty_header_, response_headers_, request_info, context_);
+  sink_->flushTrace(request_headers_, response_headers_, request_info, context_);
   // Timer should be re-enabled.
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
@@ -507,10 +513,10 @@ TEST_F(LightStepSinkTest, FlushOneSpanGrpcFailure) {
                      const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
-            EXPECT_EQ("/lightstep.collector.CollectorService/Report",
-                      message->headers().get(Http::Headers::get().Path));
-            EXPECT_EQ("lightstep_saas", message->headers().get(Http::Headers::get().Host));
-            EXPECT_EQ("application/grpc", message->headers().get(Http::Headers::get().ContentType));
+            EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
+                         message->headers().Path()->value().c_str());
+            EXPECT_STREQ("lightstep_saas", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
           }));
@@ -528,10 +534,10 @@ TEST_F(LightStepSinkTest, FlushOneSpanGrpcFailure) {
       .WillOnce(Return(5000U));
   EXPECT_CALL(context_, operationName()).WillOnce(ReturnRef(operation_name_));
 
-  sink_->flushTrace(empty_header_, response_headers_, request_info, context_);
+  sink_->flushTrace(request_headers_, response_headers_, request_info, context_);
 
   Http::MessagePtr msg(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
 
   // No trailers, gRPC is considered failed.
   callback->onSuccess(std::move(msg));

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::NiceMock;
@@ -123,7 +124,8 @@ public:
   void respond(size_t index, const std::string& code, bool conn_close, bool body = false,
                bool trailers = false,
                const Optional<std::string>& service_cluster = Optional<std::string>()) {
-    Http::HeaderMapPtr response_headers(new Http::HeaderMapImpl{{":status", code}});
+    std::unique_ptr<Http::TestHeaderMapImpl> response_headers(
+        new Http::TestHeaderMapImpl{{":status", code}});
     if (service_cluster.valid()) {
       response_headers->addViaCopy(Http::Headers::get().EnvoyUpstreamHealthCheckedCluster,
                                    service_cluster.value());
@@ -141,7 +143,7 @@ public:
 
     if (trailers) {
       test_sessions_[index]->stream_response_callbacks_->decodeTrailers(
-          Http::HeaderMapPtr{new Http::HeaderMapImpl{{"some", "trailer"}}});
+          Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{"some", "trailer"}}});
     }
   }
 

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::DoAll;
@@ -67,7 +68,7 @@ protected:
         .WillOnce(Invoke([](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                             Optional<std::chrono::milliseconds>) -> Http::AsyncClient::Request* {
           callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
-              Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "503"}}})});
+              Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
           return nullptr;
         }));
   }
@@ -116,7 +117,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   cluster_->setInitializedCb([&]() -> void { membership_updated_.ready(); });
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/upstream/test_data/sds_response.json"))});
 
@@ -140,7 +141,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   timer_->callback_();
 
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
       "test/common/upstream/test_data/sds_response_weight_change.json"))});
   EXPECT_CALL(*timer_, enableTimer(_));
@@ -176,7 +177,7 @@ TEST_F(SdsTest, NoHealthChecker) {
 
   EXPECT_CALL(*timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "503"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}}));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
@@ -200,7 +201,7 @@ TEST_F(SdsTest, HealthChecker) {
   // Load in all of the hosts the first time, this will setup first pass health checking. We expect
   // all the hosts to load in unhealthy.
   Http::MessagePtr message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/upstream/test_data/sds_response.json"))});
 
@@ -243,7 +244,7 @@ TEST_F(SdsTest, HealthChecker) {
 
   EXPECT_CALL(*timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/upstream/test_data/sds_response_2.json"))});
   callbacks_->onSuccess(std::move(message));
@@ -262,7 +263,7 @@ TEST_F(SdsTest, HealthChecker) {
   timer_->callback_();
   EXPECT_CALL(*timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/upstream/test_data/sds_response_2.json"))});
   callbacks_->onSuccess(std::move(message));
@@ -280,7 +281,7 @@ TEST_F(SdsTest, HealthChecker) {
   timer_->callback_();
   EXPECT_CALL(*timer_, enableTimer(_));
   message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::HeaderMapImpl{{":status", "200"}}}));
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(
       Filesystem::fileReadToEnd("test/common/upstream/test_data/sds_response_3.json"))});
   callbacks_->onSuccess(std::move(message));

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -22,10 +22,10 @@ public:
 
   uint64_t bodyLength() { return body_length_; }
   bool complete() { return end_stream_; }
-  void encodeHeaders(Http::HeaderMapImpl headers, bool end_stream);
+  void encodeHeaders(const Http::HeaderMapImpl& headers, bool end_stream);
   void encodeData(uint64_t size, bool end_stream);
   void encodeData(Buffer::Instance& data, bool end_stream);
-  void encodeTrailers(Http::HeaderMapImpl trailers);
+  void encodeTrailers(const Http::HeaderMapImpl& trailers);
   void encodeResetStream();
   const Http::HeaderMap& headers() { return *headers_; }
   const Http::HeaderMapPtr& trailers() { return trailers_; }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -175,7 +175,7 @@ protected:
   void testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type);
   void testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
                                             Http::CodecClient::Type type, uint64_t request_size,
-                                            uint64_t response_size);
+                                            uint64_t response_size, bool big_header);
   void testRouterHeaderOnlyRequestAndResponse(Network::ClientConnectionPtr&& conn,
                                               Http::CodecClient::Type type);
   void testRouterUpstreamDisconnectBeforeRequestComplete(Network::ClientConnectionPtr&& conn,

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -7,57 +7,57 @@ TEST_F(IntegrationTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       HTTP_PORT, "GET", "/healthcheck", "", Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/healthcheck/fail", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/healthcheck", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("503", response->headers().get(":status"));
+  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/healthcheck/ok", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/healthcheck", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(HTTP_BUFFER_PORT, "GET", "/healthcheck", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_F(IntegrationTest, AdminLogging) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       ADMIN_PORT, "GET", "/logging", "", Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().get(":status"));
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad level
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/logging?level=blah", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().get(":status"));
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad logger
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/logging?blah=info", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().get(":status"));
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // This is going to stomp over custom log levels that are set on the command line.
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/logging?level=warning", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
     EXPECT_EQ("warning", logger.levelString());
   }
@@ -65,7 +65,7 @@ TEST_F(IntegrationTest, AdminLogging) {
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/logging?assert=trace", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
 
   const char* level_name = spdlog::level::level_names[default_log_level_];
@@ -73,7 +73,7 @@ TEST_F(IntegrationTest, AdminLogging) {
                                                 fmt::format("/logging?level={}", level_name), "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
     EXPECT_EQ(level_name, logger.levelString());
   }
@@ -83,50 +83,50 @@ TEST_F(IntegrationTest, Admin) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       ADMIN_PORT, "GET", "/", "", Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("404", response->headers().get(":status"));
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/server_info", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/stats", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/clusters", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/cpuprofiler", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("400", response->headers().get(":status"));
+  EXPECT_STREQ("400", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/cpuprofiler?enable=y", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/cpuprofiler?enable=n", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/hot_restart_version", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/reset_counters", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(ADMIN_PORT, "GET", "/certs", "",
                                                 Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -8,5 +8,6 @@ TEST_F(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   Buffer::OwnedImpl buf("PROXY TCP4 1.2.3.4 255.255.255.255 66776 1234\r\n");
   conn->write(buf);
 
-  testRouterRequestAndResponseWithBody(std::move(conn), Http::CodecClient::Type::HTTP1, 1024, 512);
+  testRouterRequestAndResponseWithBody(std::move(conn), Http::CodecClient::Type::HTTP1, 1024, 512,
+                                       false);
 }

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -42,7 +42,7 @@ IntegrationTestServer::~IntegrationTestServer() {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       IntegrationTest::ADMIN_PORT, "GET", "/quitquitquit", "", Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   thread_->join();
 }

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -65,19 +65,19 @@ void SslIntegrationTest::checkStats() {
 TEST_F(SslIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
   testRouterRequestAndResponseWithBody(makeSslClientConnection(false),
                                        Http::CodecClient::Type::HTTP1, 16 * 1024 * 1024,
-                                       16 * 1024 * 1024);
+                                       16 * 1024 * 1024, false);
   checkStats();
 }
 
 TEST_F(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeSslClientConnection(false),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512);
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
   checkStats();
 }
 
 TEST_F(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferHttp2) {
   testRouterRequestAndResponseWithBody(makeSslClientConnection(true),
-                                       Http::CodecClient::Type::HTTP2, 1024, 512);
+                                       Http::CodecClient::Type::HTTP2, 1024, 512, false);
   checkStats();
 }
 
@@ -110,7 +110,7 @@ TEST_F(SslIntegrationTest, AdminCertEndpoint) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       ADMIN_PORT, "GET", "/certs", "", Http::CodecClient::Type::HTTP1);
   EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().get(":status"));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_F(SslIntegrationTest, AltAlpn) {
@@ -120,7 +120,7 @@ TEST_F(SslIntegrationTest, AltAlpn) {
   ON_CALL(server->runtime_->snapshot_, featureEnabled("ssl.alt_alpn", 0))
       .WillByDefault(Return(true));
   testRouterRequestAndResponseWithBody(makeSslClientConnection(true),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512);
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
   checkStats();
 }
 

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -4,7 +4,7 @@
 
 TEST_F(UdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_PORT),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512);
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
 }
 
 TEST_F(UdsIntegrationTest, RouterHeaderOnlyRequestAndResponse) {

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -55,10 +55,10 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
   encoder.getStream().addCallbacks(*response);
 
   Http::HeaderMapImpl headers;
-  headers.addViaCopy(Http::Headers::get().Method, method);
-  headers.addViaCopy(Http::Headers::get().Path, url);
-  headers.addViaCopy(Http::Headers::get().Host, host);
-  headers.addViaMoveValue(Http::Headers::get().Scheme, "http");
+  headers.insertMethod().value(method);
+  headers.insertPath().value(url);
+  headers.insertHost().value(host);
+  headers.insertScheme().value(Http::Headers::get().SchemeValues.Http);
   encoder.encodeHeaders(headers, body.empty());
   if (!body.empty()) {
     Buffer::OwnedImpl body_buffer(body);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -349,11 +349,10 @@ public:
 
 MATCHER_P(HeaderMapEqual, rhs, "") {
   Http::HeaderMapImpl& lhs = *dynamic_cast<Http::HeaderMapImpl*>(arg.get());
-  return lhs == rhs;
+  return lhs == *rhs;
 }
 
 MATCHER_P(HeaderMapEqualRef, rhs, "") {
   const Http::HeaderMapImpl& lhs = *dynamic_cast<const Http::HeaderMapImpl*>(&arg);
-  const Http::HeaderMap& rhs_temp = rhs;
-  return lhs == *dynamic_cast<const Http::HeaderMapImpl*>(&rhs_temp);
+  return lhs == *dynamic_cast<const Http::HeaderMapImpl*>(rhs);
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1,6 +1,7 @@
 #include "server/http/admin.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::NiceMock;
@@ -19,7 +20,7 @@ public:
   AdminImpl admin_;
   AdminFilter filter_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
-  Http::HeaderMapImpl request_headers_;
+  Http::TestHeaderMapImpl request_headers_;
 };
 
 TEST_F(AdminFilterTest, HeaderOnly) {

--- a/test/test_common/printers.cc
+++ b/test/test_common/printers.cc
@@ -5,8 +5,10 @@
 
 namespace Http {
 void PrintTo(const HeaderMapImpl& headers, std::ostream* os) {
-  headers.iterate([os](const LowerCaseString& key, const std::string& value)
-                      -> void { *os << "{'" << key.get() << "','" << value << "'}"; });
+  headers.iterate([](const HeaderEntry& header, void* context) -> void {
+    std::ostream* os = static_cast<std::ostream*>(context);
+    *os << "{'" << header.key().c_str() << "','" << header.value().c_str() << "'}";
+  }, os);
 }
 
 void PrintTo(const HeaderMapPtr& headers, std::ostream* os) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/http/header_map_impl.h"
+
 class TestUtility {
 public:
   /**
@@ -17,3 +19,25 @@ public:
    */
   static std::string bufferToString(const Buffer::Instance& buffer);
 };
+
+namespace Http {
+
+/**
+ * A test version of HeaderMapImpl that adds some niceties since the prod one makes it very
+ * difficult to do any string copies without really meaning to.
+ */
+class TestHeaderMapImpl : public HeaderMapImpl {
+public:
+  TestHeaderMapImpl();
+  TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
+  TestHeaderMapImpl(const HeaderMap& rhs);
+
+  void addViaCopy(const std::string& key, const std::string& value);
+  void addViaCopy(const LowerCaseString& key, const std::string& value);
+  std::string get_(const std::string& key);
+  std::string get_(const LowerCaseString& key);
+  bool has(const std::string& key);
+  bool has(const LowerCaseString& key);
+};
+
+} // Http


### PR DESCRIPTION
This change swaps out the current header map implementation for one that
is heavily optimized for performance. We implement our own string implementation
used for headers, as well as a new map implementation that allows direct access
to all headers that Envoy uses during fast path processing. We attempt to copy
and allocate as little as possible. There are some more wins that can be had that
are noted in the code but this change is too large as it is and we can do some
of them in follow ups.