### PR TITLE
perf: use splice to move between lists inside a LinkedObject

### DIFF
--- a/source/common/common/linked_object.h
+++ b/source/common/common/linked_object.h
@@ -32,9 +32,7 @@ public:
     ASSERT(inserted_);
     ASSERT(std::find(list1.begin(), list1.end(), *entry_) != list1.end());
 
-    std::unique_ptr<T> removed = std::move(*entry_);
-    list1.erase(entry_);
-    entry_ = list2.emplace(list2.begin(), std::move(removed));
+    list2.splice(list2.begin(), list1, entry_);
   }
 
   /**


### PR DESCRIPTION
This avoids a pointless alloc/free sequence.