### PR TITLE
zone aware load_balancer does not handle some of the rounding problems in calculations.

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -151,6 +151,7 @@ public:
   COUNTER(lb_healthy_panic)                                                                        \
   COUNTER(lb_local_cluster_not_ok)                                                                 \
   COUNTER(lb_zone_cluster_too_small)                                                               \
+  COUNTER(lb_zone_no_capacity_left)                                                                \
   COUNTER(lb_zone_number_differs)                                                                  \
   COUNTER(lb_zone_routing_all_directly)                                                            \
   COUNTER(lb_zone_routing_sampled)                                                                 \

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -139,6 +139,13 @@ const std::vector<HostPtr>& LoadBalancerBase::tryChooseLocalZoneHosts() {
     }
   }
 
+  // This is *extremely* unlikely but possible due to rounding errors when calculating
+  // zone percentages. In this case just select random zone.
+  if (residual_capacity[number_of_zones - 1] == 0) {
+    stats_.lb_zone_no_capacity_left_.inc();
+    return host_set_.healthyHostsPerZone()[random_.random() % number_of_zones];
+  }
+
   // Random sampling to select specific zone for cross zone traffic based on the additional
   // capacity in zones.
   uint64_t threshold = random_.random() % residual_capacity[number_of_zones - 1];

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -238,6 +238,65 @@ TEST_F(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
   EXPECT_EQ(1U, stats_.lb_zone_routing_cross_zone_.value());
 }
 
+TEST_F(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
+  init(true);
+
+  // upstream_hosts and local_hosts do not matter, zone aware routing is based on per zone hosts.
+  HostVectorPtr upstream_hosts(
+      new std::vector<HostPtr>({newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1:80")}));
+  HostVectorPtr local_hosts(
+      new std::vector<HostPtr>({newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1:0")}));
+  cluster_.healthy_hosts_ = *upstream_hosts;
+  cluster_.hosts_ = *upstream_hosts;
+
+  HostListsPtr upstream_hosts_per_zone(new std::vector<std::vector<HostPtr>>());
+  HostListsPtr local_hosts_per_zone(new std::vector<std::vector<HostPtr>>());
+
+  cluster_.healthy_hosts_per_zone_ = *upstream_hosts_per_zone;
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
+      .WillRepeatedly(Return(50));
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
+      .WillOnce(Return(6));
+
+  // The following host distribution with current precision should lead to the no_capacity_left
+  // situation.
+  std::vector<HostPtr> current;
+
+  for (int i = 0; i < 45000; ++i) {
+    current.push_back(newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1"));
+  }
+  local_hosts_per_zone->push_back(current);
+
+  current.clear();
+  for (int i = 0; i < 55000; ++i) {
+    current.push_back(newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1"));
+  }
+  local_hosts_per_zone->push_back(current);
+
+  current.clear();
+  for (int i = 0; i < 44999; ++i) {
+    current.push_back(newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1"));
+  }
+  upstream_hosts_per_zone->push_back(current);
+
+  current.clear();
+  for (int i = 0; i < 55001; ++i) {
+    current.push_back(newTestHost(Upstream::MockCluster{}, "tcp://127.0.0.1"));
+  }
+  upstream_hosts_per_zone->push_back(current);
+
+  local_cluster_hosts_->updateHosts(local_hosts, local_hosts, local_hosts_per_zone,
+                                    local_hosts_per_zone, empty_host_vector_, empty_host_vector_);
+
+  // Force request out of small zone.
+  EXPECT_CALL(random_, random()).WillOnce(Return(9999)).WillOnce(Return(2));
+  lb_->chooseHost();
+  EXPECT_EQ(1U, stats_.lb_zone_no_capacity_left_.value());
+}
+
 TEST_F(RoundRobinLoadBalancerTest, NoZoneAwareRoutingOneZone) {
   init(true);
   HostVectorPtr hosts(


### PR DESCRIPTION
Due to rounding errors we could end up in *highly* unlikely situation where we do not have left capacity to route.

Have a stat on that and return random zone in this case. We could potentially increase precision by using higher (than 10000) multiplier in calculations.

@lyft/network-team 