### PR TITLE
Fault injection filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /docs/landing_source/.bundle
 /generated
+cscope.*
+BROWSE

--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -1,0 +1,150 @@
+.. _config_http_filters_fault_injection:
+
+Fault Injection
+===============
+
+The fault injection filter can be used to test the resiliency of
+microservices to different forms of failures. The filter can be used to
+inject delays and abort requests with user-specified error codes, thereby
+providing the ability to stage different failure scenarios such as service
+failures, service overloads, high network latency, network partitions,
+etc. Faults injection can be limited to a specific set of requests based on
+a set of pre-defined request headers.
+
+The scope of failures is restricted to those that are observable by an
+application communicating over the network. CPU and disk failures on the
+local host cannot be emulated.
+
+Currently, the fault injection filter has the following limitations:
+
+* Faults will be injected on all configured routes in the Envoy instance
+* Abort codes are restricted to HTTP status codes only
+* Delays are restricted to fixed duration.
+
+Future versions will include support for restricting faults to specific
+routes, injecting *gRPC* and *HTTP/2* specific error codes and delay
+durations based on distributions.
+
+Configuration
+-------------
+
+*Note: The fault injection filter must be inserted before any other filter,
+including the router filter.*
+
+.. code-block:: json
+
+    {
+      "type" : "decoder",
+      "name" : "fault",
+      "config" : {
+        "abort" : {
+          "abort_percent" : "...",
+          "http_status" : "..."
+        },
+        "delay" : {
+          "type" : "...",
+          "fixed_delay_percent" : "...",
+          "fixed_duration_ms" : "..."
+        },
+        "headers" : []
+      }
+    }
+
+abort.abort_percent
+  *(required, integer)* The percentage of requests that
+  should be aborted with the specified *http_status* code. Valid values
+  range from 0 to 100.
+
+abort.http_status
+  *(required, integer)* The HTTP status code that will be used as the
+  response code for the request being aborted.
+
+delay.type:
+  *(required, string)* Specifies the type of delay being
+  injected. Currently only *fixed* delay type (step function) is supported.
+
+delay.fixed_delay_percent:
+  *(required, integer)* The percentage of requests that will
+  be delayed for the duration specified by *fixed_duration_ms*. Valid
+  values range from 0 to 100.
+
+delay.fixed_duration_ms:
+  *(required, integer)* The delay duration in
+  milliseconds. Must be greater than 0.
+
+:ref:`headers <config_http_filters_fault_injection_headers>`
+  *(optional, array)* Specifies a set of headers that the filter should match on.
+
+The abort and delay blocks can be omitted. If they are not specified in the
+configuration file, their respective values will be obtained from the
+runtime.
+
+Runtime
+-------
+
+The HTTP fault injection filter supports the following runtime settings:
+
+http.fault.abort.abort_percent
+  % of requests that will be aborted if the headers match. Defaults to the
+  *abort_percent* specified in config. If the config does not contain an
+  *abort* block, then *abort_percent* defaults to 0.
+
+http.fault.abort.http_status
+  HTTP status code that will be used as the  of requests that will be
+  aborted if the headers match. Defaults to the HTTP status code specified
+  in the config. If the config does not contain an *abort* block, then
+  *http_status* defaults to 0.
+
+http.fault.delay.fixed_delay_percent
+  % of requests that will be delayed if the headers match. Defaults to the
+  *delay_percent* specified in the config or 0 otherwise.
+
+http.fault.delay.fixed_duration_ms
+  The delay duration in milliseconds. If not specified, the
+  *fixed_duration_ms* specified in the config will be used. If this field
+  is missing from both the runtime and the config, no delays will be
+  injected.
+
+.. _config_http_filters_fault_injection_headers:
+
+Headers
+-------
+
+The fault injection filter can be applied selectively to requests that
+match a set of headers specified in the fault filter config. The chances of
+actual fault injection further depend on the values of *abort_percent* and
+*fixed_delay_percent* parameters. Each element of the array in the
+*headers* field should be in the following format:
+
+.. code-block:: json
+
+  [
+    {"name": "...", "value": "..."}
+  ]
+
+name
+  *(required, string)* Specifies the name of the header in the request.
+
+value
+  *(optional, string)* Specifies the value of the header. If the value is
+  absent a request that has the *name* header will match, regardless of the
+  header's value.
+
+The filter will check the request's headers against all the specified
+headers in the filter config. A match will happen if all the headers in the
+config are present in the request with the same values (or based on
+presence if the ``value`` field is not in the config).
+
+Statistics
+----------
+
+The fault filter outputs statistics in the *http.<stat_prefix>.fault.* namespace. The :ref:`stat
+prefix <config_http_conn_man_stat_prefix>` comes from the owning HTTP connection manager.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  delays_injected, Counter, Total requests that were delayed
+  aborts_injected, Counter, Total requests that were aborted
+

--- a/docs/configuration/http_filters/http_filters.rst
+++ b/docs/configuration/http_filters/http_filters.rst
@@ -7,6 +7,7 @@ HTTP filters
   :maxdepth: 2
 
   buffer_filter
+  fault_filter
   dynamodb_filter
   grpc_http1_bridge_filter
   health_check_filter

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(
   http/http2/codec_impl.cc
   http/http2/conn_pool.cc
   http/filter/buffer_filter.cc
+  http/filter/fault_filter.cc
   http/filter/ratelimit.cc
   http/user_agent.cc
   http/utility.cc

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -66,6 +66,8 @@ FaultFilterStats FaultFilter::generateStats(const std::string& prefix, Stats::St
 void FaultFilter::onResetStream() { resetInternalState(); }
 
 void FaultFilter::postDelayInjection() {
+
+  resetInternalState();
   // Delays can be followed by aborts
   if ((config_->abort_probability_ > 0) &&
       (prob_dist_(generator_) <= config_->abort_probability_)) {
@@ -79,7 +81,12 @@ void FaultFilter::postDelayInjection() {
   }
 }
 
-void FaultFilter::resetInternalState() { delay_timer_.reset(); }
+void FaultFilter::resetInternalState() {
+  if (delay_timer_) {
+    delay_timer_->disableTimer();
+    delay_timer_.reset();
+  }
+}
 
 void FaultFilter::setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) {
   callbacks_ = &callbacks;

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -5,9 +5,11 @@
 
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
+#include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
@@ -19,13 +21,18 @@ FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config), generat
 FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 
 // TODO: Need to inject faults based on header matches
-FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap&, bool) {
+FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
   /**
    * Delays and aborts are independent events. One can inject a delay
-   * followed by an abort or inject just a delay or abort In this callback,
-   * if we inject a delay, then we will inject the abort when the delay
-   * timer is fired.
+   * followed by an abort or inject just a delay or abort. In this callback,
+   * if we inject a delay, then we will inject the abort in the delay timer
+   * callback.
    */
+
+  // Check for header matches first
+  if (!matches(headers)) {
+    return FilterHeadersStatus::Continue;
+  }
 
   if ((config_->delay_probability_ > 0) &&
       (prob_dist_(generator_) <= config_->delay_probability_)) {
@@ -61,6 +68,26 @@ FilterTrailersStatus FaultFilter::decodeTrailers(HeaderMap&) {
 FaultFilterStats FaultFilter::generateStats(const std::string& prefix, Stats::Store& store) {
   std::string final_prefix = prefix + "fault.";
   return {ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(store, final_prefix))};
+}
+
+// header match semantics in fault filter works is same as the one in route block
+bool FaultFilter::matches(const Http::HeaderMap& headers) const {
+  bool matches = true;
+
+  if (!config_->fault_filter_headers_.empty()) {
+    for (const FaultFilterHeaders& header_data : config_->fault_filter_headers_) {
+      if (header_data.value_ == EMPTY_STRING) {
+        matches &= headers.has(header_data.name_);
+      } else {
+        matches &= (headers.get(header_data.name_) == header_data.value_);
+      }
+      if (!matches) {
+        break;
+      }
+    }
+  }
+
+  return matches;
 }
 
 void FaultFilter::onResetStream() { resetInternalState(); }

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -97,7 +97,6 @@ FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
   if (config_->runtime().snapshot().featureEnabled("fault.http.abort.abort_percent",
                                                    config_->abortPercent())) {
     abortWithHTTPStatus();
-    config_->stats().aborts_injected_.inc();
     return FilterHeadersStatus::StopIteration;
   }
 
@@ -125,7 +124,6 @@ void FaultFilter::postDelayInjection() {
   if (config_->runtime().snapshot().featureEnabled("fault.http.abort.abort_percent",
                                                    config_->abortPercent())) {
     abortWithHTTPStatus();
-    config_->stats().aborts_injected_.inc();
   } else {
     // Continue request processing
     callbacks_->continueDecoding();
@@ -138,6 +136,7 @@ void FaultFilter::abortWithHTTPStatus() {
       {Headers::get().Status, std::to_string(config_->runtime().snapshot().getInteger(
                                   "fault.http.abort.http_status", config_->abortCode()))}}};
   callbacks_->encodeHeaders(std::move(response_headers), true);
+  config_->stats().aborts_injected_.inc();
 }
 
 void FaultFilter::resetTimerState() {

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -73,6 +73,9 @@ void FaultFilter::postDelayInjection() {
         {Headers::get().Status, std::to_string(enumToInt(config_->abort_code_))}}};
     config_->stats_.aborts_injected_.inc();
     callbacks_->encodeHeaders(std::move(response_headers), true);
+  } else {
+    // Continue request processing
+    callbacks_->continueDecoding();
   }
 }
 

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -1,11 +1,9 @@
-#include <chrono>
-#include <random>
-
 #include "fault_filter.h"
 
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
@@ -16,7 +14,7 @@
 #include "common/http/headers.h"
 
 namespace Http {
-FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config), generator_(rd_()) {}
+FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config) {}
 
 FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 
@@ -33,15 +31,15 @@ FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
     return FilterHeadersStatus::Continue;
   }
 
-  if ((config_->delay_probability_ > 0) &&
-      (prob_dist_(generator_) <= config_->delay_probability_)) {
+  if ((config_->delay_probability_) &&
+      ((config_->random_.random() % config_->modulo_base_) <= config_->delay_probability_)) {
     // Inject delays
     delay_timer_ = callbacks_->dispatcher().createTimer([this]() -> void { postDelayInjection(); });
-    delay_timer_->enableTimer(std::chrono::milliseconds(config_->delay_duration_));
+    delay_timer_->enableTimer(config_->delay_duration_);
     config_->stats_.delays_injected_.inc();
     return FilterHeadersStatus::StopIteration;
-  } else if ((config_->abort_probability_ > 0) &&
-             (prob_dist_(generator_) <= config_->abort_probability_)) {
+  } else if ((config_->abort_probability_) &&
+             ((config_->random_.random() % config_->modulo_base_) <= config_->abort_probability_)) {
     Http::HeaderMapPtr response_headers{new HeaderMapImpl{
         {Headers::get().Status, std::to_string(enumToInt(config_->abort_code_))}}};
     callbacks_->encodeHeaders(std::move(response_headers), true);
@@ -95,8 +93,8 @@ void FaultFilter::postDelayInjection() {
 
   resetInternalState();
   // Delays can be followed by aborts
-  if ((config_->abort_probability_ > 0) &&
-      (prob_dist_(generator_) <= config_->abort_probability_)) {
+  if ((config_->abort_probability_) &&
+      ((config_->random_.random() % config_->modulo_base_) <= config_->abort_probability_)) {
     Http::HeaderMapPtr response_headers{new HeaderMapImpl{
         {Headers::get().Status, std::to_string(enumToInt(config_->abort_code_))}}};
     config_->stats_.aborts_injected_.inc();

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -1,0 +1,85 @@
+#include <chrono>
+#include <random>
+
+#include "fault_filter.h"
+
+#include "envoy/event/timer.h"
+#include "envoy/http/codes.h"
+#include "envoy/stats/stats.h"
+
+#include "common/common/assert.h"
+#include "common/common/enum_to_int.h"
+#include "common/http/codes.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/headers.h"
+
+namespace Http {
+FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config), generator_(rd_()) {}
+
+FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
+
+// TODO: Need to inject faults based on header matches
+FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap&, bool) {
+  /**
+   * Delays and aborts are independent events. One can inject a delay
+   * followed by an abort or inject just a delay or abort In this callback,
+   * if we inject a delay, then we will inject the abort when the delay
+   * timer is fired.
+   */
+
+  if ((config_->delay_probability_ > 0) &&
+      (prob_dist_(generator_) <= config_->delay_probability_)) {
+    // Inject delays
+    delay_timer_ = callbacks_->dispatcher().createTimer([this]() -> void { postDelayInjection(); });
+    delay_timer_->enableTimer(std::chrono::milliseconds(config_->delay_duration_));
+    config_->stats_.delays_injected_.inc();
+    return FilterHeadersStatus::StopIteration;
+  } else if ((config_->abort_probability_ > 0) &&
+             (prob_dist_(generator_) <= config_->abort_probability_)) {
+    Http::HeaderMapPtr response_headers{new HeaderMapImpl{
+        {Headers::get().Status, std::to_string(enumToInt(config_->abort_code_))}}};
+    callbacks_->encodeHeaders(std::move(response_headers), true);
+    config_->stats_.aborts_injected_.inc();
+    return FilterHeadersStatus::StopIteration;
+  }
+
+  return FilterHeadersStatus::Continue;
+}
+
+FilterDataStatus FaultFilter::decodeData(Buffer::Instance&, bool end_stream) {
+  if (end_stream) {
+    resetInternalState();
+  }
+  return FilterDataStatus::Continue;
+}
+
+FilterTrailersStatus FaultFilter::decodeTrailers(HeaderMap&) {
+  resetInternalState();
+  return FilterTrailersStatus::Continue;
+}
+
+FaultFilterStats FaultFilter::generateStats(const std::string& prefix, Stats::Store& store) {
+  std::string final_prefix = prefix + "fault.";
+  return {ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(store, final_prefix))};
+}
+
+void FaultFilter::onResetStream() { resetInternalState(); }
+
+void FaultFilter::postDelayInjection() {
+  // Delays can be followed by aborts
+  if ((config_->abort_probability_ > 0) &&
+      (prob_dist_(generator_) <= config_->abort_probability_)) {
+    Http::HeaderMapPtr response_headers{new HeaderMapImpl{
+        {Headers::get().Status, std::to_string(enumToInt(config_->abort_code_))}}};
+    config_->stats_.aborts_injected_.inc();
+    callbacks_->encodeHeaders(std::move(response_headers), true);
+  }
+}
+
+void FaultFilter::resetInternalState() { delay_timer_.reset(); }
+
+void FaultFilter::setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) {
+  callbacks_ = &callbacks;
+  callbacks_->addResetStreamCallback([this]() -> void { onResetStream(); });
+}
+} // Http

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -3,16 +3,72 @@
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
-#include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
+#include "common/common/empty_string.h"
 #include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
-#include "common/router/config_impl.h"
 
 namespace Http {
+
+FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::Loader& runtime,
+                                     const std::string& stat_prefix, Stats::Store& stats)
+    : runtime_(runtime), stats_{ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))} {
+
+  abort_percent_ = 0UL;
+  http_status_ = 0UL;
+  fixed_delay_percent_ = 0UL;
+  fixed_duration_ms_ = 0UL;
+
+  if (json_config.hasObject("abort")) {
+    const Json::Object& abort = json_config.getObject("abort");
+    abort_percent_ = static_cast<uint64_t>(abort.getInteger("abort_percent", 0));
+
+    if (abort_percent_ > 0) {
+      if (abort_percent_ > 100) {
+        throw EnvoyException("abort percentage cannot be greater than 100");
+      }
+    }
+
+    // TODO: Throw error if invalid return code is provided
+    if (abort.hasObject("http_status")) {
+      http_status_ = static_cast<uint64_t>(abort.getInteger("http_status"));
+    } else {
+      throw EnvoyException("missing http_status in abort config");
+    }
+  }
+
+  if (json_config.hasObject("delay")) {
+    const Json::Object& delay = json_config.getObject("delay");
+    const std::string type = delay.getString("type", "empty");
+    if (type == "fixed") {
+      fixed_delay_percent_ = static_cast<uint64_t>(delay.getInteger("fixed_delay_percent", 0));
+      fixed_duration_ms_ = static_cast<uint64_t>(delay.getInteger("fixed_duration_ms", 0));
+
+      if (fixed_delay_percent_ > 0) {
+        if (fixed_delay_percent_ > 100) {
+          throw EnvoyException("delay percentage cannot be greater than 100");
+        }
+      }
+      if (0 == fixed_duration_ms_) {
+        throw EnvoyException("delay duration must be greater than 0");
+      }
+    } else {
+      throw EnvoyException("delay type is either empty or invalid");
+    }
+  }
+
+  if (json_config.hasObject("headers")) {
+    std::vector<Json::Object> config_headers = json_config.getObjectArray("headers");
+    for (const Json::Object& header_map : config_headers) {
+      // allow header value to be empty, allows matching to be only based on header presence.
+      fault_filter_headers_.emplace_back(Http::LowerCaseString(header_map.getString("name")),
+                                         header_map.getString("value", EMPTY_STRING));
+    }
+  }
+}
 
 FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config) {}
 
@@ -24,39 +80,44 @@ FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 // callback.
 FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
   // Check for header matches first
-  if (!Router::ConfigUtility::matchHeaders(headers, config_->fault_filter_headers_)) {
+  if (!Router::ConfigUtility::matchHeaders(headers, config_->filterHeaders())) {
     return FilterHeadersStatus::Continue;
   }
 
-  if (config_->runtime_.snapshot().featureEnabled("fault.http.delay_enabled",
-                                                  config_->delay_enabled_)) {
-    delay_timer_ = callbacks_->dispatcher().createTimer([this]() -> void { postDelayInjection(); });
-    delay_timer_->enableTimer(std::chrono::milliseconds(config_->runtime_.snapshot().getInteger(
-        "fault.http.delay_duration", config_->delay_duration_)));
-    config_->stats_.delays_injected_.inc();
-    return FilterHeadersStatus::StopIteration;
-  } else if (config_->runtime_.snapshot().featureEnabled("fault.http.abort_enabled",
-                                                         config_->abort_enabled_)) {
+  if (config_->runtime().snapshot().featureEnabled("fault.http.delay.fixed_delay_percent",
+                                                   config_->delayPercent())) {
+    uint64_t duration_ms = config_->runtime().snapshot().getInteger(
+        "fault.http.delay.fixed_duration_ms", config_->delayDuration());
+
+    // Delay only if the duration is >0ms
+    if (0 != duration_ms) {
+      delay_timer_ =
+          callbacks_->dispatcher().createTimer([this]() -> void { postDelayInjection(); });
+      delay_timer_->enableTimer(std::chrono::milliseconds(duration_ms));
+      config_->stats().delays_injected_.inc();
+      return FilterHeadersStatus::StopIteration;
+    }
+  }
+
+  if (config_->runtime().snapshot().featureEnabled("fault.http.abort.abort_percent",
+                                                   config_->abortPercent())) {
+    // todo check http status codes obtained from runtime
     Http::HeaderMapPtr response_headers{new HeaderMapImpl{
-        {Headers::get().Status, std::to_string(config_->runtime_.snapshot().getInteger(
-                                    "fault.http.abort_code", config_->abort_code_))}}};
+        {Headers::get().Status, std::to_string(config_->runtime().snapshot().getInteger(
+                                    "fault.http.abort.http_status", config_->abortCode()))}}};
     callbacks_->encodeHeaders(std::move(response_headers), true);
-    config_->stats_.aborts_injected_.inc();
+    config_->stats().aborts_injected_.inc();
     return FilterHeadersStatus::StopIteration;
   }
 
   return FilterHeadersStatus::Continue;
 }
 
-FilterDataStatus FaultFilter::decodeData(Buffer::Instance&, bool end_stream) {
-  if (end_stream) {
-    resetInternalState();
-  }
+FilterDataStatus FaultFilter::decodeData(Buffer::Instance&, bool) {
   return FilterDataStatus::Continue;
 }
 
 FilterTrailersStatus FaultFilter::decodeTrailers(HeaderMap&) {
-  resetInternalState();
   return FilterTrailersStatus::Continue;
 }
 
@@ -65,18 +126,17 @@ FaultFilterStats FaultFilter::generateStats(const std::string& prefix, Stats::St
   return {ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(store, final_prefix))};
 }
 
-void FaultFilter::onResetStream() { resetInternalState(); }
+void FaultFilter::onResetStream() { resetTimerState(); }
 
 void FaultFilter::postDelayInjection() {
-
-  resetInternalState();
+  resetTimerState();
   // Delays can be followed by aborts
-  if (config_->runtime_.snapshot().featureEnabled("fault.http.abort_enabled",
-                                                  config_->abort_enabled_)) {
+  if (config_->runtime().snapshot().featureEnabled("fault.http.abort.abort_percent",
+                                                   config_->abortPercent())) {
     Http::HeaderMapPtr response_headers{new HeaderMapImpl{
-        {Headers::get().Status, std::to_string(config_->runtime_.snapshot().getInteger(
-                                    "fault.http.abort_code", config_->abort_code_))}}};
-    config_->stats_.aborts_injected_.inc();
+        {Headers::get().Status, std::to_string(config_->runtime().snapshot().getInteger(
+                                    "fault.http.abort.http_status", config_->abortCode()))}}};
+    config_->stats().aborts_injected_.inc();
     callbacks_->encodeHeaders(std::move(response_headers), true);
   } else {
     // Continue request processing
@@ -84,7 +144,7 @@ void FaultFilter::postDelayInjection() {
   }
 }
 
-void FaultFilter::resetInternalState() {
+void FaultFilter::resetTimerState() {
   if (delay_timer_) {
     delay_timer_->disableTimer();
     delay_timer_.reset();

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -20,7 +20,6 @@ FaultFilter::FaultFilter(FaultFilterConfigPtr config) : config_(config), generat
 
 FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 
-// TODO: Need to inject faults based on header matches
 FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
   /**
    * Delays and aborts are independent events. One can inject a delay

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -24,6 +24,17 @@ struct FaultFilterStats {
 };
 
 /**
+ * HTTP request headers.
+ */
+struct FaultFilterHeaders {
+  FaultFilterHeaders(const Http::LowerCaseString& name, const std::string& value)
+      : name_(name), value_(value) {}
+
+  const Http::LowerCaseString name_;
+  const std::string value_;
+};
+
+/**
  * Configuration for the fault filter.
  */
 struct FaultFilterConfig {
@@ -32,6 +43,7 @@ struct FaultFilterConfig {
   uint32_t delay_probability_; // 0-100
   uint32_t abort_code_;        // HTTP or gRPC return codes
   uint32_t abort_probability_; // 0-100
+  std::vector<FaultFilterHeaders> fault_filter_headers_;
 };
 
 typedef std::shared_ptr<const FaultFilterConfig> FaultFilterConfigPtr;
@@ -55,6 +67,7 @@ private:
   void onResetStream();
   void resetInternalState();
   void postDelayInjection();
+  bool matches(const Http::HeaderMap& headers) const;
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};
@@ -64,5 +77,4 @@ private:
   std::uniform_int_distribution<uint32_t> prob_dist_{
       std::uniform_int_distribution<uint32_t>(1, 100)};
 };
-
 } // Http

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -38,8 +38,8 @@ struct FaultFilterHeaders {
  */
 struct FaultFilterConfig {
   FaultFilterConfig(const std::string& stat_prefix, Stats::Store& stats,
-                    Runtime::RandomGenerator& random, uint32_t abort_code,
-                    uint32_t abort_probability, uint32_t delay_probability,
+                    Runtime::RandomGenerator& random, uint64_t abort_code,
+                    uint64_t abort_probability, uint64_t delay_probability,
                     std::chrono::milliseconds delay_duration,
                     std::vector<FaultFilterHeaders> fault_filter_headers)
       : random_(random), modulo_base_(100), abort_code_(abort_code),
@@ -48,11 +48,11 @@ struct FaultFilterConfig {
         stats_{ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))} {}
 
   Runtime::RandomGenerator& random_;
-  uint32_t modulo_base_; // % of traffic to inject faults on, in increments of 1%. Hardcoded to 100,
+  uint64_t modulo_base_; // % of traffic to inject faults on, in increments of 1%. Hardcoded to 100,
                          // until we need higher precision.
-  uint32_t abort_code_;  // HTTP or gRPC return codes
-  uint32_t abort_probability_;               // 0-100
-  uint32_t delay_probability_;               // 0-100
+  uint64_t abort_code_;  // HTTP or gRPC return codes
+  uint64_t abort_probability_;               // 0-100
+  uint64_t delay_probability_;               // 0-100
   std::chrono::milliseconds delay_duration_; // in milliseconds
   std::vector<FaultFilterHeaders> fault_filter_headers_;
   FaultFilterStats stats_;

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -38,21 +38,20 @@ struct FaultFilterHeaders {
  */
 struct FaultFilterConfig {
   FaultFilterConfig(const std::string& stat_prefix, Stats::Store& stats,
-                    Runtime::RandomGenerator& random, uint64_t abort_code,
-                    uint64_t abort_probability, uint64_t delay_probability,
-                    std::chrono::milliseconds delay_duration,
+                    Runtime::RandomGenerator& random, uint64_t abort_code, uint64_t abort_enabled,
+                    uint64_t delay_enabled, std::chrono::milliseconds delay_duration,
                     std::vector<FaultFilterHeaders> fault_filter_headers)
-      : random_(random), modulo_base_(100), abort_code_(abort_code),
-        abort_probability_(abort_probability), delay_probability_(delay_probability),
-        delay_duration_(delay_duration), fault_filter_headers_(fault_filter_headers),
+      : random_(random), modulo_base_(100), abort_code_(abort_code), abort_enabled_(abort_enabled),
+        delay_enabled_(delay_enabled), delay_duration_(delay_duration),
+        fault_filter_headers_(fault_filter_headers),
         stats_{ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))} {}
 
   Runtime::RandomGenerator& random_;
   uint64_t modulo_base_; // % of traffic to inject faults on, in increments of 1%. Hardcoded to 100,
                          // until we need higher precision.
   uint64_t abort_code_;  // HTTP or gRPC return codes
-  uint64_t abort_probability_;               // 0-100
-  uint64_t delay_probability_;               // 0-100
+  uint64_t abort_enabled_;                   // 0-100
+  uint64_t delay_enabled_;                   // 0-100
   std::chrono::milliseconds delay_duration_; // in milliseconds
   std::vector<FaultFilterHeaders> fault_filter_headers_;
   FaultFilterStats stats_;

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -4,6 +4,8 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"
 
+#include "common/router/config_impl.h"
+
 namespace Http {
 
 /**
@@ -23,22 +25,12 @@ struct FaultFilterStats {
 };
 
 /**
- * HTTP request headers.
- */
-struct FaultFilterHeaders {
-  FaultFilterHeaders(const Http::LowerCaseString& name, const std::string& value)
-      : name_(name), value_(value) {}
-
-  const Http::LowerCaseString name_;
-  const std::string value_;
-};
-
-/**
  * Configuration for the fault filter.
  */
 struct FaultFilterConfig {
   FaultFilterConfig(uint64_t abort_enabled, uint64_t abort_code, uint64_t delay_enabled,
-                    uint64_t delay_duration, std::vector<FaultFilterHeaders> fault_filter_headers,
+                    uint64_t delay_duration,
+                    const std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers,
                     Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Store& stats)
       : abort_enabled_(abort_enabled), abort_code_(abort_code), delay_enabled_(delay_enabled),
         delay_duration_(delay_duration), fault_filter_headers_(fault_filter_headers),
@@ -49,7 +41,7 @@ struct FaultFilterConfig {
   uint64_t abort_code_;     // HTTP or gRPC return codes
   uint64_t delay_enabled_;  // 0-100
   uint64_t delay_duration_; // in milliseconds
-  std::vector<FaultFilterHeaders> fault_filter_headers_;
+  const std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers_;
   Runtime::Loader& runtime_;
   FaultFilterStats stats_;
 };
@@ -75,10 +67,10 @@ private:
   void onResetStream();
   void resetInternalState();
   void postDelayInjection();
-  bool matches(const Http::HeaderMap& headers) const;
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};
   Event::TimerPtr delay_timer_;
 };
+
 } // Http

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+#include "envoy/stats/stats_macros.h"
+
+#include <random>
+
+namespace Http {
+
+/**
+ * All stats for the fault filter. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_FAULT_FILTER_STATS(COUNTER)                                                           \
+  COUNTER(delays_injected)                                                                         \
+  COUNTER(aborts_injected)
+// clang-format on
+
+/**
+ * Wrapper struct for connection manager stats. @see stats_macros.h
+ */
+struct FaultFilterStats {
+  ALL_FAULT_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * Configuration for the fault filter.
+ */
+struct FaultFilterConfig {
+  FaultFilterStats stats_;
+  uint32_t delay_duration_;    // in milliseconds
+  uint32_t delay_probability_; // 0-100
+  uint32_t abort_code_;        // HTTP or gRPC return codes
+  uint32_t abort_probability_; // 0-100
+};
+
+typedef std::shared_ptr<const FaultFilterConfig> FaultFilterConfigPtr;
+
+/**
+ * A filter that is capable of faulting an entire request before dispatching it upstream.
+ */
+class FaultFilter : public StreamDecoderFilter {
+public:
+  FaultFilter(FaultFilterConfigPtr config);
+  ~FaultFilter();
+
+  static FaultFilterStats generateStats(const std::string& prefix, Stats::Store& store);
+
+  FilterHeadersStatus decodeHeaders(HeaderMap& headers, bool end_stream) override;
+  FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
+  FilterTrailersStatus decodeTrailers(HeaderMap& trailers) override;
+  void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) override;
+
+private:
+  void onResetStream();
+  void resetInternalState();
+  void postDelayInjection();
+
+  FaultFilterConfigPtr config_;
+  StreamDecoderFilterCallbacks* callbacks_{};
+  Event::TimerPtr delay_timer_;
+  std::random_device rd_;
+  std::mt19937 generator_;
+  std::uniform_int_distribution<uint32_t> prob_dist_{
+      std::uniform_int_distribution<uint32_t>(1, 100)};
+};
+
+} // Http

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -37,23 +37,20 @@ struct FaultFilterHeaders {
  * Configuration for the fault filter.
  */
 struct FaultFilterConfig {
-  FaultFilterConfig(const std::string& stat_prefix, Stats::Store& stats,
-                    Runtime::RandomGenerator& random, uint64_t abort_code, uint64_t abort_enabled,
-                    uint64_t delay_enabled, std::chrono::milliseconds delay_duration,
-                    std::vector<FaultFilterHeaders> fault_filter_headers)
-      : random_(random), modulo_base_(100), abort_code_(abort_code), abort_enabled_(abort_enabled),
-        delay_enabled_(delay_enabled), delay_duration_(delay_duration),
-        fault_filter_headers_(fault_filter_headers),
-        stats_{ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))} {}
+  FaultFilterConfig(uint64_t abort_enabled, uint64_t abort_code, uint64_t delay_enabled,
+                    uint64_t delay_duration, std::vector<FaultFilterHeaders> fault_filter_headers,
+                    Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Store& stats)
+      : abort_enabled_(abort_enabled), abort_code_(abort_code), delay_enabled_(delay_enabled),
+        delay_duration_(delay_duration), fault_filter_headers_(fault_filter_headers),
+        runtime_(runtime), stats_{ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))} {
+  }
 
-  Runtime::RandomGenerator& random_;
-  uint64_t modulo_base_; // % of traffic to inject faults on, in increments of 1%. Hardcoded to 100,
-                         // until we need higher precision.
-  uint64_t abort_code_;  // HTTP or gRPC return codes
-  uint64_t abort_enabled_;                   // 0-100
-  uint64_t delay_enabled_;                   // 0-100
-  std::chrono::milliseconds delay_duration_; // in milliseconds
+  uint64_t abort_enabled_;  // 0-100
+  uint64_t abort_code_;     // HTTP or gRPC return codes
+  uint64_t delay_enabled_;  // 0-100
+  uint64_t delay_duration_; // in milliseconds
   std::vector<FaultFilterHeaders> fault_filter_headers_;
+  Runtime::Loader& runtime_;
   FaultFilterStats stats_;
 };
 

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -44,10 +44,10 @@ public:
   FaultFilterStats& stats() { return stats_; }
 
 private:
-  uint64_t abort_percent_;       // 0-100
-  uint64_t http_status_;         // HTTP or gRPC return codes
-  uint64_t fixed_delay_percent_; // 0-100
-  uint64_t fixed_duration_ms_;   // in milliseconds
+  uint64_t abort_percent_{};       // 0-100
+  uint64_t http_status_{};         // HTTP or gRPC return codes
+  uint64_t fixed_delay_percent_{}; // 0-100
+  uint64_t fixed_duration_ms_{};   // in milliseconds
   std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers_;
   Runtime::Loader& runtime_;
   FaultFilterStats stats_;
@@ -74,6 +74,7 @@ private:
   void onResetStream();
   void resetTimerState();
   void postDelayInjection();
+  void abortWithHTTPStatus();
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};

--- a/source/precompiled/precompiled.h
+++ b/source/precompiled/precompiled.h
@@ -17,7 +17,6 @@
 #include <sys/signalfd.h>
 #include <unistd.h>
 #include <unordered_set>
-#include <random>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/source/precompiled/precompiled.h
+++ b/source/precompiled/precompiled.h
@@ -17,6 +17,7 @@
 #include <sys/signalfd.h>
 #include <unistd.h>
 #include <unordered_set>
+#include <random>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(envoy-server OBJECT
   config/http/buffer.cc
   config/http/dynamo.cc
+  config/http/fault.cc
   config/http/grpc_http1_bridge.cc
   config/http/ratelimit.cc
   config/http/router.cc

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -1,7 +1,5 @@
-#include "envoy/http/header_map.h"
 #include "envoy/server/instance.h"
 
-#include "common/common/empty_string.h"
 #include "common/http/filter/fault_filter.h"
 #include "common/router/config_impl.h"
 #include "server/config/network/http_connection_manager.h"
@@ -22,40 +20,8 @@ public:
       return nullptr;
     }
 
-    // TODO: Throw error if invalid return code is provided
-    uint64_t delay_duration = static_cast<uint64_t>(json_config.getInteger("delay_duration", 0));
-    uint64_t delay_enabled = static_cast<uint64_t>(json_config.getInteger("delay_enabled", 0));
-    uint64_t abort_code = static_cast<uint64_t>(json_config.getInteger("abort_code", 0));
-    uint64_t abort_enabled = static_cast<uint64_t>(json_config.getInteger("abort_enabled", 0));
-
-    if (delay_enabled > 0) {
-      if (delay_enabled > 100) {
-        throw EnvoyException("delay_enabled cannot be greater than 100");
-      }
-      if (0 == delay_duration) {
-        throw EnvoyException("delay duration cannot be 0 when delay_enabled is greater than 1");
-      }
-    }
-
-    if (abort_enabled > 0) {
-      if (abort_enabled > 100) {
-        throw EnvoyException("abort_enabled cannot be greater than 100");
-      }
-    }
-
-    std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers;
-    if (json_config.hasObject("headers")) {
-      std::vector<Json::Object> config_headers = json_config.getObjectArray("headers");
-      for (const Json::Object& header_map : config_headers) {
-        // allow header value to be empty, allows matching to be only based on header presence.
-        fault_filter_headers.emplace_back(Http::LowerCaseString(header_map.getString("name")),
-                                          header_map.getString("value", EMPTY_STRING));
-      }
-    }
-
-    Http::FaultFilterConfigPtr config(new Http::FaultFilterConfig(
-        abort_enabled, abort_code, delay_enabled, delay_duration, fault_filter_headers,
-        server.runtime(), stats_prefix, server.stats()));
+    Http::FaultFilterConfigPtr config(
+        new Http::FaultFilterConfig(json_config, server.runtime(), stats_prefix, server.stats()));
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
     };

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -26,23 +26,21 @@ public:
      */
     std::chrono::milliseconds delay_duration =
         std::chrono::milliseconds(json_config.getInteger("delay_duration", 0));
-    uint64_t delay_probability =
-        static_cast<uint64_t>(json_config.getInteger("delay_probability", 0));
+    uint64_t delay_enabled = static_cast<uint64_t>(json_config.getInteger("delay_enabled", 0));
     uint64_t abort_code = static_cast<uint64_t>(json_config.getInteger("abort_code", 0));
-    uint64_t abort_probability =
-        static_cast<uint64_t>(json_config.getInteger("abort_probability", 0));
-    if (delay_probability > 0) {
-      if (delay_probability > 100) {
-        throw EnvoyException("delay probability cannot be greater than 100");
+    uint64_t abort_enabled = static_cast<uint64_t>(json_config.getInteger("abort_enabled", 0));
+    if (delay_enabled > 0) {
+      if (delay_enabled > 100) {
+        throw EnvoyException("delay_enabled cannot be greater than 100");
       }
       if (std::chrono::milliseconds(0) == delay_duration) {
-        throw EnvoyException("delay duration cannot be 0 when delay probability is greater than 1");
+        throw EnvoyException("delay duration cannot be 0 when delay enabled is greater than 1");
       }
     }
 
-    if (abort_probability > 0) {
-      if (abort_probability > 100) {
-        throw EnvoyException("abort probability cannot be greater than 100");
+    if (abort_enabled > 0) {
+      if (abort_enabled > 100) {
+        throw EnvoyException("abort enabled cannot be greater than 100");
       }
     }
 
@@ -57,8 +55,8 @@ public:
     }
 
     Http::FaultFilterConfigPtr config(new Http::FaultFilterConfig(
-        stats_prefix, server.stats(), server.random(), abort_code, abort_probability,
-        delay_probability, delay_duration, fault_filter_headers));
+        stats_prefix, server.stats(), server.random(), abort_code, abort_enabled, delay_enabled,
+        delay_duration, fault_filter_headers));
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
     };

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -1,0 +1,61 @@
+#include "envoy/server/instance.h"
+
+#include "common/http/filter/fault_filter.h"
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the fault injection filter. @see HttpFilterConfigFactory.
+ */
+class FaultFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object& json_config,
+                                             const std::string& stats_prefix,
+                                             Server::Instance& server) override {
+    if (type != HttpFilterType::Decoder || name != "fault") {
+      return nullptr;
+    }
+
+    /**
+     * TODO: Throw error if invalid return code is provided
+     */
+    uint32_t delay_duration = static_cast<uint32_t>(json_config.getInteger("delay_duration", 0));
+    uint32_t delay_probability =
+        static_cast<uint32_t>(json_config.getInteger("delay_probability", 0));
+    uint32_t abort_code = static_cast<uint32_t>(json_config.getInteger("abort_code", 0));
+    uint32_t abort_probability =
+        static_cast<uint32_t>(json_config.getInteger("abort_probability", 0));
+    if (delay_probability > 0) {
+      if (delay_probability > 100) {
+        throw EnvoyException("delay probability cannot be greater than 100");
+      }
+      if (0 == delay_duration) {
+        throw EnvoyException("delay duration cannot be 0 when delay probability is greater than 1");
+      }
+    }
+
+    if (abort_probability > 0) {
+      if (abort_probability > 100) {
+        throw EnvoyException("abort probability cannot be greater than 100");
+      }
+    }
+
+    Http::FaultFilterConfigPtr config(new Http::FaultFilterConfig{
+        Http::FaultFilter::generateStats(stats_prefix, server.stats()), delay_duration,
+        delay_probability, abort_code, abort_probability});
+    return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
+    };
+  }
+};
+
+/**
+ * Static registration for the fault filter. @see RegisterHttpFilterConfigFactory.
+ */
+static RegisterHttpFilterConfigFactory<FaultFilterConfig> register_;
+
+} // Configuration
+} // Server

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -26,11 +26,11 @@ public:
      */
     std::chrono::milliseconds delay_duration =
         std::chrono::milliseconds(json_config.getInteger("delay_duration", 0));
-    uint32_t delay_probability =
-        static_cast<uint32_t>(json_config.getInteger("delay_probability", 0));
-    uint32_t abort_code = static_cast<uint32_t>(json_config.getInteger("abort_code", 0));
-    uint32_t abort_probability =
-        static_cast<uint32_t>(json_config.getInteger("abort_probability", 0));
+    uint64_t delay_probability =
+        static_cast<uint64_t>(json_config.getInteger("delay_probability", 0));
+    uint64_t abort_code = static_cast<uint64_t>(json_config.getInteger("abort_code", 0));
+    uint64_t abort_probability =
+        static_cast<uint64_t>(json_config.getInteger("abort_probability", 0));
     if (delay_probability > 0) {
       if (delay_probability > 100) {
         throw EnvoyException("delay probability cannot be greater than 100");

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -24,8 +24,7 @@ public:
     /**
      * TODO: Throw error if invalid return code is provided
      */
-    std::chrono::milliseconds delay_duration =
-        std::chrono::milliseconds(json_config.getInteger("delay_duration", 0));
+    uint64_t delay_duration = static_cast<uint64_t>(json_config.getInteger("delay_duration", 0));
     uint64_t delay_enabled = static_cast<uint64_t>(json_config.getInteger("delay_enabled", 0));
     uint64_t abort_code = static_cast<uint64_t>(json_config.getInteger("abort_code", 0));
     uint64_t abort_enabled = static_cast<uint64_t>(json_config.getInteger("abort_enabled", 0));
@@ -33,14 +32,14 @@ public:
       if (delay_enabled > 100) {
         throw EnvoyException("delay_enabled cannot be greater than 100");
       }
-      if (std::chrono::milliseconds(0) == delay_duration) {
-        throw EnvoyException("delay duration cannot be 0 when delay enabled is greater than 1");
+      if (0 == delay_duration) {
+        throw EnvoyException("delay duration cannot be 0 when delay_enabled is greater than 1");
       }
     }
 
     if (abort_enabled > 0) {
       if (abort_enabled > 100) {
-        throw EnvoyException("abort enabled cannot be greater than 100");
+        throw EnvoyException("abort_enabled cannot be greater than 100");
       }
     }
 
@@ -55,8 +54,8 @@ public:
     }
 
     Http::FaultFilterConfigPtr config(new Http::FaultFilterConfig(
-        stats_prefix, server.stats(), server.random(), abort_code, abort_enabled, delay_enabled,
-        delay_duration, fault_filter_headers));
+        abort_enabled, abort_code, delay_enabled, delay_duration, fault_filter_headers,
+        server.runtime(), stats_prefix, server.stats()));
     return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
     };

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -3,6 +3,7 @@
 
 #include "common/common/empty_string.h"
 #include "common/http/filter/fault_filter.h"
+#include "common/router/config_impl.h"
 #include "server/config/network/http_connection_manager.h"
 
 namespace Server {
@@ -21,13 +22,12 @@ public:
       return nullptr;
     }
 
-    /**
-     * TODO: Throw error if invalid return code is provided
-     */
+    // TODO: Throw error if invalid return code is provided
     uint64_t delay_duration = static_cast<uint64_t>(json_config.getInteger("delay_duration", 0));
     uint64_t delay_enabled = static_cast<uint64_t>(json_config.getInteger("delay_enabled", 0));
     uint64_t abort_code = static_cast<uint64_t>(json_config.getInteger("abort_code", 0));
     uint64_t abort_enabled = static_cast<uint64_t>(json_config.getInteger("abort_enabled", 0));
+
     if (delay_enabled > 0) {
       if (delay_enabled > 100) {
         throw EnvoyException("delay_enabled cannot be greater than 100");
@@ -43,7 +43,7 @@ public:
       }
     }
 
-    std::vector<Http::FaultFilterHeaders> fault_filter_headers;
+    std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers;
     if (json_config.hasObject("headers")) {
       std::vector<Json::Object> config_headers = json_config.getObjectArray("headers");
       for (const Json::Object& header_map : config_headers) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(envoy-test
   common/http/conn_manager_utility_test.cc
   common/http/date_provider_impl_test.cc
   common/http/filter/buffer_filter_test.cc
+  common/http/filter/fault_filter_test.cc
   common/http/filter/ratelimit_test.cc
   common/http/header_map_impl_test.cc
   common/http/http1/codec_impl_test.cc

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -1,0 +1,392 @@
+#include "envoy/event/dispatcher.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/empty_string.h"
+#include "common/http/filter/fault_filter.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/headers.h"
+#include "common/stats/stats_impl.h"
+
+#include "test/common/http/common.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/test_common/utility.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::WithArgs;
+
+namespace Http {
+
+class FaultFilterTest : public testing::Test {
+public:
+  const std::string fixed_delay_only_json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 100,
+        "fixed_duration_ms" : 5000
+      }
+    }
+    )EOF";
+
+  const std::string abort_only_json = R"EOF(
+    {
+      "abort" : {
+        "abort_percent" : 100,
+        "http_status" : 429
+      }
+    }
+    )EOF";
+
+  const std::string fixed_delay_and_abort_json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 100,
+        "fixed_duration_ms" : 5000
+      },
+      "abort" : {
+        "abort_percent" : 100,
+        "http_status" : 503
+      }
+    }
+    )EOF";
+
+  const std::string fixed_delay_and_abort_match_headers_json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 100,
+        "fixed_duration_ms" : 5000
+      },
+      "abort" : {
+        "abort_percent" : 100,
+        "http_status" : 503
+      },
+      "headers" : [
+        {"name" : "X-Foo1", "value" : "Bar"},
+        {"name" : "X-Foo2"}
+      ]
+    }
+    )EOF";
+
+  void SetUpTest(const std::string json) {
+    Json::StringLoader config(json);
+    config_.reset(new FaultFilterConfig(config, runtime_, "", stats_));
+    filter_.reset(new FaultFilter(config_));
+    filter_->setDecoderFilterCallbacks(filter_callbacks_);
+  }
+
+  void expectDelayTimer(uint64_t duration_ms) {
+    timer_ = new Event::MockTimer(&filter_callbacks_.dispatcher_);
+    EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(duration_ms)));
+    EXPECT_CALL(*timer_, disableTimer());
+  }
+
+  FaultFilterConfigPtr config_;
+  std::unique_ptr<FaultFilter> filter_;
+  NiceMock<MockStreamDecoderFilterCallbacks> filter_callbacks_;
+  TestHeaderMapImpl request_headers_;
+  Buffer::OwnedImpl data_;
+  Stats::IsolatedStoreImpl stats_;
+  NiceMock<Runtime::MockLoader> runtime_;
+  Event::MockTimer* timer_{};
+};
+
+TEST(FaultFilterBadConfigTest, BadAbortPercent) {
+  const std::string json = R"EOF(
+    {
+      "abort" : {
+        "abort_percent" : 200,
+        "http_status" : 429
+      }
+    }
+  )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST(FaultFilterBadConfigTest, MissingHTTPStatus) {
+  const std::string json = R"EOF(
+    {
+      "abort" : {
+        "abort_percent" : 100
+      }
+    }
+  )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST(FaultFilterBadConfigTest, BadDelayType) {
+  const std::string json = R"EOF(
+    {
+      "delay" : {
+        "type" : "foo",
+        "fixed_delay_percent" : 50,
+        "fixed_duration_ms" : 5000
+      }
+    }
+  )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST(FaultFilterBadConfigTest, BadDelayPercent) {
+  const std::string json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 500,
+        "fixed_duration_ms" : 5000
+      }
+    }
+  )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST(FaultFilterBadConfigTest, BadDelayDuration) {
+  const std::string json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 50,
+        "fixed_duration_ms" : 0
+      }
+    }
+   )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
+  const std::string json = R"EOF(
+    {
+      "delay" : {
+        "type" : "fixed",
+        "fixed_delay_percent" : 50
+      }
+    }
+   )EOF";
+  Stats::IsolatedStoreImpl stats;
+  Json::StringLoader config(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(config, runtime, "", stats), EnvoyException);
+}
+
+TEST_F(FaultFilterTest, AbortWithHttpStatus) {
+  SetUpTest(abort_only_json);
+
+  // Delay related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", 0))
+      .Times(1)
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
+      .Times(1)
+      .WillOnce(Return(429));
+
+  Http::TestHeaderMapImpl response_headers{{":status", "429"}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+}
+
+TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
+  SetUpTest(fixed_delay_only_json);
+
+  // Delay related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  // Return 0ms delay
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
+      .Times(1)
+      .WillOnce(Return(0));
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 0))
+      .Times(1)
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  // Expect filter to continue execution when delay is 0ms
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
+}
+
+TEST_F(FaultFilterTest, FixedDelayNonZeroDuration) {
+  SetUpTest(fixed_delay_only_json);
+
+  // Delay related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
+      .Times(1)
+      .WillOnce(Return(5000UL));
+
+  SCOPED_TRACE("FixedDelayNonZeroDuration");
+  expectDelayTimer(5000UL);
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 0))
+      .Times(1)
+      .WillOnce(Return(false));
+
+  // Delay only case
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(1);
+  timer_->callback_();
+
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
+}
+
+TEST_F(FaultFilterTest, FixedDelayAndAbort) {
+  SetUpTest(fixed_delay_and_abort_json);
+
+  // Delay related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
+      .Times(1)
+      .WillOnce(Return(5000UL));
+
+  SCOPED_TRACE("FixedDelayAndAbort");
+  expectDelayTimer(5000UL);
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
+      .Times(1)
+      .WillOnce(Return(503));
+
+  Http::TestHeaderMapImpl response_headers{{":status", "503"}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  timer_->callback_();
+
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+}
+
+TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
+  SetUpTest(fixed_delay_and_abort_match_headers_json);
+  request_headers_.addViaCopy("x-foo1", "Bar");
+  request_headers_.addViaCopy("x-foo2", "RandomValue");
+
+  // Delay related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
+      .Times(1)
+      .WillOnce(Return(5000UL));
+
+  SCOPED_TRACE("FixedDelayAndAbortHeaderMatchSuccess");
+  expectDelayTimer(5000UL);
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 100))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
+      .Times(1)
+      .WillOnce(Return(503));
+
+  Http::TestHeaderMapImpl response_headers{{":status", "503"}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  timer_->callback_();
+
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+}
+
+TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchFail) {
+  SetUpTest(fixed_delay_and_abort_match_headers_json);
+  request_headers_.addViaCopy("x-foo1", "Bar");
+  request_headers_.addViaCopy("x-foo3", "Baz");
+
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", _))
+      .Times(0);
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", _)).Times(0);
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", _)).Times(0);
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(0);
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+
+  // Expect filter to continue execution when headers don't match
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
+}
+
+} // Http


### PR DESCRIPTION
This is a first take providing support for systematic failure injection using fault injection filters (issue #198 ). The filter supports two types of faults: `aborts` and `delays`. Several common failure scenarios  manifest at the application layer as either delayed responses to requests or failure codes from upstream clusters.

The semantics of abort vary from protocol to protocol. With HTTP, abort is expected to return a standard HTTP error code. With gRPC, abort would return one of the generic gRPC error codes. With TCP, abort would reset the tcp connection.

Similarly, the semantics of delay is different between TCP and HTTP. For HTTP, the delay is a one time delay before propagating the request upstream. For TCP, delay would be implemented as a bandwidth restriction on the TCP pipe between the downstream request and upstream cluster. [Similar principle might apply to a streaming gRPC request.]

The fault filter treats the aborts and delays as independent events and allows the user to inject either a delay or an abort or both based on a percentage of requests. This decoupling enables the user to model an overloaded service (e.g., delay response by 5s and return a HTTP 503).

This PR is a work in progress. The current PR has been tested only with HTTP (with Front proxy example, using curl client). I would like to get some feedback on the current approach. With the current code base, it is possible to inject delays and HTTP error codes, with optional ability to restrict the faults to requests containing a specific set of headers.

Some example configuration blocks (note: fault filter should be inserted before the routing filter).
`delay_enabled` and `abort_enabled` range from 1 to 100. `delay_duration` is in milliseconds. `abort_code` corresponds to HTTP or gRPC return codes (gRPC return code has not been tested).

A simple fault filter injecting a 5s delay
```json
 "filters": [
                {
                    "type" : "decoder",
                    "name" : "fault",
                    "config" : {
                        "delay_enabled" : 100,
                        "delay_duration" : 5000,
                    }
                },
                {
                "type": "decoder",
                "name": "router",
                "config": {}
              }
            ]
```

A fault filter injecting a 5s delay with 50% probability, followed by an abort (code HTTP 503) with a 50% probability

```json
 "filters": [
                {
                    "type" : "decoder",
                    "name" : "fault",
                    "config" : {
                        "delay_enabled" : 50,
                        "delay_duration" : 5000,
                        "abort_enabled" : 50,
                        "abort_code" : 503
                    }
                },
                {
                "type": "decoder",
                "name": "router",
                "config": {}
              }
            ]
```

Simple delay fault with header match
```json
 "filters": [
                {
                    "type" : "decoder",
                    "name" : "fault",
                    "config" : {
                        "delay_enabled" : 100,
                        "delay_duration" : 5000
                        "headers" : [
                            {
                               "name" : "X-Foo-Bar",
                               "value" : "Bar"
                            }
                        ]
                    }
                },
                {
                "type": "decoder",
                "name": "router",
                "config": {}
              }
            ]
```


TODO:
* test cases
* docs
