### PR TITLE
perf: cache date string used for setting date header

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   http/codes.cc
   http/conn_manager_impl.cc
   http/conn_manager_utility.cc
+  http/date_provider_impl.cc
   http/header_map_impl.cc
   http/message_impl.cc
   http/pooled_stream_encoder.cc

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -263,7 +263,6 @@ void ConnectionManagerImpl::onDrainTimeout() {
   checkForDeferredClose();
 }
 
-DateFormatter ConnectionManagerImpl::ActiveStream::date_formatter_("%a, %d %b %Y %H:%M:%S GMT");
 std::atomic<uint64_t> ConnectionManagerImpl::ActiveStream::next_stream_id_(0);
 
 ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connection_manager)
@@ -527,8 +526,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
   }
 
   // Base headers.
+  connection_manager_.config_.dateProvider().setDateHeader(headers);
   headers.insertServer().value(connection_manager_.config_.serverName());
-  headers.insertDate().value(date_formatter_.now());
   headers.insertEnvoyProtocolVersion().value(connection_manager_.codec_->protocolString());
   ConnectionManagerUtility::mutateResponseHeaders(headers, *request_headers_,
                                                   connection_manager_.config_);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "date_provider.h"
 #include "user_agent.h"
 
 #include "envoy/event/deferred_deletable.h"
@@ -15,7 +16,6 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/common/linked_object.h"
-#include "common/common/utility.h"
 #include "common/http/access_log/request_info_impl.h"
 
 namespace Http {
@@ -117,6 +117,11 @@ public:
   virtual ServerConnectionPtr createCodec(Network::Connection& connection,
                                           const Buffer::Instance& data,
                                           ServerConnectionCallbacks& callbacks) PURE;
+
+  /**
+   * @return DateProvider& the date provider to use for
+   */
+  virtual DateProvider& dateProvider() PURE;
 
   /**
    * @return the time in milliseconds the connection manager will wait betwen issuing a "shutdown
@@ -369,8 +374,6 @@ private:
 
     // Tracing::TracingContext
     virtual const std::string& operationName() const override;
-
-    static DateFormatter date_formatter_;
 
     // All state for the stream. Put here for readability. We could move this to a bit field
     // eventually if we want.

--- a/source/common/http/date_provider.h
+++ b/source/common/http/date_provider.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+#include "envoy/http/header_map.h"
+
+namespace Http {
+
+/**
+ * Fills headers with a date header.
+ */
+class DateProvider {
+public:
+  virtual ~DateProvider() {}
+
+  /**
+   * Set the Date header potentially using a cached value.
+   * @param headers supplies the headers to fill.
+   */
+  virtual void setDateHeader(HeaderMap& headers) PURE;
+};
+
+} // Http

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -1,0 +1,32 @@
+#include "date_provider_impl.h"
+
+namespace Http {
+
+DateFormatter DateProviderImplBase::date_formatter_("%a, %d %b %Y %H:%M:%S GMT");
+
+TlsCachingDateProviderImpl::TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher,
+                                                       ThreadLocal::Instance& tls)
+    : tls_(tls), tls_slot_(tls.allocateSlot()),
+      refresh_timer_(dispatcher.createTimer([this]() -> void { onRefreshDate(); })) {
+
+  onRefreshDate();
+}
+
+void TlsCachingDateProviderImpl::onRefreshDate() {
+  std::string new_date_string = date_formatter_.now();
+  tls_.set(tls_slot_, [new_date_string](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectPtr {
+    return ThreadLocal::ThreadLocalObjectPtr{new ThreadLocalCachedDate(new_date_string)};
+  });
+
+  refresh_timer_->enableTimer(std::chrono::milliseconds(500));
+}
+
+void TlsCachingDateProviderImpl::setDateHeader(HeaderMap& headers) {
+  headers.insertDate().value(tls_.getTyped<ThreadLocalCachedDate>(tls_slot_).date_string_);
+}
+
+void SlowDateProviderImpl::setDateHeader(HeaderMap& headers) {
+  headers.insertDate().value(date_formatter_.now());
+}
+
+} // Http

--- a/source/common/http/date_provider_impl.h
+++ b/source/common/http/date_provider_impl.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "date_provider.h"
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "common/common/utility.h"
+
+namespace Http {
+
+/**
+ * Base for all providers.
+ */
+class DateProviderImplBase : public DateProvider {
+protected:
+  static DateFormatter date_formatter_;
+};
+
+/**
+ * A caching thread local provider. This implementation updates the date string every 500ms and
+ * caches on each thread.
+ */
+class TlsCachingDateProviderImpl : public DateProviderImplBase {
+public:
+  TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher, ThreadLocal::Instance& tls);
+
+  // Http::DateProvider
+  void setDateHeader(HeaderMap& headers) override;
+
+private:
+  struct ThreadLocalCachedDate : public ThreadLocal::ThreadLocalObject {
+    ThreadLocalCachedDate(const std::string& date_string) : date_string_(date_string) {}
+
+    // ThreadLocal::ThreadLocalObject
+    void shutdown() override {}
+
+    const std::string date_string_;
+  };
+
+  void onRefreshDate();
+
+  ThreadLocal::Instance& tls_;
+  uint32_t tls_slot_;
+  Event::TimerPtr refresh_timer_;
+};
+
+/**
+ * A basic provider that just creates the date string every time.
+ */
+class SlowDateProviderImpl : public DateProviderImplBase {
+public:
+  // Http::DateProvider
+  void setDateHeader(HeaderMap& headers) override;
+};
+
+} // Http

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -76,7 +76,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
       route_config_(new Router::ConfigImpl(config.getObject("route_config"), server.runtime(),
                                            server.clusterManager())),
       drain_timeout_(config.getInteger("drain_timeout_ms", 5000)),
-      generate_request_id_(config.getBoolean("generate_request_id", true)) {
+      generate_request_id_(config.getBoolean("generate_request_id", true)),
+      date_provider_(server.dispatcher(), server.threadLocal()) {
 
   if (config.hasObject("use_remote_address")) {
     use_remote_address_ = config.getBoolean("use_remote_address");

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -5,6 +5,7 @@
 
 #include "common/common/logger.h"
 #include "common/http/conn_manager_impl.h"
+#include "common/http/date_provider_impl.h"
 #include "common/json/json_loader.h"
 
 namespace Server {
@@ -62,6 +63,7 @@ public:
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
+  Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }
   bool generateRequestId() override { return generate_request_id_; }
@@ -107,6 +109,7 @@ private:
   Router::ConfigPtr route_config_;
   std::chrono::milliseconds drain_timeout_;
   bool generate_request_id_;
+  Http::TlsCachingDateProviderImpl date_provider_;
 };
 
 /**

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -7,6 +7,7 @@
 
 #include "common/common/logger.h"
 #include "common/http/conn_manager_impl.h"
+#include "common/http/date_provider_impl.h"
 #include "common/http/utility.h"
 #include "server/config/network/http_connection_manager.h"
 
@@ -43,6 +44,7 @@ public:
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
                                         Http::ServerConnectionCallbacks& callbacks) override;
+  Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }
   bool generateRequestId() override { return false; }
@@ -102,6 +104,7 @@ private:
   Optional<std::chrono::milliseconds> idle_timeout_;
   Optional<std::string> user_agent_;
   Optional<Http::TracingConnectionManagerConfig> tracing_config_;
+  Http::SlowDateProviderImpl date_provider_;
 };
 
 /**

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -12,6 +12,7 @@
 
 #include "common/access_log/access_log_manager.h"
 #include "common/api/api_impl.h"
+#include "common/common/utility.h"
 #include "common/common/version.h"
 #include "common/memory/stats.h"
 #include "common/network/utility.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(envoy-test
   common/http/common.cc
   common/http/conn_manager_impl_test.cc
   common/http/conn_manager_utility_test.cc
+  common/http/date_provider_impl_test.cc
   common/http/filter/buffer_filter_test.cc
   common/http/filter/ratelimit_test.cc
   common/http/header_map_impl_test.cc

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -1,3 +1,4 @@
+#include "common/common/utility.h"
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/http/header_map_impl.h"
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -7,6 +7,7 @@
 #include "common/http/access_log/access_log_impl.h"
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/http/conn_manager_impl.h"
+#include "common/http/date_provider_impl.h"
 #include "common/http/exception.h"
 #include "common/http/headers.h"
 #include "common/http/header_map_impl.h"
@@ -69,6 +70,7 @@ public:
                                   ServerConnectionCallbacks&) override {
     return ServerConnectionPtr{codec_};
   }
+  Http::DateProvider& dateProvider() override { return date_provider_; }
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool generateRequestId() override { return true; }
@@ -106,6 +108,7 @@ public:
   std::unique_ptr<Ssl::MockConnection> ssl_connection_;
   NiceMock<Router::MockConfig> route_config_;
   Optional<Http::TracingConnectionManagerConfig> tracing_config_;
+  Http::SlowDateProviderImpl date_provider_;
 };
 
 TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {

--- a/test/common/http/date_provider_impl_test.cc
+++ b/test/common/http/date_provider_impl_test.cc
@@ -1,0 +1,30 @@
+#include "common/http/date_provider_impl.h"
+#include "common/http/header_map_impl.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+
+using testing::NiceMock;
+
+namespace Http {
+
+TEST(DateProviderImplTest, All) {
+  Event::MockDispatcher dispatcher;
+  NiceMock<ThreadLocal::MockInstance> tls;
+  Event::MockTimer* timer = new Event::MockTimer(&dispatcher);
+  EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(500)));
+
+  TlsCachingDateProviderImpl provider(dispatcher, tls);
+  HeaderMapImpl headers;
+  provider.setDateHeader(headers);
+  EXPECT_NE(nullptr, headers.Date());
+
+  EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(500)));
+  timer->callback_();
+
+  headers.removeDate();
+  provider.setDateHeader(headers);
+  EXPECT_NE(nullptr, headers.Date());
+}
+
+} // Http

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -63,6 +63,7 @@ public:
   MOCK_METHOD0(accessLogs, const std::list<AccessLog::InstancePtr>&());
   MOCK_METHOD3(createCodec_, ServerConnection*(Network::Connection&, const Buffer::Instance&,
                                                ServerConnectionCallbacks&));
+  MOCK_METHOD0(dateProvider, DateProvider&());
   MOCK_METHOD0(drainTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(filterFactory, FilterChainFactory&());
   MOCK_METHOD0(generateRequestId, bool());


### PR DESCRIPTION
Creating this string on every request is actually quite expensive.