### PR TITLE
fix header map trie for large char

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -206,12 +206,12 @@ HeaderMapImpl::StaticLookupTable::StaticLookupTable() {
 
 void HeaderMapImpl::StaticLookupTable::add(const char* key, StaticLookupEntry::EntryCb cb) {
   StaticLookupEntry* current = &root_;
-  while (*key) {
-    if (!current->entries_[*key]) {
-      current->entries_[*key].reset(new StaticLookupEntry());
+  while (uint8_t c = *key) {
+    if (!current->entries_[c]) {
+      current->entries_[c].reset(new StaticLookupEntry());
     }
 
-    current = current->entries_[*key].get();
+    current = current->entries_[c].get();
     key++;
   }
 
@@ -221,7 +221,7 @@ void HeaderMapImpl::StaticLookupTable::add(const char* key, StaticLookupEntry::E
 HeaderMapImpl::StaticLookupEntry::EntryCb
 HeaderMapImpl::StaticLookupTable::find(const char* key) const {
   const StaticLookupEntry* current = &root_;
-  while (char c = *key) {
+  while (uint8_t c = *key) {
     current = current->entries_[c].get();
     if (current) {
       key++;

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -305,4 +305,12 @@ TEST(HeaderMapImplTest, Equality) {
   EXPECT_FALSE(headers1 == headers2);
 }
 
+TEST(HeaderMapImplTest, LargeCharInHeader) {
+  HeaderMapImpl headers;
+  LowerCaseString static_key("\x90hello");
+  std::string static_value("value");
+  headers.addStatic(static_key, static_value);
+  EXPECT_STREQ("value", headers.get(static_key)->value().c_str());
+}
+
 } // Http


### PR DESCRIPTION
Need to cast to uint8_t before array lookup.