### PR TITLE
tcp proxy: fix connection/fd leak during local close

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -35,7 +35,15 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
   });
 }
 
-ConnectionImpl::~ConnectionImpl() { ASSERT(fd_ == -1); }
+ConnectionImpl::~ConnectionImpl() {
+  ASSERT(fd_ == -1);
+
+  // In general we assume that owning code has called close() previously to the destructor being
+  // run. This generally must be done so that callbacks run in the correct context (vs. deferred
+  // deletion). Hence the assert above. However, call close() here just to be completely sure that
+  // the fd is closed and make it more likely that we crash from a bad close callback.
+  close(ConnectionCloseType::NoFlush);
+}
 
 void ConnectionImpl::addWriteFilter(WriteFilterPtr filter) {
   filter_manager_.addWriteFilter(filter);

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -96,7 +96,7 @@ TEST_F(TcpProxyTest, UpstreamDisconnect) {
   upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_F(TcpProxyTest, DowntsreamDisconnectRemote) {
+TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
   setup(true);
 
   Buffer::OwnedImpl buffer("hello");
@@ -114,7 +114,7 @@ TEST_F(TcpProxyTest, DowntsreamDisconnectRemote) {
   filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_F(TcpProxyTest, DowntsreamDisconnectLocal) {
+TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
   setup(true);
 
   Buffer::OwnedImpl buffer("hello");

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -96,7 +96,7 @@ TEST_F(TcpProxyTest, UpstreamDisconnect) {
   upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_F(TcpProxyTest, DowntsreamDisconnect) {
+TEST_F(TcpProxyTest, DowntsreamDisconnectRemote) {
   setup(true);
 
   Buffer::OwnedImpl buffer("hello");
@@ -112,6 +112,24 @@ TEST_F(TcpProxyTest, DowntsreamDisconnect) {
 
   EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(TcpProxyTest, DowntsreamDisconnectLocal) {
+  setup(true);
+
+  Buffer::OwnedImpl buffer("hello");
+  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  filter_->onData(buffer);
+
+  EXPECT_CALL(*connect_timer_, disableTimer());
+  upstream_connection_->raiseEvents(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl response("world");
+  EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
+  upstream_read_filter_->onData(response);
+
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::LocalClose);
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectTimeout) {


### PR DESCRIPTION
This can happen when the connection gets closed locally by another filter
(e.g., the rate limit filter).

This is a regression from both c172a4 and a10174. The first commit makes it
so that we create the upstream connection in the constructor and not when
we first have data. The second commit which removed bufferevent removes the
safeguard that would have happened in the destructor which would have closed
the fd in the bev.

This commit fixes the main leaking issue but also puts a failsafe into the
connection destructor such that we will close the fd always and be more likely
to crash instead of keep going.