### PR TITLE
perf: various fixes to reduce allocations

### DIFF
--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -1,0 +1,46 @@
+#pragma once
+
+namespace Http {
+
+class StreamCallbackHelper {
+public:
+  void runResetCallbacks(StreamResetReason reason) {
+    if (reset_callbacks_run_) {
+      return;
+    }
+
+    for (StreamCallbacks* callbacks : callbacks_) {
+      if (callbacks) {
+        callbacks->onResetStream(reason);
+      }
+    }
+
+    reset_callbacks_run_ = true;
+  }
+
+protected:
+  StreamCallbackHelper() {
+    // Set space for 8 callbacks (64 bytes).
+    callbacks_.reserve(8);
+  }
+
+  void addCallbacks_(StreamCallbacks& callbacks) { callbacks_.push_back(&callbacks); }
+
+  void removeCallbacks_(StreamCallbacks& callbacks) {
+    // For performance reasons we just clear the callback and do not resize the vector.
+    // Reset callbacks scale with the number of filters per request and do not get added and
+    // removed multiple times.
+    for (size_t i = 0; i < callbacks_.size(); i++) {
+      if (callbacks_[i] == &callbacks) {
+        callbacks_[i] = nullptr;
+        return;
+      }
+    }
+  }
+
+private:
+  std::vector<StreamCallbacks*> callbacks_;
+  bool reset_callbacks_run_{};
+};
+
+} // Http

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -203,18 +203,6 @@ void ConnectionImpl::StreamImpl::resetStreamWorker(StreamResetReason reason) {
   UNREFERENCED_PARAMETER(rc);
 }
 
-void ConnectionImpl::StreamImpl::runResetCallbacks(StreamResetReason reason) {
-  if (reset_callbacks_run_) {
-    return;
-  }
-
-  for (StreamCallbacks* callbacks : callbacks_) {
-    callbacks->onResetStream(reason);
-  }
-
-  reset_callbacks_run_ = true;
-}
-
 ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -24,10 +24,11 @@ public:
 
 private:
   struct ThreadLocalData {
-    std::map<uint32_t, ThreadLocalObjectPtr> data_;
+    std::vector<ThreadLocalObjectPtr> data_;
   };
 
   void reset();
+  static void setThreadLocal(uint32_t index, ThreadLocalObjectPtr object);
 
   static std::atomic<uint32_t> next_slot_id_;
   static thread_local ThreadLocalData thread_local_data_;


### PR DESCRIPTION
1) Use vector in thread local vs map
2) Remove extra allocation for each request from codec client
3) remove extra allocation for each request from http/1.1 conn pool
4) Use vector for stream reset callbacks