### PR TITLE
network filters: add onNewConnection() callback

### DIFF
--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -94,7 +94,7 @@ public:
    * construction that requires the backing connection should take place in the context of this
    * function.
    *
-   * IMPORTANT: No outbound networking and complex processing should be done in this function.
+   * IMPORTANT: No outbound networking or complex processing should be done in this function.
    *            That should be done in the context of onNewConnection() if needed.
    *
    * @param callbacks supplies the callbacks.

--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -137,7 +137,7 @@ public:
   virtual void addReadFilter(ReadFilterPtr filter) PURE;
 
   /**
-   * Initialize all of the installe read filters. This effectively calls onNewConnection() on
+   * Initialize all of the installed read filters. This effectively calls onNewConnection() on
    * each of them.
    */
   virtual void initializeReadFilters() PURE;

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -99,12 +99,10 @@ void Config::requestComplete() {
 }
 
 Network::FilterStatus Instance::onData(Buffer::Instance&) {
-  if (auth_checked_) {
-    return Network::FilterStatus::Continue;
-  }
+  return Network::FilterStatus::Continue;
+}
 
-  auth_checked_ = true;
-
+Network::FilterStatus Instance::onNewConnection() {
   // If this is not an SSL connection, do no further checking. High layers should redirect, etc.
   // if SSL is required.
   if (!read_callbacks_->connection().ssl()) {

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -103,6 +103,7 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override;
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;
   }
@@ -110,7 +111,6 @@ public:
 private:
   ConfigPtr config_;
   Network::ReadFilterCallbacks* read_callbacks_{};
-  bool auth_checked_{};
 };
 
 } // ClientSsl

--- a/source/common/filter/echo.h
+++ b/source/common/filter/echo.h
@@ -13,6 +13,7 @@ class Echo : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;
   }

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -25,6 +25,11 @@ InstanceStats Config::generateStats(const std::string& name, Stats::Store& store
 }
 
 Network::FilterStatus Instance::onData(Buffer::Instance&) {
+  return status_ == Status::Calling ? Network::FilterStatus::StopIteration
+                                    : Network::FilterStatus::Continue;
+}
+
+Network::FilterStatus Instance::onNewConnection() {
   if (status_ == Status::NotStarted &&
       !config_->runtime().snapshot().featureEnabled("ratelimit.tcp_filter_enabled", 100)) {
     status_ = Status::Complete;

--- a/source/common/filter/ratelimit.h
+++ b/source/common/filter/ratelimit.h
@@ -67,6 +67,7 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override;
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     filter_callbacks_ = &callbacks;
     filter_callbacks_->connection().addConnectionCallbacks(*this);

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -60,11 +60,11 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override { return initializeUpstreamConnection(); }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;
     conn_log_info("new tcp proxy session", read_callbacks_->connection());
     read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
-    initializeUpstreamConnection();
   }
 
 private:
@@ -103,7 +103,7 @@ private:
     TcpProxy& parent_;
   };
 
-  void initializeUpstreamConnection();
+  Network::FilterStatus initializeUpstreamConnection();
   void onConnectTimeout();
   void onDownstreamBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
                                 int64_t delta);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -205,6 +205,7 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
 
   // Http::ConnectionCallbacks

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -85,6 +85,7 @@ public:
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;
     read_callbacks_->connection().addConnectionCallbacks(*this);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -53,6 +53,8 @@ void ConnectionImpl::addFilter(FilterPtr filter) { filter_manager_.addFilter(fil
 
 void ConnectionImpl::addReadFilter(ReadFilterPtr filter) { filter_manager_.addReadFilter(filter); }
 
+void ConnectionImpl::initializeReadFilters() { filter_manager_.initializeReadFilters(); }
+
 void ConnectionImpl::close(ConnectionCloseType type) {
   if (fd_ == -1) {
     return;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -25,6 +25,7 @@ public:
   void addWriteFilter(WriteFilterPtr filter) override;
   void addFilter(FilterPtr filter) override;
   void addReadFilter(ReadFilterPtr filter) override;
+  void initializeReadFilters() override;
 
   // Network::Connection
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;

--- a/source/common/network/filter_impl.h
+++ b/source/common/network/filter_impl.h
@@ -8,6 +8,7 @@ namespace Network {
 class ReadFilterBaseImpl : public ReadFilter {
 public:
   void initializeReadFilterCallbacks(ReadFilterCallbacks&) override {}
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
 };
 
 /**
@@ -16,6 +17,7 @@ public:
 class FilterBaseImpl : public Filter {
 public:
   void initializeReadFilterCallbacks(ReadFilterCallbacks&) override {}
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
 };
 
 } // Network

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -36,6 +36,7 @@ public:
   void addFilter(FilterPtr filter);
   void addReadFilter(ReadFilterPtr filter);
   void destroyFilters();
+  void initializeReadFilters();
   void onRead();
   FilterStatus onWrite();
 
@@ -53,6 +54,7 @@ private:
 
     FilterManagerImpl& parent_;
     ReadFilterPtr filter_;
+    bool initialized_{};
   };
 
   typedef std::unique_ptr<ActiveReadFilter> ActiveReadFilterPtr;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -14,17 +14,13 @@
 namespace Server {
 namespace Configuration {
 
-void FilterChainUtility::buildFilterChain(Network::Connection& connection,
+void FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager,
                                           const std::list<NetworkFilterFactoryCb>& factories) {
   for (const NetworkFilterFactoryCb& factory : factories) {
-    // It's possible for a connection to be closed immediately in the middle of chain creation.
-    // If this happened, do not instantiate any more filters.
-    if (connection.state() != Network::Connection::State::Open) {
-      break;
-    }
-
-    factory(connection);
+    factory(filter_manager);
   }
+
+  filter_manager.initializeReadFilters();
 }
 
 MainImpl::MainImpl(Server::Instance& server) : server_(server) {}

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -43,7 +43,7 @@ public:
    * Given a connection and a list of factories, create a new filter chain. Chain creation will
    * exit early if any filters immediately close the connection.
    */
-  static void buildFilterChain(Network::Connection& connection,
+  static void buildFilterChain(Network::FilterManager& filter_manager,
                                const std::list<NetworkFilterFactoryCb>& factories);
 };
 

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -97,6 +97,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
 
   // Check no SSL case, mulitple iterations.
   EXPECT_CALL(filter_callbacks_.connection_, ssl()).WillOnce(Return(nullptr));
+  EXPECT_EQ(Network::FilterStatus::Continue, instance_->onNewConnection());
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
 
@@ -107,7 +108,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
       .WillOnce(ReturnRefOfCopy(std::string("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest()).WillOnce(Return("digest"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onData(dummy));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
 
   // Respond.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -125,6 +126,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
       .WillOnce(ReturnRefOfCopy(std::string("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest())
       .WillOnce(Return("1b7d42ef0025ad89c1c911d6c10d7e86a4cb7c5863b2980abcbad1895f8b5314"));
+  EXPECT_EQ(Network::FilterStatus::Continue, instance_->onNewConnection());
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
 
@@ -133,6 +135,7 @@ TEST_F(ClientSslAuthFilterTest, Basic) {
   EXPECT_CALL(filter_callbacks_.connection_, ssl()).WillOnce(Return(&ssl_));
   EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
       .WillOnce(ReturnRefOfCopy(std::string("1.2.3.4")));
+  EXPECT_EQ(Network::FilterStatus::Continue, instance_->onNewConnection());
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
   EXPECT_EQ(Network::FilterStatus::Continue, instance_->onData(dummy));
 

--- a/test/common/filter/ratelimit_test.cc
+++ b/test/common/filter/ratelimit_test.cc
@@ -67,6 +67,7 @@ TEST_F(RateLimitFilterTest, OK) {
       .WillOnce(WithArgs<0>(
           Invoke([&](RequestCallbacks& callbacks) -> void { request_callbacks_ = &callbacks; })));
 
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
@@ -90,6 +91,7 @@ TEST_F(RateLimitFilterTest, OverLimit) {
       .WillOnce(WithArgs<0>(
           Invoke([&](RequestCallbacks& callbacks) -> void { request_callbacks_ = &callbacks; })));
 
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
 
@@ -111,6 +113,7 @@ TEST_F(RateLimitFilterTest, OverLimitNotEnforcing) {
       .WillOnce(WithArgs<0>(
           Invoke([&](RequestCallbacks& callbacks) -> void { request_callbacks_ = &callbacks; })));
 
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
 
@@ -135,6 +138,7 @@ TEST_F(RateLimitFilterTest, Error) {
       .WillOnce(WithArgs<0>(
           Invoke([&](RequestCallbacks& callbacks) -> void { request_callbacks_ = &callbacks; })));
 
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
 
@@ -157,6 +161,7 @@ TEST_F(RateLimitFilterTest, Disconnect) {
       .WillOnce(WithArgs<0>(
           Invoke([&](RequestCallbacks& callbacks) -> void { request_callbacks_ = &callbacks; })));
 
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data));
 
@@ -174,6 +179,7 @@ TEST_F(RateLimitFilterTest, ImmediateOK) {
       .WillOnce(WithArgs<0>(Invoke([&](RequestCallbacks& callbacks)
                                        -> void { callbacks.complete(LimitStatus::OK); })));
 
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data));
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data));
@@ -192,6 +198,7 @@ TEST_F(RateLimitFilterTest, RuntimeDisable) {
       .WillOnce(Return(false));
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
 
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data));
 }

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -66,6 +66,9 @@ public:
 
     filter_.reset(new TcpProxy(config_, cluster_manager_));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
+    EXPECT_EQ(return_connection ? Network::FilterStatus::Continue
+                                : Network::FilterStatus::StopIteration,
+              filter_->onNewConnection());
   }
 
   TcpProxyConfigPtr config_;
@@ -183,6 +186,7 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
   // The downstream connection closes if the proxy can't make an upstream connection.
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
+  filter_->onNewConnection();
 
   EXPECT_EQ(
       1U,

--- a/test/common/mongo/proxy_test.cc
+++ b/test/common/mongo/proxy_test.cc
@@ -56,6 +56,7 @@ public:
     access_log_.reset(new AccessLog(api_, "test", dispatcher_, lock, store_));
     filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_));
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
+    filter_->onNewConnection();
   }
 
   Buffer::OwnedImpl fake_data_;

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -49,6 +49,12 @@ TEST_F(NetworkFilterManagerTest, All) {
   read_filter->callbacks_->upstreamHost(Upstream::HostDescriptionPtr{host_description});
   EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
 
+  EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::StopIteration));
+  manager.initializeReadFilters();
+
+  EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
+  read_filter->callbacks_->continueReading();
+
   read_buffer_.add("hello");
   EXPECT_CALL(*read_filter, onData(BufferStringEqual("hello")))
       .WillOnce(Return(FilterStatus::StopIteration));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -48,6 +48,7 @@ public:
   MOCK_METHOD1(close, void(ConnectionCloseType type));
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(id, uint64_t());
+  MOCK_METHOD0(initializeReadFilters, void());
   MOCK_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
@@ -75,6 +76,7 @@ public:
   MOCK_METHOD1(close, void(ConnectionCloseType type));
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(id, uint64_t());
+  MOCK_METHOD0(initializeReadFilters, void());
   MOCK_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
@@ -120,6 +122,7 @@ public:
   ~MockReadFilter();
 
   MOCK_METHOD1(onData, FilterStatus(Buffer::Instance& data));
+  MOCK_METHOD0(onNewConnection, FilterStatus());
   MOCK_METHOD1(initializeReadFilterCallbacks, void(ReadFilterCallbacks& callbacks));
 
   ReadFilterCallbacks* callbacks_{};
@@ -139,6 +142,7 @@ public:
   ~MockFilter();
 
   MOCK_METHOD1(onData, FilterStatus(Buffer::Instance& data));
+  MOCK_METHOD0(onNewConnection, FilterStatus());
   MOCK_METHOD1(onWrite, FilterStatus(Buffer::Instance& data));
   MOCK_METHOD1(initializeReadFilterCallbacks, void(ReadFilterCallbacks& callbacks));
 

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -17,11 +17,8 @@ TEST(FilterChainUtility, buildFilterChain) {
   factories.push_back(factory);
   factories.push_back(factory);
 
-  // Make sure we short circuit if needed.
-  InSequence s;
-  EXPECT_CALL(connection, state()).WillOnce(Return(Network::Connection::State::Open));
-  EXPECT_CALL(watcher, ready());
-  EXPECT_CALL(connection, state()).WillOnce(Return(Network::Connection::State::Closing));
+  EXPECT_CALL(watcher, ready()).Times(2);
+  EXPECT_CALL(connection, initializeReadFilters());
   FilterChainUtility::buildFilterChain(connection, factories);
 }
 


### PR DESCRIPTION
This is more fallout from c172a4. For network filters we want the
ability to do things when the connection is created, but also to
allow stopping iterations of further filters. In the previous change,
we made it so that the proxy filter will always make a new connection
to upstream regardless of what other filters do. We change that now
such that the tcp proxy filter will only make the upstream connection
in the onNewConnection() callback. Other filters (currently client_ssl
and ratelimit) now do their work on their own onNewConnection() callback
and stop iteration if necessary to prevent the tcp proxy filter from
making the upstream connection until it is supposed to.