### PR TITLE
network: cleanup connection logic and crash when fd cannot be allocated

### DIFF
--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -6,7 +6,6 @@
  * assert macro that uses our builtin logging which gives us thread ID and can log to various
  * sinks.
  */
-#ifndef COVERAGE
 #define RELEASE_ASSERT(X)                                                                          \
   {                                                                                                \
     if (!(X)) {                                                                                    \
@@ -15,9 +14,6 @@
       abort();                                                                                     \
     }                                                                                              \
   }
-#else
-#define RELEASE_ASSERT(X)
-#endif
 
 #ifndef NDEBUG
 #define ASSERT(X) RELEASE_ASSERT(X)

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -48,7 +48,7 @@ public:
 protected:
   enum class PostIoAction { Close, KeepOpen };
 
-  virtual void closeSocket();
+  virtual void closeSocket(uint32_t close_type);
   void doConnect(const sockaddr* addr, socklen_t addrlen);
   void raiseEvents(uint32_t events);
 
@@ -67,7 +67,6 @@ private:
   };
   // clang-format on
 
-  void doLocalClose();
   virtual PostIoAction doReadFromSocket();
   virtual PostIoAction doWriteToSocket();
   void onBufferChange(ConnectionBufferType type, uint64_t old_size, int64_t delta);

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -26,6 +26,14 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, ListenSocket& sock
   if (!listener_) {
     throw CreateListenerException(fmt::format("cannot listen on socket: {}", socket.name()));
   }
+
+  evconnlistener_set_error_cb(listener_.get(), errorCallback);
+}
+
+void ListenerImpl::errorCallback(evconnlistener*, void*) {
+  // We should never get an error callback. This can happen if we run out of FDs or memory. In those
+  // cases just crash.
+  PANIC(fmt::format("listener accept failure: {}", strerror(errno)));
 }
 
 void ListenerImpl::newConnection(int fd, sockaddr* addr) {

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -41,6 +41,8 @@ protected:
   ProxyProtocol proxy_protocol_;
 
 private:
+  static void errorCallback(evconnlistener* listener, void* context);
+
   Event::Libevent::ListenerPtr listener_;
 };
 

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -195,7 +195,7 @@ void ClientConnectionImpl::connect() {
   doConnect(addr_info->ai_addr, addr_info->ai_addrlen);
 }
 
-void ConnectionImpl::closeSocket() {
+void ConnectionImpl::closeSocket(uint32_t close_type) {
   if (handshake_complete_) {
     // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
     // there is no room on the socket. We can extend the state machine to handle this at some point
@@ -206,7 +206,7 @@ void ConnectionImpl::closeSocket() {
     drainErrorQueue();
   }
 
-  Network::ConnectionImpl::closeSocket();
+  Network::ConnectionImpl::closeSocket(close_type);
 }
 
 std::string ConnectionImpl::nextProtocol() {

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -26,7 +26,7 @@ private:
   void drainErrorQueue();
 
   // Network::ConnectionImpl
-  void closeSocket() override;
+  void closeSocket(uint32_t close_type) override;
   PostIoAction doReadFromSocket() override;
   PostIoAction doWriteToSocket() override;
   void onConnected() override;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(envoy-test
   common/network/connection_impl_test.cc
   common/network/dns_impl_test.cc
   common/network/filter_manager_impl_test.cc
+  common/network/listener_impl_test.cc
   common/network/listen_socket_impl_test.cc
   common/network/proxy_protocol_test.cc
   common/network/utility_test.cc

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -14,13 +14,9 @@ using testing::Test;
 
 namespace Network {
 
-TEST(ConnectionImplTest, BadFd) {
+TEST(ConnectionImplDeathTest, BadFd) {
   Event::DispatcherImpl dispatcher;
-  ConnectionImpl connection(dispatcher, -1, "127.0.0.1");
-  MockConnectionCallbacks callbacks;
-  connection.addConnectionCallbacks(callbacks);
-  EXPECT_CALL(callbacks, onEvent(ConnectionEvent::RemoteClose));
-  dispatcher.run(Event::Dispatcher::RunType::Block);
+  EXPECT_DEATH(ConnectionImpl(dispatcher, -1, "127.0.0.1"), ".*assert failure: fd_ != -1.*");
 }
 
 TEST(ConnectionImplTest, BufferCallbacks) {

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -1,0 +1,39 @@
+#include "common/network/listener_impl.h"
+#include "common/stats/stats_impl.h"
+
+#include "test/mocks/network/mocks.h"
+
+using testing::_;
+using testing::Invoke;
+
+namespace Network {
+
+static void errorCallbackTest() {
+  // Force the error callback to fire by closing the socket under the listener. We run this entire
+  // test in the forked process to avoid confusion when the fork happens.
+  Stats::IsolatedStoreImpl stats_store;
+  Event::DispatcherImpl dispatcher;
+  Network::TcpListenSocket socket(10000);
+  Network::MockListenerCallbacks listener_callbacks;
+  Network::ListenerPtr listener =
+      dispatcher.createListener(socket, listener_callbacks, stats_store, false);
+
+  Network::ClientConnectionPtr client_connection =
+      dispatcher.createClientConnection("tcp://127.0.0.1:10000");
+  client_connection->connect();
+
+  EXPECT_CALL(listener_callbacks, onNewConnection_(_))
+      .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
+        client_connection->close(ConnectionCloseType::NoFlush);
+        conn->close(ConnectionCloseType::NoFlush);
+        socket.close();
+      }));
+
+  dispatcher.run(Event::Dispatcher::RunType::Block);
+}
+
+TEST(ListenerImplDeathTest, ErrorCallback) {
+  EXPECT_DEATH(errorCallbackTest(), ".*listener accept failure.*");
+}
+
+} // Network

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -1,5 +1,13 @@
 #include "server/options_impl.h"
 
+TEST(OptionsImplDeathTest, HotRestartVersion) {
+  std::vector<const char*> argv;
+  argv.push_back("envoy");
+  argv.push_back("--hot-restart-version");
+  EXPECT_EXIT(OptionsImpl(argv.size(), const_cast<char**>(&argv[0]), "1", spdlog::level::warn),
+              testing::ExitedWithCode(0), "");
+}
+
 TEST(OptionsImplTest, All) {
   std::vector<const char*> argv;
   argv.push_back("envoy");


### PR DESCRIPTION
The fix in 8d5366 looks good. This commit further cleans up the socket
close logic to make it simpler and more unified. It also changes the
behavior to crash the process if we can't allocate a socket or we have
an error during accept. In practice those only happen when we run out of
FDs which should be considered an OOM condition where we also crash on
purpose.