### PR TITLE
http/1.1: correctly handle connection header for for incoming requests

### DIFF
--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -5,6 +5,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/http/header_map.h"
+#include "envoy/http/protocol.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Http {
@@ -64,7 +65,12 @@ public:
   /**
    * @return the protocol of the request.
    */
-  virtual const std::string& protocol() const PURE;
+  virtual Protocol protocol() const PURE;
+
+  /**
+   * Set the request's protocol.
+   */
+  virtual void protocol(Protocol protocol) PURE;
 
   /**
    * @return the response code.

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -3,6 +3,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/http/header_map.h"
+#include "envoy/http/protocol.h"
 
 namespace Http {
 
@@ -145,14 +146,6 @@ public:
 };
 
 /**
- * A list of features that a codec provides.
- */
-class CodecFeatures {
-public:
-  static const uint64_t Multiplexing = 0x1;
-};
-
-/**
  * A list of options that can be specified when creating a codec.
  */
 class CodecOptions {
@@ -174,19 +167,15 @@ public:
   virtual void dispatch(Buffer::Instance& data) PURE;
 
   /**
-   * Get the features that a connection provides. Maps to entries in CodecFeatures.
-   */
-  virtual uint64_t features() PURE;
-
-  /**
    * Indicate "go away" to the remote. No new streams can be created beyond this point.
    */
   virtual void goAway() PURE;
 
   /**
-   * @return const std::string& the human readable name of the protocol that this codec wraps.
+   * @return the protocol backing the connection. This can change if for example an HTTP/1.1
+   *         connection gets an HTTP/1.0 request on it.
    */
-  virtual const std::string& protocolString() PURE;
+  virtual Protocol protocol() PURE;
 
   /**
    * Indicate a "shutdown notice" to the remote. This is a hint that the remote should not send

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -190,7 +190,6 @@ private:
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
-  HEADER_FUNC(EnvoyProtocolVersion)                                                                \
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \
   HEADER_FUNC(EnvoyUpstreamCanary)                                                                 \
@@ -214,8 +213,7 @@ private:
   HEADER_FUNC(Status)                                                                              \
   HEADER_FUNC(TransferEncoding)                                                                    \
   HEADER_FUNC(Upgrade)                                                                             \
-  HEADER_FUNC(UserAgent)                                                                           \
-  HEADER_FUNC(Version)
+  HEADER_FUNC(UserAgent)
 
 /**
  * The following functions are defined for each inline header above. E.g., for ContentLength we

--- a/include/envoy/http/protocol.h
+++ b/include/envoy/http/protocol.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Http {
+
+/**
+ * Possible HTTP connection/request protocols.
+ */
+enum class Protocol { Http10, Http11, Http2 };
+
+} // Http

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -30,8 +30,7 @@ Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::HeaderMap& head
     setupStatTracking(headers);
   }
 
-  if (decoder_callbacks_->requestInfo().protocol() == Http::Http1::PROTOCOL_STRING &&
-      grpc_request) {
+  if (decoder_callbacks_->requestInfo().protocol() != Http::Protocol::Http2 && grpc_request) {
     do_bridging_ = true;
   }
 

--- a/source/common/http/access_log/access_log_formatter.h
+++ b/source/common/http/access_log/access_log_formatter.h
@@ -45,9 +45,10 @@ private:
 class AccessLogFormatUtils {
 public:
   static FormatterPtr defaultAccessLogFormatter();
+  static const std::string& protocolToString(Protocol protocol);
 
 private:
-  AccessLogFormatUtils(){};
+  AccessLogFormatUtils();
 
   static const std::string DEFAULT_FORMAT;
 };

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -6,7 +6,7 @@ namespace Http {
 namespace AccessLog {
 
 struct RequestInfoImpl : public RequestInfo {
-  RequestInfoImpl(const std::string& protocol)
+  RequestInfoImpl(Protocol protocol)
       : protocol_(protocol), start_time_(std::chrono::system_clock::now()) {}
 
   // Http::AccessLog::RequestInfo
@@ -14,7 +14,8 @@ struct RequestInfoImpl : public RequestInfo {
 
   uint64_t bytesReceived() const override { return bytes_received_; }
 
-  const std::string& protocol() const override { return protocol_; }
+  Protocol protocol() const override { return protocol_; }
+  void protocol(Protocol protocol) override { protocol_ = protocol; }
 
   const Optional<uint32_t>& responseCode() const override { return response_code_; }
 
@@ -39,7 +40,7 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  const std::string& protocol_;
+  Protocol protocol_;
   const SystemTime start_time_;
   uint64_t bytes_received_{};
   Optional<uint32_t> response_code_;

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -38,7 +38,7 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
                                    const Optional<std::chrono::milliseconds>& timeout)
     : request_(std::move(request)), parent_(parent), callbacks_(callbacks),
       stream_id_(parent.config_.random_.random()), router_(parent.config_),
-      request_info_(EMPTY_STRING), route_(parent_.cluster_.name(), timeout) {
+      request_info_(Protocol::Http11), route_(parent_.cluster_.name(), timeout) {
 
   router_.setDecoderFilterCallbacks(*this);
   request_->headers().insertEnvoyInternalRequest().value(
@@ -50,6 +50,7 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
   }
 
   // TODO: Support request trailers.
+  // TODO: Correctly set protocol in request info when we support access logging.
 }
 
 AsyncRequestImpl::~AsyncRequestImpl() { ASSERT(!reset_callback_); }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -171,7 +171,7 @@ Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
     // Processing incoming data may release outbound data so check for closure here as well.
     checkForDeferredClose();
 
-    // The HTTP/1.1 codec will pause dispatch after a single message is complete. We want to
+    // The HTTP/1 codec will pause dispatch after a single message is complete. We want to
     // either redispatch if there are no streams and we have more data, or if we have a single
     // complete stream but have not responded yet we will pause socket reads to apply back pressure.
     if (codec_->protocol() != Protocol::Http2) {
@@ -348,7 +348,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Make sure we are getting a codec version we support.
   Protocol protocol = connection_manager_.codec_->protocol();
-  if (!(protocol == Protocol::Http11 || protocol == Protocol::Http2)) {
+  if (protocol == Protocol::Http10) {
     // The protocol may have shifted in the HTTP/1.0 case so reset it.
     request_info_.protocol(protocol);
     HeaderMapImpl headers{

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -12,6 +12,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/common/enum_to_int.h"
+#include "common/common/utility.h"
 #include "common/http/codes.h"
 #include "common/http/exception.h"
 #include "common/http/header_map_impl.h"
@@ -66,11 +67,10 @@ ConnectionManagerImpl::~ConnectionManagerImpl() {
   }
 
   if (codec_) {
-    if (codec_->protocolString() == Http1::PROTOCOL_STRING) {
-      stats_.named_.downstream_cx_http1_active_.dec();
-    } else {
-      ASSERT(codec_->protocolString() == Http2::PROTOCOL_STRING);
+    if (codec_->protocol() == Protocol::Http2) {
       stats_.named_.downstream_cx_http2_active_.dec();
+    } else {
+      stats_.named_.downstream_cx_http1_active_.dec();
     }
   }
 
@@ -104,14 +104,14 @@ void ConnectionManagerImpl::destroyStream(ActiveStream& stream) {
     read_callbacks_->connection().dispatcher().deferredDelete(stream.removeFromList(streams_));
   }
 
-  if (reset_stream && !(codec_->features() & CodecFeatures::Multiplexing)) {
+  if (reset_stream && codec_->protocol() != Protocol::Http2) {
     drain_state_ = DrainState::Closing;
   }
 
   checkForDeferredClose();
 
   // Reading may have been disabled for the non-multiplexing case, so enable it again.
-  if (drain_state_ != DrainState::Closing && !(codec_->features() & CodecFeatures::Multiplexing) &&
+  if (drain_state_ != DrainState::Closing && codec_->protocol() != Protocol::Http2 &&
       !read_callbacks_->connection().readEnabled()) {
     read_callbacks_->connection().readDisable(false);
   }
@@ -138,13 +138,12 @@ StreamDecoder& ConnectionManagerImpl::newStream(StreamEncoder& response_encoder)
 Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
   if (!codec_) {
     codec_ = config_.createCodec(read_callbacks_->connection(), data, *this);
-    if (codec_->protocolString() == Http1::PROTOCOL_STRING) {
-      stats_.named_.downstream_cx_http1_total_.inc();
-      stats_.named_.downstream_cx_http1_active_.inc();
-    } else {
-      ASSERT(codec_->protocolString() == Http2::PROTOCOL_STRING);
+    if (codec_->protocol() == Protocol::Http2) {
       stats_.named_.downstream_cx_http2_total_.inc();
       stats_.named_.downstream_cx_http2_active_.inc();
+    } else {
+      stats_.named_.downstream_cx_http1_total_.inc();
+      stats_.named_.downstream_cx_http1_active_.inc();
     }
   }
 
@@ -175,7 +174,7 @@ Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
     // The HTTP/1.1 codec will pause dispatch after a single message is complete. We want to
     // either redispatch if there are no streams and we have more data, or if we have a single
     // complete stream but have not responded yet we will pause socket reads to apply back pressure.
-    if (!(codec_->features() & CodecFeatures::Multiplexing)) {
+    if (codec_->protocol() != Protocol::Http2) {
       if (read_callbacks_->connection().state() == Network::Connection::State::Open &&
           data.length() > 0 && streams_.empty()) {
         redispatch = true;
@@ -268,14 +267,13 @@ std::atomic<uint64_t> ConnectionManagerImpl::ActiveStream::next_stream_id_(0);
 ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connection_manager)
     : connection_manager_(connection_manager), stream_id_(next_stream_id_++),
       request_timer_(connection_manager_.stats_.named_.downstream_rq_time_.allocateSpan()),
-      request_info_(connection_manager_.codec_->protocolString()) {
+      request_info_(connection_manager_.codec_->protocol()) {
   connection_manager_.stats_.named_.downstream_rq_total_.inc();
   connection_manager_.stats_.named_.downstream_rq_active_.inc();
-  if (connection_manager_.codec_->protocolString() == Http1::PROTOCOL_STRING) {
-    connection_manager_.stats_.named_.downstream_rq_http1_total_.inc();
-  } else {
-    ASSERT(connection_manager_.codec_->protocolString() == Http2::PROTOCOL_STRING);
+  if (connection_manager_.codec_->protocol() == Protocol::Http2) {
     connection_manager_.stats_.named_.downstream_rq_http2_total_.inc();
+  } else {
+    connection_manager_.stats_.named_.downstream_rq_http1_total_.inc();
   }
 }
 
@@ -349,8 +347,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
       *request_headers_, connection_manager_.stats_.prefix_, connection_manager_.stats_.store_);
 
   // Make sure we are getting a codec version we support.
-  const HeaderString& codec_version = request_headers_->Version()->value();
-  if (!(codec_version == "HTTP/1.1" || codec_version == "HTTP/2")) {
+  Protocol protocol = connection_manager_.codec_->protocol();
+  if (!(protocol == Protocol::Http11 || protocol == Protocol::Http2)) {
+    // The protocol may have shifted in the HTTP/1.0 case so reset it.
+    request_info_.protocol(protocol);
     HeaderMapImpl headers{
         {Headers::get().Status, std::to_string(enumToInt(Code::UpgradeRequired))}};
     encodeHeaders(nullptr, headers, true);
@@ -389,6 +389,13 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::NotFound))}};
     encodeHeaders(nullptr, headers, true);
     return;
+  }
+
+  if (protocol == Protocol::Http11 && request_headers_->Connection() &&
+      0 ==
+          StringUtil::caseInsensitiveCompare(request_headers_->Connection()->value().c_str(),
+                                             Http::Headers::get().ConnectionValues.Close.c_str())) {
+    state_.saw_connection_close_ = true;
   }
 
   ConnectionManagerUtility::mutateRequestHeaders(
@@ -528,7 +535,6 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
   // Base headers.
   connection_manager_.config_.dateProvider().setDateHeader(headers);
   headers.insertServer().value(connection_manager_.config_.serverName());
-  headers.insertEnvoyProtocolVersion().value(connection_manager_.codec_->protocolString());
   ConnectionManagerUtility::mutateResponseHeaders(headers, *request_headers_,
                                                   connection_manager_.config_);
 
@@ -545,11 +551,16 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     stream_log_debug("drain closing connection", *this);
   }
 
+  if (connection_manager_.drain_state_ == DrainState::NotDraining && state_.saw_connection_close_) {
+    stream_log_debug("closing connection due to connection close header", *this);
+    connection_manager_.drain_state_ = DrainState::Closing;
+  }
+
   // If we are destroying a stream before remote is complete and the connection does not support
   // multiplexing, we should disconnect since we don't want to wait around for the request to
   // finish.
   if (!state_.remote_complete_) {
-    if (!(connection_manager_.codec_->features() & CodecFeatures::Multiplexing)) {
+    if (connection_manager_.codec_->protocol() != Protocol::Http2) {
       connection_manager_.drain_state_ = DrainState::Closing;
     }
 
@@ -557,7 +568,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
   }
 
   if (connection_manager_.drain_state_ == DrainState::Closing &&
-      !(connection_manager_.codec_->features() & CodecFeatures::Multiplexing)) {
+      connection_manager_.codec_->protocol() != Protocol::Http2) {
     headers.insertConnection().value(Headers::get().ConnectionValues.Close);
   }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -379,8 +379,11 @@ private:
     // All state for the stream. Put here for readability. We could move this to a bit field
     // eventually if we want.
     struct State {
-      bool remote_complete_{};
-      bool local_complete_{};
+      State() : remote_complete_(false), local_complete_(false), saw_connection_close_(false) {}
+
+      bool remote_complete_ : 1;
+      bool local_complete_ : 1;
+      bool saw_connection_close_ : 1;
     };
 
     // NOTE: This is used for stable randomness. For performance reasons we use an incrementing

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -20,7 +20,6 @@ void ConnectionManagerUtility::mutateRequestHeaders(Http::HeaderMap& request_hea
   request_headers.removeProxyConnection();
   request_headers.removeTransferEncoding();
   request_headers.removeUpgrade();
-  request_headers.removeVersion();
 
   // If we are "using remote address" this means that we create/append to XFF with our immediate
   // peer. Cases where we don't "use remote address" include trusted double proxy where we expect
@@ -111,7 +110,6 @@ void ConnectionManagerUtility::mutateResponseHeaders(Http::HeaderMap& response_h
                                                      ConnectionManagerConfig& config) {
   response_headers.removeConnection();
   response_headers.removeTransferEncoding();
-  response_headers.removeVersion();
 
   for (const Http::LowerCaseString& to_remove : config.routeConfig().responseHeadersToRemove()) {
     response_headers.remove(to_remove);

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -23,7 +23,6 @@ public:
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
-  const LowerCaseString EnvoyProtocolVersion{"x-envoy-protocol-version"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
   const LowerCaseString EnvoyUpstreamAltStatName{"x-envoy-upstream-alt-stat-name"};
   const LowerCaseString EnvoyUpstreamCanary{"x-envoy-upstream-canary"};
@@ -52,7 +51,6 @@ public:
   const LowerCaseString TransferEncoding{"transfer-encoding"};
   const LowerCaseString Upgrade{"upgrade"};
   const LowerCaseString UserAgent{"user-agent"};
-  const LowerCaseString Version{":version"};
 
   struct {
     const std::string Close{"close"};

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -339,18 +339,13 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
   current_header_value_.append(data, length);
 }
 
-static const std::string HTTP_1_1 = "HTTP/1.1";
-static const std::string HTTP_1_0 = "HTTP/1.0";
-
 int ConnectionImpl::onHeadersCompleteBase() {
   conn_log_trace("headers complete", connection_);
   completeLastHeader();
-  if (parser_.http_major == 1 && parser_.http_minor == 1) {
-    current_header_map_->insertVersion().value(HTTP_1_1);
-  } else {
+  if (!(parser_.http_major == 1 && parser_.http_minor == 1)) {
     // This is not necessarily true, but it's good enough since higher layers only care if this is
     // HTTP/1.1 or not.
-    current_header_map_->insertVersion().value(HTTP_1_0);
+    protocol_ = Protocol::Http10;
   }
 
   int rc = onHeadersComplete(std::move(current_header_map_));

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -13,8 +13,6 @@
 namespace Http {
 namespace Http1 {
 
-const std::string PROTOCOL_STRING = "HTTP/1.1";
-
 class ConnectionImpl;
 
 /**
@@ -130,9 +128,8 @@ public:
 
   // Http::Connection
   void dispatch(Buffer::Instance& data) override;
-  uint64_t features() override { return 0; }
   void goAway() override {} // Called during connection manager drain flow
-  const std::string& protocolString() override { return Http1::PROTOCOL_STRING; }
+  Protocol protocol() override { return protocol_; }
   void shutdownNotice() override {} // Called during connection manager drain flow
   bool wantsToWrite() override { return false; }
 
@@ -236,6 +233,7 @@ private:
   Buffer::OwnedImpl output_buffer_;
   Buffer::RawSlice reserved_iovec_;
   char* reserved_current_{};
+  Protocol protocol_{Protocol::Http11};
 };
 
 /**

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -281,7 +281,6 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
     }
 
     if (frame->headers.cat == NGHTTP2_HCAT_REQUEST || frame->headers.cat == NGHTTP2_HCAT_RESPONSE) {
-      stream->headers_->insertVersion().value(PROTOCOL_STRING);
       stream->decoder_->decodeHeaders(std::move(stream->headers_), stream->remote_end_stream_);
     } else {
       ASSERT(frame->headers.cat == NGHTTP2_HCAT_HEADERS);

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -19,7 +19,6 @@ namespace Http {
 namespace Http2 {
 
 const std::string ALPN_STRING = "h2";
-const std::string PROTOCOL_STRING = "HTTP/2";
 
 // This is not the full client magic, but it's the smallest size that should be able to
 // differentiate between HTTP/1 and HTTP/2.
@@ -70,9 +69,8 @@ public:
 
   // Http::Connection
   void dispatch(Buffer::Instance& data) override;
-  uint64_t features() override { return CodecFeatures::Multiplexing; }
   void goAway() override;
-  const std::string& protocolString() override { return PROTOCOL_STRING; }
+  Protocol protocol() override { return Protocol::Http2; }
   void shutdownNotice() override;
   bool wantsToWrite() override { return nghttp2_session_want_write(session_); }
 

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -229,7 +229,8 @@ std::string LightStepSink::buildRequestLine(const Http::HeaderMap& request_heade
     path = path.substr(0, max_path_length);
   }
 
-  return fmt::format("{} {} {}", request_headers.Method()->value().c_str(), path, info.protocol());
+  return fmt::format("{} {} {}", request_headers.Method()->value().c_str(), path,
+                     Http::AccessLog::AccessLogFormatUtils::protocolToString(info.protocol()));
 }
 
 std::string LightStepSink::buildResponseCode(const Http::AccessLog::RequestInfo& info) {

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -36,7 +36,8 @@ public:
 
   SystemTime startTime() const override { return start_time_; }
   uint64_t bytesReceived() const override { return 1; }
-  const std::string& protocol() const override { return protocol_; }
+  Protocol protocol() const override { return protocol_; }
+  void protocol(Protocol protocol) override { protocol_ = protocol; }
   const Optional<uint32_t>& responseCode() const override { return response_code_; }
   uint64_t bytesSent() const override { return 2; }
   std::chrono::milliseconds duration() const override {
@@ -50,7 +51,7 @@ public:
   void healthCheck(bool is_hc) { hc_request_ = is_hc; }
 
   SystemTime start_time_;
-  std::string protocol_{"HTTP/1.1"};
+  Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;
   FailureReason failure_reason_{FailureReason::None};
   uint64_t duration_{3};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -151,12 +151,11 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
 
         // Test not charging stats on the second call.
         if (data.length() == 4) {
-          Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-              {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+          Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
           decoder->decodeHeaders(std::move(headers), true);
         } else {
-          Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-              {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/healthcheck"}}};
+          Http::HeaderMapPtr headers{
+              new TestHeaderMapImpl{{":authority", "host"}, {":path", "/healthcheck"}}};
           decoder->decodeHeaders(std::move(headers), true);
         }
 
@@ -183,8 +182,8 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPath) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "http://api.lyft.com/"}}};
+        Http::HeaderMapPtr headers{
+            new TestHeaderMapImpl{{":authority", "host"}, {":path", "http://api.lyft.com/"}}};
         decoder->decodeHeaders(std::move(headers), true);
         data.drain(4);
       }));
@@ -219,8 +218,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), true);
       }));
 
@@ -263,8 +261,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseBeforeRequestComplete) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
       }));
 
@@ -303,8 +300,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
       }));
 
@@ -421,8 +417,7 @@ TEST_F(HttpConnectionManagerImplTest, IdleTimeout) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
 
         Buffer::OwnedImpl fake_data("hello");
@@ -477,8 +472,7 @@ TEST_F(HttpConnectionManagerImplTest, IntermediateBufferingEarlyResponse) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
 
         Buffer::OwnedImpl fake_data("hello");
@@ -530,8 +524,7 @@ TEST_F(HttpConnectionManagerImplTest, DoubleBuffering) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
         decoder->decodeData(fake_data, true);
       }));
@@ -575,8 +568,7 @@ TEST_F(HttpConnectionManagerImplTest, ZeroByteDataFiltering) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
       }));
 
@@ -630,8 +622,7 @@ TEST_F(HttpConnectionManagerImplTest, MultipleFilters) {
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&](Buffer::Instance&) -> void {
         decoder = &conn_manager_->newStream(encoder);
-        Http::HeaderMapPtr headers{new TestHeaderMapImpl{
-            {":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}}};
+        Http::HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
         decoder->decodeHeaders(std::move(headers), false);
 
         Buffer::OwnedImpl fake_data("hello");

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -256,7 +256,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
 
 TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
   {
-    TestHeaderMapImpl headers{{":version", "HTTP/1.1"}, {":authority", "host"}, {":path", "/"}};
+    TestHeaderMapImpl headers{{":authority", "host"}, {":path", "/"}};
     EXPECT_CALL(random_, uuid()).WillOnce(Return("generated_uuid"));
 
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
@@ -354,10 +354,8 @@ TEST_F(ConnectionManagerUtilityTest, MutateResponseHeaders) {
   config_.route_config_.response_headers_to_remove_.push_back(LowerCaseString("custom_header"));
   config_.route_config_.response_headers_to_add_.push_back({LowerCaseString("to_add"), "foo"});
 
-  TestHeaderMapImpl response_headers{{"connection", "foo"},
-                                     {"transfer-encoding", "foo"},
-                                     {":version", "foo"},
-                                     {"custom_header", "foo"}};
+  TestHeaderMapImpl response_headers{
+      {"connection", "foo"}, {"transfer-encoding", "foo"}, {"custom_header", "foo"}};
   TestHeaderMapImpl request_headers{{"x-request-id", "request-id"}};
 
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, config_);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -431,8 +431,8 @@ TEST_F(LightStepSinkTest, FlushSeveralSpans) {
   Optional<uint32_t> code(200);
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(code));
 
-  const std::string protocol = "http/1";
-  EXPECT_CALL(request_info, protocol()).Times(2).WillRepeatedly(ReturnRef(protocol));
+  Http::Protocol protocol = Http::Protocol::Http11;
+  EXPECT_CALL(request_info, protocol()).Times(2).WillRepeatedly(Return(protocol));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
       .Times(2)
       .WillRepeatedly(Return(2));
@@ -488,8 +488,8 @@ TEST_F(LightStepSinkTest, FlushSpansTimer) {
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10UL));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(100UL));
 
-  const std::string protocol = "http/1";
-  EXPECT_CALL(request_info, protocol()).WillOnce(ReturnRef(protocol));
+  Http::Protocol protocol = Http::Protocol::Http11;
+  EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
       .WillOnce(Return(5));
   EXPECT_CALL(context_, operationName()).WillOnce(ReturnRef(operation_name_));
@@ -535,8 +535,8 @@ TEST_F(LightStepSinkTest, FlushOneSpanGrpcFailure) {
   Optional<uint32_t> code(200);
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(code));
 
-  const std::string protocol = "http/1";
-  EXPECT_CALL(request_info, protocol()).WillOnce(ReturnRef(protocol));
+  Http::Protocol protocol = Http::Protocol::Http11;
+  EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -56,7 +56,7 @@ MockStreamEncoder::MockStreamEncoder() {
 MockStreamEncoder::~MockStreamEncoder() {}
 
 MockServerConnection::MockServerConnection() {
-  ON_CALL(*this, protocolString()).WillByDefault(ReturnRef(protocol_));
+  ON_CALL(*this, protocol()).WillByDefault(Return(protocol_));
 }
 
 MockServerConnection::~MockServerConnection() {}

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -37,7 +37,8 @@ public:
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
-  MOCK_CONST_METHOD0(protocol, const std::string&());
+  MOCK_CONST_METHOD0(protocol, Protocol());
+  MOCK_METHOD1(protocol, void(Protocol protocol));
   MOCK_CONST_METHOD0(responseCode, Optional<uint32_t>&());
   MOCK_CONST_METHOD0(bytesSent, uint64_t());
   MOCK_CONST_METHOD0(duration, std::chrono::milliseconds());
@@ -157,13 +158,12 @@ public:
 
   // Http::Connection
   MOCK_METHOD1(dispatch, void(Buffer::Instance& data));
-  MOCK_METHOD0(features, uint64_t());
   MOCK_METHOD0(goAway, void());
-  MOCK_METHOD0(protocolString, const std::string&());
+  MOCK_METHOD0(protocol, Protocol());
   MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
 
-  const std::string protocol_{"HTTP/1.1"};
+  Protocol protocol_{Protocol::Http11};
 };
 
 class MockClientConnection : public ClientConnection {
@@ -173,9 +173,8 @@ public:
 
   // Http::Connection
   MOCK_METHOD1(dispatch, void(Buffer::Instance& data));
-  MOCK_METHOD0(features, uint64_t());
   MOCK_METHOD0(goAway, void());
-  MOCK_METHOD0(protocolString, const std::string&());
+  MOCK_METHOD0(protocol, Protocol());
   MOCK_METHOD0(shutdownNotice, void());
   MOCK_METHOD0(wantsToWrite, bool());
 


### PR DESCRIPTION
We didn't previously handle the Connection: close header for incoming
HTTP/1.1 requests. This commit fixes that.

There are also some perf related changes/cleanup in this commit also:
1) Remove synthetic :version header and replace with an explicit codec
   protocol method.
2) Remove the x-envoy-protocol-version response header. This was used
   for debugging when we first rolled out HTTP/2 support and no longer
   has any real value.