### PR TITLE
ssl: do not attempt to call SSL_shutdown on a closed socket

### DIFF
--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -196,7 +196,7 @@ void ClientConnectionImpl::connect() {
 }
 
 void ConnectionImpl::closeSocket(uint32_t close_type) {
-  if (handshake_complete_) {
+  if (handshake_complete_ && state() != State::Closed) {
     // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
     // there is no room on the socket. We can extend the state machine to handle this at some point
     // if needed.


### PR DESCRIPTION
Regression from 210b5d. This seems to cause the SSL engine to hang vs.
just fail the call.