### PR TITLE
perf: simplify connection buffer stats

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -13,13 +13,6 @@ struct RawSlice {
 };
 
 /**
- * Buffer change callback.
- * @param old_size supplies the size of the buffer prior to the change.
- * @param data supplies how much data was added or removed.
- */
-typedef std::function<void(uint64_t old_size, int64_t delta)> Callback;
-
-/**
  * A basic buffer abstraction.
  */
 class Instance {
@@ -117,13 +110,6 @@ public:
    * @return the index where the match starts or -1 if there is no match.
    */
   virtual ssize_t search(const void* data, uint64_t size, size_t start) const PURE;
-
-  /**
-   * Set a buffer change callback. Only a single callback can be set at a time. The callback
-   * is invoked inline with buffer changes.
-   * @param callback supplies the callback to set. Pass nullptr to clear the callback.
-   */
-  virtual void setCallback(Callback callback) PURE;
 
   /**
    * Write the buffer out to a file descriptor.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -35,14 +35,6 @@ public:
   virtual ~ConnectionCallbacks() {}
 
   /**
-   * Callback for connection buffer changes.
-   * @param type supplies which buffer has changed.
-   * @param old_size supplies the original size of the buffer.
-   * @param delta supplies how much data was added or removed from the buffer.
-   */
-  virtual void onBufferChange(ConnectionBufferType type, uint64_t old_size, int64_t delta) PURE;
-
-  /**
    * Callback for connection events.
    * @param events supplies the ConnectionEvent events that occurred as a bitmask.
    */
@@ -63,6 +55,13 @@ enum class ConnectionCloseType {
 class Connection : public Event::DeferredDeletable, public FilterManager {
 public:
   enum class State { Open, Closing, Closed };
+
+  struct BufferStats {
+    Stats::Counter& read_total_;
+    Stats::Gauge& read_current_;
+    Stats::Counter& write_total_;
+    Stats::Gauge& write_current_;
+  };
 
   virtual ~Connection() {}
 
@@ -115,6 +114,13 @@ public:
    * @return The address of the remote client
    */
   virtual const std::string& remoteAddress() PURE;
+
+  /**
+   * Set the buffer stats to update when the connection's read/write buffers change. Note that
+   * for performance reasons these stats are eventually consistent and may not always accurately
+   * represent the buffer contents at any given point in time.
+   */
+  virtual void setBufferStats(const BufferStats& stats) PURE;
 
   /**
    * @return the SSL connection data if this is an SSL connection, or nullptr if it is not.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -4,10 +4,6 @@
 
 #include "common/event/libevent.h"
 
-// Forward decls to avoid leaking libevent headers to rest of program.
-struct evbuffer_cb_info;
-typedef void (*evbuffer_cb_func)(evbuffer* buffer, const evbuffer_cb_info* info, void* arg);
-
 namespace Buffer {
 
 /**
@@ -34,17 +30,10 @@ public:
   int read(int fd, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   ssize_t search(const void* data, uint64_t size, size_t start) const override;
-  void setCallback(Callback callback) override;
   int write(int fd) override;
 
 private:
-  void onBufferChange(const evbuffer_cb_info& info);
-
-  static const evbuffer_cb_func buffer_cb_; // Static callback used for all evbuffer callbacks.
-                                            // This allows us to add/remove by value.
-
   Event::Libevent::BufferPtr buffer_;
-  Callback cb_; // The per buffer callback. Invoked via the buffer_cb_ static thunk.
 };
 
 } // Buffer

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -110,7 +110,6 @@ public:
   }
 
   // Network::ConnectionCallbacks
-  void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
   void onEvent(uint32_t events) override;
 
 private:

--- a/source/common/filter/ratelimit.h
+++ b/source/common/filter/ratelimit.h
@@ -74,7 +74,6 @@ public:
   }
 
   // Network::ConnectionCallbacks
-  void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
   void onEvent(uint32_t events) override;
 
   // RateLimit::RequestCallbacks

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -17,6 +17,8 @@ namespace Filter {
  */
 // clang-format off
 #define ALL_TCP_PROXY_STATS(COUNTER, GAUGE)                                                        \
+  COUNTER(downstream_cx_rx_bytes_total)                                                            \
+  GAUGE  (downstream_cx_rx_bytes_buffered) \
   COUNTER(downstream_cx_tx_bytes_total)                                                            \
   GAUGE  (downstream_cx_tx_bytes_buffered)
 // clang-format on
@@ -61,22 +63,13 @@ public:
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;
   Network::FilterStatus onNewConnection() override { return initializeUpstreamConnection(); }
-  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
-    read_callbacks_ = &callbacks;
-    conn_log_info("new tcp proxy session", read_callbacks_->connection());
-    read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
-  }
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
 
 private:
   struct DownstreamCallbacks : public Network::ConnectionCallbacks {
     DownstreamCallbacks(TcpProxy& parent) : parent_(parent) {}
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
-                        int64_t delta) override {
-      parent_.onDownstreamBufferChange(type, old_size, delta);
-    }
-
     void onEvent(uint32_t event) override { parent_.onDownstreamEvent(event); }
 
     TcpProxy& parent_;
@@ -87,11 +80,6 @@ private:
     UpstreamCallbacks(TcpProxy& parent) : parent_(parent) {}
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
-                        int64_t delta) override {
-      parent_.onUpstreamBufferChange(type, old_size, delta);
-    }
-
     void onEvent(uint32_t event) override { parent_.onUpstreamEvent(event); }
 
     // Network::ReadFilter
@@ -105,10 +93,7 @@ private:
 
   Network::FilterStatus initializeUpstreamConnection();
   void onConnectTimeout();
-  void onDownstreamBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
-                                int64_t delta);
   void onDownstreamEvent(uint32_t event);
-  void onUpstreamBufferChange(Network::ConnectionBufferType type, uint64_t old_size, int64_t delta);
   void onUpstreamData(Buffer::Instance& data);
   void onUpstreamEvent(uint32_t event);
 

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -18,7 +18,7 @@ namespace Filter {
 // clang-format off
 #define ALL_TCP_PROXY_STATS(COUNTER, GAUGE)                                                        \
   COUNTER(downstream_cx_rx_bytes_total)                                                            \
-  GAUGE  (downstream_cx_rx_bytes_buffered) \
+  GAUGE  (downstream_cx_rx_bytes_buffered)                                                         \
   COUNTER(downstream_cx_tx_bytes_total)                                                            \
   GAUGE  (downstream_cx_tx_bytes_buffered)
 // clang-format on

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -99,6 +99,10 @@ public:
    */
   StreamEncoder& newStream(StreamDecoder& response_decoder);
 
+  void setBufferStats(const Network::Connection::BufferStats& stats) {
+    connection_->setBufferStats(stats);
+  }
+
   void setCodecClientCallbacks(CodecClientCallbacks& callbacks) {
     codec_client_callbacks_ = &callbacks;
   }
@@ -180,7 +184,6 @@ private:
   void onData(Buffer::Instance& data);
 
   // Network::ConnectionCallbacks
-  void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
   void onEvent(uint32_t events) override;
 
   std::list<ActiveRequestPtr> active_requests_;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -57,6 +57,11 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
         [this]() -> void { onIdleTimeout(); });
     idle_timer_->enableTimer(config_.idleTimeout().value());
   }
+
+  read_callbacks_->connection().setBufferStats({stats_.named_.downstream_cx_rx_bytes_total_,
+                                                stats_.named_.downstream_cx_rx_bytes_buffered_,
+                                                stats_.named_.downstream_cx_tx_bytes_total_,
+                                                stats_.named_.downstream_cx_tx_bytes_buffered_});
 }
 
 ConnectionManagerImpl::~ConnectionManagerImpl() {
@@ -187,14 +192,6 @@ Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
   } while (redispatch);
 
   return Network::FilterStatus::StopIteration;
-}
-
-void ConnectionManagerImpl::onBufferChange(Network::ConnectionBufferType type, uint64_t,
-                                           int64_t delta) {
-  Network::Utility::updateBufferStats(type, delta, stats_.named_.downstream_cx_rx_bytes_total_,
-                                      stats_.named_.downstream_cx_rx_bytes_buffered_,
-                                      stats_.named_.downstream_cx_tx_bytes_total_,
-                                      stats_.named_.downstream_cx_tx_bytes_buffered_);
 }
 
 void ConnectionManagerImpl::resetAllStreams() {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -215,8 +215,6 @@ public:
   StreamDecoder& newStream(StreamEncoder& response_encoder) override;
 
   // Network::ConnectionCallbacks
-  void onBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
-                      int64_t delta) override;
   void onEvent(uint32_t events) override;
 
 private:

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -70,8 +70,6 @@ protected:
     void onConnectTimeout();
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType type, uint64_t old_size,
-                        int64_t delta) override;
     void onEvent(uint32_t events) override { parent_.onConnectionEvent(*this, events); }
 
     ConnPoolImpl& parent_;

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -226,21 +226,17 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_active_.inc();
   parent_.host_->cluster().stats().upstream_cx_http2_total_.inc();
   conn_length_ = parent_.host_->cluster().stats().upstream_cx_length_ms_.allocateSpan();
+
+  client_->setBufferStats({parent_.host_->cluster().stats().upstream_cx_rx_bytes_total_,
+                           parent_.host_->cluster().stats().upstream_cx_rx_bytes_buffered_,
+                           parent_.host_->cluster().stats().upstream_cx_tx_bytes_total_,
+                           parent_.host_->cluster().stats().upstream_cx_tx_bytes_buffered_});
 }
 
 ConnPoolImpl::ActiveClient::~ActiveClient() {
   parent_.host_->stats().cx_active_.dec();
   parent_.host_->cluster().stats().upstream_cx_active_.dec();
   conn_length_->complete();
-}
-
-void ConnPoolImpl::ActiveClient::onBufferChange(Network::ConnectionBufferType type, uint64_t,
-                                                int64_t delta) {
-  Network::Utility::updateBufferStats(
-      type, delta, parent_.host_->cluster().stats().upstream_cx_rx_bytes_total_,
-      parent_.host_->cluster().stats().upstream_cx_rx_bytes_buffered_,
-      parent_.host_->cluster().stats().upstream_cx_tx_bytes_total_,
-      parent_.host_->cluster().stats().upstream_cx_tx_bytes_buffered_);
 }
 
 CodecClientPtr ProdConnPoolImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -37,7 +37,6 @@ protected:
     void onConnectTimeout() { parent_.onConnectTimeout(*this); }
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType type, uint64_t, int64_t delta) override;
     void onEvent(uint32_t events) override { parent_.onConnectionEvent(*this, events); }
 
     // CodecClientCallbacks

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -104,7 +104,6 @@ public:
 
   // Network::ConnectionCallbacks
   void onEvent(uint32_t event) override;
-  void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
 
 private:
   struct ActiveQuery {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -253,10 +253,8 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     if (rc == 0) {
       action = PostIoAction::Close;
       break;
-    }
-
-    // Remote error (might be no data).
-    if (rc == -1) {
+    } else if (rc == -1) {
+      // Remote error (might be no data).
       conn_log_trace("read error: {}", *this, errno);
       if (errno == EAGAIN) {
         action = PostIoAction::KeepOpen;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -12,6 +12,24 @@
 
 namespace Network {
 
+void ConnectionImplUtility::updateBufferStats(uint64_t delta, uint64_t new_total,
+                                              uint64_t& previous_total, Stats::Counter& stat_total,
+                                              Stats::Gauge& stat_current) {
+  if (delta) {
+    stat_total.add(delta);
+  }
+
+  if (new_total != previous_total) {
+    if (new_total > previous_total) {
+      stat_current.add(new_total - previous_total);
+    } else {
+      stat_current.sub(previous_total - new_total);
+    }
+
+    previous_total = new_total;
+  }
+}
+
 std::atomic<uint64_t> ConnectionImpl::next_global_id_;
 
 ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
@@ -25,13 +43,6 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
 
   file_event_ =
       dispatcher_.createFileEvent(fd_, [this](uint32_t events) -> void { onFileEvent(events); });
-
-  read_buffer_.setCallback([this](uint64_t old_size, int64_t delta) -> void {
-    onBufferChange(ConnectionBufferType::Read, old_size, delta);
-  });
-  write_buffer_.setCallback([this](uint64_t old_size, int64_t delta) -> void {
-    onBufferChange(ConnectionBufferType::Write, old_size, delta);
-  });
 }
 
 ConnectionImpl::~ConnectionImpl() {
@@ -93,20 +104,10 @@ void ConnectionImpl::closeSocket(uint32_t close_type) {
 
   conn_log_debug("closing socket: {}", *this, close_type);
 
-  // Drain input and output buffers so that callbacks get fired. This does not happen automatically
-  // as part of destruction.
-  uint64_t current_read_buffer_length = read_buffer_.length();
-  read_buffer_.setCallback(nullptr);
-  if (current_read_buffer_length > 0) {
-    onBufferChange(ConnectionBufferType::Read, current_read_buffer_length,
-                   -current_read_buffer_length);
-  }
-  uint64_t current_write_buffer_length = write_buffer_.length();
-  write_buffer_.setCallback(nullptr);
-  if (current_write_buffer_length > 0) {
-    onBufferChange(ConnectionBufferType::Write, current_write_buffer_length,
-                   -current_write_buffer_length);
-  }
+  // Drain input and output buffers.
+  updateReadBufferStats(0, 0);
+  updateWriteBufferStats(0, 0);
+  buffer_stats_.reset();
 
   file_event_.reset();
   ::close(fd_);
@@ -148,18 +149,12 @@ void ConnectionImpl::noDelay(bool enable) {
 
 uint64_t ConnectionImpl::id() { return id_; }
 
-void ConnectionImpl::onBufferChange(ConnectionBufferType type, uint64_t old_size, int64_t delta) {
-  for (ConnectionCallbacks* callbacks : callbacks_) {
-    callbacks->onBufferChange(type, old_size, delta);
-  }
-}
-
-void ConnectionImpl::onRead() {
+void ConnectionImpl::onRead(uint64_t read_buffer_size) {
   if (!(state_ & InternalState::ReadEnabled)) {
     return;
   }
 
-  if (read_buffer_.length() == 0) {
+  if (read_buffer_size == 0) {
     return;
   }
 
@@ -243,7 +238,9 @@ void ConnectionImpl::onFileEvent(uint32_t events) {
   }
 }
 
-ConnectionImpl::PostIoAction ConnectionImpl::doReadFromSocket() {
+ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
+  PostIoAction action;
+  uint64_t bytes_read = 0;
   do {
     // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
     // use an ioctl() before every read to figure out how much data there is to read.
@@ -254,38 +251,50 @@ ConnectionImpl::PostIoAction ConnectionImpl::doReadFromSocket() {
 
     // Remote close. Might need to raise data before raising close.
     if (rc == 0) {
-      return PostIoAction::Close;
+      action = PostIoAction::Close;
+      break;
     }
 
     // Remote error (might be no data).
     if (rc == -1) {
       conn_log_trace("read error: {}", *this, errno);
       if (errno == EAGAIN) {
-        return PostIoAction::KeepOpen;
+        action = PostIoAction::KeepOpen;
       } else {
-        return PostIoAction::Close;
+        action = PostIoAction::Close;
       }
+
+      break;
+    } else {
+      bytes_read += rc;
     }
   } while (true);
+
+  return {action, bytes_read};
 }
 
 void ConnectionImpl::onReadReady() {
   ASSERT(!(state_ & InternalState::Connecting));
 
-  PostIoAction action = doReadFromSocket();
-  onRead();
+  IoResult result = doReadFromSocket();
+  uint64_t new_buffer_size = read_buffer_.length();
+  updateReadBufferStats(result.bytes_processed_, new_buffer_size);
+  onRead(new_buffer_size);
 
   // The read callback may have already closed the connection.
-  if (action == PostIoAction::Close) {
+  if (result.action_ == PostIoAction::Close) {
     conn_log_debug("remote close", *this);
     closeSocket(ConnectionEvent::RemoteClose);
   }
 }
 
-ConnectionImpl::PostIoAction ConnectionImpl::doWriteToSocket() {
+ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
+  PostIoAction action;
+  uint64_t bytes_written = 0;
   do {
     if (write_buffer_.length() == 0) {
-      return PostIoAction::KeepOpen;
+      action = PostIoAction::KeepOpen;
+      break;
     }
 
     int rc = write_buffer_.write(fd_);
@@ -293,12 +302,18 @@ ConnectionImpl::PostIoAction ConnectionImpl::doWriteToSocket() {
     if (rc == -1) {
       conn_log_trace("write error: {}", *this, errno);
       if (errno == EAGAIN) {
-        return PostIoAction::KeepOpen;
+        action = PostIoAction::KeepOpen;
       } else {
-        return PostIoAction::Close;
+        action = PostIoAction::Close;
       }
+
+      break;
+    } else {
+      bytes_written += rc;
     }
   } while (true);
+
+  return {action, bytes_written};
 }
 
 void ConnectionImpl::onConnected() { raiseEvents(ConnectionEvent::Connected); }
@@ -324,12 +339,16 @@ void ConnectionImpl::onWriteReady() {
     }
   }
 
-  if (doWriteToSocket() == PostIoAction::Close) {
+  IoResult result = doWriteToSocket();
+  uint64_t new_buffer_size = write_buffer_.length();
+  updateWriteBufferStats(result.bytes_processed_, new_buffer_size);
+
+  if (result.action_ == PostIoAction::Close) {
     // It is possible (though unlikely) for the connection to have already been closed during the
     // write callback. This can happen if we manage to complete the SSL handshake in the write
     // callback, raise a connected event, and close the connection.
     closeSocket(ConnectionEvent::RemoteClose);
-  } else if ((state_ & InternalState::CloseWithFlush) && write_buffer_.length() == 0) {
+  } else if ((state_ & InternalState::CloseWithFlush) && new_buffer_size == 0) {
     conn_log_debug("write flush complete", *this);
     closeSocket(ConnectionEvent::LocalClose);
   }
@@ -351,6 +370,31 @@ void ConnectionImpl::doConnect(const sockaddr* addr, socklen_t addrlen) {
       conn_log_debug("immediate connection error: {}", *this, errno);
     }
   }
+}
+
+void ConnectionImpl::setBufferStats(const BufferStats& stats) {
+  ASSERT(!buffer_stats_);
+  buffer_stats_.reset(new BufferStats(stats));
+}
+
+void ConnectionImpl::updateReadBufferStats(uint64_t num_read, uint64_t new_size) {
+  if (!buffer_stats_) {
+    return;
+  }
+
+  ConnectionImplUtility::updateBufferStats(num_read, new_size, last_read_buffer_size_,
+                                           buffer_stats_->read_total_,
+                                           buffer_stats_->read_current_);
+}
+
+void ConnectionImpl::updateWriteBufferStats(uint64_t num_written, uint64_t new_size) {
+  if (!buffer_stats_) {
+    return;
+  }
+
+  ConnectionImplUtility::updateBufferStats(num_written, new_size, last_write_buffer_size_,
+                                           buffer_stats_->write_total_,
+                                           buffer_stats_->write_current_);
 }
 
 ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -12,6 +12,25 @@
 namespace Network {
 
 /**
+ * Utility functions for the connection implementation.
+ */
+class ConnectionImplUtility {
+public:
+  /**
+   * Update the buffer stats for a connection.
+   * @param delta supplies the data read/written.
+   * @param new_total supplies the final total buffer size.
+   * @param previous_total supplies the previous final total buffer size. previous_total will be
+   *        updated to new_total when the call is complete.
+   * @param stat_total supplies the counter to increment with the delta.
+   * @param stat_current supplies the guage that should be updated with the delta of previous_total
+   *        and new_total.
+   */
+  static void updateBufferStats(uint64_t delta, uint64_t new_total, uint64_t& previous_total,
+                                Stats::Counter& stat_total, Stats::Gauge& stat_current);
+};
+
+/**
  * Implementation of Network::Connection.
  */
 class ConnectionImpl : public virtual Connection,
@@ -37,6 +56,7 @@ public:
   void readDisable(bool disable) override;
   bool readEnabled() override;
   const std::string& remoteAddress() override { return remote_address_; }
+  void setBufferStats(const BufferStats& stats) override;
   Ssl::Connection* ssl() override { return nullptr; }
   State state() override;
   void write(Buffer::Instance& data) override;
@@ -47,6 +67,11 @@ public:
 
 protected:
   enum class PostIoAction { Close, KeepOpen };
+
+  struct IoResult {
+    PostIoAction action_;
+    uint64_t bytes_processed_;
+  };
 
   virtual void closeSocket(uint32_t close_type);
   void doConnect(const sockaddr* addr, socklen_t addrlen);
@@ -67,14 +92,16 @@ private:
   };
   // clang-format on
 
-  virtual PostIoAction doReadFromSocket();
-  virtual PostIoAction doWriteToSocket();
+  virtual IoResult doReadFromSocket();
+  virtual IoResult doWriteToSocket();
   void onBufferChange(ConnectionBufferType type, uint64_t old_size, int64_t delta);
   virtual void onConnected();
   void onFileEvent(uint32_t events);
-  void onRead();
+  void onRead(uint64_t read_buffer_size);
   void onReadReady();
   void onWriteReady();
+  void updateReadBufferStats(uint64_t num_read, uint64_t new_size);
+  void updateWriteBufferStats(uint64_t num_written, uint64_t new_size);
 
   static std::atomic<uint64_t> next_global_id_;
 
@@ -85,6 +112,9 @@ private:
   std::list<ConnectionCallbacks*> callbacks_;
   uint32_t state_{InternalState::ReadEnabled};
   Buffer::Instance* current_write_buffer_{};
+  uint64_t last_read_buffer_size_{};
+  uint64_t last_write_buffer_size_{};
+  std::unique_ptr<BufferStats> buffer_stats_;
 };
 
 /**

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -70,27 +70,6 @@ bool IpWhiteList::contains(const std::string& remote_address) const {
 const std::string Utility::TCP_SCHEME = "tcp://";
 const std::string Utility::UNIX_SCHEME = "unix://";
 
-void Utility::updateBufferStats(ConnectionBufferType type, int64_t delta, Stats::Counter& rx_total,
-                                Stats::Gauge& rx_buffered, Stats::Counter& tx_total,
-                                Stats::Gauge& tx_buffered) {
-  if (type == ConnectionBufferType::Read) {
-    if (delta > 0) {
-      rx_total.add(delta);
-      rx_buffered.add(delta);
-    } else {
-      rx_buffered.sub(std::abs(delta));
-    }
-  } else {
-    ASSERT(type == ConnectionBufferType::Write);
-    if (delta > 0) {
-      tx_total.add(delta);
-      tx_buffered.add(delta);
-    } else {
-      tx_buffered.sub(std::abs(delta));
-    }
-  }
-}
-
 AddrInfoPtr Utility::resolveTCP(const std::string& host, uint32_t port) {
   addrinfo addrinfo_hints;
   memset(&addrinfo_hints, 0, sizeof(addrinfo_hints));

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -38,14 +38,6 @@ public:
   static const std::string UNIX_SCHEME;
 
   /**
-   * Update buffering stats for a connection. Meant to be paired with
-   * ConnectionCallbacks::onBufferChange().
-   */
-  static void updateBufferStats(ConnectionBufferType type, int64_t delta, Stats::Counter& rx_total,
-                                Stats::Gauge& rx_buffered, Stats::Counter& tx_total,
-                                Stats::Gauge& tx_buffered);
-
-  /**
    * Resolve a TCP address.
    * @param host supplies the host name.
    * @param port supplies the port.

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -27,8 +27,8 @@ private:
 
   // Network::ConnectionImpl
   void closeSocket(uint32_t close_type) override;
-  PostIoAction doReadFromSocket() override;
-  PostIoAction doWriteToSocket() override;
+  IoResult doReadFromSocket() override;
+  IoResult doWriteToSocket() override;
   void onConnected() override;
 
   ContextImpl& ctx_;

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -92,7 +92,6 @@ private:
     void shutdown() override;
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
     void onEvent(uint32_t events) override;
 
     TcpStatsdSink& parent_;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -136,7 +136,6 @@ private:
     void onResetStream(Http::StreamResetReason reason) override;
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
     void onEvent(uint32_t events) override;
 
     HttpHealthCheckerImpl& parent_;
@@ -241,7 +240,6 @@ private:
     TcpSessionCallbacks(TcpActiveHealthCheckSession& parent) : parent_(parent) {}
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
     void onEvent(uint32_t events) override { parent_.onEvent(events); }
 
     // Network::ReadFilter

--- a/source/server/connection_handler.h
+++ b/source/server/connection_handler.h
@@ -120,8 +120,6 @@ private:
     ~ActiveConnection();
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
-
     void onEvent(uint32_t event) override {
       // Any event leads to destruction of the connection.
       if (event == Network::ConnectionEvent::LocalClose ||

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -66,7 +66,6 @@ public:
   void waitForDisconnect();
 
   // Network::ConnectionCallbacks
-  void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
   void onEvent(uint32_t events) override;
 
 protected:

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -68,7 +68,6 @@ private:
     ConnectionCallbacks(IntegrationCodecClient& parent) : parent_(parent) {}
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
     void onEvent(uint32_t events) override;
 
     IntegrationCodecClient& parent_;
@@ -113,7 +112,6 @@ private:
     ConnectionCallbacks(IntegrationTcpClient& parent) : parent_(parent) {}
 
     // Network::ConnectionCallbacks
-    void onBufferChange(Network::ConnectionBufferType, uint64_t, int64_t) override {}
     void onEvent(uint32_t events) override;
 
     // Network::ReadFilter

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -16,7 +16,6 @@ public:
   ~MockConnectionCallbacks();
 
   // Network::ConnectionCallbacks
-  MOCK_METHOD3(onBufferChange, void(ConnectionBufferType type, uint64_t old_size, int64_t delta));
   MOCK_METHOD1(onEvent, void(uint32_t events));
 };
 
@@ -54,6 +53,7 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD0(readEnabled, bool());
   MOCK_METHOD0(remoteAddress, const std::string&());
+  MOCK_METHOD1(setBufferStats, void(const BufferStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_METHOD0(state, State());
   MOCK_METHOD1(write, void(Buffer::Instance& data));
@@ -82,6 +82,7 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD0(readEnabled, bool());
   MOCK_METHOD0(remoteAddress, const std::string&());
+  MOCK_METHOD1(setBufferStats, void(const BufferStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_METHOD0(state, State());
   MOCK_METHOD1(write, void(Buffer::Instance& data));

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -7,6 +7,9 @@ namespace Stats {
 MockCounter::MockCounter() {}
 MockCounter::~MockCounter() {}
 
+MockGauge::MockGauge() {}
+MockGauge::~MockGauge() {}
+
 MockTimespan::MockTimespan() {}
 MockTimespan::~MockTimespan() {}
 

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -20,6 +20,21 @@ public:
   MOCK_METHOD0(value, uint64_t());
 };
 
+class MockGauge : public Gauge {
+public:
+  MockGauge();
+  ~MockGauge();
+
+  MOCK_METHOD1(add, void(uint64_t amount));
+  MOCK_METHOD0(dec, void());
+  MOCK_METHOD0(inc, void());
+  MOCK_METHOD0(name, std::string());
+  MOCK_METHOD1(set, void(uint64_t value));
+  MOCK_METHOD1(sub, void(uint64_t amount));
+  MOCK_METHOD0(used, bool());
+  MOCK_METHOD0(value, uint64_t());
+};
+
 class MockTimespan : public Timespan {
 public:
   MockTimespan();


### PR DESCRIPTION
We spend a considerable amount of time computing instantaneous
connection buffer stats and firing callbacks. Currently we only use
this information for stats purposes. This commit makes the buffer
stats eventually consistent and much more streamlined. Eventually,
we can provide direct accessors vs. callbacks if we need to inspect
buffer information in order to apply back pressure.