### PR TITLE
http: select stable stream ID source based on route table

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -244,6 +244,13 @@ public:
    * router.
    */
   virtual const std::list<Http::LowerCaseString>& responseHeadersToRemove() const PURE;
+
+  /**
+   * Return whether the configuration makes use of runtime or not. Callers can use this to
+   * determine whether they should use a fast or slow source of randomness when calling route
+   * functions.
+   */
+  virtual bool usesRuntime() const PURE;
 };
 
 typedef std::unique_ptr<Config> ConfigPtr;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -259,10 +259,10 @@ void ConnectionManagerImpl::onDrainTimeout() {
   checkForDeferredClose();
 }
 
-std::atomic<uint64_t> ConnectionManagerImpl::ActiveStream::next_stream_id_(0);
-
 ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connection_manager)
-    : connection_manager_(connection_manager), stream_id_(next_stream_id_++),
+    : connection_manager_(connection_manager),
+      stream_id_(ConnectionManagerUtility::generateStreamId(
+          connection_manager.config_.routeConfig(), connection_manager.random_generator_)),
       request_timer_(connection_manager_.stats_.named_.downstream_rq_time_.allocateSpan()),
       request_info_(connection_manager_.codec_->protocol()) {
   connection_manager_.stats_.named_.downstream_rq_total_.inc();

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -384,11 +384,6 @@ private:
       bool saw_connection_close_ : 1;
     };
 
-    // NOTE: This is used for stable randomness. For performance reasons we use an incrementing
-    //       counter shared across all threads. This may lead to burstiness but in general should
-    //       provide the intended behavior when doing runtime routing, etc.
-    static std::atomic<uint64_t> next_stream_id_;
-
     ConnectionManagerImpl& connection_manager_;
     const uint64_t stream_id_;
     StreamEncoder* response_encoder_{};

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -8,6 +8,18 @@
 
 namespace Http {
 
+std::atomic<uint64_t> ConnectionManagerUtility::next_stream_id_(0);
+
+uint64_t ConnectionManagerUtility::generateStreamId(const Router::Config& route_table,
+                                                    Runtime::RandomGenerator& random_generator) {
+  // See the comment for next_stream_id_ in conn_manager_utility.h for why we do this.
+  if (route_table.usesRuntime()) {
+    return random_generator.random();
+  } else {
+    return ++next_stream_id_;
+  }
+}
+
 void ConnectionManagerUtility::mutateRequestHeaders(Http::HeaderMap& request_headers,
                                                     Network::Connection& connection,
                                                     ConnectionManagerConfig& config,

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -12,6 +12,9 @@ namespace Http {
  */
 class ConnectionManagerUtility {
 public:
+  static uint64_t generateStreamId(const Router::Config& route_table,
+                                   Runtime::RandomGenerator& random_generator);
+
   static void mutateRequestHeaders(Http::HeaderMap& request_headers,
                                    Network::Connection& connection, ConnectionManagerConfig& config,
                                    Runtime::RandomGenerator& random, Runtime::Loader& runtime);
@@ -22,6 +25,12 @@ public:
 
   static bool shouldTraceRequest(const Http::AccessLog::RequestInfo& request_info,
                                  const Optional<TracingConnectionManagerConfig>& config);
+
+private:
+  // NOTE: This is used for stable randomness in the case where the route table does not use any
+  //       runtime rules. If runtime rules are used, we use true randomness which is slower but
+  //       provides behavior that most consumers would expect.
+  static std::atomic<uint64_t> next_stream_id_;
 };
 
 } // Http

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -80,6 +80,7 @@ public:
                                            uint64_t random_value) const;
   const RouteEntryImplBase* routeFromEntries(const Http::HeaderMap& headers, bool redirect,
                                              uint64_t random_value) const;
+  bool usesRuntime() const;
   const VirtualCluster* virtualClusterFromEntries(const Http::HeaderMap& headers) const;
 
 private:
@@ -179,6 +180,7 @@ public:
   RouteEntryImplBase(const VirtualHost& vhost, const Json::Object& route, Runtime::Loader& loader);
 
   bool isRedirect() const { return !host_redirect_.empty() || !path_redirect_.empty(); }
+  bool usesRuntime() const { return runtime_.valid(); }
 
   // Router::RouteEntry
   const std::string& clusterName() const override;
@@ -276,12 +278,14 @@ public:
 
   const RedirectEntry* redirectRequest(const Http::HeaderMap& headers, uint64_t random_value) const;
   const RouteEntry* routeForRequest(const Http::HeaderMap& headers, uint64_t random_value) const;
+  bool usesRuntime() const { return uses_runtime_; }
 
 private:
   const VirtualHost* findVirtualHost(const Http::HeaderMap& headers) const;
 
   std::unordered_map<std::string, VirtualHostPtr> virtual_hosts_;
   VirtualHostPtr default_virtual_host_;
+  bool uses_runtime_{};
 };
 
 /**
@@ -314,6 +318,8 @@ public:
   const std::list<Http::LowerCaseString>& responseHeadersToRemove() const override {
     return response_headers_to_remove_;
   }
+
+  bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
@@ -348,6 +354,8 @@ public:
   const std::list<Http::LowerCaseString>& responseHeadersToRemove() const override {
     return response_headers_to_remove_;
   }
+
+  bool usesRuntime() const override { return false; }
 
 private:
   std::list<Http::LowerCaseString> internal_only_headers_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -9,6 +9,7 @@
 #include "test/test_common/utility.h"
 
 using testing::_;
+using testing::InSequence;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -33,6 +34,17 @@ public:
   Optional<Http::TracingConnectionManagerConfig> tracing_not_set_;
   Optional<Http::TracingConnectionManagerConfig> set_tracing_all_;
 };
+
+TEST_F(ConnectionManagerUtilityTest, generateStreamId) {
+  InSequence s;
+
+  EXPECT_CALL(config_.route_config_, usesRuntime()).WillOnce(Return(false));
+  ConnectionManagerUtility::generateStreamId(config_.route_config_, random_);
+
+  EXPECT_CALL(config_.route_config_, usesRuntime()).WillOnce(Return(true));
+  EXPECT_CALL(random_, random()).WillOnce(Return(5));
+  EXPECT_EQ(5UL, ConnectionManagerUtility::generateStreamId(config_.route_config_, random_));
+}
 
 TEST_F(ConnectionManagerUtilityTest, ShouldTraceRequest) {
   {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -149,6 +149,8 @@ TEST(RouteMatcherTest, TestRoutes) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_FALSE(config.usesRuntime());
+
   // Base routing testing.
   EXPECT_EQ("instant-server",
             config.routeForRequest(genHeaders("api.lyft.com", "/", "GET"), 0)->clusterName());
@@ -384,6 +386,8 @@ TEST(RouteMatcherTest, Priority) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_FALSE(config.usesRuntime());
+
   EXPECT_EQ(Upstream::ResourcePriority::High,
             config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)->priority());
   EXPECT_EQ(Upstream::ResourcePriority::Default,
@@ -446,6 +450,8 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
+
+  EXPECT_FALSE(config.usesRuntime());
 
   {
     EXPECT_EQ("local_service_without_headers",
@@ -510,6 +516,8 @@ TEST(RouteMatcherTest, ContentType) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_FALSE(config.usesRuntime());
+
   {
     EXPECT_EQ("local_service",
               config.routeForRequest(genHeaders("www.lyft.com", "/", "GET"), 0)->clusterName());
@@ -563,6 +571,8 @@ TEST(RouteMatcherTest, Runtime) {
 
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_TRUE(config.usesRuntime());
+
   EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 10)).WillOnce(Return(true));
   EXPECT_EQ("something_else",
             config.routeForRequest(genHeaders("www.lyft.com", "/", "GET"), 10)->clusterName());
@@ -601,6 +611,8 @@ TEST(RouteMatcherTest, RateLimit) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
+
+  EXPECT_FALSE(config.usesRuntime());
 
   EXPECT_TRUE(config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                   ->rateLimitPolicy()
@@ -678,6 +690,8 @@ TEST(RouteMatcherTest, Shadow) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_TRUE(config.usesRuntime());
+
   EXPECT_EQ("some_cluster", config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                                 ->shadowPolicy()
                                 .cluster());
@@ -737,6 +751,8 @@ TEST(RouteMatcherTest, Retry) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
+
+  EXPECT_FALSE(config.usesRuntime());
 
   EXPECT_EQ(1U, config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                     ->retryPolicy()
@@ -898,6 +914,8 @@ TEST(RouteMatcherTest, Redirect) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(loader, runtime, cm);
 
+  EXPECT_FALSE(config.usesRuntime());
+
   EXPECT_EQ(nullptr,
             config.redirectRequest(genRedirectHeaders("www.foo.com", "/foo", true, true), 0));
   EXPECT_EQ(nullptr,
@@ -942,6 +960,7 @@ TEST(NullConfigImplTest, All) {
   EXPECT_EQ(0UL, config.internalOnlyHeaders().size());
   EXPECT_EQ(0UL, config.responseHeadersToAdd().size());
   EXPECT_EQ(0UL, config.responseHeadersToRemove().size());
+  EXPECT_FALSE(config.usesRuntime());
 }
 
 } // Router

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -124,6 +124,7 @@ public:
   MOCK_CONST_METHOD0(responseHeadersToAdd,
                      const std::list<std::pair<Http::LowerCaseString, std::string>>&());
   MOCK_CONST_METHOD0(responseHeadersToRemove, const std::list<Http::LowerCaseString>&());
+  MOCK_CONST_METHOD0(usesRuntime, bool());
 
   std::list<Http::LowerCaseString> internal_only_headers_;
   std::list<std::pair<Http::LowerCaseString, std::string>> response_headers_to_add_;


### PR DESCRIPTION
We've gone through a few different iterations of how we select the stable
random ID uses for request routing. We used to use a random number for all
requests, but this yields a performance hit when there is no need for a
true random number. Then we switched to an incrementing ID which gives
approximate randomness at high RPS, but is confusing for new users and in
certain cases does not really provide the expected behavior.

In this commit we implement both cases. If the route table does not use
runtime we use the fast approach. If it uses runtime, we use a real random
number which will provide behavior that most people would expect.