### PR TITLE
Add access log codes for fault injection

### DIFF
--- a/docs/configuration/http_conn_man/access_log.rst
+++ b/docs/configuration/http_conn_man/access_log.rst
@@ -83,6 +83,7 @@ The following command operators are supported:
   * **UC**: Upstream connection termination in addition to 503 response code.
   * **UO**: Upstream overflow (:ref:`circuit breaking <arch_overview_circuit_break>`) in addition to 503 response code.
   * **NR**: No :ref:`route configured <arch_overview_http_routing>` for a given request in addition to 404 response code.
+  * **FI**: The request was aborted as a result of :ref:`fault injection <config_http_filters_fault_injection>`.
 
 %UPSTREAM_HOST%
   Upstream host URL (e.g., tcp://ip:port for TCP connections).

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -32,7 +32,7 @@ enum class FailureReason {
   UpstreamOverflow,
   // No route found for a given request.
   NoRouteFound,
-  // Used when faults (abort with error codes) are injected
+  // Used when faults (abort with error codes) are injected,
   FaultInjected,
 };
 

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -32,7 +32,7 @@ enum class FailureReason {
   UpstreamOverflow,
   // No route found for a given request.
   NoRouteFound,
-  // Used when faults (abort with error codes) are injected,
+  // Used when faults (abort with error codes) are injected.
   FaultInjected,
 };
 

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -32,6 +32,8 @@ enum class FailureReason {
   UpstreamOverflow,
   // No route found for a given request.
   NoRouteFound,
+  // Used when faults (abort with error codes) are injected
+  FaultInjected,
 };
 
 /**

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -16,6 +16,7 @@ const std::string FilterReasonUtils::UPSTREAM_CONNECTION_FAILURE = "UF";
 const std::string FilterReasonUtils::UPSTREAM_CONNECTION_TERMINATION = "UC";
 const std::string FilterReasonUtils::UPSTREAM_OVERFLOW = "UO";
 const std::string FilterReasonUtils::NO_ROUTE_FOUND = "NR";
+const std::string FilterReasonUtils::FAULT_INJECTED = "FI";
 
 const std::string& FilterReasonUtils::toShortString(FailureReason failure_reason) {
   switch (failure_reason) {
@@ -39,6 +40,8 @@ const std::string& FilterReasonUtils::toShortString(FailureReason failure_reason
     return UPSTREAM_OVERFLOW;
   case FailureReason::NoRouteFound:
     return NO_ROUTE_FOUND;
+  case FailureReason::FaultInjected:
+    return FAULT_INJECTED;
   }
 
   throw std::invalid_argument("Unknown failure_reason");

--- a/source/common/http/access_log/access_log_formatter.h
+++ b/source/common/http/access_log/access_log_formatter.h
@@ -25,6 +25,7 @@ private:
   const static std::string UPSTREAM_CONNECTION_TERMINATION;
   const static std::string UPSTREAM_OVERFLOW;
   const static std::string NO_ROUTE_FOUND;
+  const static std::string FAULT_INJECTED;
 };
 
 /**

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -137,6 +137,7 @@ void FaultFilter::abortWithHTTPStatus() {
                                   "fault.http.abort.http_status", config_->abortCode()))}}};
   callbacks_->encodeHeaders(std::move(response_headers), true);
   config_->stats().aborts_injected_.inc();
+  callbacks_->requestInfo().onFailedResponse(Http::AccessLog::FailureReason::FaultInjected);
 }
 
 void FaultFilter::resetTimerState() {

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -22,7 +22,8 @@ TEST(FailureReasonUtilsTest, toShortStringConversion) {
       std::make_pair(FailureReason::UpstreamConnectionFailure, "UF"),
       std::make_pair(FailureReason::UpstreamConnectionTermination, "UC"),
       std::make_pair(FailureReason::UpstreamOverflow, "UO"),
-      std::make_pair(FailureReason::NoRouteFound, "NR")};
+      std::make_pair(FailureReason::NoRouteFound, "NR"),
+      std::make_pair(FailureReason::FaultInjected, "FI")};
 
   for (const auto& testCase : expected) {
     EXPECT_EQ(testCase.second, FilterReasonUtils::toShortString(testCase.first));


### PR DESCRIPTION
This PR adds an access log code "FI". FI is added to access log whenever a request is aborted by the fault injection filter.