### PR TITLE
filesystem: fix file corruption via concurrent writes

### DIFF
--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -4,13 +4,17 @@ namespace AccessLog {
 
 void AccessLogManagerImpl::reopen() {
   for (auto& access_log : access_logs_) {
-    access_log->reopen();
+    access_log.second->reopen();
   }
 }
 
 Filesystem::FilePtr AccessLogManagerImpl::createAccessLog(const std::string& file_name) {
-  access_logs_.push_back(api_.createFile(file_name, dispatcher_, lock_, stats_store_));
-  return access_logs_.back();
+  if (access_logs_.count(file_name)) {
+    return access_logs_[file_name];
+  }
+
+  access_logs_[file_name] = api_.createFile(file_name, dispatcher_, lock_, stats_store_);
+  return access_logs_[file_name];
 }
 
 } // AccessLog

--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -20,7 +20,7 @@ private:
   Event::Dispatcher& dispatcher_;
   Thread::BasicLockable& lock_;
   Stats::Store& stats_store_;
-  std::list<Filesystem::FilePtr> access_logs_;
+  std::unordered_map<std::string, Filesystem::FilePtr> access_logs_;
 };
 
 } // AccessLog

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -53,7 +53,7 @@ ssize_t OsSysCallsImpl::write(int fd, const void* buffer, size_t num_bytes) {
 FileImpl::FileImpl(const std::string& path, Event::Dispatcher& dispatcher,
                    Thread::BasicLockable& lock, OsSysCalls& os_sys_calls, Stats::Store& stats_store,
                    std::chrono::milliseconds flush_interval_msec)
-    : path_(path), lock_(lock), dispatcher_(dispatcher), os_sys_calls_(os_sys_calls),
+    : path_(path), flush_lock_(lock), dispatcher_(dispatcher), os_sys_calls_(os_sys_calls),
       flush_interval_msec_(flush_interval_msec),
       stats_{FILESYSTEM_STATS(POOL_COUNTER_PREFIX(stats_store, "filesystem."),
                               POOL_GAUGE_PREFIX(stats_store, "filesystem."))} {
@@ -73,7 +73,7 @@ void FileImpl::reopen() { reopen_file_ = true; }
 
 FileImpl::~FileImpl() {
   {
-    std::unique_lock<Thread::BasicLockable> lock(lock_);
+    std::unique_lock<std::mutex> lock(write_lock_);
     flush_thread_exit_ = true;
     flush_event_.notify_one();
   }
@@ -86,7 +86,6 @@ FileImpl::~FileImpl() {
   if (fd_ != -1) {
     if (flush_buffer_.length() > 0) {
       doWrite(flush_buffer_);
-      stats_.write_total_buffered_.sub(flush_buffer_.length());
     }
 
     os_sys_calls_.close(fd_);
@@ -97,16 +96,30 @@ void FileImpl::doWrite(Buffer::Instance& buffer) {
   uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
   Buffer::RawSlice slices[num_slices];
   buffer.getRawSlices(slices, num_slices);
+
+  // We must do the actual writes to disk under lock, so that we don't intermix chunks from
+  // different FileImpl pointing to the same underlying file. This can happen either via hot
+  // restart or if calling code opens the same underlying file into a different FileImpl in the
+  // same process.
+  // TODO PERF: Currently, we use a single cross process lock to serialize all disk writes. This
+  //            will never block network workers, but does mean that only a single flush thread can
+  //            actually flush to disk. In the future it would be nice if we did away with the cross
+  //            process lock or had multiple locks.
+  std::unique_lock<Thread::BasicLockable> lock(flush_lock_);
   for (Buffer::RawSlice& slice : slices) {
     ssize_t rc = os_sys_calls_.write(fd_, slice.mem_, slice.len_);
     ASSERT(rc == static_cast<ssize_t>(slice.len_));
     UNREFERENCED_PARAMETER(rc);
     stats_.write_completed_.inc();
   }
+  lock.unlock();
+
+  stats_.write_total_buffered_.sub(buffer.length());
+  buffer.drain(buffer.length());
 }
 
 void FileImpl::flushThreadFunc() {
-  std::unique_lock<Thread::BasicLockable> lock(lock_);
+  std::unique_lock<std::mutex> lock(write_lock_);
 
   while (true) {
     // flush_event_ can be woken up either by large enough flush_buffer or by timer.
@@ -120,12 +133,8 @@ void FileImpl::flushThreadFunc() {
     }
 
     ASSERT(flush_buffer_.length() > 0);
-    Buffer::RawSlice slices[1];
-    flush_buffer_.getRawSlices(slices, 1);
-    Buffer::OwnedImpl copy(slices[0].mem_, slices[0].len_);
-    flush_buffer_.drain(slices[0].len_);
-    stats_.write_total_buffered_.sub(slices[0].len_);
-
+    about_to_write_buffer_.move(flush_buffer_);
+    ASSERT(flush_buffer_.length() == 0);
     lock.unlock();
 
     // if we failed to open file before (-1 == fd_), then simply ignore
@@ -137,7 +146,7 @@ void FileImpl::flushThreadFunc() {
           open();
         }
 
-        doWrite(copy);
+        doWrite(about_to_write_buffer_);
       } catch (const EnvoyException&) {
         stats_.reopen_failed_.inc();
       }
@@ -148,7 +157,7 @@ void FileImpl::flushThreadFunc() {
 }
 
 void FileImpl::write(const std::string& data) {
-  std::unique_lock<Thread::BasicLockable> lock(lock_);
+  std::unique_lock<std::mutex> lock(write_lock_);
 
   if (flush_thread_ == nullptr) {
     createFlushStructures();

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -82,17 +82,30 @@ private:
 
   int fd_;
   std::string path_;
-  Thread::BasicLockable& lock_;
+  Thread::BasicLockable& flush_lock_; // This lock is used only by the flush thread when writing
+                                      // to disk. This is used to make sure that file blocks do
+                                      // not get interleaved.
+  std::mutex write_lock_; // The lock is used when filling the flush buffer. It allows multiple
+                          // threads to write to the same file at relatively high performance.
+                          // It is always local to the process.
   Thread::ThreadPtr flush_thread_;
   std::condition_variable_any flush_event_;
   std::atomic<bool> flush_thread_exit_{};
   std::atomic<bool> reopen_file_{};
-  Buffer::OwnedImpl flush_buffer_;
+  Buffer::OwnedImpl flush_buffer_; // This buffer is used by multiple threads. It gets filled and
+                                   // then flushed either when max size is reached or when a timer
+                                   // fires.
+  Buffer::OwnedImpl about_to_write_buffer_; // This buffer is used only by the flush thread. Data
+                                            // is moved from flush_buffer_ under lock, and then
+                                            // the lock is released so that flush_buffer_ can
+                                            // continue to fill. This buffer is then used for the
+                                            // final write to disk.
   Event::TimerPtr flush_timer_;
   Event::Dispatcher& dispatcher_;
   OsSysCalls& os_sys_calls_;
-  // Time interval buffer gets flushed no matter if it reached the MIN_FLUSH_SIZE or not.
-  const std::chrono::milliseconds flush_interval_msec_;
+  const std::chrono::milliseconds flush_interval_msec_; // Time interval buffer gets flushed no
+                                                        // matter if it reached the MIN_FLUSH_SIZE
+                                                        // or not.
   FileSystemStats stats_;
 };
 

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -25,6 +25,10 @@ TEST(AccessLogManagerImpl, reopenAllFiles) {
   EXPECT_CALL(api, createFile("bar", _, _, _)).WillOnce(Return(log2));
   access_log_manager.createAccessLog("bar");
 
+  // Make sure that getting the access log with the same name returns the same underlying file.
+  EXPECT_EQ(log1, access_log_manager.createAccessLog("foo"));
+  EXPECT_EQ(log2, access_log_manager.createAccessLog("bar"));
+
   EXPECT_CALL(*log1, reopen());
   EXPECT_CALL(*log2, reopen());
   access_log_manager.reopen();


### PR DESCRIPTION
If two FileImpl point to the same underlying file (either via hot restart or
if the same file is opened multiple times which can happen during certain logging
configurations), the current code has a race condition where the flush buffer
might be split across writes and then interleaved with another flush.

This commit fixes that by doing two things:
1) Lock when writing to disk to make sure that no interleaving happens when
   writing blocks.
2) Introduce a new lock to guard filling the buffer that is local process only.
3) Make the access log manager return the same underlying FileImpl when asked
   for the same file name. This will reduce contention for the per process like
   and also lead to less threads in certain cases.