### PR TITLE
outlier detection: charge all failures to host

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -91,45 +91,41 @@ Filter::~Filter() {
   ASSERT(!retry_state_);
 }
 
-const std::string& Filter::upstreamZone() {
-  return upstream_host_ ? upstream_host_->zone() : EMPTY_STRING;
+const std::string& Filter::upstreamZone(Upstream::HostDescriptionPtr upstream_host) {
+  return upstream_host ? upstream_host->zone() : EMPTY_STRING;
 }
 
-void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers) {
+void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
+                                Upstream::HostDescriptionPtr upstream_host) {
   if (config_.emit_dynamic_stats_ && !callbacks_->requestInfo().healthCheck()) {
     const Http::HeaderEntry* upstream_canary_header = response_headers.EnvoyUpstreamCanary();
     const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
 
     bool is_canary = (upstream_canary_header && upstream_canary_header->value() == "true") ||
-                     (upstream_host_ ? upstream_host_->canary() : false);
+                     (upstream_host ? upstream_host->canary() : false);
     bool internal_request = internal_request_header && internal_request_header->value() == "true";
-
-    if (upstream_host_) {
-      upstream_host_->outlierDetector().putHttpResponseCode(
-          Http::Utility::getResponseStatus(response_headers));
-    }
 
     Http::CodeUtility::ResponseStatInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_headers, internal_request,
         route_->virtualHostName(), request_vcluster_ ? request_vcluster_->name() : "",
-        config_.service_zone_, upstreamZone(), is_canary};
+        config_.service_zone_, upstreamZone(upstream_host), is_canary};
 
     Http::CodeUtility::chargeResponseStat(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
       Http::CodeUtility::ResponseStatInfo info{config_.stats_store_, alt_prefix, response_headers,
                                                internal_request, "", "", config_.service_zone_,
-                                               upstreamZone(), is_canary};
+                                               upstreamZone(upstream_host), is_canary};
 
       Http::CodeUtility::chargeResponseStat(info);
     }
   }
 }
 
-void Filter::chargeUpstreamCode(Http::Code code) {
+void Filter::chargeUpstreamCode(Http::Code code, Upstream::HostDescriptionPtr upstream_host) {
   Http::HeaderMapImpl fake_response_headers{
       {Http::Headers::get().Status, std::to_string(enumToInt(code))}};
-  chargeUpstreamCode(fake_response_headers);
+  chargeUpstreamCode(fake_response_headers, upstream_host);
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool end_stream) {
@@ -181,7 +177,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   // See if we are supposed to immediately kill some percentage of this cluster's traffic.
   if (cluster_->maintenanceMode()) {
     callbacks_->requestInfo().onFailedResponse(Http::AccessLog::FailureReason::UpstreamOverflow);
-    chargeUpstreamCode(Http::Code::ServiceUnavailable);
+    chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr);
     Http::Utility::sendLocalReply(*callbacks_, Http::Code::ServiceUnavailable, "maintenance mode");
     return Http::FilterHeadersStatus::StopIteration;
   }
@@ -227,7 +223,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
 void Filter::sendNoHealthyUpstreamResponse() {
   callbacks_->requestInfo().onFailedResponse(Http::AccessLog::FailureReason::NoHealthyUpstream);
-  chargeUpstreamCode(Http::Code::ServiceUnavailable);
+  chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr);
   Http::Utility::sendLocalReply(*callbacks_, Http::Code::ServiceUnavailable, "no healthy upstream");
 }
 
@@ -343,6 +339,14 @@ void Filter::onUpstreamReset(UpstreamResetType type,
     stream_log_debug("upstream reset", *callbacks_);
   }
 
+  Upstream::HostDescriptionPtr upstream_host;
+  if (upstream_request_) {
+    upstream_host = upstream_request_->upstream_host_;
+    upstream_host->outlierDetector().putHttpResponseCode(
+        enumToInt(type == UpstreamResetType::Reset ? Http::Code::ServiceUnavailable
+                                                   : Http::Code::GatewayTimeout));
+  }
+
   // We don't retry on a global timeout or if we already started the response.
   if (type != UpstreamResetType::GlobalTimeout && !downstream_response_started_ && retry_state_ &&
       retry_state_->shouldRetry(nullptr, reset_reason, [this]() -> void { doRetry(); }) &&
@@ -373,7 +377,7 @@ void Filter::onUpstreamReset(UpstreamResetType type,
       body = "upstream connect error or disconnect/reset before headers";
     }
 
-    chargeUpstreamCode(code);
+    chargeUpstreamCode(code, upstream_host);
     Http::Utility::sendLocalReply(*callbacks_, code, body);
   }
 }
@@ -402,6 +406,9 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   stream_log_debug("upstream headers complete: end_stream={}", *callbacks_, end_stream);
   ASSERT(!downstream_response_started_);
 
+  upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(
+      Http::Utility::getResponseStatus(*headers));
+
   if (retry_state_ &&
       retry_state_->shouldRetry(headers.get(), Optional<Http::StreamResetReason>(),
                                 [this]() -> void { doRetry(); }) &&
@@ -426,8 +433,8 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
 
   upstream_request_->upstream_canary_ =
       (headers->EnvoyUpstreamCanary() && headers->EnvoyUpstreamCanary()->value() == "true") ||
-      (upstream_host_ ? upstream_host_->canary() : false);
-  chargeUpstreamCode(*headers);
+      upstream_request_->upstream_host_->canary();
+  chargeUpstreamCode(*headers, upstream_request_->upstream_host_);
 
   downstream_response_started_ = true;
   if (end_stream) {
@@ -460,7 +467,7 @@ void Filter::onUpstreamComplete() {
     std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now() - downstream_request_complete_time_);
 
-    upstream_host_->outlierDetector().putResponseTime(response_time);
+    upstream_request_->upstream_host_->outlierDetector().putResponseTime(response_time);
 
     const Http::HeaderEntry* internal_request_header = downstream_headers_->EnvoyInternalRequest();
     bool internal_request = internal_request_header && internal_request_header->value() == "true";
@@ -468,14 +475,16 @@ void Filter::onUpstreamComplete() {
     Http::CodeUtility::ResponseTimingInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_time,
         upstream_request_->upstream_canary_, internal_request, route_->virtualHostName(),
-        request_vcluster_ ? request_vcluster_->name() : "", config_.service_zone_, upstreamZone()};
+        request_vcluster_ ? request_vcluster_->name() : "", config_.service_zone_,
+        upstreamZone(upstream_request_->upstream_host_)};
 
     Http::CodeUtility::chargeResponseTiming(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
-      Http::CodeUtility::ResponseTimingInfo info{
-          config_.stats_store_, alt_prefix, response_time, upstream_request_->upstream_canary_,
-          internal_request, "", "", config_.service_zone_, upstreamZone()};
+      Http::CodeUtility::ResponseTimingInfo info{config_.stats_store_, alt_prefix, response_time,
+                                                 upstream_request_->upstream_canary_,
+                                                 internal_request, "", "", config_.service_zone_,
+                                                 upstreamZone(upstream_request_->upstream_host_)};
 
       Http::CodeUtility::chargeResponseTiming(info);
     }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -131,7 +131,7 @@ private:
     void onPerTryTimeout();
 
     void onUpstreamHostSelected(Upstream::HostDescriptionPtr host) {
-      parent_.upstream_host_ = host;
+      upstream_host_ = host;
       parent_.callbacks_->requestInfo().onUpstreamHostSelected(host);
     }
 
@@ -156,6 +156,7 @@ private:
     Http::StreamEncoder* request_encoder_{};
     Optional<Http::StreamResetReason> deferred_reset_reason_;
     Buffer::InstancePtr buffered_request_body_;
+    Upstream::HostDescriptionPtr upstream_host_;
 
     bool calling_encode_headers_ : 1;
     bool upstream_canary_ : 1;
@@ -170,9 +171,10 @@ private:
   Http::AccessLog::FailureReason
   streamResetReasonToFailureReason(Http::StreamResetReason reset_reason);
 
-  const std::string& upstreamZone();
-  void chargeUpstreamCode(const Http::HeaderMap& response_headers);
-  void chargeUpstreamCode(Http::Code code);
+  static const std::string& upstreamZone(Upstream::HostDescriptionPtr upstream_host);
+  void chargeUpstreamCode(const Http::HeaderMap& response_headers,
+                          Upstream::HostDescriptionPtr upstream_host);
+  void chargeUpstreamCode(Http::Code code, Upstream::HostDescriptionPtr upstream_host);
   void cleanup();
   virtual RetryStatePtr createRetryState(const RetryPolicy& policy,
                                          Http::HeaderMap& request_headers,
@@ -207,7 +209,6 @@ private:
   RetryStatePtr retry_state_;
   Http::HeaderMap* downstream_headers_{};
   Http::HeaderMap* downstream_trailers_{};
-  Upstream::HostDescriptionPtr upstream_host_;
   SystemTime downstream_request_complete_time_;
 
   bool downstream_response_started_ : 1;


### PR DESCRIPTION
Previously we only charged the final response code to a host and
ignored retires. For outlier detection purposes, we need to charge all
failures to the host to account for retries.

This commit also includes a small refactor to move upstream host into
the upstream request where it should be.