### PR TITLE
docs: specify docutils 0.12

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-sphinx==1.4.5
+docutils==0.12
+sphinx==1.5.0
 sphinx_rtd_theme==0.1.9
 sphinxcontrib-httpdomain==1.5.0
 GitPython==2.0.8


### PR DESCRIPTION
The new 0.13.1 release appears to be break our docs build so just
require 0.12 for now. Also upgrade sphinx to 1.5.0.