### PR TITLE
per host timeout stat

### DIFF
--- a/docs/operations/admin.rst
+++ b/docs/operations/admin.rst
@@ -29,11 +29,24 @@ modify different aspects of the server.
     cx_active, Gauge, Total active connections
     cx_connect_fail, Counter, Total connection failures
     rq_total, Counter, Total requests
+    rq_timeout, Counter, Total timed out requests
     rq_active, Gauge, Total active requests
-    healthy, Boolean, Whether the host is healthy (1) or not (0)
+    healthy, String, The health status of the host. See below
     weight, Integer, Load balancing weight (1-100)
     zone, String, Service zone
     canary, Boolean, Whether the host is a canary
+
+  Host health status
+    A host is either healthy or unhealthy because of one or more different failing health states.
+    If the host is healthy the ``healthy`` output will be equal to *healthy*.
+
+    If the host is not healthy, the ``healthy`` output will be composed of one or more of the
+    following strings:
+
+    */failed_active_hc*: The host has failed an :ref:`active health check
+    <config_cluster_manager_cluster_hc>`.
+
+    */failed_outlier_check*: The host has failed an outlier detection check.
 
 .. http:get:: /cpuprofiler
 

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -14,6 +14,7 @@ namespace Upstream {
   GAUGE  (cx_active)                                                                               \
   COUNTER(cx_connect_fail)                                                                         \
   COUNTER(rq_total)                                                                                \
+  COUNTER(rq_timeout)                                                                              \
   GAUGE  (rq_active)
 // clang-format on
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -326,6 +326,7 @@ void Filter::onResponseTimeout() {
   // It's possible to timeout during a retry backoff delay when we have no upstream request. In
   // this case we fake a reset since onUpstreamReset() doesn't care.
   if (upstream_request_) {
+    upstream_request_->upstream_host_->stats().rq_timeout_.inc();
     upstream_request_->resetStream();
   }
 
@@ -641,6 +642,7 @@ void Filter::UpstreamRequest::onPerTryTimeout() {
   parent_.config_.cm_.get(parent_.route_->clusterName())
       ->stats()
       .upstream_rq_per_try_timeout_.inc();
+  upstream_host_->stats().rq_timeout_.inc();
   resetStream();
   parent_.onUpstreamReset(UpstreamResetType::PerTryTimeout,
                           Optional<Http::StreamResetReason>(Http::StreamResetReason::LocalReset));

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -12,6 +12,10 @@ std::string HostUtility::healthFlagsToString(const Host& host) {
     ret += "/failed_active_hc";
   }
 
+  if (host.healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
+    ret += "/failed_outlier_check";
+  }
+
   return ret;
 }
 

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -286,6 +286,7 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
 
   EXPECT_EQ(1UL,
             cm_.cluster_.stats_store_.counter("cluster.fake_cluster.upstream_rq_timeout").value());
+  EXPECT_EQ(1UL, cm_.conn_pool_.host_->stats().rq_timeout_.value());
   EXPECT_EQ(1UL, stats_store_.counter("cluster.fake_cluster.upstream_rq_504").value());
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -215,6 +215,7 @@ TEST_F(RouterTest, UpstreamTimeout) {
 
   EXPECT_EQ(1U,
             cm_.cluster_.stats_store_.counter("cluster.fake_cluster.upstream_rq_timeout").value());
+  EXPECT_EQ(1UL, cm_.conn_pool_.host_->stats().rq_timeout_.value());
 }
 
 TEST_F(RouterTest, UpstreamPerTryTimeout) {
@@ -254,6 +255,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeout) {
   EXPECT_EQ(1U,
             cm_.cluster_.stats_store_.counter("cluster.fake_cluster.upstream_rq_per_try_timeout")
                 .value());
+  EXPECT_EQ(1UL, cm_.conn_pool_.host_->stats().rq_timeout_.value());
 }
 
 TEST_F(RouterTest, RetryRequestNotComplete) {

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -9,8 +9,15 @@ TEST(HostUtilityTest, All) {
   MockCluster cluster;
   HostImpl host(cluster, "tcp://127.0.0.1:80", false, 1, "");
   EXPECT_EQ("healthy", HostUtility::healthFlagsToString(host));
+
   host.healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   EXPECT_EQ("/failed_active_hc", HostUtility::healthFlagsToString(host));
+
+  host.healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
+  EXPECT_EQ("/failed_active_hc/failed_outlier_check", HostUtility::healthFlagsToString(host));
+
+  host.healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
+  EXPECT_EQ("/failed_outlier_check", HostUtility::healthFlagsToString(host));
 }
 
 } // Upstream

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -2,6 +2,8 @@
 
 #include "envoy/upstream/upstream.h"
 
+#include "common/stats/stats_impl.h"
+
 namespace Upstream {
 namespace Outlier {
 
@@ -55,6 +57,8 @@ public:
 
   std::string url_{"tcp://10.0.0.1:443"};
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
+  Stats::IsolatedStoreImpl stats_store_;
+  HostStats stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))};
 };
 
 class MockHost : public Host {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -31,6 +31,7 @@ MockDetector::~MockDetector() {}
 MockHostDescription::MockHostDescription() {
   ON_CALL(*this, url()).WillByDefault(ReturnRef(url_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
+  ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
 }
 
 MockHostDescription::~MockHostDescription() {}


### PR DESCRIPTION
Add a per host timeout stat. Also fix the admin output for per host health
status along with the documentation.