### PR TITLE
build: add ENVOY_STRIP cmake option

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -26,7 +26,7 @@ elif [[ "$1" == "debug" ]]; then
   TEST_TARGET="envoy.check"
 elif [[ "$1" == "server_only" ]]; then
   echo "normal build server only..."
-  EXTRA_CMAKE_FLAGS="-DENVOY_DEBUG:BOOL=OFF"
+  EXTRA_CMAKE_FLAGS="-DENVOY_DEBUG:BOOL=OFF -DENVOY_STRIP:BOOL=ON"
   TEST_TARGET="envoy"
 else
   echo "normal build with tests..."

--- a/common.cmake
+++ b/common.cmake
@@ -32,5 +32,7 @@ if (ENVOY_TCMALLOC)
   add_definitions(-DTCMALLOC)
 endif()
 
+option(ENVOY_STRIP "strip symbols from binaries" OFF)
+
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ENVOY_COTIRE_MODULE_DIR}")
 include(cotire)

--- a/source/exe/CMakeLists.txt
+++ b/source/exe/CMakeLists.txt
@@ -23,3 +23,11 @@ include_directories(SYSTEM ${ENVOY_OPENSSL_INCLUDE_DIR})
 set_target_properties(envoy PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT
                       "../precompiled/precompiled.h")
 cotire(envoy)
+
+if (ENVOY_STRIP)
+  add_custom_command(TARGET envoy POST_BUILD
+    COMMAND objcopy --only-keep-debug $<TARGET_FILE:envoy> $<TARGET_FILE:envoy>.dbg
+    COMMAND strip $<TARGET_FILE:envoy>
+    COMMAND objcopy --add-gnu-debuglink=$<TARGET_FILE:envoy>.dbg $<TARGET_FILE:envoy>
+  )
+endif()


### PR DESCRIPTION
Strips debug symbols from envoy and creates a linked envoy.dbg file.