### PR TITLE
Access log flags for delay injection 

### DIFF
--- a/docs/configuration/http_conn_man/access_log.rst
+++ b/docs/configuration/http_conn_man/access_log.rst
@@ -83,7 +83,8 @@ The following command operators are supported:
   * **UC**: Upstream connection termination in addition to 503 response code.
   * **UO**: Upstream overflow (:ref:`circuit breaking <arch_overview_circuit_break>`) in addition to 503 response code.
   * **NR**: No :ref:`route configured <arch_overview_http_routing>` for a given request in addition to 404 response code.
-  * **FI**: The request was aborted with an injected response code via :ref:`fault injection <config_http_filters_fault_injection>`.
+  * **DI**: The request processing was delayed for a period specified via :ref:`fault injection <config_http_filters_fault_injection>`.
+  * **FI**: The request was aborted with a response code specified via :ref:`fault injection <config_http_filters_fault_injection>`.
 
 %UPSTREAM_HOST%
   Upstream host URL (e.g., tcp://ip:port for TCP connections).

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -29,8 +29,10 @@ enum ResponseFlag {
   UpstreamOverflow = 0x80,
   // No route found for a given request.
   NoRouteFound = 0x100,
-  // Abort with error code is injected.
-  FaultInjected = 0x200
+  // Request was delayed before proxying.
+  DelayInjected = 0x200,
+  // Abort with error code was injected.
+  FaultInjected = 0x400
 };
 
 /**

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -84,7 +84,9 @@ bool ResponseFlagUtils::isTraceableFailure(const Http::AccessLog::RequestInfo& r
          request_info.getResponseFlag(Http::AccessLog::ResponseFlag::UpstreamRequestTimeout) |
          request_info.getResponseFlag(
              Http::AccessLog::ResponseFlag::UpstreamConnectionTermination) |
-         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
+         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound) |
+         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected) |
+         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected);
 }
 
 const std::string AccessLogFormatUtils::DEFAULT_FORMAT =

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -246,9 +246,8 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
                  : "0";
     };
   } else if (field_name == "BYTES_SENT") {
-    field_extractor_ = [](const RequestInfo& request_info) {
-      return std::to_string(request_info.bytesSent());
-    };
+    field_extractor_ =
+        [](const RequestInfo& request_info) { return std::to_string(request_info.bytesSent()); };
   } else if (field_name == "DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
       return std::to_string(request_info.duration().count());

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -16,6 +16,7 @@ const std::string ResponseFlagUtils::UPSTREAM_CONNECTION_FAILURE = "UF";
 const std::string ResponseFlagUtils::UPSTREAM_CONNECTION_TERMINATION = "UC";
 const std::string ResponseFlagUtils::UPSTREAM_OVERFLOW = "UO";
 const std::string ResponseFlagUtils::NO_ROUTE_FOUND = "NR";
+const std::string ResponseFlagUtils::DELAY_INJECTED = "DI";
 const std::string ResponseFlagUtils::FAULT_INJECTED = "FI";
 
 void ResponseFlagUtils::appendString(std::string& result, const std::string& append) {
@@ -65,6 +66,10 @@ const std::string ResponseFlagUtils::toShortString(const RequestInfo& request_in
     appendString(result, NO_ROUTE_FOUND);
   }
 
+  if (request_info.getResponseFlag(ResponseFlag::DelayInjected)) {
+    appendString(result, DELAY_INJECTED);
+  }
+
   if (request_info.getResponseFlag(ResponseFlag::FaultInjected)) {
     appendString(result, FAULT_INJECTED);
   }
@@ -80,6 +85,7 @@ bool ResponseFlagUtils::isTraceableFailure(const Http::AccessLog::RequestInfo& r
          request_info.getResponseFlag(
              Http::AccessLog::ResponseFlag::UpstreamConnectionTermination) |
          request_info.getResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound) |
+         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected) |
          request_info.getResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected);
 }
 
@@ -240,8 +246,9 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
                  : "0";
     };
   } else if (field_name == "BYTES_SENT") {
-    field_extractor_ =
-        [](const RequestInfo& request_info) { return std::to_string(request_info.bytesSent()); };
+    field_extractor_ = [](const RequestInfo& request_info) {
+      return std::to_string(request_info.bytesSent());
+    };
   } else if (field_name == "DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
       return std::to_string(request_info.duration().count());

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -84,9 +84,7 @@ bool ResponseFlagUtils::isTraceableFailure(const Http::AccessLog::RequestInfo& r
          request_info.getResponseFlag(Http::AccessLog::ResponseFlag::UpstreamRequestTimeout) |
          request_info.getResponseFlag(
              Http::AccessLog::ResponseFlag::UpstreamConnectionTermination) |
-         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound) |
-         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected) |
-         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected);
+         request_info.getResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
 }
 
 const std::string AccessLogFormatUtils::DEFAULT_FORMAT =

--- a/source/common/http/access_log/access_log_formatter.h
+++ b/source/common/http/access_log/access_log_formatter.h
@@ -27,6 +27,7 @@ private:
   const static std::string UPSTREAM_CONNECTION_TERMINATION;
   const static std::string UPSTREAM_OVERFLOW;
   const static std::string NO_ROUTE_FOUND;
+  const static std::string DELAY_INJECTED;
   const static std::string FAULT_INJECTED;
 };
 

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -90,6 +90,7 @@ FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
           callbacks_->dispatcher().createTimer([this]() -> void { postDelayInjection(); });
       delay_timer_->enableTimer(std::chrono::milliseconds(duration_ms));
       config_->stats().delays_injected_.inc();
+      callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected);
       return FilterHeadersStatus::StopIteration;
     }
   }

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -230,22 +230,10 @@ TEST(AccessLogFormatterTest, ParserFailures) {
   AccessLogFormatParser parser;
 
   std::vector<std::string> test_cases = {
-      "{{%PROTOCOL%}}   ++ %REQ(FIRST?SECOND)% %RESP(FIRST?SECOND)",
-      "%REQ(FIRST?SECOND)T%",
-      "RESP(FIRST)%",
-      "%REQ(valid)% %NOT_VALID%",
-      "%REQ(FIRST?SECOND%",
-      "%%",
-      "%protocol%",
-      "%REQ(TEST):%",
-      "%REQ(TEST):3q4%",
-      "%RESP(TEST):%",
-      "%RESP(X?Y):%",
-      "%RESP(X?Y):343o24%",
-      "%REQ(TEST):10",
-      "REQ(:TEST):10%",
-      "%REQ(TEST:10%",
-      "%REQ("};
+      "{{%PROTOCOL%}}   ++ %REQ(FIRST?SECOND)% %RESP(FIRST?SECOND)", "%REQ(FIRST?SECOND)T%",
+      "RESP(FIRST)%", "%REQ(valid)% %NOT_VALID%", "%REQ(FIRST?SECOND%", "%%", "%protocol%",
+      "%REQ(TEST):%", "%REQ(TEST):3q4%", "%RESP(TEST):%", "%RESP(X?Y):%", "%RESP(X?Y):343o24%",
+      "%REQ(TEST):10", "REQ(:TEST):10%", "%REQ(TEST:10%", "%REQ("};
 
   for (const std::string& test_case : test_cases) {
     EXPECT_THROW(parser.parse(test_case), EnvoyException);

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -24,7 +24,7 @@ TEST(ResponseFlagUtilsTest, toShortStringConversion) {
       std::make_pair(ResponseFlag::UpstreamConnectionTermination, "UC"),
       std::make_pair(ResponseFlag::UpstreamOverflow, "UO"),
       std::make_pair(ResponseFlag::NoRouteFound, "NR"),
-      std::make_pair(ResponseFlag::FaultInjected, "DI"),
+      std::make_pair(ResponseFlag::DelayInjected, "DI"),
       std::make_pair(ResponseFlag::FaultInjected, "FI")};
 
   for (const auto& testCase : expected) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -68,7 +68,6 @@ TEST_F(ConnectionManagerUtilityTest, ShouldTraceRequest) {
         Http::AccessLog::ResponseFlag::NoHealthyUpstream,
         Http::AccessLog::ResponseFlag::UpstreamRequestTimeout,
         Http::AccessLog::ResponseFlag::UpstreamOverflow,
-        Http::AccessLog::ResponseFlag::DelayInjected, Http::AccessLog::ResponseFlag::FaultInjected,
         Http::AccessLog::ResponseFlag::NoRouteFound};
 
     for (Http::AccessLog::ResponseFlag flag : upstream_failed_response_flag) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -68,7 +68,9 @@ TEST_F(ConnectionManagerUtilityTest, ShouldTraceRequest) {
         Http::AccessLog::ResponseFlag::NoHealthyUpstream,
         Http::AccessLog::ResponseFlag::UpstreamRequestTimeout,
         Http::AccessLog::ResponseFlag::UpstreamOverflow,
-        Http::AccessLog::ResponseFlag::FaultInjected, Http::AccessLog::ResponseFlag::NoRouteFound};
+        Http::AccessLog::ResponseFlag::DelayInjected,
+        Http::AccessLog::ResponseFlag::FaultInjected,
+        Http::AccessLog::ResponseFlag::NoRouteFound};
 
     for (Http::AccessLog::ResponseFlag flag : upstream_failed_response_flag) {
       ON_CALL(request_info, getResponseFlag(flag)).WillByDefault(Return(true));
@@ -345,12 +347,10 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 
   config_.route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
 
-  TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
-                            {"x-envoy-retry-on", "foo"},
-                            {"x-envoy-upstream-alt-stat-name", "foo"},
-                            {"x-envoy-upstream-rq-timeout-ms", "foo"},
-                            {"x-envoy-expected-rq-timeout-ms", "10"},
-                            {"custom_header", "foo"}};
+  TestHeaderMapImpl headers{
+      {"x-envoy-downstream-service-cluster", "foo"}, {"x-envoy-retry-on", "foo"},
+      {"x-envoy-upstream-alt-stat-name", "foo"},     {"x-envoy-upstream-rq-timeout-ms", "foo"},
+      {"x-envoy-expected-rq-timeout-ms", "10"},      {"custom_header", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
   EXPECT_EQ("50.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_FALSE(headers.has("x-envoy-internal"));

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -68,6 +68,7 @@ TEST_F(ConnectionManagerUtilityTest, ShouldTraceRequest) {
         Http::AccessLog::ResponseFlag::NoHealthyUpstream,
         Http::AccessLog::ResponseFlag::UpstreamRequestTimeout,
         Http::AccessLog::ResponseFlag::UpstreamOverflow,
+        Http::AccessLog::ResponseFlag::DelayInjected, Http::AccessLog::ResponseFlag::FaultInjected,
         Http::AccessLog::ResponseFlag::NoRouteFound};
 
     for (Http::AccessLog::ResponseFlag flag : upstream_failed_response_flag) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -68,8 +68,7 @@ TEST_F(ConnectionManagerUtilityTest, ShouldTraceRequest) {
         Http::AccessLog::ResponseFlag::NoHealthyUpstream,
         Http::AccessLog::ResponseFlag::UpstreamRequestTimeout,
         Http::AccessLog::ResponseFlag::UpstreamOverflow,
-        Http::AccessLog::ResponseFlag::DelayInjected,
-        Http::AccessLog::ResponseFlag::FaultInjected,
+        Http::AccessLog::ResponseFlag::DelayInjected, Http::AccessLog::ResponseFlag::FaultInjected,
         Http::AccessLog::ResponseFlag::NoRouteFound};
 
     for (Http::AccessLog::ResponseFlag flag : upstream_failed_response_flag) {
@@ -347,10 +346,12 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 
   config_.route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
 
-  TestHeaderMapImpl headers{
-      {"x-envoy-downstream-service-cluster", "foo"}, {"x-envoy-retry-on", "foo"},
-      {"x-envoy-upstream-alt-stat-name", "foo"},     {"x-envoy-upstream-rq-timeout-ms", "foo"},
-      {"x-envoy-expected-rq-timeout-ms", "10"},      {"custom_header", "foo"}};
+  TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+                            {"x-envoy-retry-on", "foo"},
+                            {"x-envoy-upstream-alt-stat-name", "foo"},
+                            {"x-envoy-upstream-rq-timeout-ms", "foo"},
+                            {"x-envoy-expected-rq-timeout-ms", "10"},
+                            {"custom_header", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
   EXPECT_EQ("50.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_FALSE(headers.has("x-envoy-internal"));

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -201,8 +201,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", _)).Times(0);
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_.request_info_,
-              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected))
-      .Times(0);
+              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected)).Times(0);
 
   // Abort related calls
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 100))
@@ -287,8 +286,7 @@ TEST_F(FaultFilterTest, FixedDelayNonZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(filter_callbacks_.request_info_,
-              setResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected))
-      .Times(0);
+              setResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected)).Times(0);
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(1);
   timer_->callback_();
 

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -200,6 +200,9 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", _)).Times(0);
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected))
+      .Times(0);
 
   // Abort related calls
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.abort.abort_percent", 100))
@@ -271,6 +274,8 @@ TEST_F(FaultFilterTest, FixedDelayNonZeroDuration) {
   SCOPED_TRACE("FixedDelayNonZeroDuration");
   expectDelayTimer(5000UL);
 
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
   // Abort related calls
@@ -281,7 +286,9 @@ TEST_F(FaultFilterTest, FixedDelayNonZeroDuration) {
   // Delay only case
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(0);
-  EXPECT_CALL(filter_callbacks_.request_info_, setResponseFlag(_)).Times(0);
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected))
+      .Times(0);
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(1);
   timer_->callback_();
 
@@ -306,6 +313,9 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
 
   SCOPED_TRACE("FixedDelayAndAbort");
   expectDelayTimer(5000UL);
+
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected));
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
@@ -351,6 +361,9 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
 
   SCOPED_TRACE("FixedDelayAndAbortHeaderMatchSuccess");
   expectDelayTimer(5000UL);
+
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Http::AccessLog::ResponseFlag::DelayInjected));
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 


### PR DESCRIPTION
This PR adds access log flags when delays are injected as part of fault injection.
Please note that certain unrelated changes in the PR are merely `clang-formatting` (from emacs), and it seems to be following the formatting guidelines set forth in the code.