### PR TITLE
Stop building libevent with OpenSSL support.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -38,9 +38,7 @@ rm -fr openssl*
 wget https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz
 tar xf libevent-2.0.22-stable.tar.gz
 cd libevent-2.0.22-stable
-./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --disable-libevent-regress \
-    CPPFLAGS=-I$THIRDPARTY_BUILD/include LDFLAGS=-L$THIRDPARTY_BUILD/lib \
-    OPENSSL_LIBADD=-ldl
+./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --disable-libevent-regress --disable-openssl
 make install
 cd ..
 rm -fr libevent*

--- a/source/exe/CMakeLists.txt
+++ b/source/exe/CMakeLists.txt
@@ -5,7 +5,6 @@ if (ENVOY_TCMALLOC)
 endif()
 
 target_link_libraries(envoy event)
-target_link_libraries(envoy event_openssl)
 target_link_libraries(envoy event_pthreads)
 target_link_libraries(envoy http_parser)
 target_link_libraries(envoy ssl)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,7 +141,6 @@ if (ENVOY_TCMALLOC)
 endif()
 
 target_link_libraries(envoy-test event)
-target_link_libraries(envoy-test event_openssl)
 target_link_libraries(envoy-test event_pthreads)
 target_link_libraries(envoy-test http_parser)
 target_link_libraries(envoy-test ssl)


### PR DESCRIPTION
Missed in commit a10174c29cf9106d081c06d6963d564dca3a4557.