### PR TITLE
refactor to prepare for dynamic cluster add/remove

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -26,10 +26,10 @@ public:
   virtual std::unordered_map<std::string, ConstClusterPtr> clusters() PURE;
 
   /**
-   * @return const Cluster* the primary cluster with the given name or nullptr if it does
-   *         not exist.
+   * @return ClusterInfoPtr the cluster info with the given name or nullptr if it does not
+   * exist. This is thread safe.
    */
-  virtual const Cluster* get(const std::string& cluster) PURE;
+  virtual ClusterInfoPtr get(const std::string& cluster) PURE;
 
   /**
    * Allocate a load balanced HTTP connection pool for a cluster. This is *per-thread* so that

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -25,7 +25,7 @@ struct HostStats {
   ALL_HOST_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-class Cluster;
+class ClusterInfo;
 
 /**
  * A description of an upstream host.
@@ -42,7 +42,7 @@ public:
   /**
    * @return the cluster the host is a member of.
    */
-  virtual const Cluster& cluster() const PURE;
+  virtual const ClusterInfo& cluster() const PURE;
 
   /**
    * @return the host's outlier detection sink.

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -56,12 +56,9 @@ void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callb
 }
 
 Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
-  Upstream::ResourceManager& upstream_cluster_resource_manager =
-      cluster_manager_.get(config_->clusterName())
-          ->resourceManager(Upstream::ResourcePriority::Default);
-
-  if (!upstream_cluster_resource_manager.connections().canCreate()) {
-    cluster_manager_.get(config_->clusterName())->stats().upstream_cx_overflow_.inc();
+  Upstream::ClusterInfoPtr cluster = cluster_manager_.get(config_->clusterName());
+  if (!cluster->resourceManager(Upstream::ResourcePriority::Default).connections().canCreate()) {
+    cluster->stats().upstream_cx_overflow_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return Network::FilterStatus::StopIteration;
   }
@@ -74,7 +71,7 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return Network::FilterStatus::StopIteration;
   }
-  upstream_cluster_resource_manager.connections().inc();
+  cluster->resourceManager(Upstream::ResourcePriority::Default).connections().inc();
 
   upstream_connection_->addReadFilter(upstream_callbacks_);
   upstream_connection_->addConnectionCallbacks(*upstream_callbacks_);
@@ -88,8 +85,7 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
 
   connect_timeout_timer_ = read_callbacks_->connection().dispatcher().createTimer(
       [this]() -> void { onConnectTimeout(); });
-  connect_timeout_timer_->enableTimer(
-      cluster_manager_.get(config_->clusterName())->connectTimeout());
+  connect_timeout_timer_->enableTimer(cluster->connectTimeout());
 
   read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_total_.inc();
   read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_active_.inc();

--- a/source/common/grpc/rpc_channel_impl.cc
+++ b/source/common/grpc/rpc_channel_impl.cc
@@ -28,7 +28,7 @@ void RpcChannelImpl::CallMethod(const proto::MethodDescriptor* method, proto::Rp
 
   // This should be caught in configuration, and a request will fail normally anyway, but assert
   // here for clarity.
-  ASSERT(cm_.get(cluster_)->features() & Upstream::Cluster::Features::HTTP2);
+  ASSERT(cm_.get(cluster_)->features() & Upstream::ClusterInfo::Features::HTTP2);
 
   Http::MessagePtr message =
       Common::prepareHeaders(cluster_, method->service()->full_name(), method->name());

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -7,7 +7,7 @@ const AsyncRequestImpl::NullRateLimitPolicy AsyncRequestImpl::RouteEntryImpl::ra
 const AsyncRequestImpl::NullRetryPolicy AsyncRequestImpl::RouteEntryImpl::retry_policy_;
 const AsyncRequestImpl::NullShadowPolicy AsyncRequestImpl::RouteEntryImpl::shadow_policy_;
 
-AsyncClientImpl::AsyncClientImpl(const Upstream::Cluster& cluster, Stats::Store& stats_store,
+AsyncClientImpl::AsyncClientImpl(const Upstream::ClusterInfo& cluster, Stats::Store& stats_store,
                                  Event::Dispatcher& dispatcher, const std::string& local_zone_name,
                                  Upstream::ClusterManager& cm, Runtime::Loader& runtime,
                                  Runtime::RandomGenerator& random,

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -21,7 +21,7 @@ class AsyncRequestImpl;
 
 class AsyncClientImpl final : public AsyncClient {
 public:
-  AsyncClientImpl(const Upstream::Cluster& cluster, Stats::Store& stats_store,
+  AsyncClientImpl(const Upstream::ClusterInfo& cluster, Stats::Store& stats_store,
                   Event::Dispatcher& dispatcher, const std::string& local_zone_name,
                   Upstream::ClusterManager& cm, Runtime::Loader& runtime,
                   Runtime::RandomGenerator& random, Router::ShadowWriterPtr&& shadow_writer,
@@ -33,7 +33,7 @@ public:
                 const Optional<std::chrono::milliseconds>& timeout) override;
 
 private:
-  const Upstream::Cluster& cluster_;
+  const Upstream::ClusterInfo& cluster_;
   Router::FilterConfig config_;
   Event::Dispatcher& dispatcher_;
   std::list<std::unique_ptr<AsyncRequestImpl>> active_requests_;

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -16,7 +16,7 @@ const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_4XX;
 
 RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
                                      Http::HeaderMap& request_headers,
-                                     const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                                     const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                      Runtime::RandomGenerator& random,
                                      Event::Dispatcher& dispatcher,
                                      Upstream::ResourcePriority priority) {
@@ -34,7 +34,7 @@ RetryStatePtr RetryStateImpl::create(const RetryPolicy& route_policy,
 }
 
 RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
-                               const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                               const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                Upstream::ResourcePriority priority)
     : cluster_(cluster), runtime_(runtime), random_(random), dispatcher_(dispatcher),

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -16,7 +16,7 @@ namespace Router {
 class RetryStateImpl : public RetryState {
 public:
   static RetryStatePtr create(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
-                              const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                              const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                               Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                               Upstream::ResourcePriority priority);
   ~RetryStateImpl();
@@ -31,7 +31,7 @@ public:
 
 private:
   RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,
-                 const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                 const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                  Upstream::ResourcePriority priority);
 
@@ -40,7 +40,7 @@ private:
   bool wouldRetry(const Http::HeaderMap* response_headers,
                   const Optional<Http::StreamResetReason>& reset_reason);
 
-  const Upstream::Cluster& cluster_;
+  const Upstream::ClusterInfo& cluster_;
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;
   Event::Dispatcher& dispatcher_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -22,7 +22,8 @@
 
 namespace Router {
 
-void FilterUtility::setUpstreamScheme(Http::HeaderMap& headers, const Upstream::Cluster& cluster) {
+void FilterUtility::setUpstreamScheme(Http::HeaderMap& headers,
+                                      const Upstream::ClusterInfo& cluster) {
   if (cluster.sslContext()) {
     headers.insertScheme().value(Http::Headers::get().SchemeValues.Https);
   } else {
@@ -700,7 +701,7 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
 
 RetryStatePtr
 ProdFilter::createRetryState(const RetryPolicy& policy, Http::HeaderMap& request_headers,
-                             const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                             const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                              Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                              Upstream::ResourcePriority priority) {
   return RetryStateImpl::create(policy, request_headers, cluster, runtime, random, dispatcher,

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -42,7 +42,7 @@ public:
   /**
    * Set the :scheme header based on the properties of the upstream cluster.
    */
-  static void setUpstreamScheme(Http::HeaderMap& headers, const Upstream::Cluster& cluster);
+  static void setUpstreamScheme(Http::HeaderMap& headers, const Upstream::ClusterInfo& cluster);
 
   /**
    * Determine whether a request should be shadowed.
@@ -178,8 +178,8 @@ private:
   void cleanup();
   virtual RetryStatePtr createRetryState(const RetryPolicy& policy,
                                          Http::HeaderMap& request_headers,
-                                         const Upstream::Cluster& cluster, Runtime::Loader& runtime,
-                                         Runtime::RandomGenerator& random,
+                                         const Upstream::ClusterInfo& cluster,
+                                         Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                                          Event::Dispatcher& dispatcher,
                                          Upstream::ResourcePriority priority) PURE;
   Upstream::ResourcePriority finalPriority();
@@ -200,7 +200,7 @@ private:
   FilterConfig& config_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   const RouteEntry* route_;
-  const Upstream::Cluster* cluster_;
+  Upstream::ClusterInfoPtr cluster_;
   std::list<std::string> alt_stat_prefixes_;
   const VirtualCluster* request_vcluster_;
   Event::TimerPtr response_timeout_;
@@ -223,7 +223,7 @@ public:
 private:
   // Filter
   RetryStatePtr createRetryState(const RetryPolicy& policy, Http::HeaderMap& request_headers,
-                                 const Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                                 const Upstream::ClusterInfo& cluster, Runtime::Loader& runtime,
                                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                  Upstream::ResourcePriority priority) override;
 };

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -204,7 +204,7 @@ LightStepSink::LightStepSink(const Json::Object& config, Upstream::ClusterManage
                                      collector_cluster_));
   }
 
-  if (!(cm_.get(collector_cluster_)->features() & Upstream::Cluster::Features::HTTP2)) {
+  if (!(cm_.get(collector_cluster_)->features() & Upstream::ClusterInfo::Features::HTTP2)) {
     throw EnvoyException(
         fmt::format("{} collector cluster must support http2 for gRPC calls", collector_cluster_));
   }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -42,7 +42,7 @@ public:
     return clusters_map;
   }
 
-  const Cluster* get(const std::string& cluster) override;
+  ClusterInfoPtr get(const std::string& cluster) override;
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
                                                          ResourcePriority priority) override;
   Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) override;
@@ -72,7 +72,7 @@ private:
     };
 
     struct ClusterEntry {
-      ClusterEntry(ThreadLocalClusterManagerImpl& parent, const Cluster& cluster,
+      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ConstClusterPtr cluster,
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Stats::Store& stats_store, Event::Dispatcher& dispatcher,
                    const std::string& local_zone_name, const std::string& local_address,
@@ -83,7 +83,7 @@ private:
       ThreadLocalClusterManagerImpl& parent_;
       HostSetImpl host_set_;
       LoadBalancerPtr lb_;
-      const Cluster& primary_cluster_;
+      ConstClusterPtr primary_cluster_;
       Http::AsyncClientImpl http_async_client_;
     };
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -44,7 +44,7 @@ void HealthCheckerImplBase::decHealthy() {
 }
 
 HealthCheckerStats HealthCheckerImplBase::generateStats(Stats::Store& store) {
-  std::string prefix(fmt::format("cluster.{}.health_check.", cluster_.name()));
+  std::string prefix(fmt::format("cluster.{}.health_check.", cluster_.info()->name()));
   return {ALL_HEALTH_CHECKER_STATS(POOL_COUNTER_PREFIX(store, prefix),
                                    POOL_GAUGE_PREFIX(store, prefix))};
 }
@@ -60,7 +60,7 @@ std::chrono::milliseconds HealthCheckerImplBase::interval() {
   // start sending traffic to this cluster. In general host updates are rare and this should
   // greatly smooth out needless health checking.
   uint64_t base_time_ms;
-  if (cluster_.stats().upstream_cx_total_.used()) {
+  if (cluster_.info()->stats().upstream_cx_total_.used()) {
     base_time_ms = interval_.count();
   } else {
     base_time_ms = NO_TRAFFIC_INTERVAL.count();
@@ -235,7 +235,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
 
   Http::HeaderMapImpl request_headers{
       {Http::Headers::get().Method, "GET"},
-      {Http::Headers::get().Host, parent_.cluster_.name()},
+      {Http::Headers::get().Host, parent_.cluster_.info()->name()},
       {Http::Headers::get().Path, parent_.path_},
       {Http::Headers::get().UserAgent, Http::Headers::get().UserAgentValues.EnvoyHealthChecker}};
 

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -35,7 +35,7 @@ public:
 
 private:
   struct LogicalHost : public HostImpl {
-    LogicalHost(const Cluster& cluster, const std::string& url, LogicalDnsCluster& parent)
+    LogicalHost(ClusterInfoPtr cluster, const std::string& url, LogicalDnsCluster& parent)
         : HostImpl(cluster, url, false, 1, ""), parent_(parent) {}
 
     // Upstream::Host
@@ -50,7 +50,7 @@ private:
 
     // Upstream:HostDescription
     bool canary() const override { return false; }
-    const Cluster& cluster() const override { return logical_host_->cluster(); }
+    const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
     Outlier::DetectorHostSink& outlierDetector() const override {
       return logical_host_->outlierDetector();
     }

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -42,11 +42,11 @@ void DetectorHostSinkImpl::putHttpResponseCode(uint64_t response_code) {
   }
 }
 
-DetectorImpl::DetectorImpl(Cluster& cluster, Event::Dispatcher& dispatcher,
+DetectorImpl::DetectorImpl(const Cluster& cluster, Event::Dispatcher& dispatcher,
                            Runtime::Loader& runtime, Stats::Store& stats,
                            SystemTimeSource& time_source, EventLoggerPtr event_logger)
     : dispatcher_(dispatcher), runtime_(runtime), time_source_(time_source),
-      stats_(generateStats(cluster.name(), stats)),
+      stats_(generateStats(cluster.info()->name(), stats)),
       interval_timer_(dispatcher.createTimer([this]() -> void { onIntervalTimer(); })),
       event_logger_(event_logger) {
   for (HostPtr host : cluster.hosts()) {

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -51,7 +51,7 @@ public:
   void putResponseTime(std::chrono::milliseconds) override {}
 
 private:
-  DetectorImpl& detector_;
+  DetectorImpl& detector_; // TODO: This is broken for dynamic cluster remove.
   std::weak_ptr<Host> host_;
   std::atomic<uint32_t> consecutive_5xx_{0};
   SystemTime ejection_time_;
@@ -83,7 +83,7 @@ struct DetectionStats {
  */
 class DetectorImpl : public Detector {
 public:
-  DetectorImpl(Cluster& cluster, Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+  DetectorImpl(const Cluster& cluster, Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                Stats::Store& stats, SystemTimeSource& time_source, EventLoggerPtr event_logger);
 
   void onConsecutive5xx(HostPtr host);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -115,11 +115,12 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
 
 Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& response) {
   for (auto& cluster : server_.clusterManager().clusters()) {
-    addCircuitSettings(cluster.second->name(), "default",
-                       cluster.second->resourceManager(Upstream::ResourcePriority::Default),
+    addCircuitSettings(cluster.second->info()->name(), "default",
+                       cluster.second->info()->resourceManager(Upstream::ResourcePriority::Default),
                        response);
-    addCircuitSettings(cluster.second->name(), "high",
-                       cluster.second->resourceManager(Upstream::ResourcePriority::High), response);
+    addCircuitSettings(cluster.second->info()->name(), "high",
+                       cluster.second->info()->resourceManager(Upstream::ResourcePriority::High),
+                       response);
 
     for (auto& host : cluster.second->hosts()) {
       std::map<std::string, uint64_t> all_stats;
@@ -132,18 +133,18 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
       }
 
       for (auto stat : all_stats) {
-        response.add(fmt::format("{}::{}::{}::{}\n", cluster.second->name(), host->url(),
+        response.add(fmt::format("{}::{}::{}::{}\n", cluster.second->info()->name(), host->url(),
                                  stat.first, stat.second));
       }
 
-      response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second->name(), host->url(),
-                               Upstream::HostUtility::healthFlagsToString(*host)));
-      response.add(
-          fmt::format("{}::{}::weight::{}\n", cluster.second->name(), host->url(), host->weight()));
-      response.add(
-          fmt::format("{}::{}::zone::{}\n", cluster.second->name(), host->url(), host->zone()));
-      response.add(
-          fmt::format("{}::{}::canary::{}\n", cluster.second->name(), host->url(), host->canary()));
+      response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second->info()->name(),
+                               host->url(), Upstream::HostUtility::healthFlagsToString(*host)));
+      response.add(fmt::format("{}::{}::weight::{}\n", cluster.second->info()->name(), host->url(),
+                               host->weight()));
+      response.add(fmt::format("{}::{}::zone::{}\n", cluster.second->info()->name(), host->url(),
+                               host->zone()));
+      response.add(fmt::format("{}::{}::canary::{}\n", cluster.second->info()->name(), host->url(),
+                               host->canary()));
     }
   }
 

--- a/test/common/grpc/rpc_channel_impl_test.cc
+++ b/test/common/grpc/rpc_channel_impl_test.cc
@@ -15,7 +15,8 @@ namespace Grpc {
 class GrpcRequestImplTest : public testing::Test {
 public:
   GrpcRequestImplTest() : http_async_client_request_(&cm_.async_client_) {
-    ON_CALL(cm_.cluster_, features()).WillByDefault(Return(Upstream::Cluster::Features::HTTP2));
+    ON_CALL(*cm_.cluster_.info_, features())
+        .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
   }
 
   void expectNormalRequest(
@@ -32,7 +33,7 @@ public:
 
   NiceMock<Upstream::MockClusterManager> cm_;
   MockRpcChannelCallbacks grpc_callbacks_;
-  RpcChannelImpl grpc_request_{cm_, "cluster", grpc_callbacks_, cm_.cluster_.stats_store_,
+  RpcChannelImpl grpc_request_{cm_, "cluster", grpc_callbacks_, cm_.cluster_.info_->stats_store_,
                                Optional<std::chrono::milliseconds>()};
   helloworld::Greeter::Stub service_{&grpc_request_};
   Http::MockAsyncClientRequest http_async_client_request_;
@@ -72,10 +73,9 @@ TEST_F(GrpcRequestImplTest, NoError) {
   EXPECT_CALL(grpc_callbacks_, onSuccess());
   http_callbacks_->onSuccess(std::move(response_http_message));
   EXPECT_EQ(response.SerializeAsString(), inner_response.SerializeAsString());
-  EXPECT_EQ(
-      1UL,
-      cm_.cluster_.stats_store_.counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.success")
-          .value());
+  EXPECT_EQ(1UL, cm_.cluster_.info_->stats_store_
+                     .counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.success")
+                     .value());
 }
 
 TEST_F(GrpcRequestImplTest, Non200Response) {
@@ -92,10 +92,9 @@ TEST_F(GrpcRequestImplTest, Non200Response) {
 
   EXPECT_CALL(grpc_callbacks_, onFailure(Optional<uint64_t>(), "non-200 response code"));
   http_callbacks_->onSuccess(std::move(response_http_message));
-  EXPECT_EQ(
-      1UL,
-      cm_.cluster_.stats_store_.counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.failure")
-          .value());
+  EXPECT_EQ(1UL, cm_.cluster_.info_->stats_store_
+                     .counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.failure")
+                     .value());
 }
 
 TEST_F(GrpcRequestImplTest, NoResponseTrailers) {
@@ -268,8 +267,8 @@ TEST_F(GrpcRequestImplTest, Cancel) {
 
 TEST_F(GrpcRequestImplTest, RequestTimeoutSet) {
   const Optional<std::chrono::milliseconds> timeout(std::chrono::milliseconds(100));
-  RpcChannelImpl grpc_request_timeout{cm_, "cluster", grpc_callbacks_, cm_.cluster_.stats_store_,
-                                      timeout};
+  RpcChannelImpl grpc_request_timeout{cm_, "cluster", grpc_callbacks_,
+                                      cm_.cluster_.info_->stats_store_, timeout};
   helloworld::Greeter::Stub service_timeout{&grpc_request_timeout};
   expectNormalRequest(timeout);
   helloworld::HelloRequest request;

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -137,7 +137,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
 }
 
 TEST_F(AccessLogImplTest, UpstreamHost) {
-  Upstream::MockCluster cluster;
+  std::shared_ptr<Upstream::MockClusterInfo> cluster{new Upstream::MockClusterInfo()};
   request_info_.upstream_host_ =
       std::make_shared<Upstream::HostDescriptionImpl>(cluster, "tcp://10.0.0.5:1234", false, "");
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -146,7 +146,8 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = upstream_connection;
-  conn_info.host_.reset(new Upstream::HostImpl(cm.cluster_, "tcp://127.0.0.1:80", false, 1, ""));
+  conn_info.host_.reset(
+      new Upstream::HostImpl(cm.cluster_.info_, "tcp://127.0.0.1:80", false, 1, ""));
   EXPECT_CALL(cm, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -646,7 +646,7 @@ TEST(RouteMatcherTest, ShadowClusterNotFound) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  EXPECT_CALL(cm, get("www2")).WillRepeatedly(Return(&cm.cluster_));
+  EXPECT_CALL(cm, get("www2")).WillRepeatedly(Return(cm.cluster_.info_));
   EXPECT_CALL(cm, get("some_cluster")).WillRepeatedly(Return(nullptr));
 
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm), EnvoyException);

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -31,7 +31,7 @@ public:
   }
 
   TestRetryPolicy policy_;
-  NiceMock<Upstream::MockCluster> cluster_;
+  NiceMock<Upstream::MockClusterInfo> cluster_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   Event::MockDispatcher dispatcher_;

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -29,8 +29,8 @@ TEST_F(TcpStatsdSinkTest, All) {
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = connection;
-  conn_info.host_.reset(
-      new Upstream::HostImpl(Upstream::MockCluster{}, "tcp://127.0.0.1:80", false, 1, ""));
+  conn_info.host_.reset(new Upstream::HostImpl(
+      Upstream::ClusterInfoPtr{new Upstream::MockClusterInfo}, "tcp://127.0.0.1:80", false, 1, ""));
 
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("statsd")).WillOnce(Return(conn_info));
   EXPECT_CALL(*connection, connect());

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -322,8 +322,9 @@ public:
   }
 
   void setupValidSink() {
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(&cluster_));
-    ON_CALL(cluster_, features()).WillByDefault(Return(Upstream::Cluster::Features::HTTP2));
+    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    ON_CALL(*cm_.cluster_.info_, features())
+        .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
     std::string valid_config = R"EOF(
       {"collector_cluster": "lightstep_saas"}
@@ -342,7 +343,6 @@ public:
   NiceMock<Event::MockTimer>* timer_;
   Stats::IsolatedStoreImpl stats_;
   NiceMock<Upstream::MockClusterManager> cm_;
-  NiceMock<Upstream::MockCluster> cluster_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -380,8 +380,8 @@ TEST_F(LightStepSinkTest, InitializeSink) {
 
   {
     // Valid config, but upstream cluster does not support http2.
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(&cluster_));
-    ON_CALL(cluster_, features()).WillByDefault(Return(0));
+    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    ON_CALL(*cm_.cluster_.info_, features()).WillByDefault(Return(0));
 
     std::string valid_config = R"EOF(
       {"collector_cluster": "lightstep_saas"}
@@ -392,8 +392,9 @@ TEST_F(LightStepSinkTest, InitializeSink) {
   }
 
   {
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(&cluster_));
-    ON_CALL(cluster_, features()).WillByDefault(Return(Upstream::Cluster::Features::HTTP2));
+    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    ON_CALL(*cm_.cluster_.info_, features())
+        .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
     std::string valid_config = R"EOF(
       {"collector_cluster": "lightstep_saas"}

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -162,8 +162,8 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
-  cluster_->stats().upstream_cx_total_.inc();
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -183,8 +183,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
 
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
-  cluster_->stats().upstream_cx_total_.inc();
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -205,8 +205,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
 
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
-  cluster_->stats().upstream_cx_total_.inc();
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -228,8 +228,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
 
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
-  cluster_->stats().upstream_cx_total_.inc();
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -250,8 +250,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
 
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
-  cluster_->stats().upstream_cx_total_.inc();
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -269,7 +269,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
   setupNoServiceValidationHC();
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(true));
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -300,7 +300,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -312,7 +312,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -329,7 +329,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -357,7 +357,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 
 TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -385,7 +385,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -405,7 +405,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
 
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -431,7 +431,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
 
   expectSessionCreate();
   expectStreamCreate(0);
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   std::vector<HostPtr> removed{cluster_->hosts_.back()};
@@ -444,7 +444,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false));
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -462,7 +462,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(2);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -614,7 +614,7 @@ public:
 };
 
 TEST_F(TcpHealthCheckerImplTest, Success) {
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   expectSessionCreate();
   expectClientCreate();
   health_checker_->start();
@@ -631,7 +631,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
 
   expectSessionCreate();
   expectClientCreate();
-  cluster_->hosts_ = {HostPtr{new HostImpl(*cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   Buffer::OwnedImpl response;

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -6,7 +6,7 @@
 namespace Upstream {
 
 TEST(HostUtilityTest, All) {
-  MockCluster cluster;
+  ClusterInfoPtr cluster{new MockClusterInfo()};
   HostImpl host(cluster, "tcp://127.0.0.1:80", false, 1, "");
   EXPECT_EQ("healthy", HostUtility::healthFlagsToString(host));
 

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -10,7 +10,7 @@ using testing::Return;
 
 namespace Upstream {
 
-static HostPtr newTestHost(const Upstream::Cluster& cluster, const std::string& url,
+static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
                            uint32_t weight = 1, const std::string& zone = "") {
   return HostPtr{new HostImpl(cluster, url, false, weight, zone)};
 }
@@ -20,7 +20,7 @@ static HostPtr newTestHost(const Upstream::Cluster& cluster, const std::string& 
  */
 class DISABLED_SimulationTest : public testing::Test {
 public:
-  DISABLED_SimulationTest() : stats_(ClusterImplBase::generateStats("", stats_store_)) {
+  DISABLED_SimulationTest() : stats_(ClusterInfoImpl::generateStats("", stats_store_)) {
     ON_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50U))
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
@@ -110,7 +110,7 @@ public:
       const std::string zone = std::to_string(i);
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        ret->push_back(newTestHost(cluster_, url, 1, zone));
+        ret->push_back(newTestHost(cluster_.info_, url, 1, zone));
       }
     }
 
@@ -129,7 +129,7 @@ public:
 
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        zone_hosts.push_back(newTestHost(cluster_, url, 1, zone));
+        zone_hosts.push_back(newTestHost(cluster_.info_, url, 1, zone));
       }
 
       ret->push_back(std::move(zone_hosts));

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -65,12 +65,13 @@ public:
 
 TEST_F(OutlierDetectorImplTest, BasicFlow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
-  cluster_.hosts_.push_back(HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:81", false, 1, "")});
+  cluster_.hosts_.push_back(
+      HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:81", false, 1, "")});
   cluster_.runCallbacks({cluster_.hosts_[1]}, {});
 
   // Cause a consecutive 5xx error.
@@ -123,7 +124,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
 
 TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -159,8 +160,8 @@ TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
 
 TEST_F(OutlierDetectorImplTest, Overflow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")},
-                     HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:81", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")},
+                     HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:81", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -197,7 +198,7 @@ TEST_F(OutlierDetectorImplTest, Overflow) {
 
 TEST_F(OutlierDetectorImplTest, NotEnforcing) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -223,7 +224,7 @@ TEST_F(OutlierDetectorImplTest, NotEnforcing) {
 
 TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -248,7 +249,7 @@ TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
 
 TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -273,7 +274,7 @@ TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
 
 TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   DetectorImpl detector(cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_);
   detector.addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
@@ -305,7 +306,7 @@ TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
 TEST(OutlierDetectionEventLoggerImplTest, All) {
   AccessLog::MockAccessLogManager log_manager;
   std::shared_ptr<Filesystem::MockFile> file(new Filesystem::MockFile());
-  NiceMock<MockCluster> cluster;
+  NiceMock<MockClusterInfo> cluster;
   std::shared_ptr<MockHostDescription> host(new NiceMock<MockHostDescription>());
   ON_CALL(*host, cluster()).WillByDefault(ReturnRef(cluster));
   NiceMock<MockSystemTimeSource> time_source;

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -125,7 +125,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(13UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(13UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -135,7 +135,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_TRUE(canary_host->canary());
   EXPECT_EQ("us-east-1d", canary_host->zone());
   EXPECT_EQ(1U, canary_host->weight());
-  EXPECT_EQ(1UL, cluster_->stats().max_host_weight_.value());
+  EXPECT_EQ(1UL, cluster_->info()->stats().max_host_weight_.value());
 
   // Test response with weight change. We should still have the same host.
   setupRequest();
@@ -152,7 +152,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_TRUE(canary_host->canary());
   EXPECT_EQ("us-east-1d", canary_host->zone());
   EXPECT_EQ(50U, canary_host->weight());
-  EXPECT_EQ(50UL, cluster_->stats().max_host_weight_.value());
+  EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -166,7 +166,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
-  EXPECT_EQ(50UL, cluster_->stats().max_host_weight_.value());
+  EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -182,7 +182,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
-  EXPECT_EQ(50UL, cluster_->stats().max_host_weight_.value());
+  EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -210,7 +210,7 @@ TEST_F(SdsTest, HealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(0UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(0UL, numHealthy());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(3UL, cluster_->hostsPerZone().size());
@@ -225,7 +225,7 @@ TEST_F(SdsTest, HealthChecker) {
   }
 
   EXPECT_EQ(12UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(12UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(12UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -236,7 +236,7 @@ TEST_F(SdsTest, HealthChecker) {
   cluster_->hosts()[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker->runCallbacks(cluster_->hosts()[0], true);
   EXPECT_EQ(13UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(13UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
@@ -254,7 +254,7 @@ TEST_F(SdsTest, HealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(13UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(13UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(13UL, numHealthy());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[0].size());
@@ -274,7 +274,7 @@ TEST_F(SdsTest, HealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(12UL, cluster_->hosts().size());
   EXPECT_EQ(12UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(12UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(12UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(12UL, numHealthy());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone()[0].size());
@@ -293,7 +293,7 @@ TEST_F(SdsTest, HealthChecker) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(12UL, cluster_->hosts().size());
   EXPECT_EQ(12UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(12UL, cluster_->stats().membership_healthy_.value());
+  EXPECT_EQ(12UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(12UL, numHealthy());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone()[0].size());

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -50,7 +50,7 @@ public:
   ~MockHostDescription();
 
   MOCK_CONST_METHOD0(canary, bool());
-  MOCK_CONST_METHOD0(cluster, const Cluster&());
+  MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
   MOCK_CONST_METHOD0(url, const std::string&());
   MOCK_CONST_METHOD0(stats, HostStats&());
@@ -72,7 +72,7 @@ public:
   MockHost();
   ~MockHost();
 
-  MOCK_CONST_METHOD0(cluster, const Cluster&());
+  MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(url, const std::string&());
   MOCK_CONST_METHOD0(counters, std::list<std::reference_wrapper<Stats::Counter>>());
   MOCK_CONST_METHOD0(gauges, std::list<std::reference_wrapper<Stats::Gauge>>());


### PR DESCRIPTION
This change refactor is required so that we can support dynamic cluster
add and remove. Previously, we had an unfortunate circular dependency where
a host needs access to a bunch of information about the cluster. Switching
that over to shared pointers creates cyclic strong dependencies. Instead, we
refactor Cluster into Cluster and ClusterInfo, and now ClusterInfo is shared
between the primary cluster and hosts. This removes the cyclic dependency.

In follow up commits we will actually add the dynamic add/remove functionality
which requires some more plumbing changes, but this change is large enough as it
is.