### PR TITLE
outlier: prepare for dynamic cluster remove

### DIFF
--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -83,7 +83,7 @@ public:
   virtual void addChangedStateCb(ChangeStateCb cb) PURE;
 };
 
-typedef std::unique_ptr<Detector> DetectorPtr;
+typedef std::shared_ptr<Detector> DetectorPtr;
 
 } // Outlier
 } // Upstream

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -123,12 +123,6 @@ public:
   virtual const std::vector<HostPtr>& healthyHosts() const PURE;
 
   /**
-   * @return all hosts that are in the zone local to this node. Required --service-zone to be
-   *         set on the command line and to use a cluster type that supports population such as
-   *         the SDS cluster type.
-   */
-
-  /**
    * @return hosts per zone, index 0 is dedicated to local zone hosts.
    * If there are no hosts in local zone for upstream cluster hostPerZone() will @return
    * empty vector.

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -163,7 +163,7 @@ void DetectorImpl::onConsecutive5xx(HostPtr host) {
   // TODO: Unfortunately conesecutive 5xx is complicated from a threading perspective because
   //       we catch consecutive 5xx on worker threads and then post back to the main thread. In
   //       the future, clusters can get removed, and this means there is a race condition with this
-  //       reverse post. The use of shared_from_this() will prevent the outleir detector from going
+  //       reverse post. The use of shared_from_this() will prevent the outlier detector from going
   //       away, but we still need to prevent callbacks from being fired, etc., so will need to add
   //       some type of shutdown() method when we support cluster remove.
   std::shared_ptr<DetectorImpl> shared_this = shared_from_this();

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -35,7 +35,7 @@ void DetectorHostSinkImpl::putHttpResponseCode(uint64_t response_code) {
   if (Http::CodeUtility::is5xx(response_code)) {
     std::shared_ptr<DetectorImpl> detector = detector_.lock();
     if (!detector) {
-      // It's possibly for the cluster/detector to go away while we still have a host in use.
+      // It's possible for the cluster/detector to go away while we still have a host in use.
       return;
     }
 
@@ -160,7 +160,7 @@ DetectionStats DetectorImpl::generateStats(const std::string& name, Stats::Store
 
 void DetectorImpl::onConsecutive5xx(HostPtr host) {
   // This event will come from all threads, so we synchronize with a post to the main thread.
-  // TODO: Unfortunately conesecutive 5xx is complicated from a threading perspective because
+  // TODO: Unfortunately consecutive 5xx is complicated from a threading perspective because
   //       we catch consecutive 5xx on worker threads and then post back to the main thread. In
   //       the future, clusters can get removed, and this means there is a race condition with this
   //       reverse post. The use of shared_from_this() will prevent the outlier detector from going

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -162,7 +162,7 @@ void ClusterImplBase::setHealthChecker(HealthCheckerPtr&& health_checker) {
   });
 }
 
-void ClusterImplBase::setOutlierDetector(Outlier::DetectorPtr&& outlier_detector) {
+void ClusterImplBase::setOutlierDetector(Outlier::DetectorPtr outlier_detector) {
   if (!outlier_detector) {
     return;
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -225,7 +225,7 @@ public:
    * Optionally set the outlier detector for the primary cluster. Done for the same reason as
    * documented in setHealthChecker().
    */
-  void setOutlierDetector(Outlier::DetectorPtr&& outlier_detector);
+  void setOutlierDetector(Outlier::DetectorPtr outlier_detector);
 
   // Upstream::Cluster
   ClusterInfoPtr info() const override { return info_; }


### PR DESCRIPTION
The threading for outlier detection is complicated. Set up a structure
that will work for dynamic remove. Also fix a stat issue where active
ejections is not decremented correctly if we destroy the detector (for
now only in the hot restart case).