### PR TITLE
redis: initial codec and proxy support

### DIFF
--- a/include/envoy/redis/codec.h
+++ b/include/envoy/redis/codec.h
@@ -19,6 +19,10 @@ public:
   RespValue() : type_(RespType::Null) {}
   ~RespValue() { cleanup(); }
 
+  /**
+   * The following are getters and setters for the internal value. A RespValue start as null,
+   * and much change type via type() before the following methods can be used.
+   */
   std::vector<RespValue>& asArray();
   const std::vector<RespValue>& asArray() const;
   std::string& asString();
@@ -26,6 +30,10 @@ public:
   int64_t& asInteger();
   int64_t asInteger() const;
 
+  /**
+   * Get/set the type of the RespValue. A RespValue can only be a single type at a time. Each time
+   * type() is called the type is changed and then the type specific as* methods can be used.
+   */
   RespType type() const { return type_; }
   void type(RespType type);
 

--- a/include/envoy/redis/codec.h
+++ b/include/envoy/redis/codec.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+
+namespace Redis {
+
+/**
+ * All RESP types as defined here: https://redis.io/topics/protocol
+ */
+enum class RespType { Null, SimpleString, BulkString, Integer, Error, Array };
+
+/**
+ * A variant implementation of a RESP value optimized for peformance. A C++11 union is used for
+ * the underlying type so that no unnecessary allocations/constructions are needed.
+ */
+class RespValue {
+public:
+  RespValue() : type_(RespType::Null) {}
+  ~RespValue() { cleanup(); }
+
+  std::vector<RespValue>& asArray();
+  const std::vector<RespValue>& asArray() const;
+  std::string& asString();
+  const std::string& asString() const;
+  int64_t& asInteger();
+  int64_t asInteger() const;
+
+  RespType type() const { return type_; }
+  void type(RespType type);
+
+private:
+  union {
+    std::vector<RespValue> array_;
+    std::string string_;
+    int64_t integer_;
+  };
+
+  void cleanup();
+
+  RespType type_;
+};
+
+typedef std::unique_ptr<RespValue> RespValuePtr;
+
+/**
+ * Callbacks that the decoder fires.
+ */
+class DecoderCallbacks {
+public:
+  virtual ~DecoderCallbacks() {}
+
+  /**
+   * Called when a new top level RESP value has been decoded. This value may include multiple
+   * sub-values in the case of arrays or nested arrays.
+   * @param value supplies the decoded value that is now owned by the callee.
+   */
+  virtual void onRespValue(RespValuePtr&& value) PURE;
+};
+
+/**
+ * A redis byte decoder for https://redis.io/topics/protocol
+ */
+class Decoder {
+public:
+  virtual ~Decoder() {}
+
+  /**
+   * Decode redis protocol bytes.
+   * @param data supplies the data to decode. All bytes will be consumed by the decoder or a
+   *        ProtocolError will be thrown.
+   */
+  virtual void decode(Buffer::Instance& data) PURE;
+};
+
+typedef std::unique_ptr<Decoder> DecoderPtr;
+
+/**
+ * A factory for a redis decoder.
+ */
+class DecoderFactory {
+public:
+  virtual ~DecoderFactory() {}
+
+  /**
+   * Create a decoder given a set of decoder callbacks.
+   */
+  virtual DecoderPtr create(DecoderCallbacks& callbacks) PURE;
+};
+
+/**
+ * A redis byte encoder for https://redis.io/topics/protocol
+ */
+class Encoder {
+public:
+  virtual ~Encoder() {}
+
+  /**
+   * Encode a RESP value to a buffer.
+   * @param value supplies the value to encode.
+   * @param out supplies the buffer to encode to.
+   */
+  virtual void encode(const RespValue& value, Buffer::Instance& out) PURE;
+};
+
+typedef std::unique_ptr<Encoder> EncoderPtr;
+
+/**
+ * A redis protocol error.
+ */
+class ProtocolError : public EnvoyException {
+public:
+  ProtocolError(const std::string& error) : EnvoyException(error) {}
+};
+
+} // Redis

--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "envoy/redis/codec.h"
+#include "envoy/upstream/cluster_manager.h"
+
+namespace Redis {
+namespace ConnPool {
+
+/**
+ * A handle to an outbound request.
+ */
+class ActiveRequest {
+public:
+  virtual ~ActiveRequest() {}
+
+  /**
+   * Cancel the request. No further request callbacks will be called.
+   */
+  virtual void cancel() PURE;
+};
+
+/**
+ * Outbound request callbacks.
+ */
+class ActiveRequestCallbacks {
+public:
+  virtual ~ActiveRequestCallbacks() {}
+
+  /**
+   * Called when a pipelined response is received.
+   * @param value supplies the response which is now owned by the callee.
+   */
+  virtual void onResponse(RespValuePtr&& value) PURE;
+
+  /**
+   * Called when a network/protocol error occurs and there is no response.
+   */
+  virtual void onFailure() PURE;
+};
+
+/**
+ * A single redis client connection.
+ */
+class Client {
+public:
+  virtual ~Client() {}
+
+  /**
+   * Adds network connection callbacks to the underlying network connection.
+   */
+  virtual void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) PURE;
+
+  /**
+   * Closes the underlying network connection. It is the callers responsibility to call
+   * failAllPendingRequests() if needed.
+   */
+  virtual void close() PURE;
+
+  /**
+   * Make a pipelined request to the remote redis server.
+   * @param request supplies the RESP request to make.
+   * @param callbacks supplies the request callbacks.
+   * @return ActiveRequest* a handle to the active request.
+   */
+  virtual ActiveRequest* makeRequest(const RespValue& request,
+                                     ActiveRequestCallbacks& callbacks) PURE;
+};
+
+typedef std::unique_ptr<Client> ClientPtr;
+
+/**
+ * A factory for individual redis client connections.
+ */
+class ClientFactory {
+public:
+  virtual ~ClientFactory() {}
+
+  /**
+   * Create a client given an upstream cluster and a cluster manager.
+   * TODO: This interface will change when we actually support consistent hashing.
+   */
+  virtual ClientPtr create(const std::string& cluster_name, Upstream::ClusterManager& cm) PURE;
+};
+
+/**
+ * A redis connection pool. Wraps M connections to N upstream hosts, consistent hashing,
+ * pipelining, failure handling, etc.
+ */
+class Instance {
+public:
+  virtual ~Instance() {}
+
+  /**
+   * Makes a redis request.
+   * @param hash_key supplies the key to use for consistent hashing.
+   * @param request supplies the request to make.
+   * @param callbacks supplies the request completion callbacks.
+   * @return ActiveRequest* a handle to the active request or nullptr if the request could not
+   *         be made for some reason.
+   */
+  virtual ActiveRequest* makeRequest(const std::string& hash_key, const RespValue& request,
+                                     ActiveRequestCallbacks& callbacks) PURE;
+};
+
+} // ConnPool
+} // Redis

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -82,6 +82,9 @@ add_library(
   network/utility.cc
   profiler/profiler.cc
   ratelimit/ratelimit_impl.cc
+  redis/codec_impl.cc
+  redis/conn_pool_impl.cc
+  redis/proxy_filter.cc
   router/config_impl.cc
   router/retry_state_impl.cc
   router/router.cc

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -21,6 +21,7 @@ namespace Logger {
   FUNCTION(main)                 \
   FUNCTION(mongo)                \
   FUNCTION(pool)                 \
+  FUNCTION(redis)                \
   FUNCTION(router)               \
   FUNCTION(runtime)              \
   FUNCTION(testing)              \

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -79,7 +79,7 @@ public:
   /**
    * Convert an unsigned integer to a base 10 string as fast as possible.
    * @param out supplies the string to fill.
-   * @param out_len supplies the length of the output buffer. Must be >= 32.
+   * @param out_len supplies the length of the output buffer. Must be >= 21.
    * @param i supplies the number to convert.
    * @return the size of the string, not including the null termination.
    */

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -1,0 +1,382 @@
+#include "codec_impl.h"
+
+#include "common/common/assert.h"
+#include "common/common/utility.h"
+
+namespace Redis {
+
+std::vector<RespValue>& RespValue::asArray() {
+  ASSERT(type_ == RespType::Array);
+  return array_;
+}
+
+const std::vector<RespValue>& RespValue::asArray() const {
+  ASSERT(type_ == RespType::Array);
+  return array_;
+}
+
+std::string& RespValue::asString() {
+  ASSERT(type_ == RespType::BulkString || type_ == RespType::Error ||
+         type_ == RespType::SimpleString);
+  return string_;
+}
+
+const std::string& RespValue::asString() const {
+  ASSERT(type_ == RespType::BulkString || type_ == RespType::Error ||
+         type_ == RespType::SimpleString);
+  return string_;
+}
+
+int64_t& RespValue::asInteger() {
+  ASSERT(type_ == RespType::Integer);
+  return integer_;
+}
+
+int64_t RespValue::asInteger() const {
+  ASSERT(type_ == RespType::Integer);
+  return integer_;
+}
+
+void RespValue::cleanup() {
+  // Need to manually delete because of the union.
+  switch (type_) {
+  case RespType::Array: {
+    array_.~vector<RespValue>();
+    break;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    string_.~basic_string<char>();
+    break;
+  }
+  case RespType::Null:
+  case RespType::Integer: {
+    break;
+  }
+  }
+}
+
+void RespValue::type(RespType type) {
+  cleanup();
+
+  // Need to use placement new because of the union.
+  type_ = type;
+  switch (type) {
+  case RespType::Array: {
+    new (&array_) std::vector<RespValue>();
+    break;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    new (&string_) std::string();
+    break;
+  }
+  case RespType::Null:
+  case RespType::Integer: {
+    break;
+  }
+  }
+}
+
+void DecoderImpl::decode(Buffer::Instance& data) {
+  uint64_t num_slices = data.getRawSlices(nullptr, 0);
+  Buffer::RawSlice slices[num_slices];
+  data.getRawSlices(slices, num_slices);
+  for (Buffer::RawSlice& slice : slices) {
+    parseSlice(slice);
+  }
+
+  data.drain(data.length());
+}
+
+void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
+  char* buffer = reinterpret_cast<char*>(slice.mem_);
+  uint64_t remaining = slice.len_;
+
+  while (remaining || state_ == State::ValueComplete) {
+    log_trace("parse slice: {} remaining", remaining);
+    switch (state_) {
+    case State::ValueRootStart: {
+      log_trace("parse slice: ValueRootStart");
+      pending_value_root_.reset(new RespValue());
+      pending_value_stack_.push_front({pending_value_root_.get(), 0});
+      state_ = State::ValueStart;
+      break;
+    }
+
+    case State::ValueStart: {
+      log_trace("parse slice: ValueStart: {}", buffer[0]);
+      pending_integer_.reset();
+      switch (buffer[0]) {
+      case '*': {
+        state_ = State::IntegerStart;
+        pending_value_stack_.front().value_->type(RespType::Array);
+        break;
+      }
+      case '$': {
+        state_ = State::IntegerStart;
+        pending_value_stack_.front().value_->type(RespType::BulkString);
+        break;
+      }
+      case '-': {
+        state_ = State::SimpleString;
+        pending_value_stack_.front().value_->type(RespType::Error);
+        break;
+      }
+      case '+': {
+        state_ = State::SimpleString;
+        pending_value_stack_.front().value_->type(RespType::SimpleString);
+        break;
+      }
+      case ':': {
+        state_ = State::IntegerStart;
+        pending_value_stack_.front().value_->type(RespType::Integer);
+        break;
+      }
+      default: { throw ProtocolError("invalid value type"); }
+      }
+
+      remaining--;
+      buffer++;
+      break;
+    }
+
+    case State::IntegerStart: {
+      log_trace("parse slice: IntegerStart: {}", buffer[0]);
+      if (buffer[0] == '-') {
+        pending_integer_.negative_ = true;
+        remaining--;
+        buffer++;
+      }
+
+      state_ = State::Integer;
+      break;
+    }
+
+    case State::Integer: {
+      log_trace("parse slice: Integer: {}", buffer[0]);
+      char c = buffer[0];
+      if (buffer[0] == '\r') {
+        state_ = State::IntegerLF;
+      } else {
+        if (c < '0' || c > '9') {
+          throw ProtocolError("invalid integer character");
+        } else {
+          pending_integer_.integer_ = (pending_integer_.integer_ * 10) + (c - '0');
+        }
+      }
+
+      remaining--;
+      buffer++;
+      break;
+    }
+
+    case State::IntegerLF: {
+      if (buffer[0] != '\n') {
+        throw ProtocolError("expected new line");
+      }
+
+      if (pending_integer_.negative_) {
+        pending_integer_.integer_ *= -1;
+      }
+
+      log_trace("parse slice: IntegerLF: {}", pending_integer_.integer_);
+      remaining--;
+      buffer++;
+
+      PendingValue& current_value = pending_value_stack_.front();
+      if (current_value.value_->type() == RespType::Array) {
+        if (pending_integer_.integer_ < 0) {
+          // Null array. Convert to null.
+          current_value.value_->type(RespType::Null);
+          state_ = State::ValueComplete;
+        } else if (pending_integer_.integer_ == 0) {
+          state_ = State::ValueComplete;
+        } else {
+          std::vector<RespValue> values(pending_integer_.integer_);
+          current_value.value_->asArray().swap(values);
+          pending_value_stack_.push_front({&current_value.value_->asArray()[0], 0});
+          state_ = State::ValueStart;
+        }
+      } else if (current_value.value_->type() == RespType::Integer) {
+        current_value.value_->asInteger() = pending_integer_.integer_;
+        state_ = State::ValueComplete;
+      } else {
+        ASSERT(current_value.value_->type() == RespType::BulkString);
+        if (pending_integer_.integer_ >= 0) {
+          // TODO: reserve and define max length since we don't stream currently.
+          state_ = State::BulkStringBody;
+        } else {
+          // Null bulk string. Switch type to null and move to value complete.
+          current_value.value_->type(RespType::Null);
+          state_ = State::ValueComplete;
+        }
+      }
+
+      break;
+    }
+
+    case State::BulkStringBody: {
+      ASSERT(pending_integer_.integer_ >= 0);
+      uint64_t length_to_copy =
+          std::min(static_cast<uint64_t>(pending_integer_.integer_), remaining);
+      pending_value_stack_.front().value_->asString().append(buffer, length_to_copy);
+      pending_integer_.integer_ -= length_to_copy;
+      remaining -= length_to_copy;
+      buffer += length_to_copy;
+
+      if (pending_integer_.integer_ == 0) {
+        log_trace("parse slice: BulkStringBody complete: {}",
+                  pending_value_stack_.front().value_->asString());
+        state_ = State::CR;
+      }
+
+      break;
+    }
+
+    case State::CR: {
+      log_trace("parse slice: CR");
+      if (buffer[0] != '\r') {
+        throw ProtocolError("expected carriage return");
+      }
+
+      remaining--;
+      buffer++;
+      state_ = State::LF;
+      break;
+    }
+
+    case State::LF: {
+      log_trace("parse slice: LF");
+      if (buffer[0] != '\n') {
+        throw ProtocolError("expected new line");
+      }
+
+      remaining--;
+      buffer++;
+      state_ = State::ValueComplete;
+      break;
+    }
+
+    case State::SimpleString: {
+      log_trace("parse slice: SimpleString: {}", buffer[0]);
+      if (buffer[0] == '\r') {
+        state_ = State::LF;
+      } else {
+        pending_value_stack_.front().value_->asString().push_back(buffer[0]);
+      }
+
+      remaining--;
+      buffer++;
+      break;
+    }
+
+    case State::ValueComplete: {
+      log_trace("parse slice: ValueComplete");
+      ASSERT(!pending_value_stack_.empty());
+      pending_value_stack_.pop_front();
+      if (pending_value_stack_.empty()) {
+        callbacks_.onRespValue(std::move(pending_value_root_));
+        state_ = State::ValueRootStart;
+      } else {
+        PendingValue& current_value = pending_value_stack_.front();
+        ASSERT(current_value.value_->type() == RespType::Array);
+        if (current_value.current_array_element_ < current_value.value_->asArray().size() - 1) {
+          current_value.current_array_element_++;
+          pending_value_stack_.push_front(
+              {&current_value.value_->asArray()[current_value.current_array_element_], 0});
+          state_ = State::ValueStart;
+        }
+      }
+
+      break;
+    }
+    }
+  }
+}
+
+void EncoderImpl::encode(const RespValue& value, Buffer::Instance& out) {
+  switch (value.type()) {
+  case RespType::Array: {
+    encodeArray(value.asArray(), out);
+    break;
+  }
+  case RespType::SimpleString: {
+    encodeSimpleString(value.asString(), out);
+    break;
+  }
+  case RespType::BulkString: {
+    encodeBulkString(value.asString(), out);
+    break;
+  }
+  case RespType::Error: {
+    encodeError(value.asString(), out);
+    break;
+  }
+  case RespType::Null: {
+    out.add("$-1\r\n", 5);
+    break;
+  }
+  case RespType::Integer:
+    encodeInteger(value.asInteger(), out);
+    break;
+  }
+}
+
+void EncoderImpl::encodeArray(const std::vector<RespValue>& array, Buffer::Instance& out) {
+  char buffer[32];
+  char* current = buffer;
+  *current++ = '*';
+  current += StringUtil::itoa(current, 31, array.size());
+  *current++ = '\r';
+  *current++ = '\n';
+  out.add(buffer, current - buffer);
+
+  for (const RespValue& value : array) {
+    encode(value, out);
+  }
+}
+
+void EncoderImpl::encodeBulkString(const std::string& string, Buffer::Instance& out) {
+  char buffer[32];
+  char* current = buffer;
+  *current++ = '$';
+  current += StringUtil::itoa(current, 31, string.size());
+  *current++ = '\r';
+  *current++ = '\n';
+  out.add(buffer, current - buffer);
+  out.add(string);
+  out.add("\r\n", 2);
+}
+
+void EncoderImpl::encodeError(const std::string& string, Buffer::Instance& out) {
+  out.add("-", 1);
+  out.add(string);
+  out.add("\r\n", 2);
+}
+
+void EncoderImpl::encodeInteger(int64_t integer, Buffer::Instance& out) {
+  char buffer[32];
+  char* current = buffer;
+  *current++ = ':';
+  if (integer >= 0) {
+    current += StringUtil::itoa(current, 31, integer);
+  } else {
+    *current++ = '-';
+    current += StringUtil::itoa(current, 30, integer * -1);
+  }
+
+  *current++ = '\r';
+  *current++ = '\n';
+  out.add(buffer, current - buffer);
+}
+
+void EncoderImpl::encodeSimpleString(const std::string& string, Buffer::Instance& out) {
+  out.add("+", 1);
+  out.add(string);
+  out.add("\r\n", 2);
+}
+
+} // Redis

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -84,7 +84,7 @@ void DecoderImpl::decode(Buffer::Instance& data) {
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   Buffer::RawSlice slices[num_slices];
   data.getRawSlices(slices, num_slices);
-  for (Buffer::RawSlice& slice : slices) {
+  for (const Buffer::RawSlice& slice : slices) {
     parseSlice(slice);
   }
 
@@ -92,7 +92,7 @@ void DecoderImpl::decode(Buffer::Instance& data) {
 }
 
 void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
-  char* buffer = reinterpret_cast<char*>(slice.mem_);
+  const char* buffer = reinterpret_cast<const char*>(slice.mem_);
   uint64_t remaining = slice.len_;
 
   while (remaining || state_ == State::ValueComplete) {

--- a/source/common/redis/codec_impl.h
+++ b/source/common/redis/codec_impl.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "envoy/redis/codec.h"
+
+#include "common/common/logger.h"
+
+namespace Redis {
+
+/**
+ * Decoder implementation of https://redis.io/topics/protocol
+ *
+ * This implementation buffers when needed and will always consume all bytes passed for decoding.
+ */
+class DecoderImpl : public Decoder, Logger::Loggable<Logger::Id::redis> {
+public:
+  DecoderImpl(DecoderCallbacks& callbacks) : callbacks_(callbacks) {}
+
+  // Redis::Decoder
+  void decode(Buffer::Instance& data) override;
+
+private:
+  enum class State {
+    ValueRootStart,
+    ValueStart,
+    IntegerStart,
+    Integer,
+    IntegerLF,
+    BulkStringBody,
+    CR,
+    LF,
+    SimpleString,
+    ValueComplete
+  };
+
+  struct PendingInteger {
+    void reset() {
+      integer_ = 0;
+      negative_ = false;
+    }
+
+    int64_t integer_;
+    bool negative_;
+  };
+
+  struct PendingValue {
+    RespValue* value_;
+    uint64_t current_array_element_;
+  };
+
+  void parseSlice(const Buffer::RawSlice& slice);
+
+  DecoderCallbacks& callbacks_;
+  State state_{State::ValueRootStart};
+  PendingInteger pending_integer_;
+  RespValuePtr pending_value_root_;
+  std::forward_list<PendingValue> pending_value_stack_;
+};
+
+/**
+ * A factory implementation that returns a real decoder.
+ */
+class DecoderFactoryImpl : public DecoderFactory {
+public:
+  // Redis::DecoderFactory
+  DecoderPtr create(DecoderCallbacks& callbacks) override {
+    return DecoderPtr{new DecoderImpl(callbacks)};
+  }
+};
+
+/**
+ * Encoder implementation of https://redis.io/topics/protocol
+ */
+class EncoderImpl : public Encoder {
+public:
+  // Redis::Encoder
+  void encode(const RespValue& value, Buffer::Instance& out) override;
+
+private:
+  void encodeArray(const std::vector<RespValue>& array, Buffer::Instance& out);
+  void encodeBulkString(const std::string& string, Buffer::Instance& out);
+  void encodeError(const std::string& string, Buffer::Instance& out);
+  void encodeInteger(int64_t integer, Buffer::Instance& out);
+  void encodeSimpleString(const std::string& string, Buffer::Instance& out);
+};
+
+} // Redis

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -1,0 +1,134 @@
+#include "conn_pool_impl.h"
+
+#include "common/common/assert.h"
+
+namespace Redis {
+namespace ConnPool {
+
+ClientPtr ClientImpl::create(const std::string& cluster_name, Upstream::ClusterManager& cm,
+                             EncoderPtr&& encoder, DecoderFactory& decoder_factory) {
+
+  Upstream::Host::CreateConnectionData data = cm.tcpConnForCluster(cluster_name);
+  if (!data.connection_) {
+    return nullptr;
+  }
+
+  std::unique_ptr<ClientImpl> client(new ClientImpl(std::move(encoder), decoder_factory));
+  client->connection_ = std::move(data.connection_);
+  client->connection_->addConnectionCallbacks(*client);
+  client->connection_->addReadFilter(Network::ReadFilterPtr{new UpstreamReadFilter(*client)});
+  client->connection_->connect();
+  client->connection_->noDelay(true);
+  return std::move(client);
+}
+
+ClientImpl::~ClientImpl() {
+  ASSERT(pending_requests_.empty());
+  ASSERT(connection_->state() == Network::Connection::State::Closed);
+}
+
+void ClientImpl::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
+
+ActiveRequest* ClientImpl::makeRequest(const RespValue& request,
+                                       ActiveRequestCallbacks& callbacks) {
+  ASSERT(connection_->state() == Network::Connection::State::Open);
+  pending_requests_.emplace_back(callbacks);
+  encoder_->encode(request, encoder_buffer_);
+  connection_->write(encoder_buffer_);
+  return &pending_requests_.back();
+}
+
+void ClientImpl::onData(Buffer::Instance& data) {
+  try {
+    decoder_->decode(data);
+  } catch (ProtocolError&) {
+    connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+}
+
+void ClientImpl::onEvent(uint32_t events) {
+  if ((events & Network::ConnectionEvent::RemoteClose) ||
+      (events & Network::ConnectionEvent::LocalClose)) {
+    while (!pending_requests_.empty()) {
+      PendingRequest& request = pending_requests_.front();
+      if (!request.canceled_) {
+        request.callbacks_.onFailure();
+      }
+      pending_requests_.pop_front();
+    }
+  }
+}
+
+void ClientImpl::onRespValue(RespValuePtr&& value) {
+  ASSERT(!pending_requests_.empty());
+  PendingRequest& request = pending_requests_.front();
+  if (!request.canceled_) {
+    request.callbacks_.onResponse(std::move(value));
+  }
+  pending_requests_.pop_front();
+}
+
+void ClientImpl::PendingRequest::cancel() {
+  // If we get a cancellation, we just mark the pending request as cancelled, and then we drop
+  // the response as it comes through. There is no reason to blow away the connection when the
+  // remote is already responding as fast as possible.
+  canceled_ = true;
+}
+
+ClientFactoryImpl ClientFactoryImpl::instance_;
+
+ClientPtr ClientFactoryImpl::create(const std::string& cluster_name, Upstream::ClusterManager& cm) {
+  return ClientImpl::create(cluster_name, cm, EncoderPtr{new EncoderImpl()}, decoder_factory_);
+}
+
+InstanceImpl::InstanceImpl(const std::string& cluster_name, Upstream::ClusterManager& cm,
+                           ClientFactory& client_factory, ThreadLocal::Instance& tls)
+    : cluster_name_(cluster_name), cm_(cm), client_factory_(client_factory), tls_(tls),
+      tls_slot_(tls.allocateSlot()) {
+  tls.set(tls_slot_, [this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectPtr {
+    return std::make_shared<ThreadLocalPool>(*this, dispatcher);
+  });
+}
+
+ActiveRequest* InstanceImpl::makeRequest(const std::string&, const RespValue& value,
+                                         ActiveRequestCallbacks& callbacks) {
+  return tls_.getTyped<ThreadLocalPool>(tls_slot_).makeRequest(value, callbacks);
+}
+
+ActiveRequest* InstanceImpl::ThreadLocalPool::makeRequest(const RespValue& request,
+                                                          ActiveRequestCallbacks& callbacks) {
+  if (!client_) {
+    client_.reset(new ThreadLocalActiveClient(*this));
+    client_->client_ = parent_.client_factory_.create(parent_.cluster_name_, parent_.cm_);
+    if (client_->client_) {
+      client_->client_->addConnectionCallbacks(*client_);
+    } else {
+      client_.reset();
+    }
+  }
+
+  if (client_) {
+    // TODO: In the case of retry, this is broken. This client could be in the process of being
+    //       shut down. Since the entire pool implementation is going to get reworked to support
+    //       real pooling we won't worry about this now.
+    return client_->client_->makeRequest(request, callbacks);
+  } else {
+    return nullptr;
+  }
+}
+
+void InstanceImpl::ThreadLocalPool::onEvent(ThreadLocalActiveClient&, uint32_t events) {
+  if ((events & Network::ConnectionEvent::RemoteClose) ||
+      (events & Network::ConnectionEvent::LocalClose)) {
+    dispatcher_.deferredDelete(std::move(client_));
+  }
+}
+
+void InstanceImpl::ThreadLocalPool::shutdown() {
+  if (client_) {
+    client_->client_->close();
+  }
+}
+
+} // ConnPool
+} // Redis

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -99,9 +99,9 @@ ActiveRequest* InstanceImpl::ThreadLocalPool::makeRequest(const RespValue& reque
                                                           ActiveRequestCallbacks& callbacks) {
   if (!client_) {
     client_.reset(new ThreadLocalActiveClient(*this));
-    client_->client_ = parent_.client_factory_.create(parent_.cluster_name_, parent_.cm_);
-    if (client_->client_) {
-      client_->client_->addConnectionCallbacks(*client_);
+    client_->redis_client_ = parent_.client_factory_.create(parent_.cluster_name_, parent_.cm_);
+    if (client_->redis_client_) {
+      client_->redis_client_->addConnectionCallbacks(*client_);
     } else {
       client_.reset();
     }
@@ -111,7 +111,7 @@ ActiveRequest* InstanceImpl::ThreadLocalPool::makeRequest(const RespValue& reque
     // TODO: In the case of retry, this is broken. This client could be in the process of being
     //       shut down. Since the entire pool implementation is going to get reworked to support
     //       real pooling we won't worry about this now.
-    return client_->client_->makeRequest(request, callbacks);
+    return client_->redis_client_->makeRequest(request, callbacks);
   } else {
     return nullptr;
   }
@@ -126,7 +126,7 @@ void InstanceImpl::ThreadLocalPool::onEvent(ThreadLocalActiveClient&, uint32_t e
 
 void InstanceImpl::ThreadLocalPool::shutdown() {
   if (client_) {
-    client_->client_->close();
+    client_->redis_client_->close();
   }
 }
 

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "envoy/upstream/cluster_manager.h"
+#include "envoy/redis/conn_pool.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/network/filter_impl.h"
+#include "common/redis/codec_impl.h"
+
+namespace Redis {
+namespace ConnPool {
+
+// TODO: Stats
+// TODO: Connect timeout
+// TODO: Op timeout
+
+class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
+public:
+  static ClientPtr create(const std::string& cluster_name, Upstream::ClusterManager& cm,
+                          EncoderPtr&& encoder, DecoderFactory& decoder_factory);
+
+  ~ClientImpl();
+
+  // Redis::ConnPool::Client
+  void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) override {
+    connection_->addConnectionCallbacks(callbacks);
+  }
+  void close() override;
+  ActiveRequest* makeRequest(const RespValue& request, ActiveRequestCallbacks& callbacks) override;
+
+private:
+  struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
+    UpstreamReadFilter(ClientImpl& parent) : parent_(parent) {}
+
+    // Network::ReadFilter
+    Network::FilterStatus onData(Buffer::Instance& data) override {
+      parent_.onData(data);
+      return Network::FilterStatus::Continue;
+    }
+
+    ClientImpl& parent_;
+  };
+
+  struct PendingRequest : public ActiveRequest {
+    PendingRequest(ActiveRequestCallbacks& callbacks) : callbacks_(callbacks) {}
+
+    // Redis::ConnPool::ActiveRequest
+    void cancel() override;
+
+    ActiveRequestCallbacks& callbacks_;
+    bool canceled_{};
+  };
+
+  ClientImpl(EncoderPtr&& encoder, DecoderFactory& decoder_factory)
+      : encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)) {}
+
+  void onData(Buffer::Instance& data);
+
+  // Redis::DecoderCallbacks
+  void onRespValue(RespValuePtr&& value) override;
+
+  // Network::ConnectionCallbacks
+  void onEvent(uint32_t events) override;
+
+  Network::ClientConnectionPtr connection_;
+  EncoderPtr encoder_;
+  Buffer::OwnedImpl encoder_buffer_;
+  DecoderPtr decoder_;
+  std::list<PendingRequest> pending_requests_;
+};
+
+class ClientFactoryImpl : public ClientFactory {
+public:
+  // Redis::ConnPool::ClientFactoryImpl
+  ClientPtr create(const std::string& cluster_name, Upstream::ClusterManager& cm) override;
+
+  static ClientFactoryImpl instance_;
+
+private:
+  DecoderFactoryImpl decoder_factory_;
+};
+
+// TODO: Real hashing connection pool with N connections per upstream.
+
+class InstanceImpl : public Instance {
+public:
+  InstanceImpl(const std::string& cluster_name, Upstream::ClusterManager& cm,
+               ClientFactory& client_factory, ThreadLocal::Instance& tls);
+
+  // Redis::ConnPool::Instance
+  ActiveRequest* makeRequest(const std::string& hash_key, const RespValue& request,
+                             ActiveRequestCallbacks& callbacks) override;
+
+private:
+  struct ThreadLocalPool;
+
+  struct ThreadLocalActiveClient : public Network::ConnectionCallbacks,
+                                   public Event::DeferredDeletable {
+    ThreadLocalActiveClient(ThreadLocalPool& parent) : parent_(parent) {}
+
+    // Network::ConnectionCallbacks
+    void onEvent(uint32_t events) override { parent_.onEvent(*this, events); }
+
+    ThreadLocalPool& parent_;
+    ClientPtr client_;
+  };
+
+  typedef std::unique_ptr<ThreadLocalActiveClient> ThreadLocalActiveClientPtr;
+
+  struct ThreadLocalPool : public ThreadLocal::ThreadLocalObject {
+    ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher)
+        : parent_(parent), dispatcher_(dispatcher) {}
+
+    ActiveRequest* makeRequest(const RespValue& request, ActiveRequestCallbacks& callbacks);
+    void onEvent(ThreadLocalActiveClient& client, uint32_t events);
+
+    // ThreadLocal::ThreadLocalObject
+    void shutdown() override;
+
+    InstanceImpl& parent_;
+    Event::Dispatcher& dispatcher_;
+    ThreadLocalActiveClientPtr client_;
+  };
+
+  const std::string cluster_name_;
+  Upstream::ClusterManager& cm_;
+  ClientFactory& client_factory_;
+  ThreadLocal::Instance& tls_;
+  uint32_t tls_slot_;
+};
+
+} // ConnPool
+} // Redis

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -103,7 +103,7 @@ private:
     void onEvent(uint32_t events) override { parent_.onEvent(*this, events); }
 
     ThreadLocalPool& parent_;
-    ClientPtr client_;
+    ClientPtr redis_client_;
   };
 
   typedef std::unique_ptr<ThreadLocalActiveClient> ThreadLocalActiveClientPtr;

--- a/source/common/redis/proxy_filter.cc
+++ b/source/common/redis/proxy_filter.cc
@@ -1,0 +1,75 @@
+#include "proxy_filter.h"
+
+#include "common/common/assert.h"
+
+namespace Redis {
+
+ProxyFilterConfig::ProxyFilterConfig(const Json::Object& config, Upstream::ClusterManager& cm)
+    : cluster_name_{config.getString("cluster_name")} {
+  if (!cm.get(cluster_name_)) {
+    throw EnvoyException(
+        fmt::format("redis filter config: unknown cluster name '{}'", cluster_name_));
+  }
+}
+
+ProxyFilter::~ProxyFilter() { ASSERT(pending_requests_.empty()); }
+
+void ProxyFilter::onRespValue(RespValuePtr&& value) {
+  pending_requests_.emplace_back(*this);
+  PendingRequest& request = pending_requests_.back();
+  request.request_handle_ = conn_pool_.makeRequest("", *value, request);
+  if (!request.request_handle_) {
+    respondWithFailure("no healthy upstream");
+    pending_requests_.pop_back();
+  }
+}
+
+void ProxyFilter::onEvent(uint32_t events) {
+  if (events & Network::ConnectionEvent::RemoteClose ||
+      events & Network::ConnectionEvent::LocalClose) {
+    while (!pending_requests_.empty()) {
+      pending_requests_.front().request_handle_->cancel();
+      pending_requests_.pop_front();
+    }
+  }
+}
+
+void ProxyFilter::onResponse(PendingRequest& request, RespValuePtr&& value) {
+  // TODO: Currently the connection pool is a single connection so out of order can't happen.
+  ASSERT(!pending_requests_.empty());
+  ASSERT(&request == &pending_requests_.front());
+  UNREFERENCED_PARAMETER(request);
+  pending_requests_.pop_front();
+  encoder_->encode(*value, encoder_buffer_);
+  callbacks_->connection().write(encoder_buffer_);
+}
+
+void ProxyFilter::onFailure(PendingRequest& request) {
+  // TODO: Currently the connection pool is a single connection so out of order can't happen.
+  ASSERT(!pending_requests_.empty());
+  ASSERT(&request == &pending_requests_.front());
+  UNREFERENCED_PARAMETER(request);
+  pending_requests_.pop_front();
+  respondWithFailure("upstream connection error");
+}
+
+Network::FilterStatus ProxyFilter::onData(Buffer::Instance& data) {
+  try {
+    decoder_->decode(data);
+    return Network::FilterStatus::Continue;
+  } catch (ProtocolError&) {
+    respondWithFailure("downstream protocol error");
+    callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    return Network::FilterStatus::StopIteration;
+  }
+}
+
+void ProxyFilter::respondWithFailure(const std::string& message) {
+  RespValue error;
+  error.type(RespType::Error);
+  error.asString() = message;
+  encoder_->encode(error, encoder_buffer_);
+  callbacks_->connection().write(encoder_buffer_);
+}
+
+} // Redis

--- a/source/common/redis/proxy_filter.h
+++ b/source/common/redis/proxy_filter.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "envoy/network/filter.h"
+#include "envoy/redis/codec.h"
+#include "envoy/redis/conn_pool.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/json/json_loader.h"
+
+namespace Redis {
+
+// TODO: Stats
+// TODO: Actual multiplexing, command verification, and splitting
+
+/**
+ * Configuration for the redis proxy filter.
+ */
+class ProxyFilterConfig {
+public:
+  ProxyFilterConfig(const Json::Object& config, Upstream::ClusterManager& cm);
+
+  const std::string& clusterName() { return cluster_name_; }
+
+private:
+  const std::string cluster_name_;
+};
+
+/**
+ * A redis multiplexing proxy filter. This filter will take incoming redis pipelined commands, and
+ * mulitplex them onto a consistently hashed connection pool of backend servers.
+ * TODO: When we actually support command splitting, better documentation of what we support and
+ *       what we are doing.
+ */
+class ProxyFilter : public Network::ReadFilter,
+                    public DecoderCallbacks,
+                    public Network::ConnectionCallbacks {
+public:
+  ProxyFilter(DecoderFactory& factory, EncoderPtr&& encoder, ConnPool::Instance& conn_pool)
+      : decoder_(factory.create(*this)), encoder_(std::move(encoder)), conn_pool_(conn_pool) {}
+
+  ~ProxyFilter();
+
+  // Network::ReadFilter
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
+    callbacks_ = &callbacks;
+    callbacks_->connection().addConnectionCallbacks(*this);
+  }
+  Network::FilterStatus onData(Buffer::Instance& data) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
+
+  // Network::ConnectionCallbacks
+  void onEvent(uint32_t events) override;
+
+  // Redis::DecoderCallbacks
+  void onRespValue(RespValuePtr&& value) override;
+
+private:
+  struct PendingRequest : public ConnPool::ActiveRequestCallbacks {
+    PendingRequest(ProxyFilter& parent) : parent_(parent) {}
+
+    // Redis::ConnPool::ActiveRequestCallbacks
+    void onResponse(RespValuePtr&& value) override { parent_.onResponse(*this, std::move(value)); }
+    void onFailure() override { parent_.onFailure(*this); }
+
+    ProxyFilter& parent_;
+    ConnPool::ActiveRequest* request_handle_;
+  };
+
+  void onResponse(PendingRequest& request, RespValuePtr&& value);
+  void onFailure(PendingRequest& request);
+  void respondWithFailure(const std::string& message);
+
+  DecoderPtr decoder_;
+  EncoderPtr encoder_;
+  ConnPool::Instance& conn_pool_;
+  Buffer::OwnedImpl encoder_buffer_;
+  Network::ReadFilterCallbacks* callbacks_{};
+  std::list<PendingRequest> pending_requests_;
+};
+
+} // Redis

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -26,7 +26,7 @@ protected:
 private:
   enum class ZoneRoutingState { NoZoneRouting, ZoneDirect, ZoneResidual };
 
-  /*
+  /**
    * @return decision on quick exit from zone aware routing based on cluster configuration.
    * This gets recalculated on update callback.
    */

--- a/source/precompiled/precompiled.h
+++ b/source/precompiled/precompiled.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
+#include <forward_list>
 #include <fstream>
 #include <iostream>
 #include <list>

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(envoy-server OBJECT
   config/network/http_connection_manager.cc
   config/network/mongo_proxy.cc
   config/network/ratelimit.cc
+  config/network/redis_proxy.cc
   config/network/tcp_proxy.cc
   configuration_impl.cc
   connection_handler.cc

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -36,7 +36,7 @@ public:
 };
 
 /**
- * Static registration for the tcp_proxy filter. @see RegisterNetworkFilterConfigFactory.
+ * Static registration for the mongo filter. @see RegisterNetworkFilterConfigFactory.
  */
 static RegisterNetworkFilterConfigFactory<MongoProxyFilterConfigFactory> registered_;
 

--- a/source/server/config/network/redis_proxy.cc
+++ b/source/server/config/network/redis_proxy.cc
@@ -1,0 +1,34 @@
+#include "redis_proxy.h"
+
+#include "common/redis/codec_impl.h"
+#include "common/redis/conn_pool_impl.h"
+#include "common/redis/proxy_filter.h"
+
+namespace Server {
+namespace Configuration {
+
+NetworkFilterFactoryCb RedisProxyFilterConfigFactory::tryCreateFilterFactory(
+    NetworkFilterType type, const std::string& name, const Json::Object& config,
+    Server::Instance& server) {
+  if (type != NetworkFilterType::Read || name != "redis_proxy") {
+    return nullptr;
+  }
+
+  Redis::ProxyFilterConfig filter_config(config, server.clusterManager());
+  std::shared_ptr<Redis::ConnPool::Instance> conn_pool(new Redis::ConnPool::InstanceImpl(
+      filter_config.clusterName(), server.clusterManager(),
+      Redis::ConnPool::ClientFactoryImpl::instance_, server.threadLocal()));
+  return [conn_pool](Network::FilterManager& filter_manager) -> void {
+    Redis::DecoderFactoryImpl factory;
+    filter_manager.addReadFilter(Network::ReadFilterPtr{
+        new Redis::ProxyFilter(factory, Redis::EncoderPtr{new Redis::EncoderImpl()}, *conn_pool)});
+  };
+}
+
+/**
+ * Static registration for the redis filter. @see RegisterNetworkFilterConfigFactory.
+ */
+static RegisterNetworkFilterConfigFactory<RedisProxyFilterConfigFactory> registered_;
+
+} // Configuration
+} // Server

--- a/source/server/config/network/redis_proxy.h
+++ b/source/server/config/network/redis_proxy.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "server/configuration_impl.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the redis proxy filter. @see NetworkFilterConfigFactory.
+ */
+class RedisProxyFilterConfigFactory : public NetworkFilterConfigFactory {
+public:
+  // NetworkFilterConfigFactory
+  NetworkFilterFactoryCb tryCreateFilterFactory(NetworkFilterType type, const std::string& name,
+                                                const Json::Object& config,
+                                                Server::Instance& server);
+};
+
+} // Configuration
+} // Server

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,9 @@ add_executable(envoy-test
   common/network/proxy_protocol_test.cc
   common/network/utility_test.cc
   common/ratelimit/ratelimit_impl_test.cc
+  common/redis/codec_impl_test.cc
+  common/redis/conn_pool_impl_test.cc
+  common/redis/proxy_filter_test.cc
   common/router/config_impl_test.cc
   common/router/retry_state_impl_test.cc
   common/router/router_test.cc
@@ -119,6 +122,7 @@ add_executable(envoy-test
   mocks/http/mocks.cc
   mocks/network/mocks.cc
   mocks/ratelimit/mocks.cc
+  mocks/redis/mocks.cc
   mocks/router/mocks.cc
   mocks/runtime/mocks.cc
   mocks/server/mocks.cc
@@ -127,6 +131,7 @@ add_executable(envoy-test
   mocks/thread_local/mocks.cc
   mocks/tracing/mocks.cc
   mocks/upstream/mocks.cc
+  server/config/network/config_test.cc
   server/config/network/http_connection_manager_test.cc
   server/configuration_impl_test.cc
   server/connection_handler_test.cc

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -57,9 +57,20 @@ TEST_F(RedisEncoderDecoderImplTest, SimpleString) {
 TEST_F(RedisEncoderDecoderImplTest, Integer) {
   RespValue value;
   value.type(RespType::Integer);
-  value.asInteger() = 100;
+  value.asInteger() = std::numeric_limits<int64_t>::max();
   encoder_.encode(value, buffer_);
-  EXPECT_EQ(":100\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ(":9223372036854775807\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, NegativeInteger) {
+  RespValue value;
+  value.type(RespType::Integer);
+  value.asInteger() = std::numeric_limits<int64_t>::min();
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ(":-9223372036854775808\r\n", TestUtility::bufferToString(buffer_));
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -1,0 +1,156 @@
+#include "common/redis/codec_impl.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/assert.h"
+
+#include "test/mocks/redis/mocks.h"
+#include "test/test_common/utility.h"
+
+namespace Redis {
+
+class RedisEncoderDecoderImplTest : public testing::Test, public DecoderCallbacks {
+public:
+  RedisEncoderDecoderImplTest() : decoder_(*this) {}
+
+  // Redis::DecoderCallbacks
+  void onRespValue(RespValuePtr&& value) override {
+    decoded_values_.emplace_back(std::move(value));
+  }
+
+  EncoderImpl encoder_;
+  DecoderImpl decoder_;
+  Buffer::OwnedImpl buffer_;
+  std::vector<RespValuePtr> decoded_values_;
+};
+
+TEST_F(RedisEncoderDecoderImplTest, Null) {
+  RespValue value;
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("$-1\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, Error) {
+  RespValue value;
+  value.type(RespType::Error);
+  value.asString() = "error";
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("-error\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, SimpleString) {
+  RespValue value;
+  value.type(RespType::SimpleString);
+  value.asString() = "simple string";
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("+simple string\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, Integer) {
+  RespValue value;
+  value.type(RespType::Integer);
+  value.asInteger() = 100;
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ(":100\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, EmptyArray) {
+  RespValue value;
+  value.type(RespType::Array);
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("*0\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, Array) {
+  std::vector<RespValue> values(2);
+  values[0].type(RespType::BulkString);
+  values[0].asString() = "hello";
+  values[1].type(RespType::Integer);
+  values[1].asInteger() = -5;
+
+  RespValue value;
+  value.type(RespType::Array);
+  value.asArray().swap(values);
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("*2\r\n$5\r\nhello\r\n:-5\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, NestedArray) {
+  std::vector<RespValue> nested_values(3);
+  nested_values[0].type(RespType::BulkString);
+  nested_values[0].asString() = "hello";
+  nested_values[1].type(RespType::Integer);
+  nested_values[1].asInteger() = 0;
+
+  std::vector<RespValue> values(2);
+  values[0].type(RespType::Array);
+  values[0].asArray().swap(nested_values);
+  values[1].type(RespType::BulkString);
+  values[1].asString() = "world";
+
+  RespValue value;
+  value.type(RespType::Array);
+  value.asArray().swap(values);
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ("*2\r\n*3\r\n$5\r\nhello\r\n:0\r\n$-1\r\n$5\r\nworld\r\n",
+            TestUtility::bufferToString(buffer_));
+
+  // To test partial decode we will feed the buffer in 1 char at a time.
+  for (char c : TestUtility::bufferToString(buffer_)) {
+    Buffer::OwnedImpl temp_buffer(&c, 1);
+    decoder_.decode(temp_buffer);
+    EXPECT_EQ(0UL, temp_buffer.length());
+  }
+
+  EXPECT_EQ(value, *decoded_values_[0]);
+}
+
+TEST_F(RedisEncoderDecoderImplTest, NullArray) {
+  buffer_.add("*-1\r\n");
+  decoder_.decode(buffer_);
+  EXPECT_EQ(RespType::Null, decoded_values_[0]->type());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, InvalidType) {
+  buffer_.add("^");
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
+TEST_F(RedisEncoderDecoderImplTest, InvalidInteger) {
+  buffer_.add(":-a");
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
+TEST_F(RedisEncoderDecoderImplTest, InvalidIntegerExpectLF) {
+  buffer_.add(":-123\ra");
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
+TEST_F(RedisEncoderDecoderImplTest, InvalidBulkStringExpectCR) {
+  buffer_.add("$1\r\nab");
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
+TEST_F(RedisEncoderDecoderImplTest, InvalidBulkStringExpectLF) {
+  buffer_.add("$1\r\na\ra");
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
+} // Redis

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -1,0 +1,226 @@
+#include "common/redis/conn_pool_impl.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/redis/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+using testing::Ref;
+using testing::Return;
+using testing::SaveArg;
+
+namespace Redis {
+namespace ConnPool {
+
+class RedisClientImplTest : public testing::Test, public DecoderFactory {
+public:
+  // Redis::DecoderFactory
+  DecoderPtr create(DecoderCallbacks& callbacks) override {
+    callbacks_ = &callbacks;
+    return DecoderPtr{decoder_};
+  }
+
+  void setup() {
+    upstream_connection_ = new NiceMock<Network::MockClientConnection>();
+    Upstream::MockHost::MockCreateConnectionData conn_info;
+    conn_info.connection_ = upstream_connection_;
+    conn_info.host_.reset(
+        new Upstream::HostImpl(cm_.cluster_.info_, "tcp://127.0.0.1:80", false, 1, ""));
+    EXPECT_CALL(cm_, tcpConnForCluster_("foo")).WillOnce(Return(conn_info));
+    EXPECT_CALL(*upstream_connection_, addReadFilter(_))
+        .WillOnce(SaveArg<0>(&upstream_read_filter_));
+    EXPECT_CALL(*upstream_connection_, connect());
+    EXPECT_CALL(*upstream_connection_, noDelay(true));
+    client_ = ClientImpl::create(cluster_name_, cm_, EncoderPtr{encoder_}, *this);
+  }
+
+  const std::string cluster_name_{"foo"};
+  Upstream::MockClusterManager cm_;
+  MockEncoder* encoder_{new MockEncoder()};
+  MockDecoder* decoder_{new MockDecoder()};
+  DecoderCallbacks* callbacks_{};
+  NiceMock<Network::MockClientConnection>* upstream_connection_{};
+  Network::ReadFilterPtr upstream_read_filter_;
+  ClientPtr client_;
+};
+
+TEST_F(RedisClientImplTest, NoClient) {
+  Upstream::MockHost::MockCreateConnectionData conn_info;
+  EXPECT_CALL(cm_, tcpConnForCluster_("foo")).WillOnce(Return(conn_info));
+  EXPECT_EQ(nullptr, ClientImpl::create(cluster_name_, cm_, EncoderPtr{encoder_}, *this));
+
+  // In this test decoder is not consumed so we need to delete it.
+  delete decoder_;
+}
+
+TEST_F(RedisClientImplTest, Basic) {
+  setup();
+
+  RespValue request1;
+  MockActiveRequestCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  ActiveRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  RespValue request2;
+  MockActiveRequestCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  ActiveRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        InSequence s;
+        RespValuePtr response1(new RespValue());
+        EXPECT_CALL(callbacks1, onResponse_(Ref(response1)));
+        callbacks_->onRespValue(std::move(response1));
+
+        RespValuePtr response2(new RespValue());
+        EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+        callbacks_->onRespValue(std::move(response2));
+      }));
+  upstream_read_filter_->onData(fake_data);
+
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  client_->close();
+}
+
+TEST_F(RedisClientImplTest, Cancel) {
+  setup();
+
+  RespValue request1;
+  MockActiveRequestCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  ActiveRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  RespValue request2;
+  MockActiveRequestCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  ActiveRequest* handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  handle1->cancel();
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        InSequence s;
+        RespValuePtr response1(new RespValue());
+        EXPECT_CALL(callbacks1, onResponse_(_)).Times(0);
+        callbacks_->onRespValue(std::move(response1));
+
+        RespValuePtr response2(new RespValue());
+        EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+        callbacks_->onRespValue(std::move(response2));
+      }));
+  upstream_read_filter_->onData(fake_data);
+
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  client_->close();
+}
+
+TEST_F(RedisClientImplTest, FailAll) {
+  setup();
+
+  Network::MockConnectionCallbacks connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  RespValue request1;
+  MockActiveRequestCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  ActiveRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
+  EXPECT_CALL(callbacks1, onFailure());
+  upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(RedisClientImplTest, ProtocolError) {
+  setup();
+
+  RespValue request1;
+  MockActiveRequestCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  ActiveRequest* handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void { throw ProtocolError("error"); }));
+  upstream_read_filter_->onData(fake_data);
+}
+
+TEST(RedisClientFactoryImplTest, Basic) {
+  ClientFactoryImpl factory;
+  Upstream::MockClusterManager cm;
+  EXPECT_CALL(cm, tcpConnForCluster_("foo"));
+  EXPECT_EQ(nullptr, factory.create("foo", cm));
+}
+
+class RedisConnPoolImplTest : public testing::Test, public ClientFactory {
+public:
+  // Redis::ConnPool::ClientFactory
+  ClientPtr create(const std::string& cluster_name, Upstream::ClusterManager& cm) override {
+    return ClientPtr{create_(cluster_name, cm)};
+  }
+
+  MOCK_METHOD2(create_, Client*(const std::string& cluster_name, Upstream::ClusterManager& cm));
+
+  const std::string cluster_name_{"foo"};
+  Upstream::MockClusterManager cm_;
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  InstanceImpl conn_pool_{cluster_name_, cm_, *this, tls_};
+};
+
+TEST_F(RedisConnPoolImplTest, Basic) {
+  RespValue value;
+  MockActiveRequest active_request;
+  MockActiveRequestCallbacks callbacks;
+  MockClient* client = new NiceMock<MockClient>();
+
+  EXPECT_CALL(*this, create_("foo", _)).WillOnce(Return(client));
+  EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request));
+  ActiveRequest* request = conn_pool_.makeRequest("foo", value, callbacks);
+  EXPECT_EQ(&active_request, request);
+
+  EXPECT_CALL(*client, close());
+  tls_.shutdownThread();
+};
+
+TEST_F(RedisConnPoolImplTest, NoClient) {
+  RespValue value;
+  MockActiveRequestCallbacks callbacks;
+  EXPECT_CALL(*this, create_("foo", _)).WillOnce(Return(nullptr));
+  ActiveRequest* request = conn_pool_.makeRequest("foo", value, callbacks);
+  EXPECT_EQ(nullptr, request);
+
+  tls_.shutdownThread();
+}
+
+TEST_F(RedisConnPoolImplTest, RemoteClose) {
+  RespValue value;
+  MockActiveRequest active_request;
+  MockActiveRequestCallbacks callbacks;
+  MockClient* client = new NiceMock<MockClient>();
+
+  EXPECT_CALL(*this, create_("foo", _)).WillOnce(Return(client));
+  EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks))).WillOnce(Return(&active_request));
+  conn_pool_.makeRequest("foo", value, callbacks);
+
+  EXPECT_CALL(tls_.dispatcher_, deferredDelete_(_));
+  client->raiseEvents(Network::ConnectionEvent::RemoteClose);
+
+  tls_.shutdownThread();
+}
+
+} // ConnPool
+} // Redis

--- a/test/common/redis/proxy_filter_test.cc
+++ b/test/common/redis/proxy_filter_test.cc
@@ -1,0 +1,164 @@
+#include "common/redis/proxy_filter.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/redis/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+
+using testing::_;
+using testing::ByRef;
+using testing::DoAll;
+using testing::Eq;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Ref;
+using testing::Return;
+using testing::WithArg;
+
+namespace Redis {
+
+TEST(RedisProxyFilterConfigTest, Normal) {
+  std::string json_string = R"EOF(
+  {
+    "cluster_name": "fake_cluster"
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<Upstream::MockClusterManager> cm;
+  ProxyFilterConfig config(*json_config, cm);
+  EXPECT_EQ("fake_cluster", config.clusterName());
+}
+
+TEST(RedisProxyFilterConfigTest, InvalidCluster) {
+  std::string json_string = R"EOF(
+  {
+    "cluster_name": "fake_cluster"
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<Upstream::MockClusterManager> cm;
+  EXPECT_CALL(cm, get("fake_cluster")).WillOnce(Return(nullptr));
+  EXPECT_THROW(ProxyFilterConfig(*json_config, cm), EnvoyException);
+}
+
+class RedisProxyFilterTest : public testing::Test, public DecoderFactory {
+public:
+  RedisProxyFilterTest() {
+    filter_.initializeReadFilterCallbacks(filter_callbacks_);
+    EXPECT_EQ(Network::FilterStatus::Continue, filter_.onNewConnection());
+  }
+
+  // Redis::DecoderFactory
+  DecoderPtr create(DecoderCallbacks& callbacks) override {
+    decoder_callbacks_ = &callbacks;
+    return DecoderPtr{decoder_};
+  }
+
+  MockEncoder* encoder_{new MockEncoder()};
+  MockDecoder* decoder_{new MockDecoder()};
+  DecoderCallbacks* decoder_callbacks_{};
+  ConnPool::MockInstance conn_pool_;
+  ProxyFilter filter_{*this, EncoderPtr{encoder_}, conn_pool_};
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+};
+
+TEST_F(RedisProxyFilterTest, Basic) {
+  Buffer::OwnedImpl fake_data;
+  ConnPool::MockActiveRequest request_handle1;
+  ConnPool::ActiveRequestCallbacks* request_callbacks1;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        RespValuePtr request1(new RespValue());
+        EXPECT_CALL(conn_pool_, makeRequest("", Ref(*request1), _))
+            .WillOnce(
+                DoAll(WithArg<2>(SaveArgAddress(&request_callbacks1)), Return(&request_handle1)));
+        decoder_callbacks_->onRespValue(std::move(request1));
+      }));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_.onData(fake_data));
+
+  RespValuePtr response1(new RespValue());
+  EXPECT_CALL(*encoder_, encode(Ref(*response1), _));
+  EXPECT_CALL(filter_callbacks_.connection_, write(_));
+  request_callbacks1->onResponse(std::move(response1));
+
+  filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(RedisProxyFilterTest, UpstreamFailure) {
+  Buffer::OwnedImpl fake_data;
+  ConnPool::MockActiveRequest request_handle1;
+  ConnPool::ActiveRequestCallbacks* request_callbacks1;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        RespValuePtr request1(new RespValue());
+        EXPECT_CALL(conn_pool_, makeRequest("", Ref(*request1), _))
+            .WillOnce(
+                DoAll(WithArg<2>(SaveArgAddress(&request_callbacks1)), Return(&request_handle1)));
+        decoder_callbacks_->onRespValue(std::move(request1));
+      }));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_.onData(fake_data));
+
+  RespValue error;
+  error.type(RespType::Error);
+  error.asString() = "upstream connection error";
+  EXPECT_CALL(*encoder_, encode(Eq(ByRef(error)), _));
+  EXPECT_CALL(filter_callbacks_.connection_, write(_));
+  request_callbacks1->onFailure();
+
+  filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::LocalClose);
+}
+
+TEST_F(RedisProxyFilterTest, DownstreamDisconnectWithActive) {
+  Buffer::OwnedImpl fake_data;
+  ConnPool::MockActiveRequest request_handle1;
+  ConnPool::ActiveRequestCallbacks* request_callbacks1;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        RespValuePtr request1(new RespValue());
+        EXPECT_CALL(conn_pool_, makeRequest("", Ref(*request1), _))
+            .WillOnce(
+                DoAll(WithArg<2>(SaveArgAddress(&request_callbacks1)), Return(&request_handle1)));
+        decoder_callbacks_->onRespValue(std::move(request1));
+      }));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_.onData(fake_data));
+
+  EXPECT_CALL(request_handle1, cancel());
+  filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(RedisProxyFilterTest, NoClient) {
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void {
+        RespValuePtr request1(new RespValue());
+        EXPECT_CALL(conn_pool_, makeRequest("", Ref(*request1), _)).WillOnce(Return(nullptr));
+        decoder_callbacks_->onRespValue(std::move(request1));
+      }));
+
+  RespValue error;
+  error.type(RespType::Error);
+  error.asString() = "no healthy upstream";
+  EXPECT_CALL(*encoder_, encode(Eq(ByRef(error)), _));
+  EXPECT_CALL(filter_callbacks_.connection_, write(_));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_.onData(fake_data));
+
+  filter_callbacks_.connection_.raiseEvents(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(RedisProxyFilterTest, ProtocolError) {
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance&) -> void { throw ProtocolError("error"); }));
+
+  RespValue error;
+  error.type(RespType::Error);
+  error.asString() = "downstream protocol error";
+  EXPECT_CALL(*encoder_, encode(Eq(ByRef(error)), _));
+  EXPECT_CALL(filter_callbacks_.connection_, write(_));
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_.onData(fake_data));
+}
+
+} // Redis

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -19,11 +19,11 @@ uint64_t MockConnectionBase::next_id_;
 void MockConnectionBase::raiseEvents(uint32_t events) {
   if ((events & Network::ConnectionEvent::RemoteClose) ||
       (events & Network::ConnectionEvent::LocalClose)) {
-    if (closed_) {
+    if (state_ == Connection::State::Closed) {
       return;
     }
 
-    closed_ = true;
+    state_ = Connection::State::Closed;
   }
 
   for (Network::ConnectionCallbacks* callbacks : callbacks_) {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -27,7 +27,6 @@ public:
 
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   std::list<Network::ConnectionCallbacks*> callbacks_;
-  bool closed_{};
   uint64_t id_{next_id_++};
   std::string remote_address_;
   bool read_enabled_{true};

--- a/test/mocks/redis/mocks.cc
+++ b/test/mocks/redis/mocks.cc
@@ -1,0 +1,73 @@
+#include "mocks.h"
+
+#include "common/common/assert.h"
+
+using testing::_;
+using testing::Invoke;
+
+namespace Redis {
+
+bool operator==(const RespValue& lhs, const RespValue& rhs) {
+  if (lhs.type() != rhs.type()) {
+    return false;
+  }
+
+  switch (lhs.type()) {
+  case RespType::Array: {
+    if (lhs.asArray().size() != rhs.asArray().size()) {
+      return false;
+    }
+
+    bool equal = true;
+    for (uint64_t i = 0; i < lhs.asArray().size(); i++) {
+      equal &= (lhs.asArray()[i] == rhs.asArray()[i]);
+    }
+
+    return equal;
+  }
+  case RespType::SimpleString:
+  case RespType::BulkString:
+  case RespType::Error: {
+    return lhs.asString() == rhs.asString();
+  }
+  case RespType::Null: {
+    return true;
+  }
+  case RespType::Integer: {
+    return lhs.asInteger() == rhs.asInteger();
+  }
+  }
+
+  NOT_IMPLEMENTED;
+}
+
+MockEncoder::MockEncoder() {}
+MockEncoder::~MockEncoder() {}
+
+MockDecoder::MockDecoder() {}
+MockDecoder::~MockDecoder() {}
+
+namespace ConnPool {
+
+MockClient::MockClient() {
+  ON_CALL(*this, addConnectionCallbacks(_))
+      .WillByDefault(Invoke([this](Network::ConnectionCallbacks& callbacks)
+                                -> void { callbacks_.push_back(&callbacks); }));
+  ON_CALL(*this, close())
+      .WillByDefault(
+          Invoke([this]() -> void { raiseEvents(Network::ConnectionEvent::LocalClose); }));
+}
+
+MockClient::~MockClient() {}
+
+MockActiveRequest::MockActiveRequest() {}
+MockActiveRequest::~MockActiveRequest() {}
+
+MockActiveRequestCallbacks::MockActiveRequestCallbacks() {}
+MockActiveRequestCallbacks::~MockActiveRequestCallbacks() {}
+
+MockInstance::MockInstance() {}
+MockInstance::~MockInstance() {}
+
+} // ConnPool
+} // Redis

--- a/test/mocks/redis/mocks.h
+++ b/test/mocks/redis/mocks.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "envoy/redis/conn_pool.h"
+
+namespace Redis {
+
+bool operator==(const RespValue& lhs, const RespValue& rhs);
+
+class MockEncoder : public Encoder {
+public:
+  MockEncoder();
+  ~MockEncoder();
+
+  MOCK_METHOD2(encode, void(const RespValue& value, Buffer::Instance& out));
+};
+
+class MockDecoder : public Decoder {
+public:
+  MockDecoder();
+  ~MockDecoder();
+
+  MOCK_METHOD1(decode, void(Buffer::Instance& data));
+};
+
+namespace ConnPool {
+
+class MockClient : public Client {
+public:
+  MockClient();
+  ~MockClient();
+
+  void raiseEvents(uint32_t events) {
+    for (Network::ConnectionCallbacks* callbacks : callbacks_) {
+      callbacks->onEvent(events);
+    }
+  }
+
+  MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
+  MOCK_METHOD0(close, void());
+  MOCK_METHOD2(makeRequest,
+               ActiveRequest*(const RespValue& request, ActiveRequestCallbacks& callbacks));
+
+  std::list<Network::ConnectionCallbacks*> callbacks_;
+};
+
+class MockActiveRequest : public ActiveRequest {
+public:
+  MockActiveRequest();
+  ~MockActiveRequest();
+
+  MOCK_METHOD0(cancel, void());
+};
+
+class MockActiveRequestCallbacks : public ActiveRequestCallbacks {
+public:
+  MockActiveRequestCallbacks();
+  ~MockActiveRequestCallbacks();
+
+  void onResponse(RespValuePtr&& value) override { onResponse_(value); }
+
+  MOCK_METHOD1(onResponse_, void(RespValuePtr& value));
+  MOCK_METHOD0(onFailure, void());
+};
+
+class MockInstance : public Instance {
+public:
+  MockInstance();
+  ~MockInstance();
+
+  MOCK_METHOD3(makeRequest, ActiveRequest*(const std::string& hash_key, const RespValue& request,
+                                           ActiveRequestCallbacks& callbacks));
+};
+
+} // ConnPool
+} // Redis

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -1,0 +1,29 @@
+#include "server/config/network/redis_proxy.h"
+
+#include "test/mocks/server/mocks.h"
+
+using testing::_;
+using testing::NiceMock;
+
+namespace Server {
+namespace Configuration {
+
+TEST(NetworkFilterConfigTest, RedisProxy) {
+  std::string json_string = R"EOF(
+  {
+    "cluster_name": "fake_cluster"
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  RedisProxyFilterConfigFactory factory;
+  NetworkFilterFactoryCb cb =
+      factory.tryCreateFilterFactory(NetworkFilterType::Read, "redis_proxy", *json_config, server);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addReadFilter(_));
+  cb(connection);
+}
+
+} // Configuration
+} // Server


### PR DESCRIPTION
This is an initial implementation of redis support in Envoy. It
includes a codec as well a simple proxy filter and "connection pool."
The connection pool is trivial and just makes a single connection. It
does no consistent hashing, op splitting, etc. However, this commit
is sufficient for Envoy to proxy to a single redis server and
encode/decode the entire conversation. All of the main interfaces
are in place.

To keep this change as self contained as possible there is quite a bit
missing that will be done in individual follow up changes:
  - stats
  - timeouts
  - consistent hashing
  - supported op checking and splitting where appropriate (e.g., MGET)
  - A real connection pool that supports hashing, and M connections to
    N upstreams
  - redis active HC and outlier detection