### PR TITLE
Expose Virtual Host in Route Entry

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -120,6 +120,19 @@ public:
   virtual Upstream::ResourcePriority priority() const PURE;
 };
 
+/**
+ * Virtual host defintion.
+ */
+class VirtualHost {
+public:
+  virtual ~VirtualHost() {}
+
+  /**
+   * @return const std::string& the name of the virtual host.
+   */
+  virtual const std::string& name() const PURE;
+};
+
 class RateLimitPolicy;
 
 /**
@@ -177,9 +190,9 @@ public:
   virtual const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const PURE;
 
   /**
-   * @return const std::string& the virtual host that owns the route.
+   * @return const VirtualHost& the virtual host that owns the route.
    */
-  virtual const std::string& virtualHostName() const PURE;
+  virtual const VirtualHost& virtualHost() const PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -8,6 +8,7 @@ const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>
 const AsyncRequestImpl::NullRateLimitPolicy AsyncRequestImpl::RouteEntryImpl::rate_limit_policy_;
 const AsyncRequestImpl::NullRetryPolicy AsyncRequestImpl::RouteEntryImpl::retry_policy_;
 const AsyncRequestImpl::NullShadowPolicy AsyncRequestImpl::RouteEntryImpl::shadow_policy_;
+const AsyncRequestImpl::NullVirtualHost AsyncRequestImpl::RouteEntryImpl::virtual_host_;
 
 AsyncClientImpl::AsyncClientImpl(const Upstream::ClusterInfo& cluster, Stats::Store& stats_store,
                                  Event::Dispatcher& dispatcher, const std::string& local_zone_name,

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -84,6 +84,11 @@ private:
     const std::string& runtimeKey() const override { return EMPTY_STRING; }
   };
 
+  struct NullVirtualHost : public Router::VirtualHost {
+    // Router::VirtualHost
+    const std::string& name() const override { return EMPTY_STRING; }
+  };
+
   struct RouteEntryImpl : public Router::RouteEntry {
     RouteEntryImpl(const std::string& cluster_name,
                    const Optional<std::chrono::milliseconds>& timeout)
@@ -108,11 +113,12 @@ private:
     const Router::VirtualCluster* virtualCluster(const Http::HeaderMap&) const override {
       return nullptr;
     }
-    const std::string& virtualHostName() const { return EMPTY_STRING; }
+    const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;
     static const NullShadowPolicy shadow_policy_;
+    static const NullVirtualHost virtual_host_;
 
     const std::string& cluster_name_;
     Optional<std::chrono::milliseconds> timeout_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -72,12 +72,14 @@ public:
 /**
  * Holds all routing configuration for an entire virtual host.
  */
-class VirtualHost {
+class VirtualHostImpl : public VirtualHost {
 public:
-  VirtualHost(const Json::Object& virtual_host, Runtime::Loader& runtime,
-              Upstream::ClusterManager& cm);
+  VirtualHostImpl(const Json::Object& virtual_host, Runtime::Loader& runtime,
+                  Upstream::ClusterManager& cm);
 
-  const std::string& name() const { return name_; }
+  // Router::VirtualHost
+  const std::string& name() const override { return name_; }
+
   const RedirectEntry* redirectFromEntries(const Http::HeaderMap& headers,
                                            uint64_t random_value) const;
   const RouteEntryImplBase* routeFromEntries(const Http::HeaderMap& headers, bool redirect,
@@ -120,7 +122,7 @@ private:
   SslRequirements ssl_requirements_;
 };
 
-typedef std::shared_ptr<VirtualHost> VirtualHostPtr;
+typedef std::shared_ptr<VirtualHostImpl> VirtualHostPtr;
 
 /**
  * Implementation of RetryPolicy that reads from the JSON route config.
@@ -159,7 +161,8 @@ private:
  */
 class RouteEntryImplBase : public RouteEntry, public Matchable, public RedirectEntry {
 public:
-  RouteEntryImplBase(const VirtualHost& vhost, const Json::Object& route, Runtime::Loader& loader);
+  RouteEntryImplBase(const VirtualHostImpl& vhost, const Json::Object& route,
+                     Runtime::Loader& loader);
 
   bool isRedirect() const { return !host_redirect_.empty() || !path_redirect_.empty(); }
   bool usesRuntime() const { return runtime_.valid(); }
@@ -174,8 +177,8 @@ public:
   const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
     return vhost_.virtualClusterFromEntries(headers);
   }
-  const std::string& virtualHostName() const override { return vhost_.name(); }
   std::chrono::milliseconds timeout() const override { return timeout_; }
+  const VirtualHost& virtualHost() const override { return vhost_; }
 
   // Router::RedirectEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -201,7 +204,7 @@ private:
   // Default timeout is 15s if nothing is specified in the route config.
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;
 
-  const VirtualHost& vhost_;
+  const VirtualHostImpl& vhost_;
   const std::string cluster_name_;
   const std::chrono::milliseconds timeout_;
   const Optional<RuntimeData> runtime_;
@@ -220,7 +223,7 @@ private:
  */
 class PrefixRouteEntryImpl : public RouteEntryImplBase {
 public:
-  PrefixRouteEntryImpl(const VirtualHost& vhost, const Json::Object& route,
+  PrefixRouteEntryImpl(const VirtualHostImpl& vhost, const Json::Object& route,
                        Runtime::Loader& loader);
 
   // Router::RouteEntry
@@ -238,7 +241,8 @@ private:
  */
 class PathRouteEntryImpl : public RouteEntryImplBase {
 public:
-  PathRouteEntryImpl(const VirtualHost& vhost, const Json::Object& route, Runtime::Loader& loader);
+  PathRouteEntryImpl(const VirtualHostImpl& vhost, const Json::Object& route,
+                     Runtime::Loader& loader);
 
   // Router::RouteEntry
   void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
@@ -263,7 +267,7 @@ public:
   bool usesRuntime() const { return uses_runtime_; }
 
 private:
-  const VirtualHost* findVirtualHost(const Http::HeaderMap& headers) const;
+  const VirtualHostImpl* findVirtualHost(const Http::HeaderMap& headers) const;
 
   std::unordered_map<std::string, VirtualHostPtr> virtual_hosts_;
   VirtualHostPtr default_virtual_host_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -77,15 +77,15 @@ public:
   VirtualHostImpl(const Json::Object& virtual_host, Runtime::Loader& runtime,
                   Upstream::ClusterManager& cm);
 
-  // Router::VirtualHost
-  const std::string& name() const override { return name_; }
-
   const RedirectEntry* redirectFromEntries(const Http::HeaderMap& headers,
                                            uint64_t random_value) const;
   const RouteEntryImplBase* routeFromEntries(const Http::HeaderMap& headers, bool redirect,
                                              uint64_t random_value) const;
   bool usesRuntime() const;
   const VirtualCluster* virtualClusterFromEntries(const Http::HeaderMap& headers) const;
+
+  // Router::VirtualHost
+  const std::string& name() const override { return name_; }
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -108,7 +108,7 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
 
     Http::CodeUtility::ResponseStatInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_headers, internal_request,
-        route_->virtualHostName(), request_vcluster_ ? request_vcluster_->name() : "",
+        route_->virtualHost().name(), request_vcluster_ ? request_vcluster_->name() : "",
         config_.service_zone_, upstreamZone(upstream_host), is_canary};
 
     Http::CodeUtility::chargeResponseStat(info);
@@ -480,7 +480,7 @@ void Filter::onUpstreamComplete() {
 
     Http::CodeUtility::ResponseTimingInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_time,
-        upstream_request_->upstream_canary_, internal_request, route_->virtualHostName(),
+        upstream_request_->upstream_canary_, internal_request, route_->virtualHost().name(),
         request_vcluster_ ? request_vcluster_->name() : "", config_.service_zone_,
         upstreamZone(upstream_request_->upstream_host_)};
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -182,7 +182,7 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
     const RouteEntry* route = config.routeForRequest(headers, 0);
     EXPECT_EQ("www2", route->clusterName());
-    EXPECT_EQ("www2", route->virtualHostName());
+    EXPECT_EQ("www2", route->virtualHost().name());
     route->finalizeRequestHeaders(headers);
     EXPECT_EQ("/api/new_endpoint/foo", headers.get_(Http::Headers::get().Path));
   }

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -22,7 +22,7 @@ TEST(BadRateLimitConfiguration, MissingActions) {
 }
 )EOF";
 
-  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::LoadFromString(json)), EnvoyException);
+  EXPECT_THROW(RateLimitPolicyImpl(*Json::Factory::LoadFromString(json)), EnvoyException);
 }
 
 TEST(BadRateLimitConfiguration, BadType) {
@@ -208,6 +208,7 @@ TEST_F(RateLimitPolicyEntryTest, RateLimitPolicyEntryMembers) {
   ]
 }
 )EOF";
+
   SetUpTest(json);
 
   EXPECT_EQ(2, rate_limit_entry_->stage());
@@ -225,6 +226,7 @@ TEST_F(RateLimitPolicyEntryTest, RemoteAddress) {
   ]
 }
 )EOF";
+
   SetUpTest(json);
   std::string address = "10.0.0.1";
 
@@ -244,6 +246,7 @@ TEST_F(RateLimitPolicyEntryTest, RemoteAddressRouteKey) {
   ]
 }
 )EOF";
+
   SetUpTest(json);
   std::string address = "10.0.1";
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -40,7 +40,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, shadowPolicy()).WillByDefault(ReturnRef(shadow_policy_));
   ON_CALL(*this, timeout()).WillByDefault(Return(std::chrono::milliseconds(10)));
   ON_CALL(*this, virtualCluster(_)).WillByDefault(Return(&virtual_cluster_));
-  ON_CALL(*this, virtualHostName()).WillByDefault(ReturnRef(vhost_name_));
+  ON_CALL(*this, virtualHost()).WillByDefault(ReturnRef(virtual_host_));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -111,6 +111,13 @@ public:
   Upstream::ResourcePriority priority_{Upstream::ResourcePriority::Default};
 };
 
+class TestVirtualHost : public VirtualHost {
+public:
+  // Router::VirtualHost
+  const std::string& name() const override { return name_; }
+  std::string name_{"fake_vhost"};
+};
+
 class MockRouteEntry : public RouteEntry {
 public:
   MockRouteEntry();
@@ -126,13 +133,14 @@ public:
   MOCK_CONST_METHOD0(timeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD1(virtualCluster, const VirtualCluster*(const Http::HeaderMap& headers));
   MOCK_CONST_METHOD0(virtualHostName, const std::string&());
+  MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
 
   std::string cluster_name_{"fake_cluster"};
-  std::string vhost_name_{"fake_vhost"};
   TestVirtualCluster virtual_cluster_;
   TestRetryPolicy retry_policy_;
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
   TestShadowPolicy shadow_policy_;
+  TestVirtualHost virtual_host_;
 };
 
 class MockConfig : public Config {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -115,6 +115,7 @@ class TestVirtualHost : public VirtualHost {
 public:
   // Router::VirtualHost
   const std::string& name() const override { return name_; }
+
   std::string name_{"fake_vhost"};
 };
 


### PR DESCRIPTION
This expose the virtual host that owns the route entry. The virtual host is needed within http/filter/ratelimit.cc to be able to apply ratelimits at the virtual host layer. The next PR will expose RateLimitPolicy on VirtualHost.

This PR also enhances test coverage on RateLimitPolicyEntry and simplifies the test code within router_ratelimit_test.cc