### PR TITLE
async client: fail all active requests during destruction

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -119,6 +119,7 @@ private:
   };
 
   void cleanup();
+  void failDueToClientDestroy();
   void onComplete();
 
   // Http::StreamDecoderFilterCallbacks


### PR DESCRIPTION
Required for dynamic cluster remove.