### PR TITLE
cluster manager: support dynamic add/remove

### DIFF
--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -2,11 +2,20 @@
 
 #include "envoy/common/pure.h"
 
-namespace Event {
-class Dispatcher;
-}
-
 namespace Network {
+
+/**
+ * An active async DNS query.
+ */
+class ActiveDnsQuery {
+public:
+  virtual ~ActiveDnsQuery() {}
+
+  /**
+   * Cancel an outstanding DNS request.
+   */
+  virtual void cancel() PURE;
+};
 
 /**
  * An asynchronous DNS resolver.
@@ -14,11 +23,6 @@ namespace Network {
 class DnsResolver {
 public:
   virtual ~DnsResolver() {}
-
-  /**
-   * @return Event::Dispatcher& the dispatcher backing the resolver.
-   */
-  virtual Event::Dispatcher& dispatcher() PURE;
 
   /**
    * Called when a resolution attempt is complete.
@@ -31,8 +35,9 @@ public:
    * Initiate an async DNS resolution.
    * @param dns_name supplies the DNS name to lookup.
    * @param callback supplies the callback to invoke when the resolution is complete.
+   * @return a handle that can be used to cancel the resolution.
    */
-  virtual void resolve(const std::string& dns_name, ResolveCb callback) PURE;
+  virtual ActiveDnsQuery& resolve(const std::string& dns_name, ResolveCb callback) PURE;
 };
 
 typedef std::unique_ptr<DnsResolver> DnsResolverPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -2,6 +2,7 @@
 
 #include "envoy/http/async_client.h"
 #include "envoy/http/conn_pool.h"
+#include "envoy/json/json_object.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Upstream {
@@ -15,15 +16,27 @@ public:
   virtual ~ClusterManager() {}
 
   /**
+   * Add or update a cluster via API. The semantics of this API are:
+   * 1) The hash of the config is used to determine if an already existing cluser has changed.
+   *    Nothing is done if the hash matches the previously running configuration.
+   * 2) Statically defined clusters (those present when Envoy starts) can not be updated via API.
+   *
+   * @return true if the action results in an add/update of a cluster.
+   */
+  virtual bool addOrUpdatePrimaryCluster(const Json::Object& config) PURE;
+
+  /**
    * Set a callback that will be invoked when all owned clusters have been initialized.
    */
   virtual void setInitializedCb(std::function<void()> callback) PURE;
 
+  typedef std::unordered_map<std::string, std::reference_wrapper<const Cluster>> ClusterInfoMap;
+
   /**
-   * @return std::unordered_map<std::string, ConstClusterPtr> all current clusters. These are are
-   * the primary (not thread local) clusters so should just be used for stats/admin.
+   * @return ClusterInfoMap all current clusters. These are are the primary (not thread local)
+   * clusters so should just be used for stats/admin.
    */
-  virtual std::unordered_map<std::string, ConstClusterPtr> clusters() PURE;
+  virtual ClusterInfoMap clusters() PURE;
 
   /**
    * @return ClusterInfoPtr the cluster info with the given name or nullptr if it does not
@@ -59,9 +72,43 @@ public:
   virtual Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) PURE;
 
   /**
-   * Shutdown the cluster prior to destroying connection pools and other thread local data.
+   * Remove a primary cluster via API. Only clusters added via addOrUpdatePrimaryCluster() can
+   * be removed in this manner. Statically defined clusters present when Envoy starts cannot be
+   * removed.
+   *
+   * @return true if the action results in the removal of a cluster.
+   */
+  virtual bool removePrimaryCluster(const std::string& cluster) PURE;
+
+  /**
+   * Shutdown the cluster manager prior to destroying connection pools and other thread local data.
    */
   virtual void shutdown() PURE;
+};
+
+/**
+ * Global configuration for any SDS clusters.
+ */
+struct SdsConfig {
+  std::string local_zone_name_;
+  std::string sds_cluster_name_;
+  std::chrono::milliseconds refresh_delay_;
+};
+
+/**
+ * Factory for objects needed during cluster manager operation.
+ */
+class ClusterManagerFactory {
+public:
+  virtual ~ClusterManagerFactory() {}
+
+  virtual Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher& dispatcher,
+                                                             ConstHostPtr host,
+                                                             ResourcePriority priority) PURE;
+
+  virtual ClusterPtr clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
+                                     const Optional<SdsConfig>& sds_config,
+                                     Outlier::EventLoggerPtr outlier_event_logger) PURE;
 };
 
 } // Upstream

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -33,8 +33,8 @@ public:
   typedef std::unordered_map<std::string, std::reference_wrapper<const Cluster>> ClusterInfoMap;
 
   /**
-   * @return ClusterInfoMap all current clusters. These are are the primary (not thread local)
-   * clusters so should just be used for stats/admin.
+   * @return ClusterInfoMap all current clusters. These are the primary (not thread local)
+   * clusters which should only be used for stats/admin.
    */
   virtual ClusterInfoMap clusters() PURE;
 
@@ -102,10 +102,16 @@ class ClusterManagerFactory {
 public:
   virtual ~ClusterManagerFactory() {}
 
+  /**
+   * Allocate an HTTP connection pool.
+   */
   virtual Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher& dispatcher,
                                                              ConstHostPtr host,
                                                              ResourcePriority priority) PURE;
 
+  /**
+   * Allocate a cluster from configuration JSON.
+   */
   virtual ClusterPtr clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
                                      const Optional<SdsConfig>& sds_config,
                                      Outlier::EventLoggerPtr outlier_event_logger) PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -239,6 +239,11 @@ public:
   virtual uint64_t httpCodecOptions() const PURE;
 
   /**
+   * @return the type of load balancing that the cluster should use.
+   */
+  virtual LoadBalancerType lbType() const PURE;
+
+  /**
    * @return Whether the cluster is currently in maintenance mode and should not be routed to.
    *         Different filters may handle this situation in different ways. The implementation
    *         of this routine is typically based on randomness and may not return the same answer
@@ -288,15 +293,25 @@ typedef std::shared_ptr<const ClusterInfo> ClusterInfoPtr;
  */
 class Cluster : public virtual HostSet {
 public:
+  enum class InitializePhase { Primary, Secondary };
+
   /**
    * @return the information about this upstream cluster.
    */
   virtual ClusterInfoPtr info() const PURE;
 
   /**
-   * @return the type of load balancing that the cluster should use.
+   * Initialize the cluster. This will be called either immediately at creation or after all primary
+   * clusters have been initialized (determined via initializePhase()).
    */
-  virtual LoadBalancerType lbType() const PURE;
+  virtual void initialize() PURE;
+
+  /**
+   * @return the phase in which the cluster is initialized at boot. This mechanism is used such that
+   *         clusters that depend on other clusters can correctly initialize. (E.g., an SDS cluster
+   *         that depends on resolution of the SDS server itself).
+   */
+  virtual InitializePhase initializePhase() const PURE;
 
   /**
    * Set a callback that will be invoked after the cluster has undergone first time initialization.
@@ -304,14 +319,8 @@ public:
    * resolution is complete.
    */
   virtual void setInitializedCb(std::function<void()> callback) PURE;
-
-  /**
-   * Shutdown the cluster prior to destroying connection pools and other thread local data.
-   */
-  virtual void shutdown() PURE;
 };
 
-typedef std::shared_ptr<Cluster> ClusterPtr;
-typedef std::shared_ptr<const Cluster> ConstClusterPtr;
+typedef std::unique_ptr<Cluster> ClusterPtr;
 
 } // Upstream

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -20,15 +20,18 @@ public:
   ~DnsResolverImpl();
 
   // Network::DnsResolver
-  Event::Dispatcher& dispatcher() override { return dispatcher_; }
-  void resolve(const std::string& dns_name, ResolveCb callback) override;
+  ActiveDnsQuery& resolve(const std::string& dns_name, ResolveCb callback) override;
 
 private:
-  struct PendingResolution : LinkedObject<PendingResolution> {
+  struct PendingResolution : LinkedObject<PendingResolution>, public ActiveDnsQuery {
+    // Network::ActiveDnsQuery
+    void cancel() override { cancelled_ = true; }
+
     std::string host_;
     addrinfo hints_;
     gaicb async_cb_data_;
     ResolveCb callback_;
+    bool cancelled_{};
   };
 
   typedef std::unique_ptr<PendingResolution> PendingResolutionPtr;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1,7 +1,5 @@
 #include "cluster_manager_impl.h"
-#include "health_checker_impl.h"
 #include "load_balancer_impl.h"
-#include "logical_dns_cluster.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
@@ -16,30 +14,31 @@
 
 namespace Upstream {
 
-ClusterManagerImpl::ClusterManagerImpl(
-    const Json::Object& config, Stats::Store& stats, ThreadLocal::Instance& tls,
-    Network::DnsResolver& dns_resolver, Ssl::ContextManager& ssl_context_manager,
-    Runtime::Loader& runtime, Runtime::RandomGenerator& random, const std::string& local_zone_name,
-    const std::string& local_address, AccessLog::AccessLogManager& log_manager)
-    : runtime_(runtime), tls_(tls), stats_(stats), thread_local_slot_(tls.allocateSlot()) {
+ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManagerFactory& factory,
+                                       Stats::Store& stats, ThreadLocal::Instance& tls,
+                                       Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                                       const std::string& local_zone_name,
+                                       const std::string& local_address,
+                                       AccessLog::AccessLogManager& log_manager)
+    : factory_(factory), runtime_(runtime), stats_(stats), tls_(tls), random_(random),
+      thread_local_slot_(tls.allocateSlot()), local_zone_name_(local_zone_name),
+      local_address_(local_address) {
 
   std::vector<Json::ObjectPtr> clusters = config.getObjectArray("clusters");
   pending_cluster_init_ = clusters.size();
 
-  Outlier::EventLoggerPtr outlier_event_logger;
   if (config.hasObject("outlier_detection")) {
     std::string event_log_file_path =
         config.getObject("outlier_detection")->getString("event_log_path", "");
     if (!event_log_file_path.empty()) {
-      outlier_event_logger.reset(new Outlier::EventLoggerImpl(log_manager, event_log_file_path,
-                                                              ProdSystemTimeSource::instance_));
+      outlier_event_logger_.reset(new Outlier::EventLoggerImpl(log_manager, event_log_file_path,
+                                                               ProdSystemTimeSource::instance_));
     }
   }
 
   if (config.hasObject("sds")) {
     pending_cluster_init_++;
-    loadCluster(*config.getObject("sds")->getObject("cluster"), stats, dns_resolver,
-                ssl_context_manager, runtime, random, outlier_event_logger);
+    loadCluster(*config.getObject("sds")->getObject("cluster"), false);
 
     SdsConfig sds_config{
         local_zone_name, config.getObject("sds")->getObject("cluster")->getString("name"),
@@ -49,8 +48,7 @@ ClusterManagerImpl::ClusterManagerImpl(
   }
 
   for (const Json::ObjectPtr& cluster : clusters) {
-    loadCluster(*cluster, stats, dns_resolver, ssl_context_manager, runtime, random,
-                outlier_event_logger);
+    loadCluster(*cluster, false);
   }
 
   Optional<std::string> local_cluster_name;
@@ -63,73 +61,109 @@ ClusterManagerImpl::ClusterManagerImpl(
   }
 
   tls.set(thread_local_slot_,
-          [this, &stats, &runtime, &random, local_zone_name, local_address, local_cluster_name](
-              Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectPtr {
-            return ThreadLocal::ThreadLocalObjectPtr{new ThreadLocalClusterManagerImpl(
-                *this, dispatcher, runtime, random, local_zone_name, local_address,
-                local_cluster_name)};
-          });
+          [this, local_cluster_name](Event::Dispatcher& dispatcher)
+              -> ThreadLocal::ThreadLocalObjectPtr {
+                return ThreadLocal::ThreadLocalObjectPtr{
+                    new ThreadLocalClusterManagerImpl(*this, dispatcher, local_cluster_name)};
+              });
 
   // To avoid threading issues, for those clusters that start with hosts already in them (like
   // the static cluster), we need to post an update onto each thread to notify them of the update.
   for (auto& cluster : primary_clusters_) {
-    if (cluster.second->hosts().empty()) {
-      continue;
-    }
-
-    postThreadLocalClusterUpdate(*cluster.second, cluster.second->hosts(), std::vector<HostPtr>{});
+    postInitializeCluster(*cluster.second.cluster_);
   }
 }
 
-void ClusterManagerImpl::loadCluster(const Json::Object& cluster, Stats::Store& stats,
-                                     Network::DnsResolver& dns_resolver,
-                                     Ssl::ContextManager& ssl_context_manager,
-                                     Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                                     Outlier::EventLoggerPtr event_logger) {
-
-  std::string string_type = cluster.getString("type");
-  ClusterImplBasePtr new_cluster;
-  if (string_type == "static") {
-    new_cluster.reset(new StaticClusterImpl(cluster, runtime, stats, ssl_context_manager));
-  } else if (string_type == "strict_dns") {
-    new_cluster.reset(
-        new StrictDnsClusterImpl(cluster, runtime, stats, ssl_context_manager, dns_resolver));
-  } else if (string_type == "logical_dns") {
-    new_cluster.reset(
-        new LogicalDnsCluster(cluster, runtime, stats, ssl_context_manager, dns_resolver, tls_));
-  } else if (string_type == "sds") {
-    if (!sds_config_.valid()) {
-      throw EnvoyException("cannot create an sds cluster without an sds config");
-    }
-
-    sds_clusters_.push_back(new SdsClusterImpl(cluster, runtime, stats, ssl_context_manager,
-                                               sds_config_.value(), *this,
-                                               dns_resolver.dispatcher(), random));
-    new_cluster.reset(sds_clusters_.back());
-  } else {
-    throw EnvoyException(fmt::format("cluster: unknown cluster type '{}'", string_type));
+void ClusterManagerImpl::postInitializeCluster(Cluster& cluster) {
+  if (cluster.hosts().empty()) {
+    return;
   }
 
-  if (primary_clusters_.find(new_cluster->info()->name()) != primary_clusters_.end()) {
-    throw EnvoyException(fmt::format("route: duplicate cluster '{}'", new_cluster->info()->name()));
+  postThreadLocalClusterUpdate(cluster, cluster.hosts(), std::vector<HostPtr>{});
+}
+
+bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const Json::Object& new_config) {
+  // First we need to see if this new config is new or an update to an existing dynamic cluster.
+  // We don't allow updates to statically configured clusters in the main configuration.
+  // TODO: Stats
+  std::string cluster_name = new_config.getString("name");
+  auto existing_cluster = primary_clusters_.find(cluster_name);
+  if (existing_cluster != primary_clusters_.end() &&
+      (!existing_cluster->second.added_via_api_ ||
+       existing_cluster->second.config_hash_ == new_config.hash())) {
+    return false;
   }
 
-  new_cluster->setInitializedCb([this]() -> void {
-    ASSERT(pending_cluster_init_ > 0);
-    if (--pending_cluster_init_ == 0) {
-      if (initialized_callback_) {
-        initialized_callback_();
-      }
-    } else if (pending_cluster_init_ == sds_clusters_.size()) {
-      // All other clusters have initialized. Now we start up the SDS clusters since they will
-      // depend on DNS resolution for the SDS cluster itself.
-      for (SdsClusterImpl* cluster : sds_clusters_) {
-        cluster->initialize();
-      }
-    }
+  loadCluster(new_config, true);
+  ClusterInfoPtr new_cluster = primary_clusters_.at(cluster_name).cluster_->info();
+  tls_.runOnAllThreads([this, new_cluster]() -> void {
+    ThreadLocalClusterManagerImpl& cluster_manager =
+        tls_.getTyped<ThreadLocalClusterManagerImpl>(thread_local_slot_);
+
+    cluster_manager.thread_local_clusters_[new_cluster->name()].reset(
+        new ThreadLocalClusterManagerImpl::ClusterEntry(cluster_manager, new_cluster));
+
   });
 
-  const ClusterImplBase& primary_cluster_reference = *new_cluster;
+  postInitializeCluster(*primary_clusters_.at(cluster_name).cluster_);
+  return true;
+}
+
+bool ClusterManagerImpl::removePrimaryCluster(const std::string& cluster_name) {
+  // TODO: Stats
+  auto existing_cluster = primary_clusters_.find(cluster_name);
+  if (existing_cluster == primary_clusters_.end() || !existing_cluster->second.added_via_api_) {
+    return false;
+  }
+
+  primary_clusters_.erase(cluster_name);
+  tls_.runOnAllThreads([this, cluster_name]() -> void {
+    ThreadLocalClusterManagerImpl& cluster_manager =
+        tls_.getTyped<ThreadLocalClusterManagerImpl>(thread_local_slot_);
+
+    cluster_manager.thread_local_clusters_.erase(cluster_name);
+  });
+
+  return true;
+}
+
+void ClusterManagerImpl::loadCluster(const Json::Object& cluster, bool added_via_api) {
+  ClusterPtr new_cluster =
+      factory_.clusterFromJson(cluster, *this, sds_config_, outlier_event_logger_);
+
+  if (!added_via_api) {
+    if (primary_clusters_.find(new_cluster->info()->name()) != primary_clusters_.end()) {
+      throw EnvoyException(
+          fmt::format("cluster manager: duplicate cluster '{}'", new_cluster->info()->name()));
+    }
+
+    if (new_cluster->initializePhase() == Cluster::InitializePhase::Primary) {
+      new_cluster->initialize();
+    } else {
+      ASSERT(new_cluster->initializePhase() == Cluster::InitializePhase::Secondary);
+      secondary_init_clusters_.push_back(new_cluster.get());
+    }
+
+    ASSERT(pending_cluster_init_ > 0);
+    new_cluster->setInitializedCb([this]() -> void {
+      ASSERT(pending_cluster_init_ > 0);
+      if (--pending_cluster_init_ == 0) {
+        if (initialized_callback_) {
+          initialized_callback_();
+        }
+      } else if (pending_cluster_init_ == secondary_init_clusters_.size()) {
+        // All other clusters have initialized. Now we start up the SDS clusters since they will
+        // depend on DNS resolution for the SDS cluster itself.
+        for (Cluster* cluster : secondary_init_clusters_) {
+          cluster->initialize();
+        }
+      }
+    });
+  } else {
+    new_cluster->initialize();
+  }
+
+  const Cluster& primary_cluster_reference = *new_cluster;
   new_cluster->addMemberUpdateCb([&primary_cluster_reference, this](
       const std::vector<HostPtr>& hosts_added, const std::vector<HostPtr>& hosts_removed) {
     // This fires when a cluster is about to have an updated member set. We need to send this
@@ -137,23 +171,11 @@ void ClusterManagerImpl::loadCluster(const Json::Object& cluster, Stats::Store& 
     postThreadLocalClusterUpdate(primary_cluster_reference, hosts_added, hosts_removed);
   });
 
-  if (cluster.hasObject("health_check")) {
-    Json::ObjectPtr health_check_config = cluster.getObject("health_check");
-    std::string hc_type = health_check_config->getString("type");
-    if (hc_type == "http") {
-      new_cluster->setHealthChecker(HealthCheckerPtr{new ProdHttpHealthCheckerImpl(
-          *new_cluster, *health_check_config, dns_resolver.dispatcher(), stats, runtime, random)});
-    } else if (hc_type == "tcp") {
-      new_cluster->setHealthChecker(HealthCheckerPtr{new TcpHealthCheckerImpl(
-          *new_cluster, *health_check_config, dns_resolver.dispatcher(), stats, runtime, random)});
-    } else {
-      throw EnvoyException(fmt::format("cluster: unknown health check type '{}'", hc_type));
-    }
-  }
-
-  new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
-      *new_cluster, cluster, dns_resolver.dispatcher(), runtime, stats, event_logger));
-  primary_clusters_.emplace(new_cluster->info()->name(), new_cluster);
+  // emplace() will do nothing if the key already exists. Always erase first.
+  primary_clusters_.erase(primary_cluster_reference.info()->name());
+  primary_clusters_.emplace(
+      primary_cluster_reference.info()->name(),
+      PrimaryClusterData{cluster.hash(), added_via_api, std::move(new_cluster)});
 }
 
 ClusterInfoPtr ClusterManagerImpl::get(const std::string& cluster) {
@@ -162,7 +184,7 @@ ClusterInfoPtr ClusterManagerImpl::get(const std::string& cluster) {
 
   auto entry = cluster_manager.thread_local_clusters_.find(cluster);
   if (entry != cluster_manager.thread_local_clusters_.end()) {
-    return entry->second->primary_cluster_->info();
+    return entry->second->cluster_info_;
   } else {
     return nullptr;
   }
@@ -182,24 +204,23 @@ ClusterManagerImpl::httpConnPoolForCluster(const std::string& cluster, ResourceP
   return entry->second->connPool(priority);
 }
 
-void ClusterManagerImpl::postThreadLocalClusterUpdate(const ClusterImplBase& primary_cluster,
+void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& primary_cluster,
                                                       const std::vector<HostPtr>& hosts_added,
                                                       const std::vector<HostPtr>& hosts_removed) {
   const std::string& name = primary_cluster.info()->name();
-  ConstHostVectorPtr hosts_copy = primary_cluster.rawHosts();
-  ConstHostVectorPtr healthy_hosts_copy = primary_cluster.rawHealthyHosts();
-  ConstHostListsPtr hosts_per_zone_copy = primary_cluster.rawHostsPerZone();
-  ConstHostListsPtr healthy_hosts_per_zone_copy = primary_cluster.rawHealthyHostsPerZone();
-  ThreadLocal::Instance& tls = tls_;
-  uint32_t thead_local_slot = thread_local_slot_;
+  ConstHostVectorPtr hosts_copy(new std::vector<HostPtr>(primary_cluster.hosts()));
+  ConstHostVectorPtr healthy_hosts_copy(new std::vector<HostPtr>(primary_cluster.healthyHosts()));
+  ConstHostListsPtr hosts_per_zone_copy(
+      new std::vector<std::vector<HostPtr>>(primary_cluster.hostsPerZone()));
+  ConstHostListsPtr healthy_hosts_per_zone_copy(
+      new std::vector<std::vector<HostPtr>>(primary_cluster.healthyHostsPerZone()));
 
-  tls_.runOnAllThreads(
-      [name, hosts_copy, healthy_hosts_copy, hosts_per_zone_copy, healthy_hosts_per_zone_copy,
-       hosts_added, hosts_removed, &tls, thead_local_slot]() mutable -> void {
-        ThreadLocalClusterManagerImpl::updateClusterMembership(
-            name, hosts_copy, healthy_hosts_copy, hosts_per_zone_copy, healthy_hosts_per_zone_copy,
-            hosts_added, hosts_removed, tls, thead_local_slot);
-      });
+  tls_.runOnAllThreads([this, name, hosts_copy, healthy_hosts_copy, hosts_per_zone_copy,
+                        healthy_hosts_per_zone_copy, hosts_added, hosts_removed]() -> void {
+    ThreadLocalClusterManagerImpl::updateClusterMembership(
+        name, hosts_copy, healthy_hosts_copy, hosts_per_zone_copy, healthy_hosts_per_zone_copy,
+        hosts_added, hosts_removed, tls_, thread_local_slot_);
+  });
 }
 
 Host::CreateConnectionData ClusterManagerImpl::tcpConnForCluster(const std::string& cluster) {
@@ -213,9 +234,9 @@ Host::CreateConnectionData ClusterManagerImpl::tcpConnForCluster(const std::stri
 
   ConstHostPtr logical_host = entry->second->lb_->chooseHost();
   if (logical_host) {
-    return logical_host->createConnection(cluster_manager.dispatcher_);
+    return logical_host->createConnection(cluster_manager.thread_local_dispatcher_);
   } else {
-    entry->second->primary_cluster_->info()->stats().upstream_cx_none_healthy_.inc();
+    entry->second->cluster_info_->stats().upstream_cx_none_healthy_.inc();
     return {nullptr, nullptr};
   }
 }
@@ -232,21 +253,19 @@ Http::AsyncClient& ClusterManagerImpl::httpAsyncClientForCluster(const std::stri
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(
-    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
-    Runtime::RandomGenerator& random, const std::string& local_zone_name,
-    const std::string& local_address, const Optional<std::string>& local_cluster_name)
-    : parent_(parent), dispatcher_(dispatcher) {
+    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
+    const Optional<std::string>& local_cluster_name)
+    : parent_(parent), thread_local_dispatcher_(dispatcher) {
   // If local cluster is defined then we need to initialize it first.
   if (local_cluster_name.valid()) {
-    auto& local_cluster = parent.primary_clusters_[local_cluster_name.value()];
+    auto& local_cluster = parent.primary_clusters_.at(local_cluster_name.value()).cluster_;
     thread_local_clusters_[local_cluster_name.value()].reset(
-        new ClusterEntry(*this, local_cluster, runtime, random, parent.stats_, dispatcher,
-                         local_zone_name, local_address, nullptr));
+        new ClusterEntry(*this, local_cluster->info()));
   }
 
-  const HostSet* local_host_set =
-      local_cluster_name.valid() ? &thread_local_clusters_[local_cluster_name.value()]->host_set_
-                                 : nullptr;
+  local_host_set_ = local_cluster_name.valid()
+                        ? &thread_local_clusters_[local_cluster_name.value()]->host_set_
+                        : nullptr;
 
   for (auto& cluster : parent.primary_clusters_) {
     // If local cluster name is set then we already initialized this cluster.
@@ -255,23 +274,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl
     }
 
     thread_local_clusters_[cluster.first].reset(
-        new ClusterEntry(*this, cluster.second, runtime, random, parent.stats_, dispatcher,
-                         local_zone_name, local_address, local_host_set));
-  }
-
-  for (auto& cluster : thread_local_clusters_) {
-    cluster.second->host_set_.addMemberUpdateCb(
-        [this](const std::vector<HostPtr>&, const std::vector<HostPtr>& hosts_removed) -> void {
-          // We need to go through and purge any connection pools for hosts that got deleted.
-          // Even if two hosts actually point to the same address this will be safe, since if a
-          // host is readded it will be a different physical HostPtr.
-          for (const HostPtr& old_host : hosts_removed) {
-            auto container = host_http_conn_pool_map_.find(old_host);
-            if (container != host_http_conn_pool_map_.end()) {
-              drainConnPools(old_host, container->second);
-            }
-          }
-        });
+        new ClusterEntry(*this, cluster.second.cluster_->info()));
   }
 }
 
@@ -294,7 +297,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
       container.drains_remaining_--;
       if (container.drains_remaining_ == 0) {
         for (Http::ConnectionPool::InstancePtr& pool : container.pools_) {
-          dispatcher_.deferredDelete(std::move(pool));
+          thread_local_dispatcher_.deferredDelete(std::move(pool));
         }
         host_http_conn_pool_map_.erase(old_host);
       }
@@ -324,33 +327,44 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::shutdown() {
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
-    ThreadLocalClusterManagerImpl& parent, ConstClusterPtr cluster, Runtime::Loader& runtime,
-    Runtime::RandomGenerator& random, Stats::Store& stats_store, Event::Dispatcher& dispatcher,
-    const std::string& local_zone_name, const std::string& local_address,
-    const HostSet* local_host_set)
-    : parent_(parent), primary_cluster_(cluster),
-      http_async_client_(*cluster->info(), stats_store, dispatcher, local_zone_name, parent.parent_,
-                         runtime, random,
+    ThreadLocalClusterManagerImpl& parent, ClusterInfoPtr cluster)
+    : parent_(parent), cluster_info_(cluster),
+      http_async_client_(*cluster, parent.parent_.stats_, parent.thread_local_dispatcher_,
+                         parent.parent_.local_zone_name_, parent.parent_, parent.parent_.runtime_,
+                         parent.parent_.random_,
                          Router::ShadowWriterPtr{new Router::ShadowWriterImpl(parent.parent_)},
-                         local_address) {
+                         parent.parent_.local_address_) {
 
   switch (cluster->lbType()) {
   case LoadBalancerType::LeastRequest: {
-    lb_.reset(new LeastRequestLoadBalancer(host_set_, local_host_set, cluster->info()->stats(),
-                                           runtime, random));
+    lb_.reset(new LeastRequestLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+                                           parent.parent_.runtime_, parent.parent_.random_));
     break;
   }
   case LoadBalancerType::Random: {
-    lb_.reset(new RandomLoadBalancer(host_set_, local_host_set, cluster->info()->stats(), runtime,
-                                     random));
+    lb_.reset(new RandomLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+                                     parent.parent_.runtime_, parent.parent_.random_));
     break;
   }
   case LoadBalancerType::RoundRobin: {
-    lb_.reset(new RoundRobinLoadBalancer(host_set_, local_host_set, cluster->info()->stats(),
-                                         runtime, random));
+    lb_.reset(new RoundRobinLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+                                         parent.parent_.runtime_, parent.parent_.random_));
     break;
   }
   }
+
+  host_set_.addMemberUpdateCb(
+      [this](const std::vector<HostPtr>&, const std::vector<HostPtr>& hosts_removed) -> void {
+        // We need to go through and purge any connection pools for hosts that got deleted.
+        // Even if two hosts actually point to the same address this will be safe, since if a
+        // host is readded it will be a different physical HostPtr.
+        for (const HostPtr& old_host : hosts_removed) {
+          auto container = parent_.host_http_conn_pool_map_.find(old_host);
+          if (container != parent_.host_http_conn_pool_map_.end()) {
+            parent_.drainConnPools(old_host, container->second);
+          }
+        }
+      });
 }
 
 Http::ConnectionPool::Instance*
@@ -358,31 +372,40 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::connPool(
     ResourcePriority priority) {
   ConstHostPtr host = lb_->chooseHost();
   if (!host) {
-    primary_cluster_->info()->stats().upstream_cx_none_healthy_.inc();
+    cluster_info_->stats().upstream_cx_none_healthy_.inc();
     return nullptr;
   }
 
   ConnPoolsContainer& container = parent_.host_http_conn_pool_map_[host];
   ASSERT(enumToInt(priority) < container.pools_.size());
   if (!container.pools_[enumToInt(priority)]) {
-    container.pools_[enumToInt(priority)] = parent_.parent_.allocateConnPool(
-        parent_.dispatcher_, host, parent_.parent_.stats_, priority);
+    container.pools_[enumToInt(priority)] =
+        parent_.parent_.factory_.allocateConnPool(parent_.thread_local_dispatcher_, host, priority);
   }
 
   return container.pools_[enumToInt(priority)].get();
 }
 
 Http::ConnectionPool::InstancePtr
-ProdClusterManagerImpl::allocateConnPool(Event::Dispatcher& dispatcher, ConstHostPtr host,
-                                         Stats::Store& store, ResourcePriority priority) {
+ProdClusterManagerFactory::allocateConnPool(Event::Dispatcher& dispatcher, ConstHostPtr host,
+                                            ResourcePriority priority) {
   if ((host->cluster().features() & ClusterInfo::Features::HTTP2) &&
       runtime_.snapshot().featureEnabled("upstream.use_http2", 100)) {
     return Http::ConnectionPool::InstancePtr{
-        new Http::Http2::ProdConnPoolImpl(dispatcher, host, store, priority)};
+        new Http::Http2::ProdConnPoolImpl(dispatcher, host, stats_, priority)};
   } else {
     return Http::ConnectionPool::InstancePtr{
-        new Http::Http1::ConnPoolImplProd(dispatcher, host, store, priority)};
+        new Http::Http1::ConnPoolImplProd(dispatcher, host, stats_, priority)};
   }
+}
+
+ClusterPtr
+ProdClusterManagerFactory::clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
+                                           const Optional<SdsConfig>& sds_config,
+                                           Outlier::EventLoggerPtr outlier_event_logger) {
+  return ClusterImplBase::create(cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_,
+                                 runtime_, random_, primary_dispatcher_, sds_config,
+                                 outlier_event_logger);
 }
 
 } // Upstream

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -102,7 +102,6 @@ bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const Json::Object& new_confi
 
     cluster_manager.thread_local_clusters_[new_cluster->name()].reset(
         new ThreadLocalClusterManagerImpl::ClusterEntry(cluster_manager, new_cluster));
-
   });
 
   postInitializeCluster(*primary_clusters_.at(cluster_name).cluster_);
@@ -152,8 +151,7 @@ void ClusterManagerImpl::loadCluster(const Json::Object& cluster, bool added_via
           initialized_callback_();
         }
       } else if (pending_cluster_init_ == secondary_init_clusters_.size()) {
-        // All other clusters have initialized. Now we start up the SDS clusters since they will
-        // depend on DNS resolution for the SDS cluster itself.
+        // All primary clusters have initialized. Now we start up the secondary clusters.
         for (Cluster* cluster : secondary_init_clusters_) {
           cluster->initialize();
         }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -13,18 +13,49 @@
 namespace Upstream {
 
 /**
+ * Production implementation of ClusterManagerFactory.
+ */
+class ProdClusterManagerFactory : public ClusterManagerFactory {
+public:
+  ProdClusterManagerFactory(Runtime::Loader& runtime, Stats::Store& stats,
+                            ThreadLocal::Instance& tls, Runtime::RandomGenerator& random,
+                            Network::DnsResolver& dns_resolver,
+                            Ssl::ContextManager& ssl_context_manager,
+                            Event::Dispatcher& primary_dispatcher)
+      : runtime_(runtime), stats_(stats), tls_(tls), random_(random), dns_resolver_(dns_resolver),
+        ssl_context_manager_(ssl_context_manager), primary_dispatcher_(primary_dispatcher) {}
+
+  // Upstream::ClusterManagerFactory
+  Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher& dispatcher,
+                                                     ConstHostPtr host,
+                                                     ResourcePriority priority) override;
+  ClusterPtr clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
+                             const Optional<SdsConfig>& sds_config,
+                             Outlier::EventLoggerPtr outlier_event_logger) override;
+
+private:
+  Runtime::Loader& runtime_;
+  Stats::Store& stats_;
+  ThreadLocal::Instance& tls_;
+  Runtime::RandomGenerator& random_;
+  Network::DnsResolver& dns_resolver_;
+  Ssl::ContextManager& ssl_context_manager_;
+  Event::Dispatcher& primary_dispatcher_;
+};
+
+/**
  * Implementation of ClusterManager that reads from a JSON configuration, maintains a central
  * cluster list, as well as thread local caches of each cluster and associated connection pools.
  */
 class ClusterManagerImpl : public ClusterManager {
 public:
-  ClusterManagerImpl(const Json::Object& config, Stats::Store& stats, ThreadLocal::Instance& tls,
-                     Network::DnsResolver& dns_resolver, Ssl::ContextManager& ssl_context_manager,
-                     Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                     const std::string& local_zone_name, const std::string& local_address,
-                     AccessLog::AccessLogManager& log_manager);
+  ClusterManagerImpl(const Json::Object& config, ClusterManagerFactory& factory,
+                     Stats::Store& stats, ThreadLocal::Instance& tls, Runtime::Loader& runtime,
+                     Runtime::RandomGenerator& random, const std::string& local_zone_name,
+                     const std::string& local_address, AccessLog::AccessLogManager& log_manager);
 
   // Upstream::ClusterManager
+  bool addOrUpdatePrimaryCluster(const Json::Object& config) override;
   void setInitializedCb(std::function<void()> callback) override {
     if (pending_cluster_init_ == 0) {
       callback();
@@ -32,30 +63,21 @@ public:
       initialized_callback_ = callback;
     }
   }
-
-  std::unordered_map<std::string, ConstClusterPtr> clusters() override {
-    std::unordered_map<std::string, ConstClusterPtr> clusters_map;
+  ClusterInfoMap clusters() override {
+    ClusterInfoMap clusters_map;
     for (auto& cluster : primary_clusters_) {
-      clusters_map[cluster.first] = cluster.second;
+      clusters_map.emplace(cluster.first, *cluster.second.cluster_);
     }
 
     return clusters_map;
   }
-
   ClusterInfoPtr get(const std::string& cluster) override;
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
                                                          ResourcePriority priority) override;
   Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) override;
   Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) override;
-
-  void shutdown() override {
-    for (auto& cluster : primary_clusters_) {
-      cluster.second->shutdown();
-    }
-  }
-
-protected:
-  Runtime::Loader& runtime_;
+  bool removePrimaryCluster(const std::string& cluster) override;
+  void shutdown() override { primary_clusters_.clear(); }
 
 private:
   /**
@@ -72,27 +94,20 @@ private:
     };
 
     struct ClusterEntry {
-      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ConstClusterPtr cluster,
-                   Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                   Stats::Store& stats_store, Event::Dispatcher& dispatcher,
-                   const std::string& local_zone_name, const std::string& local_address,
-                   const HostSet* local_host_set);
+      ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoPtr cluster);
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 
       ThreadLocalClusterManagerImpl& parent_;
       HostSetImpl host_set_;
       LoadBalancerPtr lb_;
-      ConstClusterPtr primary_cluster_;
+      ClusterInfoPtr cluster_info_;
       Http::AsyncClientImpl http_async_client_;
     };
 
     typedef std::unique_ptr<ClusterEntry> ClusterEntryPtr;
 
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
-                                  Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                                  const std::string& local_zone_name,
-                                  const std::string& local_address,
                                   const Optional<std::string>& local_cluster_name);
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,
@@ -107,44 +122,41 @@ private:
     void shutdown() override;
 
     ClusterManagerImpl& parent_;
-    Event::Dispatcher& dispatcher_;
+    Event::Dispatcher& thread_local_dispatcher_;
     std::unordered_map<std::string, ClusterEntryPtr> thread_local_clusters_;
     std::unordered_map<ConstHostPtr, ConnPoolsContainer> host_http_conn_pool_map_;
+    const HostSet* local_host_set_{};
   };
 
-  virtual Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher& dispatcher,
-                                                             ConstHostPtr host, Stats::Store& store,
-                                                             ResourcePriority priority) PURE;
-  void loadCluster(const Json::Object& cluster, Stats::Store& stats,
-                   Network::DnsResolver& dns_resolver, Ssl::ContextManager& ssl_context_manager,
-                   Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                   Outlier::EventLoggerPtr event_logger);
-  void postThreadLocalClusterUpdate(const ClusterImplBase& primary_cluster,
+  struct PrimaryClusterData {
+    PrimaryClusterData(uint64_t config_hash, bool added_via_api, ClusterPtr&& cluster)
+        : config_hash_(config_hash), added_via_api_(added_via_api), cluster_(std::move(cluster)) {}
+
+    const uint64_t config_hash_;
+    const bool added_via_api_;
+    ClusterPtr cluster_;
+  };
+
+  void loadCluster(const Json::Object& cluster, bool added_via_api);
+  void postInitializeCluster(Cluster& cluster);
+  void postThreadLocalClusterUpdate(const Cluster& primary_cluster,
                                     const std::vector<HostPtr>& hosts_added,
                                     const std::vector<HostPtr>& hosts_removed);
 
-  ThreadLocal::Instance& tls_;
+  ClusterManagerFactory& factory_;
+  Runtime::Loader& runtime_;
   Stats::Store& stats_;
+  ThreadLocal::Instance& tls_;
+  Runtime::RandomGenerator& random_;
   uint32_t thread_local_slot_;
-  std::unordered_map<std::string, ClusterImplBasePtr> primary_clusters_;
+  std::unordered_map<std::string, PrimaryClusterData> primary_clusters_;
   std::function<void()> initialized_callback_;
   uint32_t pending_cluster_init_;
   Optional<SdsConfig> sds_config_;
-  std::list<SdsClusterImpl*> sds_clusters_;
-};
-
-/**
- * Prod implementation of ClusterManagerImpl that allocates real connection pools.
- */
-class ProdClusterManagerImpl : public ClusterManagerImpl {
-public:
-  using ClusterManagerImpl::ClusterManagerImpl;
-
-private:
-  // ClusterManagerImpl
-  Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher& dispatcher,
-                                                     ConstHostPtr host, Stats::Store& store,
-                                                     ResourcePriority priority) override;
+  std::list<Cluster*> secondary_init_clusters_;
+  Outlier::EventLoggerPtr outlier_event_logger_;
+  const std::string local_zone_name_;
+  const std::string local_address_;
 };
 
 } // Upstream

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -25,13 +25,16 @@ class LogicalDnsCluster : public ClusterImplBase {
 public:
   LogicalDnsCluster(const Json::Object& config, Runtime::Loader& runtime, Stats::Store& stats,
                     Ssl::ContextManager& ssl_context_manager, Network::DnsResolver& dns_resolver,
-                    ThreadLocal::Instance& tls);
+                    ThreadLocal::Instance& tls, Event::Dispatcher& dispatcher);
+
+  ~LogicalDnsCluster();
 
   // Upstream::Cluster
+  void initialize() override {}
+  InitializePhase initializePhase() const override { return InitializePhase::Primary; }
   void setInitializedCb(std::function<void()> callback) override {
     initialize_callback_ = callback;
   }
-  void shutdown() override {}
 
 private:
   struct LogicalHost : public HostImpl {
@@ -80,6 +83,7 @@ private:
   std::string dns_url_;
   std::string current_resolved_url_;
   HostPtr logical_host_;
+  Network::ActiveDnsQuery* active_dns_query_{};
 };
 
 } // Upstream

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -9,15 +9,6 @@
 namespace Upstream {
 
 /**
- * Global configuration for any SDS clusters.
- */
-struct SdsConfig {
-  std::string local_zone_name_;
-  std::string sds_cluster_name_;
-  std::chrono::milliseconds refresh_delay_;
-};
-
-/**
  * Cluster implementation that reads host information from the service discovery service.
  */
 class SdsClusterImpl : public BaseDynamicClusterImpl, public Http::AsyncClient::Callbacks {
@@ -29,16 +20,9 @@ public:
 
   ~SdsClusterImpl();
 
-  /**
-   * SDS clusters do not begin host refresh in the constructor because SDS typically depends on
-   * another upstream cluster that must initialize first. This allows the cluster manager to
-   * initialize the SDS clusters when the other clusters have been initialized. The health checker
-   * will also be installed by this time.
-   */
-  void initialize() { refreshHosts(); }
-
   // Upstream::Cluster
-  void shutdown() override;
+  void initialize() override { refreshHosts(); }
+  InitializePhase initializePhase() const override { return InitializePhase::Secondary; }
 
 private:
   void parseSdsResponse(Http::Message& response);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1,3 +1,6 @@
+#include "health_checker_impl.h"
+#include "logical_dns_cluster.h"
+#include "sds.h"
 #include "upstream_impl.h"
 
 #include "envoy/event/dispatcher.h"
@@ -67,13 +70,6 @@ ClusterInfoImpl::ClusterInfoImpl(const Json::Object& config, Runtime::Loader& ru
     Ssl::ContextConfigImpl context_config(*config.getObject("ssl_context"));
     ssl_ctx_ = &ssl_context_manager.createSslClientContext(stat_prefix_, stats, context_config);
   }
-}
-
-const ConstHostListsPtr ClusterImplBase::empty_host_lists_{new std::vector<std::vector<HostPtr>>()};
-
-ClusterImplBase::ClusterImplBase(const Json::Object& config, Runtime::Loader& runtime,
-                                 Stats::Store& stats, Ssl::ContextManager& ssl_context_manager)
-    : runtime_(runtime), info_(new ClusterInfoImpl(config, runtime, stats, ssl_context_manager)) {
 
   std::string string_lb_type = config.getString("lb_type");
   if (string_lb_type == "round_robin") {
@@ -86,6 +82,60 @@ ClusterImplBase::ClusterImplBase(const Json::Object& config, Runtime::Loader& ru
     throw EnvoyException(fmt::format("cluster: unknown LB type '{}'", string_lb_type));
   }
 }
+
+const ConstHostListsPtr ClusterImplBase::empty_host_lists_{new std::vector<std::vector<HostPtr>>()};
+
+ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& cm,
+                                   Stats::Store& stats, ThreadLocal::Instance& tls,
+                                   Network::DnsResolver& dns_resolver,
+                                   Ssl::ContextManager& ssl_context_manager,
+                                   Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                                   Event::Dispatcher& dispatcher,
+                                   const Optional<SdsConfig>& sds_config,
+                                   Outlier::EventLoggerPtr outlier_event_logger) {
+  std::unique_ptr<ClusterImplBase> new_cluster;
+  std::string string_type = cluster.getString("type");
+  if (string_type == "static") {
+    new_cluster.reset(new StaticClusterImpl(cluster, runtime, stats, ssl_context_manager));
+  } else if (string_type == "strict_dns") {
+    new_cluster.reset(new StrictDnsClusterImpl(cluster, runtime, stats, ssl_context_manager,
+                                               dns_resolver, dispatcher));
+  } else if (string_type == "logical_dns") {
+    new_cluster.reset(new LogicalDnsCluster(cluster, runtime, stats, ssl_context_manager,
+                                            dns_resolver, tls, dispatcher));
+  } else if (string_type == "sds") {
+    if (!sds_config.valid()) {
+      throw EnvoyException("cannot create an sds cluster without an sds config");
+    }
+
+    new_cluster.reset(new SdsClusterImpl(cluster, runtime, stats, ssl_context_manager,
+                                         sds_config.value(), cm, dispatcher, random));
+  } else {
+    throw EnvoyException(fmt::format("cluster: unknown cluster type '{}'", string_type));
+  }
+
+  if (cluster.hasObject("health_check")) {
+    Json::ObjectPtr health_check_config = cluster.getObject("health_check");
+    std::string hc_type = health_check_config->getString("type");
+    if (hc_type == "http") {
+      new_cluster->setHealthChecker(HealthCheckerPtr{new ProdHttpHealthCheckerImpl(
+          *new_cluster, *health_check_config, dispatcher, stats, runtime, random)});
+    } else if (hc_type == "tcp") {
+      new_cluster->setHealthChecker(HealthCheckerPtr{new TcpHealthCheckerImpl(
+          *new_cluster, *health_check_config, dispatcher, stats, runtime, random)});
+    } else {
+      throw EnvoyException(fmt::format("cluster: unknown health check type '{}'", hc_type));
+    }
+  }
+
+  new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
+      *new_cluster, cluster, dispatcher, runtime, stats, outlier_event_logger));
+  return std::move(new_cluster);
+}
+
+ClusterImplBase::ClusterImplBase(const Json::Object& config, Runtime::Loader& runtime,
+                                 Stats::Store& stats, Ssl::ContextManager& ssl_context_manager)
+    : runtime_(runtime), info_(new ClusterInfoImpl(config, runtime, stats, ssl_context_manager)) {}
 
 ConstHostVectorPtr ClusterImplBase::createHealthyHostList(const std::vector<HostPtr>& hosts) {
   HostVectorPtr healthy_list(new std::vector<HostPtr>());
@@ -156,8 +206,7 @@ void ClusterImplBase::setHealthChecker(HealthCheckerPtr&& health_checker) {
     // If we get a health check completion that resulted in a state change, signal to
     // update the host sets on all threads.
     if (changed_state) {
-      updateHosts(rawHosts(), createHealthyHostList(*rawHosts()), rawHostsPerZone(),
-                  createHealthyHostLists(*rawHostsPerZone()), {}, {});
+      reloadHealthyHosts();
     }
   });
 }
@@ -168,10 +217,14 @@ void ClusterImplBase::setOutlierDetector(Outlier::DetectorPtr outlier_detector) 
   }
 
   outlier_detector_ = std::move(outlier_detector);
-  outlier_detector_->addChangedStateCb([this](HostPtr) -> void {
-    updateHosts(rawHosts(), createHealthyHostList(*rawHosts()), rawHostsPerZone(),
-                createHealthyHostLists(*rawHostsPerZone()), {}, {});
-  });
+  outlier_detector_->addChangedStateCb([this](HostPtr) -> void { reloadHealthyHosts(); });
+}
+
+void ClusterImplBase::reloadHealthyHosts() {
+  ConstHostVectorPtr hosts_copy(new std::vector<HostPtr>(hosts()));
+  ConstHostListsPtr hosts_per_zone_copy(new std::vector<std::vector<HostPtr>>(hostsPerZone()));
+  updateHosts(hosts_copy, createHealthyHostList(hosts()), hosts_per_zone_copy,
+              createHealthyHostLists(hostsPerZone()), {}, {});
 }
 
 ClusterInfoImpl::ResourceManagers::ResourceManagers(const Json::Object& config,
@@ -295,12 +348,13 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostPtr>& n
 StrictDnsClusterImpl::StrictDnsClusterImpl(const Json::Object& config, Runtime::Loader& runtime,
                                            Stats::Store& stats,
                                            Ssl::ContextManager& ssl_context_manager,
-                                           Network::DnsResolver& dns_resolver)
+                                           Network::DnsResolver& dns_resolver,
+                                           Event::Dispatcher& dispatcher)
     : BaseDynamicClusterImpl(config, runtime, stats, ssl_context_manager),
       dns_resolver_(dns_resolver), dns_refresh_rate_ms_(std::chrono::milliseconds(
                                        config.getInteger("dns_refresh_rate_ms", 5000))) {
   for (Json::ObjectPtr& host : config.getObjectArray("hosts")) {
-    resolve_targets_.emplace_back(new ResolveTarget(*this, host->getString("url")));
+    resolve_targets_.emplace_back(new ResolveTarget(*this, dispatcher, host->getString("url")));
   }
 }
 
@@ -319,22 +373,28 @@ void StrictDnsClusterImpl::updateAllHosts(const std::vector<HostPtr>& hosts_adde
 }
 
 StrictDnsClusterImpl::ResolveTarget::ResolveTarget(StrictDnsClusterImpl& parent,
+                                                   Event::Dispatcher& dispatcher,
                                                    const std::string& url)
     : parent_(parent), dns_address_(Network::Utility::hostFromUrl(url)),
       port_(Network::Utility::portFromUrl(url)),
-      resolve_timer_(
-          parent_.dns_resolver_.dispatcher().createTimer([this]() -> void { startResolve(); })) {
+      resolve_timer_(dispatcher.createTimer([this]() -> void { startResolve(); })) {
 
   startResolve();
+}
+
+StrictDnsClusterImpl::ResolveTarget::~ResolveTarget() {
+  if (active_query_) {
+    active_query_->cancel();
+  }
 }
 
 void StrictDnsClusterImpl::ResolveTarget::startResolve() {
   log_debug("starting async DNS resolution for {}", dns_address_);
   parent_.info_->stats().update_attempt_.inc();
 
-  parent_.dns_resolver_.resolve(
+  active_query_ = &parent_.dns_resolver_.resolve(
       dns_address_, [this](std::list<std::string>&& address_list) -> void {
-
+        active_query_ = nullptr;
         log_debug("async DNS resolution complete for {}", dns_address_);
         parent_.info_->stats().update_success_.inc();
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -26,10 +26,13 @@ void FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager
 MainImpl::MainImpl(Server::Instance& server) : server_(server) {}
 
 void MainImpl::initialize(const Json::Object& json) {
-  cluster_manager_.reset(new Upstream::ProdClusterManagerImpl(
-      *json.getObject("cluster_manager"), server_.stats(), server_.threadLocal(),
-      server_.dnsResolver(), server_.sslContextManager(), server_.runtime(), server_.random(),
-      server_.options().serviceZone(), server_.getLocalAddress(), server_.accessLogManager()));
+  cluster_manager_factory_.reset(new Upstream::ProdClusterManagerFactory(
+      server_.runtime(), server_.stats(), server_.threadLocal(), server_.random(),
+      server_.dnsResolver(), server_.sslContextManager(), server_.dispatcher()));
+  cluster_manager_.reset(new Upstream::ClusterManagerImpl(
+      *json.getObject("cluster_manager"), *cluster_manager_factory_, server_.stats(),
+      server_.threadLocal(), server_.runtime(), server_.random(), server_.options().serviceZone(),
+      server_.getLocalAddress(), server_.accessLogManager()));
 
   std::vector<Json::ObjectPtr> listeners = json.getObjectArray("listeners");
   log().info("loading {} listener(s)", listeners.size());

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -111,6 +111,7 @@ private:
   }
 
   Server::Instance& server_;
+  std::unique_ptr<Upstream::ClusterManagerFactory> cluster_manager_factory_;
   std::unique_ptr<Upstream::ClusterManager> cluster_manager_;
   Tracing::HttpTracerPtr http_tracer_;
   std::list<Server::Configuration::ListenerPtr> listeners_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -115,14 +115,15 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
 
 Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& response) {
   for (auto& cluster : server_.clusterManager().clusters()) {
-    addCircuitSettings(cluster.second->info()->name(), "default",
-                       cluster.second->info()->resourceManager(Upstream::ResourcePriority::Default),
-                       response);
-    addCircuitSettings(cluster.second->info()->name(), "high",
-                       cluster.second->info()->resourceManager(Upstream::ResourcePriority::High),
-                       response);
+    addCircuitSettings(
+        cluster.second.get().info()->name(), "default",
+        cluster.second.get().info()->resourceManager(Upstream::ResourcePriority::Default),
+        response);
+    addCircuitSettings(
+        cluster.second.get().info()->name(), "high",
+        cluster.second.get().info()->resourceManager(Upstream::ResourcePriority::High), response);
 
-    for (auto& host : cluster.second->hosts()) {
+    for (auto& host : cluster.second.get().hosts()) {
       std::map<std::string, uint64_t> all_stats;
       for (Stats::Counter& counter : host->counters()) {
         all_stats[counter.name()] = counter.value();
@@ -133,18 +134,18 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
       }
 
       for (auto stat : all_stats) {
-        response.add(fmt::format("{}::{}::{}::{}\n", cluster.second->info()->name(), host->url(),
-                                 stat.first, stat.second));
+        response.add(fmt::format("{}::{}::{}::{}\n", cluster.second.get().info()->name(),
+                                 host->url(), stat.first, stat.second));
       }
 
-      response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second->info()->name(),
+      response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second.get().info()->name(),
                                host->url(), Upstream::HostUtility::healthFlagsToString(*host)));
-      response.add(fmt::format("{}::{}::weight::{}\n", cluster.second->info()->name(), host->url(),
-                               host->weight()));
-      response.add(fmt::format("{}::{}::zone::{}\n", cluster.second->info()->name(), host->url(),
-                               host->zone()));
-      response.add(fmt::format("{}::{}::canary::{}\n", cluster.second->info()->name(), host->url(),
-                               host->canary()));
+      response.add(fmt::format("{}::{}::weight::{}\n", cluster.second.get().info()->name(),
+                               host->url(), host->weight()));
+      response.add(fmt::format("{}::{}::zone::{}\n", cluster.second.get().info()->name(),
+                               host->url(), host->zone()));
+      response.add(fmt::format("{}::{}::canary::{}\n", cluster.second.get().info()->name(),
+                               host->url(), host->canary()));
     }
   }
 

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -3,10 +3,12 @@
 
 #include "common/api/api_impl.h"
 
+namespace Network {
+
 TEST(DnsImplTest, LocalAsyncLookup) {
   Api::Impl api(std::chrono::milliseconds(10000));
   Event::DispatcherPtr dispatcher = api.allocateDispatcher();
-  Network::DnsResolverPtr resolver = dispatcher->createDnsResolver();
+  DnsResolverPtr resolver = dispatcher->createDnsResolver();
 
   std::list<std::string> address_list;
   resolver->resolve("", [&](std::list<std::string>&& results) -> void {
@@ -25,3 +27,24 @@ TEST(DnsImplTest, LocalAsyncLookup) {
   dispatcher->run(Event::Dispatcher::RunType::Block);
   EXPECT_THAT(address_list, testing::Contains("127.0.0.1"));
 }
+
+TEST(DnsImplTest, Cancel) {
+  Api::Impl api(std::chrono::milliseconds(10000));
+  Event::DispatcherPtr dispatcher = api.allocateDispatcher();
+  DnsResolverPtr resolver = dispatcher->createDnsResolver();
+
+  ActiveDnsQuery& query =
+      resolver->resolve("localhost", [](std::list<std::string> && ) -> void { FAIL(); });
+
+  std::list<std::string> address_list;
+  resolver->resolve("localhost", [&](std::list<std::string>&& results) -> void {
+    address_list = results;
+    dispatcher->exit();
+  });
+
+  query.cancel();
+  dispatcher->run(Event::Dispatcher::RunType::Block);
+  EXPECT_THAT(address_list, testing::Contains("127.0.0.1"));
+}
+
+} // Network

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -9,34 +9,50 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/upstream/mocks.h"
 
 using testing::_;
+using testing::InSequence;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
+using testing::ReturnRef;
 using testing::ReturnNew;
 using testing::SaveArg;
 
 namespace Upstream {
 
-class ClusterManagerImplForTest : public ClusterManagerImpl {
+// The tests in this file are split between testing with real clusters and some with mock clusters.
+// By default we setup to call the real cluster creation function. Individual tests can override
+// the expectations when needed.
+class TestClusterManagerFactory : public ClusterManagerFactory {
 public:
-  using ClusterManagerImpl::ClusterManagerImpl;
+  TestClusterManagerFactory() {
+    ON_CALL(*this, clusterFromJson_(_, _, _, _))
+        .WillByDefault(Invoke([&](const Json::Object& cluster, ClusterManager& cm,
+                                  const Optional<SdsConfig>& sds_config,
+                                  Outlier::EventLoggerPtr outlier_event_logger) -> Cluster* {
+          return ClusterImplBase::create(cluster, cm, stats_, tls_, dns_resolver_,
+                                         ssl_context_manager_, runtime_, random_, dispatcher_,
+                                         sds_config, outlier_event_logger).release();
+        }));
+  }
 
   Http::ConnectionPool::InstancePtr allocateConnPool(Event::Dispatcher&, ConstHostPtr host,
-                                                     Stats::Store&, ResourcePriority) override {
+                                                     ResourcePriority) override {
     return Http::ConnectionPool::InstancePtr{allocateConnPool_(host)};
   }
 
-  MOCK_METHOD1(allocateConnPool_, Http::ConnectionPool::Instance*(ConstHostPtr host));
-};
-
-class ClusterManagerImplTest : public testing::Test {
-public:
-  void create(const Json::Object& config) {
-    cluster_manager_.reset(new ClusterManagerImplForTest(
-        config, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_, random_, "us-east-1d",
-        "local_address", log_manager_));
+  ClusterPtr clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
+                             const Optional<SdsConfig>& sds_config,
+                             Outlier::EventLoggerPtr outlier_event_logger) override {
+    return ClusterPtr{clusterFromJson_(cluster, cm, sds_config, outlier_event_logger)};
   }
+
+  MOCK_METHOD1(allocateConnPool_, Http::ConnectionPool::Instance*(ConstHostPtr host));
+  MOCK_METHOD4(clusterFromJson_, Cluster*(const Json::Object& cluster, ClusterManager& cm,
+                                          const Optional<SdsConfig>& sds_config,
+                                          Outlier::EventLoggerPtr outlier_event_logger));
 
   Stats::IsolatedStoreImpl stats_;
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -44,7 +60,19 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   Ssl::ContextManagerImpl ssl_context_manager_{runtime_};
-  std::unique_ptr<ClusterManagerImplForTest> cluster_manager_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+};
+
+class ClusterManagerImplTest : public testing::Test {
+public:
+  void create(const Json::Object& config) {
+    cluster_manager_.reset(new ClusterManagerImpl(config, factory_, factory_.stats_, factory_.tls_,
+                                                  factory_.runtime_, factory_.random_, "us-east-1d",
+                                                  "local_address", log_manager_));
+  }
+
+  NiceMock<TestClusterManagerFactory> factory_;
+  std::unique_ptr<ClusterManagerImpl> cluster_manager_;
   AccessLog::MockAccessLogManager log_manager_;
 };
 
@@ -231,7 +259,7 @@ TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
-  EXPECT_CALL(dns_resolver_.dispatcher_, createClientConnection_("tcp://127.0.0.1:11001"))
+  EXPECT_CALL(factory_.dispatcher_, createClientConnection_("tcp://127.0.0.1:11001"))
       .WillOnce(Return(connection));
   create(*loader);
 }
@@ -275,15 +303,161 @@ TEST_F(ClusterManagerImplTest, ShutdownOrder) {
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   create(*loader);
-  ConstClusterPtr cluster = cluster_manager_->clusters().begin()->second;
-  EXPECT_EQ("cluster_1", cluster->info()->name());
+  const Cluster& cluster = cluster_manager_->clusters().begin()->second;
+  EXPECT_EQ("cluster_1", cluster.info()->name());
 
-  // Local reference, primary reference, thread local reference.
-  EXPECT_EQ(3U, cluster.use_count());
+  // Local reference, primary reference, thread local reference, host reference.
+  EXPECT_EQ(4U, cluster.info().use_count());
 
   // Thread local reference should be gone.
-  tls_.shutdownThread();
-  EXPECT_EQ(2U, cluster.use_count());
+  factory_.tls_.shutdownThread();
+  EXPECT_EQ(3U, cluster.info().use_count());
+}
+
+TEST_F(ClusterManagerImplTest, InitializeOrder) {
+  std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "fake": ""
+    },
+    {
+      "fake": ""
+    }]
+  }
+  )EOF";
+
+  MockCluster* cluster1 = new NiceMock<MockCluster>();
+  MockCluster* cluster2 = new NiceMock<MockCluster>();
+  cluster2->info_->name_ = "fake_cluster2";
+
+  InSequence s;
+  EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster1));
+  ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
+  EXPECT_CALL(*cluster1, initialize());
+  EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster2));
+  ON_CALL(*cluster2, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  create(*loader);
+
+  ReadyWatcher initialized;
+  cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
+
+  EXPECT_CALL(*cluster2, initialize());
+  cluster1->initialize_callback_();
+
+  EXPECT_CALL(initialized, ready());
+  cluster2->initialize_callback_();
+}
+
+TEST_F(ClusterManagerImplTest, dynamicAddRemove) {
+  std::string json = R"EOF(
+  {
+    "clusters": []
+  }
+  )EOF";
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  create(*loader);
+
+  InSequence s;
+  ReadyWatcher initialized;
+  EXPECT_CALL(initialized, ready());
+  cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
+
+  std::string json_api = R"EOF(
+  {
+    "name": "fake_cluster"
+  }
+  )EOF";
+
+  Json::ObjectPtr loader_api = Json::Factory::LoadFromString(json_api);
+  MockCluster* cluster1 = new NiceMock<MockCluster>();
+  EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster1));
+  EXPECT_CALL(*cluster1, initializePhase()).Times(0);
+  EXPECT_CALL(*cluster1, initialize());
+  EXPECT_TRUE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
+
+  EXPECT_EQ(cluster1->info_, cluster_manager_->get("fake_cluster"));
+
+  // Now try to update again but with the same hash (different white space).
+  std::string json_api_2 = R"EOF(
+  {
+      "name":   "fake_cluster"
+  }
+  )EOF";
+
+  loader_api = Json::Factory::LoadFromString(json_api_2);
+  EXPECT_FALSE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
+
+  // Now do it again with a different hash.
+  std::string json_api_3 = R"EOF(
+  {
+      "name":   "fake_cluster",
+      "blah": ""
+  }
+  )EOF";
+
+  loader_api = Json::Factory::LoadFromString(json_api_3);
+  MockCluster* cluster2 = new NiceMock<MockCluster>();
+  cluster2->hosts_ = {HostPtr{new HostImpl(cluster2->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster2));
+  EXPECT_CALL(*cluster2, initializePhase()).Times(0);
+  EXPECT_CALL(*cluster2, initialize());
+  EXPECT_TRUE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
+
+  EXPECT_EQ(cluster2->info_, cluster_manager_->get("fake_cluster"));
+  EXPECT_EQ(1UL, cluster_manager_->clusters().size());
+  Http::ConnectionPool::MockInstance* cp = new Http::ConnectionPool::MockInstance();
+  EXPECT_CALL(factory_, allocateConnPool_(_)).WillOnce(Return(cp));
+  EXPECT_EQ(cp,
+            cluster_manager_->httpConnPoolForCluster("fake_cluster", ResourcePriority::Default));
+
+  // Now remove it.
+  EXPECT_TRUE(cluster_manager_->removePrimaryCluster("fake_cluster"));
+  EXPECT_EQ(nullptr, cluster_manager_->get("fake_cluster"));
+  EXPECT_EQ(0UL, cluster_manager_->clusters().size());
+
+  // Remove an unknown cluster.
+  EXPECT_FALSE(cluster_manager_->removePrimaryCluster("foo"));
+}
+
+TEST_F(ClusterManagerImplTest, addOrUpdatePrimaryClusterStaticExists) {
+  std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "fake": ""
+    }]
+  }
+  )EOF";
+
+  MockCluster* cluster1 = new NiceMock<MockCluster>();
+  InSequence s;
+  EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster1));
+  ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
+  EXPECT_CALL(*cluster1, initialize());
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  create(*loader);
+
+  ReadyWatcher initialized;
+  cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
+
+  EXPECT_CALL(initialized, ready());
+  cluster1->initialize_callback_();
+
+  std::string json_api = R"EOF(
+  {
+    "name": "fake_cluster"
+  }
+  )EOF";
+
+  Json::ObjectPtr loader_api = Json::Factory::LoadFromString(json_api);
+  EXPECT_FALSE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
+
+  // Attempt to remove a static cluster.
+  EXPECT_FALSE(cluster_manager_->removePrimaryCluster("fake_cluster"));
 }
 
 TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
@@ -303,15 +477,17 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
 
   Network::DnsResolver::ResolveCb dns_callback;
-  Event::MockTimer* dns_timer_ = new NiceMock<Event::MockTimer>(&dns_resolver_.dispatcher_);
-  EXPECT_CALL(dns_resolver_, resolve(_, _)).WillRepeatedly(SaveArg<1>(&dns_callback));
+  Event::MockTimer* dns_timer_ = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
+  Network::MockActiveDnsQuery active_dns_query;
+  EXPECT_CALL(factory_.dns_resolver_, resolve(_, _))
+      .WillRepeatedly(DoAll(SaveArg<1>(&dns_callback), ReturnRef(active_dns_query)));
   create(*loader);
 
   // Test for no hosts returning the correct values before we have hosts.
   EXPECT_EQ(nullptr,
             cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default));
   EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1").connection_);
-  EXPECT_EQ(2UL, stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
+  EXPECT_EQ(2UL, factory_.stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
 
   // Set up for an initialize callback.
   ReadyWatcher initialized;
@@ -325,7 +501,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   EXPECT_CALL(initialized, ready());
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
-  EXPECT_CALL(*cluster_manager_, allocateConnPool_(_))
+  EXPECT_CALL(factory_, allocateConnPool_(_))
       .Times(4)
       .WillRepeatedly(ReturnNew<Http::ConnectionPool::MockInstance>());
 
@@ -353,7 +529,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   dns_callback({"127.0.0.2"});
   drained_cb();
   drained_cb = nullptr;
-  EXPECT_CALL(tls_.dispatcher_, deferredDelete_(_)).Times(2);
+  EXPECT_CALL(factory_.tls_.dispatcher_, deferredDelete_(_)).Times(2);
   drained_cb_high();
   drained_cb_high = nullptr;
 

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -38,6 +38,7 @@ protected:
     timer_ = new Event::MockTimer(&dispatcher_);
     cluster_.reset(new SdsClusterImpl(*config, runtime_, stats_, ssl_context_manager_, sds_config_,
                                       cm_, dispatcher_, random_));
+    EXPECT_EQ(Cluster::InitializePhase::Secondary, cluster_->initializePhase());
   }
 
   HostPtr findHost(const std::string& address) {
@@ -98,7 +99,7 @@ TEST_F(SdsTest, Shutdown) {
   setupRequest();
   cluster_->initialize();
   EXPECT_CALL(request_, cancel());
-  cluster_->shutdown();
+  cluster_.reset();
 }
 
 TEST_F(SdsTest, PoolFailure) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -27,31 +27,36 @@ static std::list<std::string> hostListToURLs(const std::vector<HostPtr>& hosts) 
 }
 
 struct ResolverData {
-  ResolverData(Network::MockDnsResolver& dns_resolver) {
-    timer_ = new Event::MockTimer(&dns_resolver.dispatcher_);
+  ResolverData(Network::MockDnsResolver& dns_resolver, Event::MockDispatcher& dispatcher) {
+    timer_ = new Event::MockTimer(&dispatcher);
     expectResolve(dns_resolver);
   }
 
   void expectResolve(Network::MockDnsResolver& dns_resolver) {
     EXPECT_CALL(dns_resolver, resolve(_, _))
         .WillOnce(Invoke([&](const std::string&, Network::DnsResolver::ResolveCb cb)
-                             -> void { dns_callback_ = cb; }))
+                             -> Network::ActiveDnsQuery& {
+                               dns_callback_ = cb;
+                               return active_dns_query_;
+                             }))
         .RetiresOnSaturation();
   }
 
   Event::MockTimer* timer_;
   Network::DnsResolver::ResolveCb dns_callback_;
+  Network::MockActiveDnsQuery active_dns_query_;
 };
 
 TEST(StrictDnsClusterImplTest, Basic) {
   Stats::IsolatedStoreImpl stats;
   Ssl::MockContextManager ssl_context_manager;
   NiceMock<Network::MockDnsResolver> dns_resolver;
+  NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
 
   // gmock matches in LIFO order which is why these are swapped.
-  ResolverData resolver2(dns_resolver);
-  ResolverData resolver1(dns_resolver);
+  ResolverData resolver2(dns_resolver, dispatcher);
+  ResolverData resolver1(dns_resolver, dispatcher);
 
   std::string json = R"EOF(
   {
@@ -82,7 +87,8 @@ TEST(StrictDnsClusterImplTest, Basic) {
   )EOF";
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
-  StrictDnsClusterImpl cluster(*loader, runtime, stats, ssl_context_manager, dns_resolver);
+  StrictDnsClusterImpl cluster(*loader, runtime, stats, ssl_context_manager, dns_resolver,
+                               dispatcher);
   EXPECT_EQ(43U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
   EXPECT_EQ(57U,
             cluster.info()->resourceManager(ResourcePriority::Default).pendingRequests().max());
@@ -144,6 +150,15 @@ TEST(StrictDnsClusterImplTest, Basic) {
   for (const HostPtr& host : cluster.hosts()) {
     EXPECT_EQ(cluster.info().get(), &host->cluster());
   }
+
+  // Make sure we cancel.
+  resolver1.expectResolve(dns_resolver);
+  resolver1.timer_->callback_();
+  resolver2.expectResolve(dns_resolver);
+  resolver2.timer_->callback_();
+
+  EXPECT_CALL(resolver1.active_dns_query_, cancel());
+  EXPECT_CALL(resolver2.active_dns_query_, cancel());
 }
 
 TEST(HostImplTest, HostCluster) {
@@ -319,7 +334,7 @@ TEST(StaticClusterImplTest, UrlConfig) {
   EXPECT_EQ(3U, cluster.info()->resourceManager(ResourcePriority::High).retries().max());
   EXPECT_EQ(0U, cluster.info()->maxRequestsPerConnection());
   EXPECT_EQ(0U, cluster.info()->httpCodecOptions());
-  EXPECT_EQ(LoadBalancerType::Random, cluster.lbType());
+  EXPECT_EQ(LoadBalancerType::Random, cluster.info()->lbType());
   EXPECT_THAT(std::list<std::string>({"tcp://10.0.0.1:11001", "tcp://10.0.0.2:11002"}),
               ContainerEq(hostListToURLs(cluster.hosts())));
   EXPECT_EQ(2UL, cluster.healthyHosts().size());

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -61,8 +61,11 @@ MockClientConnection::MockClientConnection() {
 
 MockClientConnection::~MockClientConnection() {}
 
+MockActiveDnsQuery::MockActiveDnsQuery() {}
+MockActiveDnsQuery::~MockActiveDnsQuery() {}
+
 MockDnsResolver::MockDnsResolver() {
-  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
+  ON_CALL(*this, resolve(_, _)).WillByDefault(ReturnRef(active_query_));
 }
 
 MockDnsResolver::~MockDnsResolver() {}

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -91,16 +91,24 @@ public:
   MOCK_METHOD0(connect, void());
 };
 
+class MockActiveDnsQuery : public ActiveDnsQuery {
+public:
+  MockActiveDnsQuery();
+  ~MockActiveDnsQuery();
+
+  // Network::ActiveDnsQuery
+  MOCK_METHOD0(cancel, void());
+};
+
 class MockDnsResolver : public DnsResolver {
 public:
   MockDnsResolver();
   ~MockDnsResolver();
 
   // Network::DnsResolver
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_METHOD2(resolve, void(const std::string& dns_name, ResolveCb callback));
+  MOCK_METHOD2(resolve, ActiveDnsQuery&(const std::string& dns_name, ResolveCb callback));
 
-  testing::NiceMock<Event::MockDispatcher> dispatcher_;
+  testing::NiceMock<MockActiveDnsQuery> active_query_;
 };
 
 class MockReadFilterCallbacks : public ReadFilterCallbacks {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -53,6 +53,7 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke([this](ResourcePriority)
                                 -> Upstream::ResourceManager& { return *resource_manager_; }));
+  ON_CALL(*this, lbType()).WillByDefault(Return(Upstream::LoadBalancerType::RoundRobin));
 }
 
 MockClusterInfo::~MockClusterInfo() {}
@@ -65,7 +66,11 @@ MockCluster::MockCluster() {
   ON_CALL(*this, hostsPerZone()).WillByDefault(ReturnRef(hosts_per_zone_));
   ON_CALL(*this, healthyHostsPerZone()).WillByDefault(ReturnRef(healthy_hosts_per_zone_));
   ON_CALL(*this, info()).WillByDefault(Return(info_));
-  ON_CALL(*this, lbType()).WillByDefault(Return(Upstream::LoadBalancerType::RoundRobin));
+  ON_CALL(*this, setInitializedCb(_))
+      .WillByDefault(Invoke([this](std::function<void()> callback) -> void {
+        EXPECT_EQ(nullptr, initialize_callback_);
+        initialize_callback_ = callback;
+      }));
 }
 
 MockCluster::~MockCluster() {}

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -25,6 +25,7 @@ public:
   MOCK_CONST_METHOD0(connectTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(features, uint64_t());
   MOCK_CONST_METHOD0(httpCodecOptions, uint64_t());
+  MOCK_CONST_METHOD0(lbType, LoadBalancerType());
   MOCK_CONST_METHOD0(maintenanceMode, bool());
   MOCK_CONST_METHOD0(maxRequestsPerConnection, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());
@@ -33,9 +34,9 @@ public:
   MOCK_CONST_METHOD0(statPrefix, const std::string&());
   MOCK_CONST_METHOD0(stats, ClusterStats&());
 
-  const std::string name_{"fake_cluster"};
-  const std::string alt_stat_name_{"fake_alt_cluster"};
-  const std::string stat_prefix_{"cluster.fake_cluster."};
+  std::string name_{"fake_cluster"};
+  std::string alt_stat_name_{"fake_alt_cluster"};
+  std::string stat_prefix_{"cluster.fake_cluster."};
   uint64_t max_requests_per_connection_{};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStats stats_;
@@ -63,9 +64,9 @@ public:
 
   // Upstream::Cluster
   MOCK_CONST_METHOD0(info, ClusterInfoPtr());
-  MOCK_CONST_METHOD0(lbType, LoadBalancerType());
+  MOCK_METHOD0(initialize, void());
+  MOCK_CONST_METHOD0(initializePhase, InitializePhase());
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
-  MOCK_METHOD0(shutdown, void());
 
   std::vector<HostPtr> hosts_;
   std::vector<HostPtr> healthy_hosts_;
@@ -73,6 +74,7 @@ public:
   std::vector<std::vector<HostPtr>> healthy_hosts_per_zone_;
   std::list<MemberUpdateCb> callbacks_;
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+  std::function<void()> initialize_callback_;
 };
 
 class MockClusterManager : public ClusterManager {
@@ -86,13 +88,15 @@ public:
   }
 
   // Upstream::ClusterManager
+  MOCK_METHOD1(addOrUpdatePrimaryCluster, bool(const Json::Object& config));
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
-  MOCK_METHOD0(clusters, std::unordered_map<std::string, ConstClusterPtr>());
+  MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ClusterInfoPtr(const std::string& cluster));
   MOCK_METHOD2(httpConnPoolForCluster, Http::ConnectionPool::Instance*(const std::string& cluster,
                                                                        ResourcePriority priority));
   MOCK_METHOD1(tcpConnForCluster_, MockHost::MockCreateConnectionData(const std::string& cluster));
   MOCK_METHOD1(httpAsyncClientForCluster, Http::AsyncClient&(const std::string& cluster));
+  MOCK_METHOD1(removePrimaryCluster, bool(const std::string& cluster));
   MOCK_METHOD0(shutdown, void());
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;


### PR DESCRIPTION
This is all of the plumbing required to support the CDS API. I will do the
actual polling API in a follow up as this change is large enough as it is
(it's also missing stats and some debug logging which I will also do in a follow
up).

What this change does:
1) Add 2 new CM APIs which allow clusters to be added and removed at runtime.
2) Changes the ownership logic of clusters such that primary clusters are now
   a unique_ptr and are inline destroyed on the main thread. Workers only have
   access to the backing shared ClusterInfo.
3) Fixes DNS so that requests can be cancelled and correctly implements cancel
   in the relevant cluster destructors.
4) Most of this change is actually a refactor so that the CM only interacts with
   the cluster interface. Otherwise testing all of the required scenarios is
   too complicated. With the refactor done it's much easier to test all of the
   different scenarios. This required generalizing a few things about how we
   were initializing SDS clusters.

A few notes about this implementation:
1) Dynamic clusters are immediately added, without any initialize phase. This means
   that there will be a period of fetching/HC for dynamic clusters depending on the
   configuration.
2) There are no integration tests. We should add those in the future.