### PR TITLE
grpc bridge: set content-length on response

### DIFF
--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -84,7 +84,7 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::HeaderMap& tr
     }
 
     // Since we are buffering, set content-length so that HTTP/1.1 callers can better determine
-    // if this is a complete request.
+    // if this is a complete response.
     response_headers_->insertContentLength().value(
         encoder_callbacks_->encodingBuffer() ? encoder_callbacks_->encodingBuffer()->length() : 0);
   }

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -82,6 +82,11 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::HeaderMap& tr
     if (grpc_message_header) {
       response_headers_->insertGrpcMessage().value(*grpc_message_header);
     }
+
+    // Since we are buffering, set content-length so that HTTP/1.1 callers can better determine
+    // if this is a complete request.
+    response_headers_->insertContentLength().value(
+        encoder_callbacks_->encodingBuffer() ? encoder_callbacks_->encodingBuffer()->length() : 0);
   }
 
   // NOTE: We will still write the trailers, but the HTTP/1.1 codec will just eat them and end

--- a/source/common/grpc/http1_bridge_filter.h
+++ b/source/common/grpc/http1_bridge_filter.h
@@ -27,7 +27,9 @@ public:
   Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap& trailers) override;
-  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks&) override {}
+  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override {
+    encoder_callbacks_ = &callbacks;
+  }
 
 private:
   void chargeStat(const Http::HeaderMap& headers);
@@ -35,6 +37,7 @@ private:
 
   Stats::Store& stats_store_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+  Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   Http::HeaderMap* response_headers_{};
   bool do_bridging_{};
   bool do_stat_tracking_{};


### PR DESCRIPTION
This can help HTTP/1.1 clients understand if they got a truncated
response.