### PR TITLE
local info: refactor information about the local env

### DIFF
--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -5,15 +5,30 @@
 namespace LocalInfo {
 
 /**
- *
+ * Information about the local environment.
  */
 class LocalInfo {
 public:
   virtual ~LocalInfo() {}
 
+  /**
+   * Human readable network address.
+   */
   virtual const std::string& address() const PURE;
+
+  /**
+   * Human readable zone name.
+   */
   virtual const std::string& zoneName() const PURE;
+
+  /**
+   * Human readable cluster name.
+   */
   virtual const std::string& clusterName() const PURE;
+
+  /**
+   * Human readable individual node name.
+   */
   virtual const std::string& nodeName() const PURE;
 };
 

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -12,22 +12,22 @@ public:
   virtual ~LocalInfo() {}
 
   /**
-   * Human readable network address.
+   * Human readable network address. E.g., "127.0.0.1".
    */
   virtual const std::string& address() const PURE;
 
   /**
-   * Human readable zone name.
+   * Human readable zone name. E.g., "us-east-1a".
    */
   virtual const std::string& zoneName() const PURE;
 
   /**
-   * Human readable cluster name.
+   * Human readable cluster name. E.g., "eta".
    */
   virtual const std::string& clusterName() const PURE;
 
   /**
-   * Human readable individual node name.
+   * Human readable individual node name. E.g., "i-123456".
    */
   virtual const std::string& nodeName() const PURE;
 };

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace LocalInfo {
+
+/**
+ *
+ */
+class LocalInfo {
+public:
+  virtual ~LocalInfo() {}
+
+  virtual const std::string& address() const PURE;
+  virtual const std::string& zoneName() const PURE;
+  virtual const std::string& clusterName() const PURE;
+  virtual const std::string& nodeName() const PURE;
+};
+
+} // LocalInfo

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -2,6 +2,7 @@
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/api/api.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/admin.h"
@@ -160,9 +161,9 @@ public:
   virtual ThreadLocal::Instance& threadLocal() PURE;
 
   /**
-   * @return the local IP address of the server
+   * @return information about the local environment the server is running in.
    */
-  virtual const std::string& getLocalAddress() PURE;
+  virtual const LocalInfo::LocalInfo& localInfo() PURE;
 };
 
 } // Server

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -51,21 +51,6 @@ public:
   virtual uint64_t restartEpoch() PURE;
 
   /**
-   * @return const std::string& the service cluster name where the server is running.
-   */
-  virtual const std::string& serviceClusterName() PURE;
-
-  /**
-   * @return const std::string& the service node name where the server is running.
-   */
-  virtual const std::string& serviceNodeName() PURE;
-
-  /**
-   * @return const std::string& the service zone where the server is running.
-   */
-  virtual const std::string& serviceZone() PURE;
-
-  /**
     * @return std::chrono::milliseconds the duration in msec between log flushes.
     */
   virtual std::chrono::milliseconds fileFlushIntervalMsec() PURE;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -90,7 +90,6 @@ public:
  * Global configuration for any SDS clusters.
  */
 struct SdsConfig {
-  std::string local_zone_name_;
   std::string sds_cluster_name_;
   std::chrono::milliseconds refresh_delay_;
 };

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -23,10 +23,9 @@ class AsyncRequestImpl;
 class AsyncClientImpl final : public AsyncClient {
 public:
   AsyncClientImpl(const Upstream::ClusterInfo& cluster, Stats::Store& stats_store,
-                  Event::Dispatcher& dispatcher, const std::string& local_zone_name,
+                  Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info,
                   Upstream::ClusterManager& cm, Runtime::Loader& runtime,
-                  Runtime::RandomGenerator& random, Router::ShadowWriterPtr&& shadow_writer,
-                  const std::string& local_address);
+                  Runtime::RandomGenerator& random, Router::ShadowWriterPtr&& shadow_writer);
   ~AsyncClientImpl();
 
   // Http::AsyncClient
@@ -38,7 +37,6 @@ private:
   Router::FilterConfig config_;
   Event::Dispatcher& dispatcher_;
   std::list<std::unique_ptr<AsyncRequestImpl>> active_requests_;
-  const std::string local_address_;
 
   friend class AsyncRequestImpl;
 };

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -30,8 +30,8 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
               fmt::format("ratelimit.{}.http_filter_enabled", route_key), 100)) {
         continue;
       }
-      rate_limit.populateDescriptors(*route, descriptors, config_->localServiceCluster(), headers,
-                                     callbacks_->downstreamAddress());
+      rate_limit.populateDescriptors(*route, descriptors, config_->localInfo().clusterName(),
+                                     headers, callbacks_->downstreamAddress());
     }
 
     if (!descriptors.empty()) {

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/filter.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/runtime/runtime.h"
 
@@ -15,14 +16,13 @@ namespace RateLimit {
  */
 class FilterConfig {
 public:
-  FilterConfig(const Json::Object& config, const std::string& local_service_cluster,
+  FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
                Stats::Store& stats_store, Runtime::Loader& runtime)
       : domain_(config.getString("domain")), stage_(config.getInteger("stage", 0)),
-        local_service_cluster_(local_service_cluster), stats_store_(stats_store),
-        runtime_(runtime) {}
+        local_info_(local_info), stats_store_(stats_store), runtime_(runtime) {}
 
   const std::string& domain() const { return domain_; }
-  const std::string& localServiceCluster() const { return local_service_cluster_; }
+  const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   int64_t stage() const { return stage_; }
   Runtime::Loader& runtime() { return runtime_; }
   Stats::Store& stats() { return stats_store_; }
@@ -30,7 +30,7 @@ public:
 private:
   const std::string domain_;
   int64_t stage_;
-  const std::string local_service_cluster_;
+  const LocalInfo::LocalInfo& local_info_;
   Stats::Store& stats_store_;
   Runtime::Loader& runtime_;
 };

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "envoy/local_info/local_info.h"
+
+namespace LocalInfo {
+
+class LocalInfoImpl : public LocalInfo {
+public:
+  LocalInfoImpl(const std::string address, const std::string zone_name,
+                const std::string cluster_name, const std::string node_name)
+      : address_(address), zone_name_(zone_name), cluster_name_(cluster_name),
+        node_name_(node_name) {}
+
+  const std::string& address() const override { return address_; }
+  const std::string& zoneName() const override { return zone_name_; }
+  const std::string& clusterName() const override { return cluster_name_; }
+  const std::string& nodeName() const override { return node_name_; }
+
+private:
+  const std::string address_;
+  const std::string zone_name_;
+  const std::string cluster_name_;
+  const std::string node_name_;
+};
+
+} // LocalInfo

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -109,14 +109,14 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
     Http::CodeUtility::ResponseStatInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_headers, internal_request,
         route_->virtualHost().name(), request_vcluster_ ? request_vcluster_->name() : "",
-        config_.service_zone_, upstreamZone(upstream_host), is_canary};
+        config_.local_info_.zoneName(), upstreamZone(upstream_host), is_canary};
 
     Http::CodeUtility::chargeResponseStat(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
-      Http::CodeUtility::ResponseStatInfo info{config_.stats_store_, alt_prefix, response_headers,
-                                               internal_request, "", "", config_.service_zone_,
-                                               upstreamZone(upstream_host), is_canary};
+      Http::CodeUtility::ResponseStatInfo info{
+          config_.stats_store_, alt_prefix, response_headers, internal_request, "", "",
+          config_.local_info_.zoneName(), upstreamZone(upstream_host), is_canary};
 
       Http::CodeUtility::chargeResponseStat(info);
     }
@@ -481,16 +481,16 @@ void Filter::onUpstreamComplete() {
     Http::CodeUtility::ResponseTimingInfo info{
         config_.stats_store_, cluster_->statPrefix(), response_time,
         upstream_request_->upstream_canary_, internal_request, route_->virtualHost().name(),
-        request_vcluster_ ? request_vcluster_->name() : "", config_.service_zone_,
+        request_vcluster_ ? request_vcluster_->name() : "", config_.local_info_.zoneName(),
         upstreamZone(upstream_request_->upstream_host_)};
 
     Http::CodeUtility::chargeResponseTiming(info);
 
     for (const std::string& alt_prefix : alt_stat_prefixes_) {
-      Http::CodeUtility::ResponseTimingInfo info{config_.stats_store_, alt_prefix, response_time,
-                                                 upstream_request_->upstream_canary_,
-                                                 internal_request, "", "", config_.service_zone_,
-                                                 upstreamZone(upstream_request_->upstream_host_)};
+      Http::CodeUtility::ResponseTimingInfo info{
+          config_.stats_store_, alt_prefix, response_time, upstream_request_->upstream_canary_,
+          internal_request, "", "", config_.local_info_.zoneName(),
+          upstreamZone(upstream_request_->upstream_host_)};
 
       Http::CodeUtility::chargeResponseTiming(info);
     }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -3,6 +3,7 @@
 #include "envoy/http/codec.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/router/shadow_writer.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"
@@ -69,18 +70,18 @@ public:
  */
 class FilterConfig {
 public:
-  FilterConfig(const std::string& stat_prefix, const std::string& service_zone, Stats::Store& stats,
-               Upstream::ClusterManager& cm, Runtime::Loader& runtime,
+  FilterConfig(const std::string& stat_prefix, const LocalInfo::LocalInfo& local_info,
+               Stats::Store& stats, Upstream::ClusterManager& cm, Runtime::Loader& runtime,
                Runtime::RandomGenerator& random, ShadowWriterPtr&& shadow_writer,
                bool emit_dynamic_stats)
-      : stats_store_(stats), service_zone_(service_zone), cm_(cm), runtime_(runtime),
-        random_(random), stats_{ALL_ROUTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))},
+      : stats_store_(stats), local_info_(local_info), cm_(cm), runtime_(runtime), random_(random),
+        stats_{ALL_ROUTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))},
         emit_dynamic_stats_(emit_dynamic_stats), shadow_writer_(std::move(shadow_writer)) {}
 
   ShadowWriter& shadowWriter() { return *shadow_writer_; }
 
   Stats::Store& stats_store_;
-  const std::string service_zone_;
+  const LocalInfo::LocalInfo& local_info_;
   Upstream::ClusterManager& cm_;
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -54,17 +54,17 @@ void UdpStatsdSink::onTimespanComplete(const std::string& name, std::chrono::mil
   writer().writeTimer(name, ms);
 }
 
-TcpStatsdSink::TcpStatsdSink(const std::string& stat_cluster, const std::string& stat_host,
+TcpStatsdSink::TcpStatsdSink(const LocalInfo::LocalInfo& local_info,
                              const std::string& cluster_name, ThreadLocal::Instance& tls,
                              Upstream::ClusterManager& cluster_manager)
-    : stat_cluster_(stat_cluster), stat_host_(stat_host), cluster_name_(cluster_name), tls_(tls),
+    : local_info_(local_info), cluster_name_(cluster_name), tls_(tls),
       tls_slot_(tls.allocateSlot()), cluster_manager_(cluster_manager) {
 
   if (!cluster_manager.get(cluster_name)) {
     throw EnvoyException(fmt::format("unknown TCP statsd upstream cluster: {}", cluster_name));
   }
 
-  if (stat_cluster.empty() || stat_host.empty()) {
+  if (local_info_.clusterName().empty() || local_info_.nodeName().empty()) {
     throw EnvoyException(
         fmt::format("TCP statsd requires setting --service-cluster and --service-node"));
   }

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/local_info/local_info.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
 #include "envoy/thread_local/thread_local.h"
@@ -56,9 +57,8 @@ private:
  */
 class TcpStatsdSink : public Sink {
 public:
-  TcpStatsdSink(const std::string& stat_cluster, const std::string& stat_host,
-                const std::string& cluster_name, ThreadLocal::Instance& tls,
-                Upstream::ClusterManager& cluster_manager);
+  TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
+                ThreadLocal::Instance& tls, Upstream::ClusterManager& cluster_manager);
 
   // Stats::Sink
   void flushCounter(const std::string& name, uint64_t delta) override {
@@ -100,8 +100,7 @@ private:
     bool shutdown_{};
   };
 
-  std::string stat_cluster_;
-  std::string stat_host_;
+  const LocalInfo::LocalInfo& local_info_;
   std::string cluster_name_;
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
@@ -101,8 +102,9 @@ private:
 class LightStepSink : public HttpSink {
 public:
   LightStepSink(const Json::Object& config, Upstream::ClusterManager& cluster_manager,
-                Stats::Store& stats, const std::string& service_node, ThreadLocal::Instance& tls,
-                Runtime::Loader& runtime, std::unique_ptr<lightstep::TracerOptions> options);
+                Stats::Store& stats, const LocalInfo::LocalInfo& local_info,
+                ThreadLocal::Instance& tls, Runtime::Loader& runtime,
+                std::unique_ptr<lightstep::TracerOptions> options);
 
   // Tracer::HttpSink
   void flushTrace(const Http::HeaderMap& request_headers, const Http::HeaderMap& response_headers,
@@ -133,7 +135,7 @@ private:
   Upstream::ClusterManager& cm_;
   Stats::Store& stats_store_;
   LightstepTracerStats tracer_stats_;
-  const std::string service_node_;
+  const LocalInfo::LocalInfo& local_info_;
   ThreadLocal::Instance& tls_;
   Runtime::Loader& runtime_;
   std::unique_ptr<lightstep::TracerOptions> options_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -17,12 +17,10 @@ namespace Upstream {
 ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManagerFactory& factory,
                                        Stats::Store& stats, ThreadLocal::Instance& tls,
                                        Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-                                       const std::string& local_zone_name,
-                                       const std::string& local_address,
+                                       const LocalInfo::LocalInfo& local_info,
                                        AccessLog::AccessLogManager& log_manager)
     : factory_(factory), runtime_(runtime), stats_(stats), tls_(tls), random_(random),
-      thread_local_slot_(tls.allocateSlot()), local_zone_name_(local_zone_name),
-      local_address_(local_address) {
+      thread_local_slot_(tls.allocateSlot()), local_info_(local_info) {
 
   std::vector<Json::ObjectPtr> clusters = config.getObjectArray("clusters");
   pending_cluster_init_ = clusters.size();
@@ -41,7 +39,7 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
     loadCluster(*config.getObject("sds")->getObject("cluster"), false);
 
     SdsConfig sds_config{
-        local_zone_name, config.getObject("sds")->getObject("cluster")->getString("name"),
+        config.getObject("sds")->getObject("cluster")->getString("name"),
         std::chrono::milliseconds(config.getObject("sds")->getInteger("refresh_delay_ms"))};
 
     sds_config_.value(sds_config);
@@ -328,10 +326,9 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     ThreadLocalClusterManagerImpl& parent, ClusterInfoPtr cluster)
     : parent_(parent), cluster_info_(cluster),
       http_async_client_(*cluster, parent.parent_.stats_, parent.thread_local_dispatcher_,
-                         parent.parent_.local_zone_name_, parent.parent_, parent.parent_.runtime_,
+                         parent.parent_.local_info_, parent.parent_, parent.parent_.runtime_,
                          parent.parent_.random_,
-                         Router::ShadowWriterPtr{new Router::ShadowWriterImpl(parent.parent_)},
-                         parent.parent_.local_address_) {
+                         Router::ShadowWriterPtr{new Router::ShadowWriterImpl(parent.parent_)}) {
 
   switch (cluster->lbType()) {
   case LoadBalancerType::LeastRequest: {
@@ -402,7 +399,7 @@ ProdClusterManagerFactory::clusterFromJson(const Json::Object& cluster, ClusterM
                                            const Optional<SdsConfig>& sds_config,
                                            Outlier::EventLoggerPtr outlier_event_logger) {
   return ClusterImplBase::create(cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_,
-                                 runtime_, random_, primary_dispatcher_, sds_config,
+                                 runtime_, random_, primary_dispatcher_, sds_config, local_info_,
                                  outlier_event_logger);
 }
 

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -17,10 +17,12 @@ namespace Upstream {
 
 SdsClusterImpl::SdsClusterImpl(const Json::Object& config, Runtime::Loader& runtime,
                                Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
-                               const SdsConfig& sds_config, ClusterManager& cm,
-                               Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random)
+                               const SdsConfig& sds_config, const LocalInfo::LocalInfo& local_info,
+                               ClusterManager& cm, Event::Dispatcher& dispatcher,
+                               Runtime::RandomGenerator& random)
     : BaseDynamicClusterImpl(config, runtime, stats, ssl_context_manager), cm_(cm),
-      sds_config_(sds_config), service_name_(config.getString("service_name")), random_(random),
+      sds_config_(sds_config), local_info_(local_info),
+      service_name_(config.getString("service_name")), random_(random),
       refresh_timer_(dispatcher.createTimer([this]() -> void { refreshHosts(); })) {}
 
 SdsClusterImpl::~SdsClusterImpl() {
@@ -80,7 +82,7 @@ void SdsClusterImpl::parseSdsResponse(Http::Message& response) {
     HostListsPtr per_zone(new std::vector<std::vector<HostPtr>>());
 
     // If local zone name is not defined then skip populating per zone hosts.
-    if (!sds_config_.local_zone_name_.empty()) {
+    if (!local_info_.zoneName().empty()) {
       std::map<std::string, std::vector<HostPtr>> hosts_per_zone;
 
       for (HostPtr host : *current_hosts_copy) {
@@ -88,11 +90,11 @@ void SdsClusterImpl::parseSdsResponse(Http::Message& response) {
       }
 
       // Populate per_zone hosts only if upstream cluster has hosts in the same zone.
-      if (hosts_per_zone.find(sds_config_.local_zone_name_) != hosts_per_zone.end()) {
-        per_zone->push_back(hosts_per_zone[sds_config_.local_zone_name_]);
+      if (hosts_per_zone.find(local_info_.zoneName()) != hosts_per_zone.end()) {
+        per_zone->push_back(hosts_per_zone[local_info_.zoneName()]);
 
         for (auto& entry : hosts_per_zone) {
-          if (sds_config_.local_zone_name_ != entry.first) {
+          if (local_info_.zoneName() != entry.first) {
             per_zone->push_back(entry.second);
           }
         }

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -3,6 +3,7 @@
 #include "upstream_impl.h"
 
 #include "envoy/http/async_client.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -15,8 +16,8 @@ class SdsClusterImpl : public BaseDynamicClusterImpl, public Http::AsyncClient::
 public:
   SdsClusterImpl(const Json::Object& config, Runtime::Loader& runtime, Stats::Store& stats,
                  Ssl::ContextManager& ssl_context_manager, const SdsConfig& sds_config,
-                 ClusterManager& cm, Event::Dispatcher& dispatcher,
-                 Runtime::RandomGenerator& random);
+                 const LocalInfo::LocalInfo& local_info, ClusterManager& cm,
+                 Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random);
 
   ~SdsClusterImpl();
 
@@ -35,6 +36,7 @@ private:
 
   ClusterManager& cm_;
   const SdsConfig& sds_config_;
+  const LocalInfo::LocalInfo& local_info_;
   const std::string service_name_;
   Runtime::RandomGenerator& random_;
   Event::TimerPtr refresh_timer_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -92,6 +92,7 @@ ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& 
                                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                                    Event::Dispatcher& dispatcher,
                                    const Optional<SdsConfig>& sds_config,
+                                   const LocalInfo::LocalInfo& local_info,
                                    Outlier::EventLoggerPtr outlier_event_logger) {
   std::unique_ptr<ClusterImplBase> new_cluster;
   std::string string_type = cluster.getString("type");
@@ -109,7 +110,7 @@ ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& 
     }
 
     new_cluster.reset(new SdsClusterImpl(cluster, runtime, stats, ssl_context_manager,
-                                         sds_config.value(), cm, dispatcher, random));
+                                         sds_config.value(), local_info, cm, dispatcher, random));
   } else {
     throw EnvoyException(fmt::format("cluster: unknown cluster type '{}'", string_type));
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -4,6 +4,7 @@
 #include "resource_manager_impl.h"
 
 #include "envoy/event/timer.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/network/dns.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/ssl/context_manager.h"
@@ -219,6 +220,7 @@ public:
                            Ssl::ContextManager& ssl_context_manager, Runtime::Loader& runtime,
                            Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                            const Optional<SdsConfig>& sds_config,
+                           const LocalInfo::LocalInfo& local_info,
                            Outlier::EventLoggerPtr outlier_event_logger);
 
   /**

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,6 +1,8 @@
 #include "hot_restart.h"
 
 #include "common/event/libevent.h"
+#include "common/local_info/local_info_impl.h"
+#include "common/network/utility.h"
 #include "common/ssl/openssl.h"
 #include "server/drain_manager_impl.h"
 #include "server/options_impl.h"
@@ -41,8 +43,10 @@ int main(int argc, char** argv) {
   DefaultTestHooks default_test_hooks;
   Stats::ThreadLocalStoreImpl stats_store(restarter->statLock(), *restarter);
   Server::ProdComponentFactory component_factory;
+  LocalInfo::LocalInfoImpl local_info(Network::Utility::getLocalAddress(), options.serviceZone(),
+                                      options.serviceClusterName(), options.serviceNodeName());
   Server::InstanceImpl server(options, default_test_hooks, *restarter, stats_store,
-                              restarter->accessLogLock(), component_factory);
+                              restarter->accessLogLock(), component_factory, local_info);
   server.run();
   return 0;
 }

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -19,7 +19,7 @@ public:
     }
 
     Http::RateLimit::FilterConfigPtr filter_config(new Http::RateLimit::FilterConfig(
-        config, server.options().serviceClusterName(), server.stats(), server.runtime()));
+        config, server.localInfo(), server.stats(), server.runtime()));
     return [filter_config, &server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::RateLimit::Filter(
           filter_config, server.rateLimitClient(std::chrono::milliseconds(20)))});

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -19,8 +19,8 @@ public:
     }
 
     Router::FilterConfigPtr config(new Router::FilterConfig(
-        stat_prefix, server.options().serviceZone(), server.stats(), server.clusterManager(),
-        server.runtime(), server.random(),
+        stat_prefix, server.localInfo(), server.stats(), server.clusterManager(), server.runtime(),
+        server.random(),
         Router::ShadowWriterPtr{new Router::ShadowWriterImpl(server.clusterManager())},
         json_config.getBoolean("dynamic_stats", true)));
 

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -84,7 +84,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
   }
 
   if (config.hasObject("add_user_agent") && config.getBoolean("add_user_agent")) {
-    user_agent_.value(server.options().serviceClusterName());
+    user_agent_.value(server.localInfo().clusterName());
   }
 
   if (config.hasObject("tracing")) {
@@ -199,7 +199,9 @@ HttpFilterType HttpConnectionManagerConfig::stringToType(const std::string& type
   }
 }
 
-const std::string& HttpConnectionManagerConfig::localAddress() { return server_.getLocalAddress(); }
+const std::string& HttpConnectionManagerConfig::localAddress() {
+  return server_.localInfo().address();
+}
 
 } // Configuration
 } // Server

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -361,6 +361,6 @@ Http::Code AdminImpl::runCallback(const std::string& path, Buffer::Instance& res
   return code;
 }
 
-const std::string& AdminImpl::localAddress() { return server_.getLocalAddress(); }
+const std::string& AdminImpl::localAddress() { return server_.localInfo().address(); }
 
 } // Server

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -115,7 +115,7 @@ Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& head
           static_cast<Http::Code>(Http::Utility::getResponseStatus(headers)));
     }
 
-    headers.insertEnvoyUpstreamHealthCheckedCluster().value(server_.options().serviceClusterName());
+    headers.insertEnvoyUpstreamHealthCheckedCluster().value(server_.localInfo().clusterName());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -10,6 +10,10 @@ public:
   OptionsImpl(int argc, char** argv, const std::string& hot_restart_version,
               spdlog::level::level_enum default_log_level);
 
+  const std::string& serviceClusterName() { return service_cluster_; }
+  const std::string& serviceNodeName() { return service_node_; }
+  const std::string& serviceZone() { return service_zone_; }
+
   // Server::Options
   uint64_t baseId() { return base_id_; }
   uint32_t concurrency() override { return concurrency_; }
@@ -18,9 +22,6 @@ public:
   spdlog::level::level_enum logLevel() override { return log_level_; }
   std::chrono::seconds parentShutdownTime() override { return parent_shutdown_time_; }
   uint64_t restartEpoch() override { return restart_epoch_; }
-  const std::string& serviceClusterName() override { return service_cluster_; }
-  const std::string& serviceNodeName() override { return service_node_; }
-  const std::string& serviceZone() override { return service_zone_; }
   std::chrono::milliseconds fileFlushIntervalMsec() override { return file_flush_interval_msec_; }
 
 private:

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -14,7 +14,6 @@
 #include "common/common/utility.h"
 #include "common/common/version.h"
 #include "common/memory/stats.h"
-#include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/stats/stats_impl.h"
 #include "common/stats/statsd.h"
@@ -23,13 +22,13 @@ namespace Server {
 
 InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& restarter,
                            Stats::Store& store, Thread::BasicLockable& access_log_lock,
-                           ComponentFactory& component_factory)
+                           ComponentFactory& component_factory,
+                           const LocalInfo::LocalInfo& local_info)
     : options_(options), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_), stats_store_(store),
       server_stats_{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))},
       handler_(stats_store_, log(), Api::ApiPtr{new Api::Impl(options.fileFlushIntervalMsec())}),
-      dns_resolver_(handler_.dispatcher().createDnsResolver()),
-      local_address_(Network::Utility::getLocalAddress()),
+      dns_resolver_(handler_.dispatcher().createDnsResolver()), local_info_(local_info),
       access_log_manager_(handler_.api(), handler_.dispatcher(), access_log_lock, store) {
 
   failHealthcheck(false);
@@ -40,7 +39,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   }
   server_stats_.version_.set(version_int);
 
-  if (local_address_.empty()) {
+  if (local_info_.address().empty()) {
     throw EnvoyException("could not resolve local address");
   }
 
@@ -238,7 +237,7 @@ Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
     log().info("runtime subdirectory: {}", config.runtime()->subdirectory());
 
     std::string override_subdirectory =
-        config.runtime()->overrideSubdirectory() + "/" + server.options().serviceClusterName();
+        config.runtime()->overrideSubdirectory() + "/" + server.localInfo().clusterName();
     log().info("runtime override subdirectory: {}", override_subdirectory);
 
     return Runtime::LoaderPtr{new Runtime::LoaderImpl(
@@ -258,9 +257,9 @@ void InstanceImpl::initializeStatSinks() {
 
   if (config_->statsdTcpClusterName().valid()) {
     log().info("statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
-    stat_sinks_.emplace_back(new Stats::Statsd::TcpStatsdSink(
-        options_.serviceClusterName(), options_.serviceNodeName(),
-        config_->statsdTcpClusterName().value(), thread_local_, config_->clusterManager()));
+    stat_sinks_.emplace_back(
+        new Stats::Statsd::TcpStatsdSink(local_info_, config_->statsdTcpClusterName().value(),
+                                         thread_local_, config_->clusterManager()));
     stats_store_.addSink(*stat_sinks_.back());
   }
 }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -74,7 +74,8 @@ public:
 class InstanceImpl : Logger::Loggable<Logger::Id::main>, public Instance {
 public:
   InstanceImpl(Options& options, TestHooks& hooks, HotRestart& restarter, Stats::Store& store,
-               Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory);
+               Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory,
+               const LocalInfo::LocalInfo& local_info);
   ~InstanceImpl();
 
   void run();
@@ -109,7 +110,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Tracing::HttpTracer& httpTracer() override;
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
-  const std::string& getLocalAddress() override { return local_address_; }
+  const LocalInfo::LocalInfo& localInfo() override { return local_info_; }
 
 private:
   void flushStats();
@@ -138,7 +139,7 @@ private:
   Event::SignalEventPtr sig_hup_;
   Network::DnsResolverPtr dns_resolver_;
   Event::TimerPtr stat_flush_timer_;
-  const std::string local_address_;
+  const LocalInfo::LocalInfo& local_info_;
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
   DrainManagerPtr drain_manager_;
   AccessLog::AccessLogManagerImpl access_log_manager_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(envoy-test
   mocks/filesystem/mocks.cc
   mocks/grpc/mocks.cc
   mocks/http/mocks.cc
+  mocks/local_info/mocks.cc
   mocks/network/mocks.cc
   mocks/ratelimit/mocks.cc
   mocks/router/mocks.cc

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -5,6 +5,7 @@
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/ratelimit/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/test_common/utility.h"
@@ -34,7 +35,7 @@ public:
 
   void SetUpTest(const std::string json) {
     Json::ObjectPtr config = Json::Factory::LoadFromString(json);
-    config_.reset(new FilterConfig(*config, "service_cluster", stats_store_, runtime_));
+    config_.reset(new FilterConfig(*config, local_info_, stats_store_, runtime_));
 
     client_ = new ::RateLimit::MockClient();
     filter_.reset(new Filter(config_, ::RateLimit::ClientPtr{client_}));
@@ -61,6 +62,7 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Router::MockRateLimitPolicyEntry> rate_limit_policy_entry_;
   std::vector<::RateLimit::Descriptor> descriptor_{{{{"descriptor_key", "descriptor_value"}}}};
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 TEST_F(HttpRateLimitFilterTest, NoRoute) {

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -2,6 +2,7 @@
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/buffer/mocks.h"
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -17,12 +18,13 @@ class TcpStatsdSinkTest : public testing::Test {
 public:
   TcpStatsdSinkTest() {
     EXPECT_CALL(cluster_manager_, get("statsd"));
-    sink_.reset(new TcpStatsdSink("cluster", "host", "statsd", tls_, cluster_manager_));
+    sink_.reset(new TcpStatsdSink(local_info_, "statsd", tls_, cluster_manager_));
   }
 
   NiceMock<ThreadLocal::MockInstance> tls_;
   Upstream::MockClusterManager cluster_manager_;
   std::unique_ptr<TcpStatsdSink> sink_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 TEST_F(TcpStatsdSinkTest, All) {

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -5,6 +5,7 @@
 #include "common/tracing/http_tracer_impl.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
@@ -318,7 +319,7 @@ public:
     }
 
     sink_.reset(
-        new LightStepSink(config, cm_, stats_, "service_node", tls_, runtime_, std::move(opts)));
+        new LightStepSink(config, cm_, stats_, local_info_, tls_, runtime_, std::move(opts)));
   }
 
   void setupValidSink() {
@@ -347,6 +348,7 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<MockTracingContext> context_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 TEST_F(LightStepSinkTest, InitializeSink) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
@@ -34,7 +35,7 @@ public:
                                   Outlier::EventLoggerPtr outlier_event_logger) -> Cluster* {
           return ClusterImplBase::create(cluster, cm, stats_, tls_, dns_resolver_,
                                          ssl_context_manager_, runtime_, random_, dispatcher_,
-                                         sds_config, outlier_event_logger).release();
+                                         sds_config, local_info_, outlier_event_logger).release();
         }));
   }
 
@@ -61,14 +62,15 @@ public:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Ssl::ContextManagerImpl ssl_context_manager_{runtime_};
   NiceMock<Event::MockDispatcher> dispatcher_;
+  LocalInfo::MockLocalInfo local_info_;
 };
 
 class ClusterManagerImplTest : public testing::Test {
 public:
   void create(const Json::Object& config) {
     cluster_manager_.reset(new ClusterManagerImpl(config, factory_, factory_.stats_, factory_.tls_,
-                                                  factory_.runtime_, factory_.random_, "us-east-1d",
-                                                  "local_address", log_manager_));
+                                                  factory_.runtime_, factory_.random_,
+                                                  factory_.local_info_, log_manager_));
   }
 
   NiceMock<TestClusterManagerFactory> factory_;

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -3,6 +3,7 @@
 #include "common/network/utility.h"
 #include "common/upstream/sds.h"
 
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -20,9 +21,7 @@ namespace Upstream {
 
 class SdsTest : public testing::Test {
 protected:
-  SdsTest()
-      : sds_config_{"us-east-1a", "sds", std::chrono::milliseconds(30000)},
-        request_(&cm_.async_client_) {
+  SdsTest() : sds_config_{"sds", std::chrono::milliseconds(30000)}, request_(&cm_.async_client_) {
     std::string raw_config = R"EOF(
     {
       "name": "name",
@@ -36,8 +35,9 @@ protected:
     Json::ObjectPtr config = Json::Factory::LoadFromString(raw_config);
 
     timer_ = new Event::MockTimer(&dispatcher_);
+    local_info_.zone_name_ = "us-east-1a";
     cluster_.reset(new SdsClusterImpl(*config, runtime_, stats_, ssl_context_manager_, sds_config_,
-                                      cm_, dispatcher_, random_));
+                                      local_info_, cm_, dispatcher_, random_));
     EXPECT_EQ(Cluster::InitializePhase::Secondary, cluster_->initializePhase());
   }
 
@@ -93,6 +93,7 @@ protected:
   NiceMock<Runtime::MockRandomGenerator> random_;
   Http::MockAsyncClientRequest request_;
   NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 TEST_F(SdsTest, Shutdown) {

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -5,6 +5,7 @@
 #include "envoy/http/header_map.h"
 #include "envoy/server/hot_restart.h"
 
+#include "common/local_info/local_info_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 
 namespace Server {
@@ -53,7 +54,9 @@ void IntegrationTestServer::threadRoutine() {
   Thread::MutexBasicLockable lock;
   Stats::HeapRawStatDataAllocator stat_allocator;
   Stats::ThreadLocalStoreImpl stats_store(lock, stat_allocator);
-  server_.reset(new Server::InstanceImpl(options, *this, restarter, stats_store, lock, *this));
+  LocalInfo::LocalInfoImpl local_info("127.0.0.1", "zone_name", "cluster_name", "node_name");
+  server_.reset(
+      new Server::InstanceImpl(options, *this, restarter, stats_store, lock, *this, local_info));
   server_->run();
   server_.reset();
 }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -26,18 +26,12 @@ public:
   spdlog::level::level_enum logLevel() override { NOT_IMPLEMENTED; }
   std::chrono::seconds parentShutdownTime() override { return std::chrono::seconds(0); }
   uint64_t restartEpoch() override { return 0; }
-  const std::string& serviceClusterName() override { return cluster_name_; }
-  const std::string& serviceNodeName() override { return node_name_; }
-  const std::string& serviceZone() override { return zone_name_; }
   std::chrono::milliseconds fileFlushIntervalMsec() override {
     return std::chrono::milliseconds(10000);
   }
 
 private:
   const std::string config_path_;
-  const std::string cluster_name_{"cluster_name"};
-  const std::string node_name_{"node_name"};
-  const std::string zone_name_{"zone_name"};
 };
 
 class TestDrainManager : public DrainManager {

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -1,0 +1,16 @@
+#include "mocks.h"
+
+using testing::ReturnRef;
+
+namespace LocalInfo {
+
+MockLocalInfo::MockLocalInfo() {
+  ON_CALL(*this, address()).WillByDefault(ReturnRef(address_));
+  ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(zone_name_));
+  ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
+  ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_name_));
+}
+
+MockLocalInfo::~MockLocalInfo() {}
+
+} // LocalInfo

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "envoy/local_info/local_info.h"
+
+namespace LocalInfo {
+
+class MockLocalInfo : public LocalInfo {
+public:
+  MockLocalInfo();
+  ~MockLocalInfo();
+
+  MOCK_CONST_METHOD0(address, std::string&());
+  MOCK_CONST_METHOD0(zoneName, std::string&());
+  MOCK_CONST_METHOD0(clusterName, std::string&());
+  MOCK_CONST_METHOD0(nodeName, std::string&());
+
+  std::string address_{"127.0.0.1"};
+  std::string zone_name_{"zone_name"};
+  std::string cluster_name_{"cluster_name"};
+  std::string node_name_{"node_name"};
+};
+
+} // LocalInfo

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -4,15 +4,11 @@ using testing::_;
 using testing::Return;
 using testing::ReturnNew;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::SaveArg;
 
 namespace Server {
 
-MockOptions::MockOptions() {
-  ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_));
-}
-
+MockOptions::MockOptions() {}
 MockOptions::~MockOptions() {}
 
 MockAdmin::MockAdmin() {}
@@ -38,7 +34,7 @@ MockInstance::MockInstance() : ssl_context_manager_(runtime_loader_) {
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, hotRestart()).WillByDefault(ReturnRef(hot_restart_));
   ON_CALL(*this, random()).WillByDefault(ReturnRef(random_));
-  ON_CALL(*this, getLocalAddress()).WillByDefault(ReturnRefOfCopy(std::string("127.0.0.1")));
+  ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
 }
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -13,6 +13,7 @@
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
@@ -35,12 +36,7 @@ public:
   MOCK_METHOD0(logLevel, spdlog::level::level_enum());
   MOCK_METHOD0(parentShutdownTime, std::chrono::seconds());
   MOCK_METHOD0(restartEpoch, uint64_t());
-  MOCK_METHOD0(serviceClusterName, const std::string&());
-  MOCK_METHOD0(serviceNodeName, const std::string&());
-  MOCK_METHOD0(serviceZone, const std::string&());
   MOCK_METHOD0(fileFlushIntervalMsec, std::chrono::milliseconds());
-
-  std::string service_zone_;
 };
 
 class MockAdmin : public Admin {
@@ -116,7 +112,7 @@ public:
   MOCK_METHOD0(stats, Stats::Store&());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
   MOCK_METHOD0(threadLocal, ThreadLocal::Instance&());
-  MOCK_METHOD0(getLocalAddress, const std::string&());
+  MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
 
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   Stats::IsolatedStoreImpl stats_store_;
@@ -134,6 +130,7 @@ public:
   testing::NiceMock<MockHotRestart> hot_restart_;
   testing::NiceMock<MockOptions> options_;
   testing::NiceMock<Runtime::MockRandomGenerator> random_;
+  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 } // Server

--- a/test/server/http/health_check_test.cc
+++ b/test/server/http/health_check_test.cc
@@ -16,7 +16,6 @@ public:
   HealthCheckFilterTest(bool pass_through, bool caching)
       : request_headers_{{":path", "/healthcheck"}}, request_headers_no_hc_{{":path", "/foo"}} {
 
-    ON_CALL(server_.options_, serviceClusterName()).WillByDefault(ReturnRef(cluster_name_));
     if (caching) {
       cache_timer_ = new Event::MockTimer(&dispatcher_);
       EXPECT_CALL(*cache_timer_, enableTimer(_));
@@ -39,7 +38,6 @@ public:
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   Http::TestHeaderMapImpl request_headers_;
   Http::TestHeaderMapImpl request_headers_no_hc_;
-  std::string cluster_name_{"cluster_name"};
 };
 
 class HealthCheckFilterNoPassThroughTest : public HealthCheckFilterTest {


### PR DESCRIPTION
This has been bothering me for a while. We are copying things like local
zone, local cluster, etc. all over the place. It's also likely that we will
add more things in the future. This introduces a LocalInfo abstract class
which holds such information.

The change is large by number of lines but it's simple.