### PR TITLE
stats: add scope concept

### DIFF
--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -18,7 +18,6 @@ Cluster
     "ssl_context": "{...}",
     "features": "...",
     "http_codec_options": "...",
-    "alt_stat_name": "...",
     "dns_refresh_rate_ms": "...",
     "outlier_detection": "..."
   }
@@ -126,11 +125,6 @@ http_codec_options
   manager :ref:`http_codec_options <config_http_conn_man_http_codec_options>` option. When building
   an HTTP/2 mesh, if it's desired to disable HTTP/2 header compression the *no_compression*
   option should be specified both here as well as in the HTTP connection manager.
-
-alt_stat_name
-  *(optional, string)* If an alternate stat name is specified, some :ref:`statistics
-  <config_cluster_manager_cluster_stats>` will be duplicated between the standard statistics and a
-  tree specified by this parameter (e.g., *cluster.<alt_stat_name>.*).
 
 .. _config_cluster_manager_cluster_dns_refresh_rate_ms:
 

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -16,13 +16,13 @@ public:
   /**
    * Builds an Ssl::ClientContext from an Ssl::ContextConfig
    */
-  virtual Ssl::ClientContext& createSslClientContext(const std::string& name, Stats::Store& stats,
+  virtual Ssl::ClientContext& createSslClientContext(Stats::Scope& scope,
                                                      ContextConfig& config) PURE;
 
   /**
    * Builds an Ssl::ServerContext from an Ssl::ContextConfig
    */
-  virtual Ssl::ServerContext& createSslServerContext(const std::string& name, Stats::Store& stats,
+  virtual Ssl::ServerContext& createSslServerContext(Stats::Scope& stats,
                                                      ContextConfig& config) PURE;
 
   /**

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -103,16 +103,12 @@ public:
 typedef std::unique_ptr<Sink> SinkPtr;
 
 /**
- * A store for all known counters, gauges, and timers.
+ * A named scope for stats. Scopes are a grouping of stats that can be acted on as a unit if needed
+ * (for example to free/delete all of them).
  */
-class Store {
+class Scope {
 public:
-  virtual ~Store() {}
-
-  /**
-   * Add a sink that is used for stat flushing.
-   */
-  virtual void addSink(Sink& sink) PURE;
+  virtual ~Scope() {}
 
   /**
    * Deliver an individual histogram value to all registered sinks.
@@ -125,10 +121,24 @@ public:
   virtual void deliverTimingToSinks(const std::string& name, std::chrono::milliseconds ms) PURE;
 
   virtual Counter& counter(const std::string& name) PURE;
-  virtual std::list<std::reference_wrapper<Counter>> counters() const PURE;
   virtual Gauge& gauge(const std::string& name) PURE;
-  virtual std::list<std::reference_wrapper<Gauge>> gauges() const PURE;
   virtual Timer& timer(const std::string& name) PURE;
+};
+
+/**
+ * A store for all known counters, gauges, and timers.
+ */
+class Store : public Scope {
+public:
+  virtual ~Store() {}
+
+  /**
+   * Add a sink that is used for stat flushing.
+   */
+  virtual void addSink(Sink& sink) PURE;
+
+  virtual std::list<std::reference_wrapper<Counter>> counters() const PURE;
+  virtual std::list<std::reference_wrapper<Gauge>> gauges() const PURE;
 };
 
 } // Stats

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -217,12 +217,6 @@ public:
   virtual ~ClusterInfo() {}
 
   /**
-   * @return const std::string& the alternate stat name to write cluster stats to. This is useful
-   *         during parallel rollouts.
-   */
-  virtual const std::string& altStatName() const PURE;
-
-  /**
    * @return the connect timeout for upstream hosts that belong to this cluster.
    */
   virtual std::chrono::milliseconds connectTimeout() const PURE;
@@ -275,14 +269,15 @@ public:
   virtual Ssl::ClientContext* sslContext() const PURE;
 
   /**
-   * @return the stat prefix to use for cluster specific stats.
-   */
-  virtual const std::string& statPrefix() const PURE;
-
-  /**
    * @return ClusterStats& strongly named stats for this cluster.
    */
   virtual ClusterStats& stats() const PURE;
+
+  /**
+   * @return the stats scope that contains all cluster stats. This can be used to produce dynamic
+   *         stats that will be freed when the cluster is removed.
+   */
+  virtual Stats::Scope& statsScope() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoPtr;

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(
   ssl/context_manager_impl.cc
   ssl/openssl.cc
   stats/stats_impl.cc
+  stats/stats_scope_impl.cc
   stats/statsd.cc
   thread_local/thread_local_impl.cc
   tracing/http_tracer_impl.cc

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -12,13 +12,13 @@ namespace Grpc {
 
 const std::string Common::GRPC_CONTENT_TYPE{"application/grpc"};
 
-void Common::chargeStat(Stats::Store& store, const std::string& cluster,
-                        const std::string& grpc_service, const std::string& grpc_method,
-                        bool success) {
-  store.counter(fmt::format("cluster.{}.grpc.{}.{}.{}", cluster, grpc_service, grpc_method,
-                            success ? "success" : "failure")).inc();
-  store.counter(fmt::format("cluster.{}.grpc.{}.{}.total", cluster, grpc_service, grpc_method))
+void Common::chargeStat(const Upstream::ClusterInfo& cluster, const std::string& grpc_service,
+                        const std::string& grpc_method, bool success) {
+  cluster.statsScope()
+      .counter(
+           fmt::format("grpc.{}.{}.{}", grpc_service, grpc_method, success ? "success" : "failure"))
       .inc();
+  cluster.statsScope().counter(fmt::format("grpc.{}.{}.total", grpc_service, grpc_method)).inc();
 }
 
 Buffer::InstancePtr Common::serializeBody(const google::protobuf::Message& message) {

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -5,6 +5,7 @@
 #include "envoy/http/header_map.h"
 #include "envoy/http/message.h"
 #include "envoy/stats/stats.h"
+#include "envoy/upstream/upstream.h"
 
 #include "google/protobuf/message.h"
 
@@ -22,15 +23,13 @@ class Common {
 public:
   /**
    * Charge a success/failure stat to a cluster/service/method.
-   * @param store supplies the stats store.
    * @param cluster supplies the target cluster.
    * @param grpc_service supplies the service name.
    * @param grpc_method supplies the method name.
    * @param success supplies whether the call succeeded.
    */
-  static void chargeStat(Stats::Store& store, const std::string& cluster,
-                         const std::string& grpc_service, const std::string& grpc_method,
-                         bool success);
+  static void chargeStat(const Upstream::ClusterInfo& cluster, const std::string& grpc_service,
+                         const std::string& grpc_method, bool success);
   /**
    * Serialize protobuf message.
    */

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -20,7 +20,7 @@ void Http1BridgeFilter::chargeStat(const Http::HeaderMap& headers) {
   bool success = StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code) &&
                  grpc_status_code == 0;
 
-  Common::chargeStat(stats_store_, cluster_, grpc_service_, grpc_method_, success);
+  Common::chargeStat(*cluster_, grpc_service_, grpc_method_, success);
 }
 
 Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
@@ -105,7 +105,8 @@ void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
     return;
   }
 
-  cluster_ = route->clusterName();
+  // TODO: Cluster may not exist.
+  cluster_ = cm_.get(route->clusterName());
   grpc_service_ = parts[0];
   grpc_method_ = parts[1];
   do_stat_tracking_ = true;

--- a/source/common/grpc/http1_bridge_filter.h
+++ b/source/common/grpc/http1_bridge_filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/filter.h"
+#include "envoy/upstream/cluster_manager.h"
 
 namespace Grpc {
 
@@ -9,7 +10,7 @@ namespace Grpc {
  */
 class Http1BridgeFilter : public Http::StreamFilter {
 public:
-  Http1BridgeFilter(Stats::Store& stats_store) : stats_store_(stats_store) {}
+  Http1BridgeFilter(Upstream::ClusterManager& cm) : cm_(cm) {}
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
@@ -35,13 +36,13 @@ private:
   void chargeStat(const Http::HeaderMap& headers);
   void setupStatTracking(const Http::HeaderMap& headers);
 
-  Stats::Store& stats_store_;
+  Upstream::ClusterManager& cm_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   Http::HeaderMap* response_headers_{};
   bool do_bridging_{};
   bool do_stat_tracking_{};
-  std::string cluster_;
+  Upstream::ClusterInfoPtr cluster_;
   std::string grpc_service_;
   std::string grpc_method_;
 };

--- a/source/common/grpc/rpc_channel_impl.h
+++ b/source/common/grpc/rpc_channel_impl.h
@@ -24,10 +24,8 @@ namespace Grpc {
 class RpcChannelImpl : public RpcChannel, public Http::AsyncClient::Callbacks {
 public:
   RpcChannelImpl(Upstream::ClusterManager& cm, const std::string& cluster,
-                 RpcChannelCallbacks& callbacks, Stats::Store& stats_store,
-                 const Optional<std::chrono::milliseconds>& timeout)
-      : cm_(cm), cluster_(cluster), callbacks_(callbacks), stats_store_(stats_store),
-        timeout_(timeout) {}
+                 RpcChannelCallbacks& callbacks, const Optional<std::chrono::milliseconds>& timeout)
+      : cm_(cm), cluster_(cm.get(cluster)), callbacks_(callbacks), timeout_(timeout) {}
 
   ~RpcChannelImpl() { ASSERT(!http_request_ && !grpc_method_ && !grpc_response_); }
 
@@ -52,12 +50,11 @@ private:
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 
   Upstream::ClusterManager& cm_;
-  const std::string cluster_;
+  Upstream::ClusterInfoPtr cluster_;
   Http::AsyncClient::Request* http_request_{};
   const proto::MethodDescriptor* grpc_method_{};
   proto::Message* grpc_response_{};
   RpcChannelCallbacks& callbacks_;
-  Stats::Store& stats_store_;
   Optional<std::chrono::milliseconds> timeout_;
 };
 

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -10,77 +10,84 @@
 
 namespace Http {
 
-void CodeUtility::chargeBasicResponseStat(Stats::Store& store, const std::string& prefix,
+void CodeUtility::chargeBasicResponseStat(Stats::Scope& scope, const std::string& prefix,
                                           Code response_code) {
   // Build a dynamic stat for the response code and increment it.
-  store.counter(fmt::format("{}upstream_rq_{}", prefix, groupStringForResponseCode(response_code)))
+  scope.counter(fmt::format("{}upstream_rq_{}", prefix, groupStringForResponseCode(response_code)))
       .inc();
-  store.counter(fmt::format("{}upstream_rq_{}", prefix, enumToInt(response_code))).inc();
+  scope.counter(fmt::format("{}upstream_rq_{}", prefix, enumToInt(response_code))).inc();
 }
 
 void CodeUtility::chargeResponseStat(const ResponseStatInfo& info) {
   uint64_t response_code = Utility::getResponseStatus(info.response_headers_);
-  chargeBasicResponseStat(info.store_, info.prefix_, static_cast<Code>(response_code));
+  chargeBasicResponseStat(info.cluster_scope_, info.prefix_, static_cast<Code>(response_code));
 
   std::string group_string = groupStringForResponseCode(static_cast<Code>(response_code));
 
   // If the response is from a canary, also create canary stats.
   if (info.upstream_canary_) {
-    info.store_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, group_string)).inc();
-    info.store_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, response_code)).inc();
+    info.cluster_scope_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, group_string))
+        .inc();
+    info.cluster_scope_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, response_code))
+        .inc();
   }
 
   // Split stats into external vs. internal.
   if (info.internal_request_) {
-    info.store_.counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, group_string)).inc();
-    info.store_.counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, response_code))
-        .inc();
+    info.cluster_scope_.counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_,
+                                            group_string)).inc();
+    info.cluster_scope_.counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_,
+                                            response_code)).inc();
   } else {
-    info.store_.counter(fmt::format("{}external.upstream_rq_{}", info.prefix_, group_string)).inc();
-    info.store_.counter(fmt::format("{}external.upstream_rq_{}", info.prefix_, response_code))
-        .inc();
+    info.cluster_scope_.counter(fmt::format("{}external.upstream_rq_{}", info.prefix_,
+                                            group_string)).inc();
+    info.cluster_scope_.counter(fmt::format("{}external.upstream_rq_{}", info.prefix_,
+                                            response_code)).inc();
   }
 
   // Handle request virtual cluster.
   if (!info.request_vcluster_name_.empty()) {
-    info.store_.counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}", info.request_vhost_name_,
-                                    info.request_vcluster_name_, group_string)).inc();
-    info.store_.counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}", info.request_vhost_name_,
-                                    info.request_vcluster_name_, response_code)).inc();
+    info.global_store_.counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}",
+                                           info.request_vhost_name_, info.request_vcluster_name_,
+                                           group_string)).inc();
+    info.global_store_.counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}",
+                                           info.request_vhost_name_, info.request_vcluster_name_,
+                                           response_code)).inc();
   }
 
   // Handle per zone stats.
   if (!info.from_zone_.empty() && !info.to_zone_.empty()) {
-    info.store_.counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
-                                    info.to_zone_, group_string)).inc();
-    info.store_.counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
-                                    info.to_zone_, response_code)).inc();
+    info.cluster_scope_.counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_,
+                                            info.from_zone_, info.to_zone_, group_string)).inc();
+    info.cluster_scope_.counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_,
+                                            info.from_zone_, info.to_zone_, response_code)).inc();
   }
 }
 
 void CodeUtility::chargeResponseTiming(const ResponseTimingInfo& info) {
-  info.store_.deliverTimingToSinks(info.prefix_ + "upstream_rq_time", info.response_time_);
+  info.cluster_scope_.deliverTimingToSinks(info.prefix_ + "upstream_rq_time", info.response_time_);
   if (info.upstream_canary_) {
-    info.store_.deliverTimingToSinks(info.prefix_ + "canary.upstream_rq_time", info.response_time_);
+    info.cluster_scope_.deliverTimingToSinks(info.prefix_ + "canary.upstream_rq_time",
+                                             info.response_time_);
   }
 
   if (info.internal_request_) {
-    info.store_.deliverTimingToSinks(info.prefix_ + "internal.upstream_rq_time",
-                                     info.response_time_);
+    info.cluster_scope_.deliverTimingToSinks(info.prefix_ + "internal.upstream_rq_time",
+                                             info.response_time_);
   } else {
-    info.store_.deliverTimingToSinks(info.prefix_ + "external.upstream_rq_time",
-                                     info.response_time_);
+    info.cluster_scope_.deliverTimingToSinks(info.prefix_ + "external.upstream_rq_time",
+                                             info.response_time_);
   }
 
   if (!info.request_vcluster_name_.empty()) {
-    info.store_.deliverTimingToSinks("vhost." + info.request_vhost_name_ + ".vcluster." +
-                                         info.request_vcluster_name_ + ".upstream_rq_time",
-                                     info.response_time_);
+    info.global_store_.deliverTimingToSinks("vhost." + info.request_vhost_name_ + ".vcluster." +
+                                                info.request_vcluster_name_ + ".upstream_rq_time",
+                                            info.response_time_);
   }
 
   // Handle per zone stats.
   if (!info.from_zone_.empty() && !info.to_zone_.empty()) {
-    info.store_.deliverTimingToSinks(
+    info.cluster_scope_.deliverTimingToSinks(
         fmt::format("{}zone.{}.{}.upstream_rq_time", info.prefix_, info.from_zone_, info.to_zone_),
         info.response_time_);
   }

--- a/source/common/http/codes.h
+++ b/source/common/http/codes.h
@@ -14,11 +14,12 @@ public:
   /**
    * Charge a simple response stat to an upstream.
    */
-  static void chargeBasicResponseStat(Stats::Store& store, const std::string& prefix,
+  static void chargeBasicResponseStat(Stats::Scope& store, const std::string& prefix,
                                       Code response_code);
 
   struct ResponseStatInfo {
-    Stats::Store& store_;
+    Stats::Store& global_store_;
+    Stats::Scope& cluster_scope_;
     const std::string& prefix_;
     const HeaderMap& response_headers_;
     bool internal_request_;
@@ -37,7 +38,8 @@ public:
   static void chargeResponseStat(const ResponseStatInfo& info);
 
   struct ResponseTimingInfo {
-    Stats::Store& store_;
+    Stats::Store& global_store_;
+    Stats::Scope& cluster_scope_;
     const std::string& prefix_;
     std::chrono::milliseconds response_time_;
     bool upstream_canary_;

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -13,7 +13,7 @@ namespace Http {
  * All stats for the fault filter. @see stats_macros.h
  */
 // clang-format off
-#define ALL_FAULT_FILTER_STATS(COUNTER)                                                           \
+#define ALL_FAULT_FILTER_STATS(COUNTER)                                                            \
   COUNTER(delays_injected)                                                                         \
   COUNTER(aborts_injected)
 // clang-format on

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -21,6 +21,9 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
 
   const Router::RouteEntry* route = callbacks_->routeTable().routeForRequest(headers);
   if (route) {
+    // TODO: Cluster may not exist.
+    cluster_ = config_->cm().get(route->clusterName());
+
     std::vector<::RateLimit::Descriptor> descriptors;
     for (const Router::RateLimitPolicyEntry& rate_limit :
          route->rateLimitPolicy().getApplicableRateLimit(config_->stage())) {
@@ -35,9 +38,6 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
     }
 
     if (!descriptors.empty()) {
-      cluster_stat_prefix_ = fmt::format("cluster.{}.", route->clusterName());
-      cluster_ratelimit_stat_prefix_ = fmt::format("{}ratelimit.", cluster_stat_prefix_);
-
       state_ = State::Calling;
       initiating_call_ = true;
       client_->limit(*this, config_->domain(), descriptors,
@@ -77,16 +77,16 @@ void Filter::complete(::RateLimit::LimitStatus status) {
 
   switch (status) {
   case ::RateLimit::LimitStatus::OK:
-    config_->stats().counter(cluster_ratelimit_stat_prefix_ + "ok").inc();
+    cluster_->statsScope().counter("ratelimit.ok").inc();
     break;
   case ::RateLimit::LimitStatus::Error:
-    config_->stats().counter(cluster_ratelimit_stat_prefix_ + "error").inc();
+    cluster_->statsScope().counter("ratelimit.error").inc();
     break;
   case ::RateLimit::LimitStatus::OverLimit:
-    config_->stats().counter(cluster_ratelimit_stat_prefix_ + "over_limit").inc();
-    Http::CodeUtility::ResponseStatInfo info{config_->stats(), cluster_stat_prefix_,
-                                             *TOO_MANY_REQUESTS_HEADER, true, EMPTY_STRING,
-                                             EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, false};
+    cluster_->statsScope().counter("ratelimit.over_limit").inc();
+    Http::CodeUtility::ResponseStatInfo info{
+        config_->globalStore(), cluster_->statsScope(), EMPTY_STRING, *TOO_MANY_REQUESTS_HEADER,
+        true, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, false};
     Http::CodeUtility::chargeResponseStat(info);
     break;
   }

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -4,6 +4,7 @@
 #include "envoy/local_info/local_info.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/upstream/cluster_manager.h"
 
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
@@ -17,22 +18,24 @@ namespace RateLimit {
 class FilterConfig {
 public:
   FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
-               Stats::Store& stats_store, Runtime::Loader& runtime)
+               Stats::Store& global_store, Runtime::Loader& runtime, Upstream::ClusterManager& cm)
       : domain_(config.getString("domain")), stage_(config.getInteger("stage", 0)),
-        local_info_(local_info), stats_store_(stats_store), runtime_(runtime) {}
+        local_info_(local_info), global_store_(global_store), runtime_(runtime), cm_(cm) {}
 
   const std::string& domain() const { return domain_; }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   int64_t stage() const { return stage_; }
   Runtime::Loader& runtime() { return runtime_; }
-  Stats::Store& stats() { return stats_store_; }
+  Stats::Store& globalStore() { return global_store_; }
+  Upstream::ClusterManager& cm() { return cm_; }
 
 private:
   const std::string domain_;
   int64_t stage_;
   const LocalInfo::LocalInfo& local_info_;
-  Stats::Store& stats_store_;
+  Stats::Store& global_store_;
   Runtime::Loader& runtime_;
+  Upstream::ClusterManager& cm_;
 };
 
 typedef std::shared_ptr<FilterConfig> FilterConfigPtr;
@@ -65,8 +68,7 @@ private:
   StreamDecoderFilterCallbacks* callbacks_{};
   bool initiating_call_{};
   State state_{State::NotStarted};
-  std::string cluster_ratelimit_stat_prefix_;
-  std::string cluster_stat_prefix_;
+  Upstream::ClusterInfoPtr cluster_;
 };
 
 } // RateLimit

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -299,10 +299,8 @@ void ConnPoolImpl::ActiveClient::onConnectTimeout() {
 }
 
 CodecClientPtr ConnPoolImplProd::createCodecClient(Upstream::Host::CreateConnectionData& data) {
-  CodecClientStats stats{host_->cluster().stats().upstream_cx_protocol_error_};
   CodecClientPtr codec{new CodecClientProd(CodecClient::Type::HTTP1, std::move(data.connection_),
-                                           stats, store_,
-                                           data.host_description_->cluster().httpCodecOptions())};
+                                           data.host_description_)};
   return codec;
 }
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -22,9 +22,9 @@ namespace Http1 {
  */
 class ConnPoolImpl : Logger::Loggable<Logger::Id::pool>, public ConnectionPool::Instance {
 public:
-  ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host, Stats::Store& store,
+  ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host,
                Upstream::ResourcePriority priority)
-      : dispatcher_(dispatcher), host_(host), store_(store), priority_(priority) {}
+      : dispatcher_(dispatcher), host_(host), priority_(priority) {}
 
   ~ConnPoolImpl();
 
@@ -115,7 +115,6 @@ protected:
   std::list<ActiveClientPtr> ready_clients_;
   std::list<ActiveClientPtr> busy_clients_;
   std::list<PendingRequestPtr> pending_requests_;
-  Stats::Store& store_;
   std::list<DrainedCb> drained_callbacks_;
   Upstream::ResourcePriority priority_;
 };
@@ -125,9 +124,9 @@ protected:
  */
 class ConnPoolImplProd : public ConnPoolImpl {
 public:
-  ConnPoolImplProd(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host, Stats::Store& store,
+  ConnPoolImplProd(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host,
                    Upstream::ResourcePriority priority)
-      : ConnPoolImpl(dispatcher, host, store, priority) {}
+      : ConnPoolImpl(dispatcher, host, priority) {}
 
   // ConnPoolImpl
   CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -515,7 +515,7 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
 ConnectionImpl::Http2Callbacks::~Http2Callbacks() { nghttp2_session_callbacks_del(callbacks_); }
 
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
-                                           ConnectionCallbacks& callbacks, Stats::Store& stats,
+                                           ConnectionCallbacks& callbacks, Stats::Scope& stats,
                                            uint64_t codec_options)
     : ConnectionImpl(connection, stats), callbacks_(callbacks) {
   nghttp2_session_client_new(&session_, http2_callbacks_.callbacks(), base());

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -61,7 +61,7 @@ public:
  */
 class ConnectionImpl : public virtual Connection, Logger::Loggable<Logger::Id::http2> {
 public:
-  ConnectionImpl(Network::Connection& connection, Stats::Store& stats)
+  ConnectionImpl(Network::Connection& connection, Stats::Scope& stats)
       : stats_{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http2."))},
         connection_(connection) {}
 
@@ -206,7 +206,7 @@ private:
 class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, ConnectionCallbacks& callbacks,
-                       Stats::Store& stats, uint64_t codec_options);
+                       Stats::Scope& stats, uint64_t codec_options);
 
   // Http::ClientConnection
   Http::StreamEncoder& newStream(StreamDecoder& response_decoder) override;

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -3,7 +3,6 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
-#include "envoy/stats/stats.h"
 #include "envoy/upstream/upstream.h"
 
 #include "common/network/utility.h"
@@ -13,8 +12,8 @@ namespace Http {
 namespace Http2 {
 
 ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host,
-                           Stats::Store& store, Upstream::ResourcePriority priority)
-    : dispatcher_(dispatcher), host_(host), stats_store_(store), priority_(priority) {}
+                           Upstream::ResourcePriority priority)
+    : dispatcher_(dispatcher), host_(host), priority_(priority) {}
 
 ConnPoolImpl::~ConnPoolImpl() {
   if (primary_client_) {
@@ -240,10 +239,8 @@ ConnPoolImpl::ActiveClient::~ActiveClient() {
 }
 
 CodecClientPtr ProdConnPoolImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {
-  CodecClientStats stats{host_->cluster().stats().upstream_cx_protocol_error_};
   CodecClientPtr codec{new CodecClientProd(CodecClient::Type::HTTP2, std::move(data.connection_),
-                                           stats, stats_store_,
-                                           data.host_description_->cluster().httpCodecOptions())};
+                                           data.host_description_)};
   return codec;
 }
 

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -17,7 +17,7 @@ namespace Http2 {
  */
 class ConnPoolImpl : Logger::Loggable<Logger::Id::pool>, public ConnectionPool::Instance {
 public:
-  ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host, Stats::Store& store,
+  ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::ConstHostPtr host,
                Upstream::ResourcePriority priority);
   ~ConnPoolImpl();
 
@@ -73,7 +73,6 @@ protected:
   Stats::TimespanPtr conn_connect_ms_;
   Event::Dispatcher& dispatcher_;
   Upstream::ConstHostPtr host_;
-  Stats::Store& stats_store_;
   ActiveClientPtr primary_client_;
   ActiveClientPtr draining_client_;
   std::list<DrainedCb> drained_callbacks_;

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -69,9 +69,8 @@ void GrpcClientImpl::onFailure(const Optional<uint64_t>&, const std::string&) {
   request_id_.clear();
 }
 
-GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm,
-                                 Stats::Store& stats_store)
-    : cluster_name_(config.getString("cluster_name")), cm_(cm), stats_store_(stats_store) {
+GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm)
+    : cluster_name_(config.getString("cluster_name")), cm_(cm) {
   if (!cm_.get(cluster_name_)) {
     throw EnvoyException(fmt::format("unknown rate limit service cluster '{}'", cluster_name_));
   }
@@ -83,8 +82,7 @@ ClientPtr GrpcFactoryImpl::create(const Optional<std::chrono::milliseconds>& tim
 
 Grpc::RpcChannelPtr GrpcFactoryImpl::create(Grpc::RpcChannelCallbacks& callbacks,
                                             const Optional<std::chrono::milliseconds>& timeout) {
-  return Grpc::RpcChannelPtr{
-      new Grpc::RpcChannelImpl(cm_, cluster_name_, callbacks, stats_store_, timeout)};
+  return Grpc::RpcChannelPtr{new Grpc::RpcChannelImpl(cm_, cluster_name_, callbacks, timeout)};
 }
 
 } // RateLimit

--- a/source/common/ratelimit/ratelimit_impl.h
+++ b/source/common/ratelimit/ratelimit_impl.h
@@ -38,8 +38,7 @@ private:
 
 class GrpcFactoryImpl : public ClientFactory, public Grpc::RpcChannelFactory {
 public:
-  GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm,
-                  Stats::Store& stats_store);
+  GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm);
 
   // RateLimit::ClientFactory
   ClientPtr create(const Optional<std::chrono::milliseconds>& timeout) override;
@@ -51,7 +50,6 @@ public:
 private:
   const std::string cluster_name_;
   Upstream::ClusterManager& cm_;
-  Stats::Store& stats_store_;
 };
 
 class NullClientImpl : public Client {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -107,16 +107,18 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
     bool internal_request = internal_request_header && internal_request_header->value() == "true";
 
     Http::CodeUtility::ResponseStatInfo info{
-        config_.stats_store_, cluster_->statPrefix(), response_headers, internal_request,
-        route_->virtualHost().name(), request_vcluster_ ? request_vcluster_->name() : "",
+        config_.global_store_, cluster_->statsScope(), EMPTY_STRING, response_headers,
+        internal_request, route_->virtualHost().name(),
+        request_vcluster_ ? request_vcluster_->name() : EMPTY_STRING,
         config_.local_info_.zoneName(), upstreamZone(upstream_host), is_canary};
 
     Http::CodeUtility::chargeResponseStat(info);
 
-    for (const std::string& alt_prefix : alt_stat_prefixes_) {
+    if (!alt_stat_prefix_.empty()) {
       Http::CodeUtility::ResponseStatInfo info{
-          config_.stats_store_, alt_prefix, response_headers, internal_request, "", "",
-          config_.local_info_.zoneName(), upstreamZone(upstream_host), is_canary};
+          config_.global_store_, cluster_->statsScope(), alt_stat_prefix_, response_headers,
+          internal_request, EMPTY_STRING, EMPTY_STRING, config_.local_info_.zoneName(),
+          upstreamZone(upstream_host), is_canary};
 
       Http::CodeUtility::chargeResponseStat(info);
     }
@@ -163,15 +165,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
                    headers.Path()->value().c_str());
 
   cluster_ = config_.cm_.get(route_->clusterName());
-  const std::string& cluster_alt_name = cluster_->altStatName();
-  if (!cluster_alt_name.empty()) {
-    alt_stat_prefixes_.push_back(fmt::format("cluster.{}.", cluster_alt_name));
-  }
 
   const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();
   if (request_alt_name) {
-    alt_stat_prefixes_.push_back(
-        fmt::format("cluster.{}.{}.", route_->clusterName(), request_alt_name->value().c_str()));
+    alt_stat_prefix_ = std::string(request_alt_name->value().c_str()) + ".";
     headers.removeEnvoyUpstreamAltStatName();
   }
 
@@ -420,7 +417,7 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
                                 [this]() -> void { doRetry(); }) &&
       setupRetry(end_stream)) {
     Http::CodeUtility::chargeBasicResponseStat(
-        config_.stats_store_, cluster_->statPrefix() + "retry.",
+        cluster_->statsScope(), "retry.",
         static_cast<Http::Code>(Http::Utility::getResponseStatus(*headers)));
     return;
   } else {
@@ -479,18 +476,18 @@ void Filter::onUpstreamComplete() {
     bool internal_request = internal_request_header && internal_request_header->value() == "true";
 
     Http::CodeUtility::ResponseTimingInfo info{
-        config_.stats_store_, cluster_->statPrefix(), response_time,
+        config_.global_store_, cluster_->statsScope(), EMPTY_STRING, response_time,
         upstream_request_->upstream_canary_, internal_request, route_->virtualHost().name(),
-        request_vcluster_ ? request_vcluster_->name() : "", config_.local_info_.zoneName(),
-        upstreamZone(upstream_request_->upstream_host_)};
+        request_vcluster_ ? request_vcluster_->name() : EMPTY_STRING,
+        config_.local_info_.zoneName(), upstreamZone(upstream_request_->upstream_host_)};
 
     Http::CodeUtility::chargeResponseTiming(info);
 
-    for (const std::string& alt_prefix : alt_stat_prefixes_) {
+    if (!alt_stat_prefix_.empty()) {
       Http::CodeUtility::ResponseTimingInfo info{
-          config_.stats_store_, alt_prefix, response_time, upstream_request_->upstream_canary_,
-          internal_request, "", "", config_.local_info_.zoneName(),
-          upstreamZone(upstream_request_->upstream_host_)};
+          config_.global_store_, cluster_->statsScope(), alt_stat_prefix_, response_time,
+          upstream_request_->upstream_canary_, internal_request, EMPTY_STRING, EMPTY_STRING,
+          config_.local_info_.zoneName(), upstreamZone(upstream_request_->upstream_host_)};
 
       Http::CodeUtility::chargeResponseTiming(info);
     }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -74,13 +74,13 @@ public:
                Stats::Store& stats, Upstream::ClusterManager& cm, Runtime::Loader& runtime,
                Runtime::RandomGenerator& random, ShadowWriterPtr&& shadow_writer,
                bool emit_dynamic_stats)
-      : stats_store_(stats), local_info_(local_info), cm_(cm), runtime_(runtime), random_(random),
+      : global_store_(stats), local_info_(local_info), cm_(cm), runtime_(runtime), random_(random),
         stats_{ALL_ROUTER_STATS(POOL_COUNTER_PREFIX(stats, stat_prefix))},
         emit_dynamic_stats_(emit_dynamic_stats), shadow_writer_(std::move(shadow_writer)) {}
 
   ShadowWriter& shadowWriter() { return *shadow_writer_; }
 
-  Stats::Store& stats_store_;
+  Stats::Store& global_store_;
   const LocalInfo::LocalInfo& local_info_;
   Upstream::ClusterManager& cm_;
   Runtime::Loader& runtime_;
@@ -202,7 +202,7 @@ private:
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   const RouteEntry* route_;
   Upstream::ClusterInfoPtr cluster_;
-  std::list<std::string> alt_stat_prefixes_;
+  std::string alt_stat_prefix_;
   const VirtualCluster* request_vcluster_;
   Event::TimerPtr response_timeout_;
   FilterUtility::TimeoutData timeout_;

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -222,7 +222,7 @@ bool ContextImpl::verifyPeer(SSL* ssl) const {
   stats_.handshake_.inc();
 
   const char* cipher = SSL_get_cipher_name(ssl);
-  scope_.counter(fmt::format("ciphers.{}", std::string{cipher})).inc();
+  scope_.counter(fmt::format("ssl.ciphers.{}", std::string{cipher})).inc();
 
   X509Ptr cert = X509Ptr(SSL_get_peer_certificate(ssl));
 

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -57,7 +57,7 @@ public:
   std::string getCertChainInformation() override;
 
 protected:
-  ContextImpl(const std::string& name, Stats::Store& stats, ContextConfig& config);
+  ContextImpl(Stats::Scope& scope, ContextConfig& config);
 
   /**
    * Specifies the context for which the session can be reused.  Any data is acceptable here.
@@ -88,7 +88,7 @@ protected:
   static bool verifyCertificateHash(X509* cert, const std::vector<uint8_t>& certificate_hash);
 
   std::vector<uint8_t> parseAlpnProtocols(const std::string& alpn_protocols);
-  static SslStats generateStats(const std::string& prefix, Stats::Store& store);
+  static SslStats generateStats(Stats::Scope& scope);
   int32_t getDaysUntilExpiration(const X509* cert);
   X509Ptr loadCert(const std::string& cert_file);
   static std::string getSerialNumber(X509* cert);
@@ -98,8 +98,7 @@ protected:
   SslCtxPtr ctx_;
   std::string verify_subject_alt_name_;
   std::vector<uint8_t> verify_certificate_hash_;
-  Stats::Store& store_;
-  const std::string stats_prefix_;
+  Stats::Scope& scope_;
   SslStats stats_;
   std::vector<uint8_t> parsed_alpn_protocols_;
   X509Ptr ca_cert_;
@@ -110,7 +109,7 @@ protected:
 
 class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
-  ClientContextImpl(const std::string& name, Stats::Store& stats, ContextConfig& config);
+  ClientContextImpl(Stats::Scope& scope, ContextConfig& config);
 
   SslConPtr newSsl() const override;
 
@@ -120,8 +119,7 @@ private:
 
 class ServerContextImpl : public ContextImpl, public ServerContext {
 public:
-  ServerContextImpl(const std::string& name, Stats::Store& stats, ContextConfig& config,
-                    Runtime::Loader& runtime);
+  ServerContextImpl(Stats::Scope& scope, ContextConfig& config, Runtime::Loader& runtime);
 
 private:
   int alpnSelectCallback(const unsigned char** out, unsigned char* outlen, const unsigned char* in,

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -2,19 +2,17 @@
 
 namespace Ssl {
 
-Ssl::ClientContext& ContextManagerImpl::createSslClientContext(const std::string& name,
-                                                               Stats::Store& stats,
+Ssl::ClientContext& ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
                                                                ContextConfig& config) {
 
-  Ssl::ClientContext* context = new ClientContextImpl(name, stats, config);
+  Ssl::ClientContext* context = new ClientContextImpl(scope, config);
   contexts_.emplace_back(context);
   return *context;
 }
 
-Ssl::ServerContext& ContextManagerImpl::createSslServerContext(const std::string& name,
-                                                               Stats::Store& stats,
+Ssl::ServerContext& ContextManagerImpl::createSslServerContext(Stats::Scope& scope,
                                                                ContextConfig& config) {
-  Ssl::ServerContext* context = new ServerContextImpl(name, stats, config, runtime_);
+  Ssl::ServerContext* context = new ServerContextImpl(scope, config, runtime_);
   contexts_.emplace_back(context);
   return *context;
 }

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -13,11 +13,9 @@ public:
   ContextManagerImpl(Runtime::Loader& runtime) : runtime_(runtime) {}
 
   // Ssl::ContextManager
-  Ssl::ClientContext& createSslClientContext(const std::string& name, Stats::Store& stats,
-                                             ContextConfig& config) override;
+  Ssl::ClientContext& createSslClientContext(Stats::Scope& scope, ContextConfig& config) override;
 
-  Ssl::ServerContext& createSslServerContext(const std::string& name, Stats::Store& stats,
-                                             ContextConfig& config) override;
+  Ssl::ServerContext& createSslServerContext(Stats::Scope& scope, ContextConfig& config) override;
 
   size_t daysUntilFirstCertExpires() override;
 

--- a/source/common/stats/stats_scope_impl.cc
+++ b/source/common/stats/stats_scope_impl.cc
@@ -1,0 +1,20 @@
+#include "stats_scope_impl.h"
+
+namespace Stats {
+
+Counter& ScopeImpl::counter(const std::string& name) {
+  // TODO: Ref-counting.
+  return parent_.counter(prefix_ + name);
+}
+
+Gauge& ScopeImpl::gauge(const std::string& name) {
+  // TODO: Ref-counting.
+  return parent_.gauge(prefix_ + name);
+}
+
+Timer& ScopeImpl::timer(const std::string& name) {
+  // TODO: Ref-counting.
+  return parent_.timer(prefix_ + name);
+}
+
+} // Stats

--- a/source/common/stats/stats_scope_impl.h
+++ b/source/common/stats/stats_scope_impl.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "envoy/stats/stats.h"
+
+namespace Stats {
+
+class ScopeImpl : public Scope {
+public:
+  ScopeImpl(Stats::Store& parent, const std::string& prefix) : parent_(parent), prefix_(prefix) {}
+
+  // Stats::Scope
+  void deliverHistogramToSinks(const std::string& name, uint64_t value) override {
+    parent_.deliverHistogramToSinks(name, value);
+  }
+  void deliverTimingToSinks(const std::string& name, std::chrono::milliseconds ms) {
+    parent_.deliverTimingToSinks(name, ms);
+  }
+
+  Counter& counter(const std::string& name) override;
+  Gauge& gauge(const std::string& name) override;
+  Timer& timer(const std::string& name) override;
+
+private:
+  Stats::Store& parent_;
+  const std::string prefix_;
+};
+
+} // Stats

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -173,16 +173,16 @@ void LightStepRecorder::flushSpans() {
     lightstep::collector::ReportRequest request;
     std::swap(request, builder_.pending());
 
-    Http::MessagePtr message = Grpc::Common::prepareHeaders(sink_.collectorCluster(),
-                                                            lightstep::CollectorServiceFullName(),
-                                                            lightstep::CollectorMethodName());
+    Http::MessagePtr message =
+        Grpc::Common::prepareHeaders(sink_.cluster()->name(), lightstep::CollectorServiceFullName(),
+                                     lightstep::CollectorMethodName());
 
     message->body(Grpc::Common::serializeBody(std::move(request)));
 
     uint64_t timeout =
         sink_.runtime().snapshot().getInteger("tracing.lightstep.request_timeout", 5000U);
     sink_.clusterManager()
-        .httpAsyncClientForCluster(sink_.collectorCluster())
+        .httpAsyncClientForCluster(sink_.cluster()->name())
         .send(std::move(message), *this, std::chrono::milliseconds(timeout));
   }
 }
@@ -194,19 +194,18 @@ LightStepSink::LightStepSink(const Json::Object& config, Upstream::ClusterManage
                              Stats::Store& stats, const LocalInfo::LocalInfo& local_info,
                              ThreadLocal::Instance& tls, Runtime::Loader& runtime,
                              std::unique_ptr<lightstep::TracerOptions> options)
-    : collector_cluster_(config.getString("collector_cluster")), cm_(cluster_manager),
-      stats_store_(stats),
+    : cm_(cluster_manager), cluster_(cm_.get(config.getString("collector_cluster"))),
       tracer_stats_{LIGHTSTEP_TRACER_STATS(POOL_COUNTER_PREFIX(stats, "tracing.lightstep."))},
       local_info_(local_info), tls_(tls), runtime_(runtime), options_(std::move(options)),
       tls_slot_(tls.allocateSlot()) {
-  if (!cm_.get(collector_cluster_)) {
+  if (!cluster_) {
     throw EnvoyException(fmt::format("{} collector cluster is not defined on cluster manager level",
-                                     collector_cluster_));
+                                     config.getString("collector_cluster")));
   }
 
-  if (!(cm_.get(collector_cluster_)->features() & Upstream::ClusterInfo::Features::HTTP2)) {
+  if (!(cluster_->features() & Upstream::ClusterInfo::Features::HTTP2)) {
     throw EnvoyException(
-        fmt::format("{} collector cluster must support http2 for gRPC calls", collector_cluster_));
+        fmt::format("{} collector cluster must support http2 for gRPC calls", cluster_->name()));
   }
 
   tls_.set(tls_slot_, [this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectPtr {
@@ -275,21 +274,18 @@ void LightStepSink::flushTrace(const Http::HeaderMap& request_headers, const Htt
 }
 
 void LightStepRecorder::onFailure(Http::AsyncClient::FailureReason) {
-  Grpc::Common::chargeStat(sink_.statsStore(), sink_.collectorCluster(),
-                           lightstep::CollectorServiceFullName(), lightstep::CollectorMethodName(),
-                           false);
+  Grpc::Common::chargeStat(*sink_.cluster(), lightstep::CollectorServiceFullName(),
+                           lightstep::CollectorMethodName(), false);
 }
 
 void LightStepRecorder::onSuccess(Http::MessagePtr&& msg) {
   try {
     Grpc::Common::validateResponse(*msg);
 
-    Grpc::Common::chargeStat(sink_.statsStore(), sink_.collectorCluster(),
-                             lightstep::CollectorServiceFullName(),
+    Grpc::Common::chargeStat(*sink_.cluster(), lightstep::CollectorServiceFullName(),
                              lightstep::CollectorMethodName(), true);
   } catch (const Grpc::Exception& ex) {
-    Grpc::Common::chargeStat(sink_.statsStore(), sink_.collectorCluster(),
-                             lightstep::CollectorServiceFullName(),
+    Grpc::Common::chargeStat(*sink_.cluster(), lightstep::CollectorServiceFullName(),
                              lightstep::CollectorMethodName(), false);
   }
 }

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -112,9 +112,8 @@ public:
                   const TracingContext& tracing_context) override;
 
   Upstream::ClusterManager& clusterManager() { return cm_; }
-  const std::string& collectorCluster() { return collector_cluster_; }
+  Upstream::ClusterInfoPtr cluster() { return cluster_; }
   Runtime::Loader& runtime() { return runtime_; }
-  Stats::Store& statsStore() { return stats_store_; }
   LightstepTracerStats& tracerStats() { return tracer_stats_; }
 
 private:
@@ -131,9 +130,8 @@ private:
                                const Http::AccessLog::RequestInfo& info);
   std::string buildResponseCode(const Http::AccessLog::RequestInfo& info);
 
-  const std::string collector_cluster_;
   Upstream::ClusterManager& cm_;
-  Stats::Store& stats_store_;
+  Upstream::ClusterInfoPtr cluster_;
   LightstepTracerStats tracer_stats_;
   const LocalInfo::LocalInfo& local_info_;
   ThreadLocal::Instance& tls_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -387,10 +387,10 @@ ProdClusterManagerFactory::allocateConnPool(Event::Dispatcher& dispatcher, Const
   if ((host->cluster().features() & ClusterInfo::Features::HTTP2) &&
       runtime_.snapshot().featureEnabled("upstream.use_http2", 100)) {
     return Http::ConnectionPool::InstancePtr{
-        new Http::Http2::ProdConnPoolImpl(dispatcher, host, stats_, priority)};
+        new Http::Http2::ProdConnPoolImpl(dispatcher, host, priority)};
   } else {
     return Http::ConnectionPool::InstancePtr{
-        new Http::Http1::ConnPoolImplProd(dispatcher, host, stats_, priority)};
+        new Http::Http1::ConnPoolImplProd(dispatcher, host, priority)};
   }
 }
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -63,8 +63,8 @@ protected:
   };
 
   HealthCheckerImplBase(const Cluster& cluster, const Json::Object& config,
-                        Event::Dispatcher& dispatcher, Stats::Store& store,
-                        Runtime::Loader& runtime, Runtime::RandomGenerator& random);
+                        Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+                        Runtime::RandomGenerator& random);
 
   std::chrono::milliseconds interval();
 
@@ -77,14 +77,13 @@ protected:
   const uint32_t unhealthy_threshold_;
   const uint32_t healthy_threshold_;
   HealthCheckerStats stats_;
-  Stats::Store& stat_store_;
   uint64_t local_process_healthy_{};
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;
 
 private:
   void decHealthy();
-  HealthCheckerStats generateStats(Stats::Store& store);
+  HealthCheckerStats generateStats(Stats::Scope& scope);
   void incHealthy();
   void refreshHealthyStat();
   void runCallbacks(HostPtr host, bool changed_state);
@@ -102,8 +101,8 @@ private:
 class HttpHealthCheckerImpl : public HealthCheckerImplBase {
 public:
   HttpHealthCheckerImpl(const Cluster& cluster, const Json::Object& config,
-                        Event::Dispatcher& dispatcher, Stats::Store& store,
-                        Runtime::Loader& runtime, Runtime::RandomGenerator& random);
+                        Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+                        Runtime::RandomGenerator& random);
 
   // Upstream::HealthChecker
   void start() override;
@@ -226,7 +225,7 @@ public:
 class TcpHealthCheckerImpl : public HealthCheckerImplBase {
 public:
   TcpHealthCheckerImpl(const Cluster& cluster, const Json::Object& config,
-                       Event::Dispatcher& dispatcher, Stats::Store& store, Runtime::Loader& runtime,
+                       Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                        Runtime::RandomGenerator& random);
 
   // Upstream::HealthChecker

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -30,7 +30,7 @@ class DetectorImplFactory {
 public:
   static DetectorPtr createForCluster(Cluster& cluster, const Json::Object& cluster_config,
                                       Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
-                                      Stats::Store& stats, EventLoggerPtr event_logger);
+                                      EventLoggerPtr event_logger);
 };
 
 class DetectorImpl;
@@ -85,7 +85,7 @@ struct DetectionStats {
 class DetectorImpl : public Detector, public std::enable_shared_from_this<DetectorImpl> {
 public:
   static std::shared_ptr<DetectorImpl> create(const Cluster& cluster, Event::Dispatcher& dispatcher,
-                                              Runtime::Loader& runtime, Stats::Store& stats,
+                                              Runtime::Loader& runtime,
                                               SystemTimeSource& time_source,
                                               EventLoggerPtr event_logger);
   ~DetectorImpl();
@@ -98,13 +98,13 @@ public:
 
 private:
   DetectorImpl(const Cluster& cluster, Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
-               Stats::Store& stats, SystemTimeSource& time_source, EventLoggerPtr event_logger);
+               SystemTimeSource& time_source, EventLoggerPtr event_logger);
 
   void addHostSink(HostPtr host);
   void armIntervalTimer();
   void checkHostForUneject(HostPtr host, DetectorHostSinkImpl* sink, SystemTime now);
   void ejectHost(HostPtr host, EjectionType type);
-  static DetectionStats generateStats(const std::string& name, Stats::Store& store);
+  static DetectionStats generateStats(Stats::Scope& scope);
   void initialize(const Cluster& cluster);
   void onConsecutive5xxWorker(HostPtr host);
   void onIntervalTimer();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -42,9 +42,8 @@ void HostSetImpl::addMemberUpdateCb(MemberUpdateCb callback) const {
   callbacks_.emplace_back(callback);
 }
 
-ClusterStats ClusterInfoImpl::generateStats(const std::string& prefix, Stats::Store& stats) {
-  return {ALL_CLUSTER_STATS(POOL_COUNTER_PREFIX(stats, prefix), POOL_GAUGE_PREFIX(stats, prefix),
-                            POOL_TIMER_PREFIX(stats, prefix))};
+ClusterStats ClusterInfoImpl::generateStats(Stats::Scope& scope) {
+  return {ALL_CLUSTER_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope), POOL_TIMER(scope))};
 }
 
 void HostSetImpl::runUpdateCallbacks(const std::vector<HostPtr>& hosts_added,
@@ -59,8 +58,8 @@ ClusterInfoImpl::ClusterInfoImpl(const Json::Object& config, Runtime::Loader& ru
     : runtime_(runtime), name_(config.getString("name")),
       max_requests_per_connection_(config.getInteger("max_requests_per_connection", 0)),
       connect_timeout_(std::chrono::milliseconds(config.getInteger("connect_timeout_ms"))),
-      stat_prefix_(fmt::format("cluster.{}.", name_)), stats_(generateStats(stat_prefix_, stats)),
-      alt_stat_name_(config.getString("alt_stat_name", "")), features_(parseFeatures(config)),
+      stats_scope_(stats, fmt::format("cluster.{}.", name_)), stats_(generateStats(stats_scope_)),
+      features_(parseFeatures(config)),
       http_codec_options_(Http::Utility::parseCodecOptions(config)),
       resource_managers_(config, runtime, name_),
       maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)) {
@@ -68,7 +67,7 @@ ClusterInfoImpl::ClusterInfoImpl(const Json::Object& config, Runtime::Loader& ru
   ssl_ctx_ = nullptr;
   if (config.hasObject("ssl_context")) {
     Ssl::ContextConfigImpl context_config(*config.getObject("ssl_context"));
-    ssl_ctx_ = &ssl_context_manager.createSslClientContext(stat_prefix_, stats, context_config);
+    ssl_ctx_ = &ssl_context_manager.createSslClientContext(stats_scope_, context_config);
   }
 
   std::string string_lb_type = config.getString("lb_type");
@@ -120,17 +119,17 @@ ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& 
     std::string hc_type = health_check_config->getString("type");
     if (hc_type == "http") {
       new_cluster->setHealthChecker(HealthCheckerPtr{new ProdHttpHealthCheckerImpl(
-          *new_cluster, *health_check_config, dispatcher, stats, runtime, random)});
+          *new_cluster, *health_check_config, dispatcher, runtime, random)});
     } else if (hc_type == "tcp") {
       new_cluster->setHealthChecker(HealthCheckerPtr{new TcpHealthCheckerImpl(
-          *new_cluster, *health_check_config, dispatcher, stats, runtime, random)});
+          *new_cluster, *health_check_config, dispatcher, runtime, random)});
     } else {
       throw EnvoyException(fmt::format("cluster: unknown health check type '{}'", hc_type));
     }
   }
 
   new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
-      *new_cluster, cluster, dispatcher, runtime, stats, outlier_event_logger));
+      *new_cluster, cluster, dispatcher, runtime, outlier_event_logger));
   return std::move(new_cluster);
 }
 

--- a/source/server/config/http/grpc_http1_bridge.cc
+++ b/source/server/config/http/grpc_http1_bridge.cc
@@ -19,7 +19,8 @@ public:
     }
 
     return [&server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamFilter(Http::StreamFilterPtr{new Grpc::Http1BridgeFilter(server.stats())});
+      callbacks.addStreamFilter(
+          Http::StreamFilterPtr{new Grpc::Http1BridgeFilter(server.clusterManager())});
     };
   }
 };

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -19,7 +19,7 @@ public:
     }
 
     Http::RateLimit::FilterConfigPtr filter_config(new Http::RateLimit::FilterConfig(
-        config, server.localInfo(), server.stats(), server.runtime()));
+        config, server.localInfo(), server.stats(), server.runtime(), server.clusterManager()));
     return [filter_config, &server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::RateLimit::Filter(
           filter_config, server.rateLimitClient(std::chrono::milliseconds(20)))});

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -7,6 +7,7 @@
 
 #include "common/common/logger.h"
 #include "common/json/json_loader.h"
+#include "common/stats/stats_scope_impl.h"
 
 namespace Server {
 namespace Configuration {
@@ -100,6 +101,7 @@ private:
   private:
     MainImpl& parent_;
     uint64_t port_;
+    Stats::ScopeImpl scope_;
     Ssl::ServerContext* ssl_context_{};
     bool use_proxy_proto_{};
     std::list<NetworkFilterFactoryCb> filter_factories_;

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -146,8 +146,7 @@ TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
   connect_timer_->callback_();
-  EXPECT_EQ(1U, cluster_manager_.cluster_.info_->stats_store_
-                    .counter("cluster.fake_cluster.upstream_cx_connect_timeout")
+  EXPECT_EQ(1U, cluster_manager_.cluster_.info_->stats_store_.counter("upstream_cx_connect_timeout")
                     .value());
 }
 
@@ -173,8 +172,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*connect_timer_, disableTimer());
   upstream_connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
-  EXPECT_EQ(1U, cluster_manager_.cluster_.info_->stats_store_
-                    .counter("cluster.fake_cluster.upstream_cx_connect_fail")
+  EXPECT_EQ(1U, cluster_manager_.cluster_.info_->stats_store_.counter("upstream_cx_connect_fail")
                     .value());
 }
 
@@ -189,9 +187,8 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
   filter_->onNewConnection();
 
-  EXPECT_EQ(1U, cluster_manager_.cluster_.info_->stats_store_
-                    .counter("cluster.fake_cluster.upstream_cx_overflow")
-                    .value());
+  EXPECT_EQ(1U,
+            cluster_manager_.cluster_.info_->stats_store_.counter("upstream_cx_overflow").value());
 }
 
 } // Filter

--- a/test/common/grpc/rpc_channel_impl_test.cc
+++ b/test/common/grpc/rpc_channel_impl_test.cc
@@ -21,7 +21,8 @@ public:
 
   void expectNormalRequest(
       const Optional<std::chrono::milliseconds> timeout = Optional<std::chrono::milliseconds>()) {
-    EXPECT_CALL(cm_, httpAsyncClientForCluster("cluster")).WillOnce(ReturnRef(cm_.async_client_));
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))
+        .WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
         .WillOnce(Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                              Optional<std::chrono::milliseconds>) -> Http::AsyncClient::Request* {
@@ -33,7 +34,7 @@ public:
 
   NiceMock<Upstream::MockClusterManager> cm_;
   MockRpcChannelCallbacks grpc_callbacks_;
-  RpcChannelImpl grpc_request_{cm_, "cluster", grpc_callbacks_, cm_.cluster_.info_->stats_store_,
+  RpcChannelImpl grpc_request_{cm_, "fake_cluster", grpc_callbacks_,
                                Optional<std::chrono::milliseconds>()};
   helloworld::Greeter::Stub service_{&grpc_request_};
   Http::MockAsyncClientRequest http_async_client_request_;
@@ -56,7 +57,7 @@ TEST_F(GrpcRequestImplTest, NoError) {
 
   Http::TestHeaderMapImpl expected_request_headers{{":method", "POST"},
                                                    {":path", "/helloworld.Greeter/SayHello"},
-                                                   {":authority", "cluster"},
+                                                   {":authority", "fake_cluster"},
                                                    {"content-type", "application/grpc"},
                                                    {"foo", "bar"}};
 
@@ -73,9 +74,9 @@ TEST_F(GrpcRequestImplTest, NoError) {
   EXPECT_CALL(grpc_callbacks_, onSuccess());
   http_callbacks_->onSuccess(std::move(response_http_message));
   EXPECT_EQ(response.SerializeAsString(), inner_response.SerializeAsString());
-  EXPECT_EQ(1UL, cm_.cluster_.info_->stats_store_
-                     .counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.success")
-                     .value());
+  EXPECT_EQ(
+      1UL,
+      cm_.cluster_.info_->stats_store_.counter("grpc.helloworld.Greeter.SayHello.success").value());
 }
 
 TEST_F(GrpcRequestImplTest, Non200Response) {
@@ -92,9 +93,9 @@ TEST_F(GrpcRequestImplTest, Non200Response) {
 
   EXPECT_CALL(grpc_callbacks_, onFailure(Optional<uint64_t>(), "non-200 response code"));
   http_callbacks_->onSuccess(std::move(response_http_message));
-  EXPECT_EQ(1UL, cm_.cluster_.info_->stats_store_
-                     .counter("cluster.cluster.grpc.helloworld.Greeter.SayHello.failure")
-                     .value());
+  EXPECT_EQ(
+      1UL,
+      cm_.cluster_.info_->stats_store_.counter("grpc.helloworld.Greeter.SayHello.failure").value());
 }
 
 TEST_F(GrpcRequestImplTest, NoResponseTrailers) {
@@ -234,7 +235,8 @@ TEST_F(GrpcRequestImplTest, HttpAsyncRequestFailure) {
 }
 
 TEST_F(GrpcRequestImplTest, NoHttpAsyncRequest) {
-  EXPECT_CALL(cm_, httpAsyncClientForCluster("cluster")).WillOnce(ReturnRef(cm_.async_client_));
+  EXPECT_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))
+      .WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(
           Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
@@ -267,8 +269,7 @@ TEST_F(GrpcRequestImplTest, Cancel) {
 
 TEST_F(GrpcRequestImplTest, RequestTimeoutSet) {
   const Optional<std::chrono::milliseconds> timeout(std::chrono::milliseconds(100));
-  RpcChannelImpl grpc_request_timeout{cm_, "cluster", grpc_callbacks_,
-                                      cm_.cluster_.info_->stats_store_, timeout};
+  RpcChannelImpl grpc_request_timeout{cm_, "fake_cluster", grpc_callbacks_, timeout};
   helloworld::Greeter::Stub service_timeout{&grpc_request_timeout};
   expectNormalRequest(timeout);
   helloworld::HelloRequest request;

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -19,14 +19,15 @@ public:
                    const std::string& to_az = EMPTY_STRING) {
     TestHeaderMapImpl headers{{":status", std::to_string(code)}};
 
-    CodeUtility::ResponseStatInfo info{store_, "prefix.", headers, internal_request,
-                                       request_vhost_name, request_vcluster_name, from_az, to_az,
-                                       canary};
+    CodeUtility::ResponseStatInfo info{global_store_, cluster_scope_, "prefix.", headers,
+                                       internal_request, request_vhost_name, request_vcluster_name,
+                                       from_az, to_az, canary};
 
     CodeUtility::chargeResponseStat(info);
   }
 
-  Stats::IsolatedStoreImpl store_;
+  Stats::IsolatedStoreImpl global_store_;
+  Stats::IsolatedStoreImpl cluster_scope_;
 };
 
 TEST_F(CodeUtilityTest, NoCanary) {
@@ -35,24 +36,24 @@ TEST_F(CodeUtilityTest, NoCanary) {
   addResponse(401, false, false);
   addResponse(501, false, true);
 
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_201").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_201").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_3xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_301").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_3xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_301").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_4xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_401").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_4xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_401").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_5xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_501").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_5xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_501").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_201").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_201").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_3xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_301").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_3xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_301").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_4xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_401").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_4xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_401").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_5xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_501").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_5xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_501").value());
 
-  EXPECT_EQ(16U, store_.counters().size());
+  EXPECT_EQ(16U, cluster_scope_.counters().size());
 }
 
 TEST_F(CodeUtilityTest, Canary) {
@@ -60,24 +61,24 @@ TEST_F(CodeUtilityTest, Canary) {
   addResponse(300, false, false);
   addResponse(500, true, false);
 
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_200").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.internal.upstream_rq_200").value());
-  EXPECT_EQ(1U, store_.counter("prefix.canary.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.canary.upstream_rq_200").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_3xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_300").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_3xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_300").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_5xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.upstream_rq_500").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_5xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.external.upstream_rq_500").value());
-  EXPECT_EQ(1U, store_.counter("prefix.canary.upstream_rq_5xx").value());
-  EXPECT_EQ(1U, store_.counter("prefix.canary.upstream_rq_500").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_200").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.internal.upstream_rq_200").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.canary.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.canary.upstream_rq_200").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_3xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_300").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_3xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_300").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_5xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.upstream_rq_500").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_5xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.external.upstream_rq_500").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.canary.upstream_rq_5xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.canary.upstream_rq_500").value());
 
-  EXPECT_EQ(16U, store_.counters().size());
+  EXPECT_EQ(16U, cluster_scope_.counters().size());
 }
 
 TEST_F(CodeUtilityTest, All) {
@@ -144,33 +145,38 @@ TEST_F(CodeUtilityTest, All) {
 TEST_F(CodeUtilityTest, RequestVirtualCluster) {
   addResponse(200, false, false, "test-vhost", "test-cluster");
 
-  EXPECT_EQ(1U, store_.counter("vhost.test-vhost.vcluster.test-cluster.upstream_rq_2xx").value());
-  EXPECT_EQ(1U, store_.counter("vhost.test-vhost.vcluster.test-cluster.upstream_rq_200").value());
+  EXPECT_EQ(
+      1U, global_store_.counter("vhost.test-vhost.vcluster.test-cluster.upstream_rq_2xx").value());
+  EXPECT_EQ(
+      1U, global_store_.counter("vhost.test-vhost.vcluster.test-cluster.upstream_rq_200").value());
 }
 
 TEST_F(CodeUtilityTest, PerZoneStats) {
   addResponse(200, false, false, "", "", "from_az", "to_az");
 
-  EXPECT_EQ(1U, store_.counter("prefix.zone.from_az.to_az.upstream_rq_200").value());
-  EXPECT_EQ(1U, store_.counter("prefix.zone.from_az.to_az.upstream_rq_2xx").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.zone.from_az.to_az.upstream_rq_200").value());
+  EXPECT_EQ(1U, cluster_scope_.counter("prefix.zone.from_az.to_az.upstream_rq_2xx").value());
 }
 
 TEST(CodeUtilityResponseTimingTest, All) {
-  Stats::MockStore store;
+  Stats::MockStore global_store;
+  Stats::MockStore cluster_scope;
 
-  CodeUtility::ResponseTimingInfo info{store, "prefix.", std::chrono::milliseconds(5), true, true,
-                                       "vhost_name", "req_vcluster_name", "from_az", "to_az"};
+  CodeUtility::ResponseTimingInfo info{global_store, cluster_scope, "prefix.",
+                                       std::chrono::milliseconds(5), true, true, "vhost_name",
+                                       "req_vcluster_name", "from_az", "to_az"};
 
-  EXPECT_CALL(store, deliverTimingToSinks("prefix.upstream_rq_time", std::chrono::milliseconds(5)));
-  EXPECT_CALL(store,
+  EXPECT_CALL(cluster_scope,
+              deliverTimingToSinks("prefix.upstream_rq_time", std::chrono::milliseconds(5)));
+  EXPECT_CALL(cluster_scope,
               deliverTimingToSinks("prefix.canary.upstream_rq_time", std::chrono::milliseconds(5)));
-  EXPECT_CALL(store, deliverTimingToSinks("prefix.internal.upstream_rq_time",
-                                          std::chrono::milliseconds(5)));
-  EXPECT_CALL(store,
+  EXPECT_CALL(cluster_scope, deliverTimingToSinks("prefix.internal.upstream_rq_time",
+                                                  std::chrono::milliseconds(5)));
+  EXPECT_CALL(global_store,
               deliverTimingToSinks("vhost.vhost_name.vcluster.req_vcluster_name.upstream_rq_time",
                                    std::chrono::milliseconds(5)));
-  EXPECT_CALL(store, deliverTimingToSinks("prefix.zone.from_az.to_az.upstream_rq_time",
-                                          std::chrono::milliseconds(5)));
+  EXPECT_CALL(cluster_scope, deliverTimingToSinks("prefix.zone.from_az.to_az.upstream_rq_time",
+                                                  std::chrono::milliseconds(5)));
   CodeUtility::chargeResponseTiming(info);
 }
 

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -15,8 +15,8 @@ public:
   typedef std::function<void(CodecClient*)> DestroyCb;
 
   CodecClientForTest(Network::ClientConnectionPtr&& connection, Http::ClientConnection* codec,
-                     DestroyCb destroy_cb, const Http::CodecClientStats& stats)
-      : CodecClient(CodecClient::Type::HTTP1, std::move(connection), stats),
+                     DestroyCb destroy_cb, Upstream::HostDescriptionPtr host)
+      : CodecClient(CodecClient::Type::HTTP1, std::move(connection), host),
         destroy_cb_(destroy_cb) {
     codec_.reset(codec);
   }

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/upstream/mocks.h"
 
 using testing::_;
+using testing::AtLeast;
 using testing::Invoke;
 using testing::Return;
 using testing::WithArg;
@@ -120,10 +121,9 @@ TEST(RateLimitGrpcFactoryTest, NoCluster) {
 
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   Upstream::MockClusterManager cm;
-  Stats::IsolatedStoreImpl stats_store;
 
   EXPECT_CALL(cm, get("foo")).WillOnce(Return(nullptr));
-  EXPECT_THROW(GrpcFactoryImpl(*config, cm, stats_store), EnvoyException);
+  EXPECT_THROW(GrpcFactoryImpl(*config, cm), EnvoyException);
 }
 
 TEST(RateLimitGrpcFactoryTest, Create) {
@@ -135,10 +135,9 @@ TEST(RateLimitGrpcFactoryTest, Create) {
 
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   Upstream::MockClusterManager cm;
-  Stats::IsolatedStoreImpl stats_store;
 
-  EXPECT_CALL(cm, get("foo"));
-  GrpcFactoryImpl factory(*config, cm, stats_store);
+  EXPECT_CALL(cm, get("foo")).Times(AtLeast(1));
+  GrpcFactoryImpl factory(*config, cm);
   factory.create(Optional<std::chrono::milliseconds>());
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -215,8 +215,7 @@ TEST_F(RouterTest, UpstreamTimeout) {
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(504));
   response_timeout_->callback_();
 
-  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("cluster.fake_cluster.upstream_rq_timeout")
-                    .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("upstream_rq_timeout").value());
   EXPECT_EQ(1UL, cm_.conn_pool_.host_->stats().rq_timeout_.value());
 }
 
@@ -254,10 +253,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeout) {
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(504));
   per_try_timeout_->callback_();
 
-  EXPECT_EQ(
-      1U,
-      cm_.cluster_.info_->stats_store_.counter("cluster.fake_cluster.upstream_rq_per_try_timeout")
-          .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("upstream_rq_per_try_timeout").value());
   EXPECT_EQ(1UL, cm_.conn_pool_.host_->stats().rq_timeout_.value());
 }
 
@@ -597,12 +593,12 @@ TEST_F(RouterTest, RetryUpstream5xxNotComplete) {
   Http::HeaderMapPtr response_headers2(new Http::TestHeaderMapImpl{{":status", "200"}});
   response_decoder->decodeHeaders(std::move(response_headers2), true);
 
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.retry.upstream_rq_503").value());
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.upstream_rq_200").value());
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.zone.zone_name.to_az.upstream_rq_200")
-                    .value());
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.zone.zone_name.to_az.upstream_rq_2xx")
-                    .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("retry.upstream_rq_503").value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("upstream_rq_200").value());
+  EXPECT_EQ(
+      1U, cm_.cluster_.info_->stats_store_.counter("zone.zone_name.to_az.upstream_rq_200").value());
+  EXPECT_EQ(
+      1U, cm_.cluster_.info_->stats_store_.counter("zone.zone_name.to_az.upstream_rq_2xx").value());
 }
 
 TEST_F(RouterTest, Shadow) {
@@ -678,13 +674,13 @@ TEST_F(RouterTest, AltStatName) {
   EXPECT_EQ(1U,
             stats_store_.counter("vhost.fake_vhost.vcluster.fake_virtual_cluster.upstream_rq_200")
                 .value());
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.canary.upstream_rq_200").value());
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.alt_stat.upstream_rq_200").value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("canary.upstream_rq_200").value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("alt_stat.upstream_rq_200").value());
   EXPECT_EQ(
-      1U, stats_store_.counter("cluster.fake_cluster.alt_stat.zone.zone_name.to_az.upstream_rq_200")
+      1U, cm_.cluster_.info_->stats_store_.counter("alt_stat.zone.zone_name.to_az.upstream_rq_200")
               .value());
   EXPECT_EQ(
-      1U, stats_store_.counter("cluster.fake_cluster.alt_stat.zone.zone_name.to_az.upstream_rq_200")
+      1U, cm_.cluster_.info_->stats_store_.counter("alt_stat.zone.zone_name.to_az.upstream_rq_200")
               .value());
 }
 
@@ -834,7 +830,7 @@ TEST_F(RouterTest, CanaryStatusTrue) {
   ON_CALL(*cm_.conn_pool_.host_, canary()).WillByDefault(Return(true));
   response_decoder->decodeHeaders(std::move(response_headers), true);
 
-  EXPECT_EQ(1U, stats_store_.counter("cluster.fake_cluster.canary.upstream_rq_200").value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_.counter("canary.upstream_rq_200").value());
 }
 
 TEST_F(RouterTest, CanaryStatusFalse) {
@@ -864,7 +860,7 @@ TEST_F(RouterTest, CanaryStatusFalse) {
                                   {"x-envoy-virtual-cluster", "hello"}});
   response_decoder->decodeHeaders(std::move(response_headers), true);
 
-  EXPECT_EQ(0U, stats_store_.counter("cluster.fake_cluster.canary.upstream_rq_200").value());
+  EXPECT_EQ(0U, cm_.cluster_.info_->stats_store_.counter("canary.upstream_rq_200").value());
 }
 
 } // Router

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -28,7 +28,7 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
-  ServerContextImpl server_ctx("server_ctx", stats_store, server_ctx_config, runtime);
+  ServerContextImpl server_ctx(stats_store, server_ctx_config, runtime);
 
   Event::DispatcherImpl dispatcher;
   Network::TcpListenSocket socket(10000);
@@ -45,7 +45,7 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
-  ClientContextImpl client_ctx("client_ctx", stats_store, client_ctx_config);
+  ClientContextImpl client_ctx(stats_store, client_ctx_config);
   Network::ClientConnectionPtr client_connection =
       dispatcher.createSslClientConnection(client_ctx, "tcp://127.0.0.1:10000");
   client_connection->connect();
@@ -86,7 +86,7 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
 
   Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
-  ServerContextImpl server_ctx("server_ctx", stats_store, server_ctx_config, runtime);
+  ServerContextImpl server_ctx(stats_store, server_ctx_config, runtime);
 
   Event::DispatcherImpl dispatcher;
   Network::TcpListenSocket socket(10000);
@@ -103,7 +103,7 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
 
   Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
-  ClientContextImpl client_ctx("client_ctx", stats_store, client_ctx_config);
+  ClientContextImpl client_ctx(stats_store, client_ctx_config);
   Network::ClientConnectionPtr client_connection =
       dispatcher.createSslClientConnection(client_ctx, "tcp://127.0.0.1:10000");
   client_connection->connect();
@@ -140,7 +140,7 @@ TEST(SslConnectionImplTest, SslError) {
 
   Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
-  ServerContextImpl server_ctx("server_ctx", stats_store, server_ctx_config, runtime);
+  ServerContextImpl server_ctx(stats_store, server_ctx_config, runtime);
 
   Event::DispatcherImpl dispatcher;
   Network::TcpListenSocket socket(10000);

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -29,7 +29,7 @@ TEST(SslContextImplTest, TestCipherSuites) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   ContextConfigImpl cfg(*loader);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW(ClientContextImpl("", store, cfg), EnvoyException);
+  EXPECT_THROW(ClientContextImpl(store, cfg), EnvoyException);
 }
 
 TEST(SslContextImplTest, TestExpiringCert) {
@@ -43,7 +43,7 @@ TEST(SslContextImplTest, TestExpiringCert) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   ContextConfigImpl cfg(*loader);
   Stats::IsolatedStoreImpl store;
-  ClientContextImpl context("", store, cfg);
+  ClientContextImpl context(store, cfg);
 
   // This is a total hack, but right now we generate the cert and it expires in 15 days only in the
   // first second that it's valid. This can become invalid and then cause slower tests to fail.
@@ -64,7 +64,7 @@ TEST(SslContextImplTest, TestExpiredCert) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   ContextConfigImpl cfg(*loader);
   Stats::IsolatedStoreImpl store;
-  ClientContextImpl context("", store, cfg);
+  ClientContextImpl context(store, cfg);
   EXPECT_EQ(0U, context.daysUntilFirstCertExpires());
 }
 
@@ -81,7 +81,7 @@ TEST(SslContextImplTest, TestGetCertInformation) {
   ContextConfigImpl cfg(*loader);
   Stats::IsolatedStoreImpl store;
 
-  ClientContextImpl context("", store, cfg);
+  ClientContextImpl context(store, cfg);
   // This is similar to the hack above, but right now we generate the ca_cert and it expires in 15
   // days only in the first second that it's valid. We will partially match for up until Days until
   // Expiration: 1.
@@ -102,7 +102,7 @@ TEST(SslContextImplTest, TestNoCert) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString("{}");
   ContextConfigImpl cfg(*loader);
   Stats::IsolatedStoreImpl store;
-  ClientContextImpl context("", store, cfg);
+  ClientContextImpl context(store, cfg);
   EXPECT_EQ("", context.getCaCertInformation());
   EXPECT_EQ("", context.getCertChainInformation());
 }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -309,7 +309,7 @@ public:
     opts->access_token = "sample_token";
     opts->tracer_attributes["lightstep.component_name"] = "component";
 
-    ON_CALL(cm_, httpAsyncClientForCluster("lightstep_saas"))
+    ON_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))
         .WillByDefault(ReturnRef(cm_.async_client_));
     ON_CALL(context_, operationName()).WillByDefault(ReturnRef(operation_name_));
 
@@ -323,12 +323,12 @@ public:
   }
 
   void setupValidSink() {
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    EXPECT_CALL(cm_, get("fake_cluster")).WillRepeatedly(Return(cm_.cluster_.info_));
     ON_CALL(*cm_.cluster_.info_, features())
         .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
     std::string valid_config = R"EOF(
-      {"collector_cluster": "lightstep_saas"}
+      {"collector_cluster": "fake_cluster"}
     )EOF";
     Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
 
@@ -370,10 +370,10 @@ TEST_F(LightStepSinkTest, InitializeSink) {
 
   {
     // Valid config but not valid cluster.
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillOnce(Return(nullptr));
+    EXPECT_CALL(cm_, get("fake_cluster")).WillOnce(Return(nullptr));
 
     std::string valid_config = R"EOF(
-      {"collector_cluster": "lightstep_saas"}
+      {"collector_cluster": "fake_cluster"}
     )EOF";
     Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
 
@@ -382,11 +382,11 @@ TEST_F(LightStepSinkTest, InitializeSink) {
 
   {
     // Valid config, but upstream cluster does not support http2.
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    EXPECT_CALL(cm_, get("fake_cluster")).WillRepeatedly(Return(cm_.cluster_.info_));
     ON_CALL(*cm_.cluster_.info_, features()).WillByDefault(Return(0));
 
     std::string valid_config = R"EOF(
-      {"collector_cluster": "lightstep_saas"}
+      {"collector_cluster": "fake_cluster"}
     )EOF";
     Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
 
@@ -394,12 +394,12 @@ TEST_F(LightStepSinkTest, InitializeSink) {
   }
 
   {
-    EXPECT_CALL(cm_, get("lightstep_saas")).WillRepeatedly(Return(cm_.cluster_.info_));
+    EXPECT_CALL(cm_, get("fake_cluster")).WillRepeatedly(Return(cm_.cluster_.info_));
     ON_CALL(*cm_.cluster_.info_, features())
         .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
     std::string valid_config = R"EOF(
-      {"collector_cluster": "lightstep_saas"}
+      {"collector_cluster": "fake_cluster"}
     )EOF";
     Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
 
@@ -424,7 +424,7 @@ TEST_F(LightStepSinkTest, FlushSeveralSpans) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep_saas", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -454,26 +454,18 @@ TEST_F(LightStepSinkTest, FlushSeveralSpans) {
 
   callback->onSuccess(std::move(msg));
 
-  EXPECT_EQ(
-      1U,
-      stats_.counter(
-                 "cluster.lightstep_saas.grpc.lightstep.collector.CollectorService.Report.success")
-          .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_
+                    .counter("grpc.lightstep.collector.CollectorService.Report.success")
+                    .value());
 
   callback->onFailure(Http::AsyncClient::FailureReason::Reset);
 
-  EXPECT_EQ(
-      1U,
-      stats_.counter(
-                 "cluster.lightstep_saas.grpc.lightstep.collector.CollectorService.Report.failure")
-          .value());
-
-  EXPECT_EQ(
-      2U,
-      stats_.counter(
-                 "cluster.lightstep_saas.grpc.lightstep.collector.CollectorService.Report.total")
-          .value());
-
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_
+                    .counter("grpc.lightstep.collector.CollectorService.Report.failure")
+                    .value());
+  EXPECT_EQ(2U, cm_.cluster_.info_->stats_store_
+                    .counter("grpc.lightstep.collector.CollectorService.Report.total")
+                    .value());
   EXPECT_EQ(2U, stats_.counter("tracing.lightstep.spans_sent").value());
 }
 
@@ -530,7 +522,7 @@ TEST_F(LightStepSinkTest, FlushOneSpanGrpcFailure) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep_saas", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -557,17 +549,12 @@ TEST_F(LightStepSinkTest, FlushOneSpanGrpcFailure) {
   // No trailers, gRPC is considered failed.
   callback->onSuccess(std::move(msg));
 
-  EXPECT_EQ(
-      1U,
-      stats_.counter(
-                 "cluster.lightstep_saas.grpc.lightstep.collector.CollectorService.Report.failure")
-          .value());
-
-  EXPECT_EQ(
-      1U,
-      stats_.counter(
-                 "cluster.lightstep_saas.grpc.lightstep.collector.CollectorService.Report.total")
-          .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_
+                    .counter("grpc.lightstep.collector.CollectorService.Report.failure")
+                    .value());
+  EXPECT_EQ(1U, cm_.cluster_.info_->stats_store_
+                    .counter("grpc.lightstep.collector.CollectorService.Report.total")
+                    .value());
   EXPECT_EQ(1U, stats_.counter("tracing.lightstep.spans_sent").value());
 }
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -16,7 +16,7 @@ static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& 
 
 class RoundRobinLoadBalancerTest : public testing::Test {
 public:
-  RoundRobinLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats("", stats_store_)) {}
+  RoundRobinLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   void init(bool need_local_cluster) {
     if (need_local_cluster) {
@@ -369,7 +369,7 @@ TEST_F(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
 
 class LeastRequestLoadBalancerTest : public testing::Test {
 public:
-  LeastRequestLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats("", stats_store_)) {}
+  LeastRequestLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   NiceMock<MockCluster> cluster_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -527,7 +527,7 @@ TEST_F(LeastRequestLoadBalancerTest, WeightImbalanceCallbacks) {
 
 class RandomLoadBalancerTest : public testing::Test {
 public:
-  RandomLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats("", stats_store_)) {}
+  RandomLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   NiceMock<MockCluster> cluster_;
   NiceMock<Runtime::MockLoader> runtime_;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -20,7 +20,7 @@ static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& 
  */
 class DISABLED_SimulationTest : public testing::Test {
 public:
-  DISABLED_SimulationTest() : stats_(ClusterInfoImpl::generateStats("", stats_store_)) {
+  DISABLED_SimulationTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {
     ON_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50U))
         .WillByDefault(Return(50U));
     ON_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -20,9 +20,8 @@ TEST(OutlierDetectorImplFactoryTest, NoDetector) {
   NiceMock<MockCluster> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
-  Stats::IsolatedStoreImpl stats_store;
-  EXPECT_EQ(nullptr, DetectorImplFactory::createForCluster(cluster, *loader, dispatcher, runtime,
-                                                           stats_store, nullptr));
+  EXPECT_EQ(nullptr,
+            DetectorImplFactory::createForCluster(cluster, *loader, dispatcher, runtime, nullptr));
 }
 
 TEST(OutlierDetectorImplFactoryTest, Detector) {
@@ -36,9 +35,8 @@ TEST(OutlierDetectorImplFactoryTest, Detector) {
   NiceMock<MockCluster> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
-  Stats::IsolatedStoreImpl stats_store;
-  EXPECT_NE(nullptr, DetectorImplFactory::createForCluster(cluster, *loader, dispatcher, runtime,
-                                                           stats_store, nullptr));
+  EXPECT_NE(nullptr,
+            DetectorImplFactory::createForCluster(cluster, *loader, dispatcher, runtime, nullptr));
 }
 
 class CallbackChecker {
@@ -57,7 +55,6 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Runtime::MockLoader> runtime_;
   Event::MockTimer* interval_timer_ = new Event::MockTimer(&dispatcher_);
-  Stats::IsolatedStoreImpl stats_store_;
   CallbackChecker checker_;
   MockSystemTimeSource time_source_;
   std::shared_ptr<MockEventLogger> event_logger_{new MockEventLogger()};
@@ -67,8 +64,8 @@ TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -85,21 +82,19 @@ TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
   EXPECT_TRUE(cluster_.hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
-  EXPECT_EQ(1UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 
   detector.reset();
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 }
 
 TEST_F(OutlierDetectorImplTest, DestroyHostInUse) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   detector.reset();
@@ -115,8 +110,8 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_.push_back(
@@ -141,8 +136,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
   EXPECT_TRUE(cluster_.hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
-  EXPECT_EQ(1UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 
   // Interval that doesn't bring the host back in.
   EXPECT_CALL(time_source_, currentSystemTime())
@@ -162,21 +156,18 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
 
   cluster_.runCallbacks({}, cluster_.hosts_);
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
-  EXPECT_EQ(1UL,
-            stats_store_.counter("cluster.fake_cluster.outlier_detection.ejections_total").value());
-  EXPECT_EQ(1UL,
-            stats_store_.counter("cluster.fake_cluster.outlier_detection.ejections_consecutive_5xx")
-                .value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.counter("outlier_detection.ejections_total").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.counter("outlier_detection.ejections_consecutive_5xx")
+                     .value());
 }
 
 TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -193,14 +184,12 @@ TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
   EXPECT_TRUE(cluster_.hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
-  EXPECT_EQ(1UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 
   std::vector<HostPtr> old_hosts = std::move(cluster_.hosts_);
   cluster_.runCallbacks({}, old_hosts);
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 
   EXPECT_CALL(time_source_, currentSystemTime())
       .WillOnce(Return(SystemTime(std::chrono::milliseconds(9999))));
@@ -213,8 +202,8 @@ TEST_F(OutlierDetectorImplTest, Overflow) {
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")},
                      HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:81", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   ON_CALL(runtime_.snapshot_, getInteger("outlier_detection.max_ejection_percent", _))
@@ -241,18 +230,17 @@ TEST_F(OutlierDetectorImplTest, Overflow) {
   cluster_.hosts_[1]->outlierDetector().putHttpResponseCode(503);
   EXPECT_FALSE(cluster_.hosts_[1]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
   EXPECT_EQ(1UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
-  EXPECT_EQ(1UL, stats_store_.counter("cluster.fake_cluster.outlier_detection.ejections_overflow")
-                     .value());
+            cluster_.info_->stats_store_.counter("outlier_detection.ejections_overflow").value());
 }
 
 TEST_F(OutlierDetectorImplTest, NotEnforcing) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -265,21 +253,18 @@ TEST_F(OutlierDetectorImplTest, NotEnforcing) {
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
   EXPECT_FALSE(cluster_.hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
-  EXPECT_EQ(1UL,
-            stats_store_.counter("cluster.fake_cluster.outlier_detection.ejections_total").value());
-  EXPECT_EQ(1UL,
-            stats_store_.counter("cluster.fake_cluster.outlier_detection.ejections_consecutive_5xx")
-                .value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.counter("outlier_detection.ejections_total").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.counter("outlier_detection.ejections_consecutive_5xx")
+                     .value());
 }
 
 TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -296,16 +281,15 @@ TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   cluster_.runCallbacks({}, old_hosts);
   post_cb();
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 }
 
 TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -323,16 +307,15 @@ TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
   EXPECT_EQ(nullptr, weak_detector.lock());
   post_cb();
 
-  EXPECT_EQ(0UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(0UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 }
 
 TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_[0]->outlierDetector().putHttpResponseCode(503);
@@ -356,16 +339,15 @@ TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
   EXPECT_TRUE(cluster_.hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   post_cb();
 
-  EXPECT_EQ(1UL,
-            stats_store_.gauge("cluster.fake_cluster.outlier_detection.ejections_active").value());
+  EXPECT_EQ(1UL, cluster_.info_->stats_store_.gauge("outlier_detection.ejections_active").value());
 }
 
 TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
-  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
-      cluster_, dispatcher_, runtime_, stats_store_, time_source_, event_logger_));
+  std::shared_ptr<DetectorImpl> detector(
+      DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   // Cause a consecutive 5xx error.

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -100,7 +100,9 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_EQ(4U, cluster.info()->resourceManager(ResourcePriority::High).retries().max());
   EXPECT_EQ(3U, cluster.info()->maxRequestsPerConnection());
   EXPECT_EQ(Http::CodecOptions::NoCompression, cluster.info()->httpCodecOptions());
-  EXPECT_EQ("cluster.name.", cluster.info()->statPrefix());
+
+  cluster.info()->stats().upstream_rq_total_.inc();
+  EXPECT_EQ(1UL, stats.counter("cluster.name.upstream_rq_total").value());
 
   EXPECT_CALL(runtime.snapshot_, featureEnabled("upstream.maintenance_mode.name", 0));
   EXPECT_FALSE(cluster.info()->maintenanceMode());

--- a/test/example_configs_test.cc
+++ b/test/example_configs_test.cc
@@ -15,12 +15,10 @@ class NullSslContextManager : public Ssl::ContextManager,
                               public Ssl::ServerContext,
                               public Ssl::ClientContext {
 public:
-  Ssl::ClientContext& createSslClientContext(const std::string&, Stats::Store&,
-                                             Ssl::ContextConfig&) override {
+  Ssl::ClientContext& createSslClientContext(Stats::Scope&, Ssl::ContextConfig&) override {
     return *this;
   }
-  Ssl::ServerContext& createSslServerContext(const std::string&, Stats::Store&,
-                                             Ssl::ContextConfig&) override {
+  Ssl::ServerContext& createSslServerContext(Stats::Scope&, Ssl::ContextConfig&) override {
     return *this;
   }
   size_t daysUntilFirstCertExpires() override { return 0; }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -7,7 +7,9 @@
 
 #include "common/api/api_impl.h"
 #include "common/buffer/buffer_impl.h"
+#include "common/upstream/upstream_impl.h"
 
+#include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
 
 IntegrationTestServerPtr BaseIntegrationTest::test_server_;
@@ -78,9 +80,9 @@ void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason) {
 
 IntegrationCodecClient::IntegrationCodecClient(Event::Dispatcher& dispatcher,
                                                Network::ClientConnectionPtr&& conn,
-                                               const Http::CodecClientStats& stats,
-                                               Stats::Store& store, CodecClient::Type type)
-    : CodecClientProd(type, std::move(conn), stats, store, 0), callbacks_(*this),
+                                               Upstream::HostDescriptionPtr host_description,
+                                               CodecClient::Type type)
+    : CodecClientProd(type, std::move(conn), host_description), callbacks_(*this),
       codec_callbacks_(*this) {
   connection_->addConnectionCallbacks(callbacks_);
   setCodecConnectionCallbacks(codec_callbacks_);
@@ -229,10 +231,11 @@ IntegrationCodecClientPtr BaseIntegrationTest::makeHttpConnection(uint32_t port,
 IntegrationCodecClientPtr
 BaseIntegrationTest::makeHttpConnection(Network::ClientConnectionPtr&& conn,
                                         Http::CodecClient::Type type) {
-  return IntegrationCodecClientPtr{new IntegrationCodecClient(
-      *dispatcher_, std::move(conn),
-      Http::CodecClientStats{ALL_CODEC_CLIENT_STATS(POOL_COUNTER(stats_store_))}, stats_store_,
-      type)};
+  std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
+  Upstream::HostDescriptionPtr host_description{
+      new Upstream::HostDescriptionImpl(cluster, "tcp://127.0.0.1:80", false, "")};
+  return IntegrationCodecClientPtr{
+      new IntegrationCodecClient(*dispatcher_, std::move(conn), host_description, type)};
 }
 
 IntegrationTcpClientPtr BaseIntegrationTest::makeTcpConnection(uint32_t port) {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -49,7 +49,7 @@ typedef std::unique_ptr<IntegrationStreamDecoder> IntegrationStreamDecoderPtr;
 class IntegrationCodecClient : public Http::CodecClientProd {
 public:
   IntegrationCodecClient(Event::Dispatcher& dispatcher, Network::ClientConnectionPtr&& conn,
-                         const Http::CodecClientStats& stats, Stats::Store& store,
+                         Upstream::HostDescriptionPtr host_description,
                          Http::CodecClient::Type type);
 
   void makeHeaderOnlyRequest(const Http::HeaderMap& headers, IntegrationStreamDecoder& response);

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -12,8 +12,7 @@ ServerContextPtr SslIntegrationTest::upstream_ssl_ctx_;
 ClientContextPtr SslIntegrationTest::client_ssl_ctx_alpn_;
 ClientContextPtr SslIntegrationTest::client_ssl_ctx_no_alpn_;
 
-ServerContextPtr SslIntegrationTest::createUpstreamSslContext(const std::string& name,
-                                                              Stats::Store& store) {
+ServerContextPtr SslIntegrationTest::createUpstreamSslContext(Stats::Scope& scope) {
   std::string json = R"EOF(
 {
   "cert_chain_file": "test/config/integration/certs/upstreamcert.pem",
@@ -23,11 +22,10 @@ ServerContextPtr SslIntegrationTest::createUpstreamSslContext(const std::string&
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   ContextConfigImpl cfg(*loader);
-  return ServerContextPtr(new TestServerContextImpl(name, store, cfg));
+  return ServerContextPtr(new TestServerContextImpl(scope, cfg));
 }
 
-ClientContextPtr SslIntegrationTest::createClientSslContext(const std::string& name,
-                                                            Stats::Store& store, bool alpn) {
+ClientContextPtr SslIntegrationTest::createClientSslContext(Stats::Scope& scope, bool alpn) {
   std::string json_no_alpn = R"EOF(
 {
   "ca_cert_file": "test/config/integration/certs/cacert.pem",
@@ -47,7 +45,7 @@ ClientContextPtr SslIntegrationTest::createClientSslContext(const std::string& n
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(alpn ? json_alpn : json_no_alpn);
   ContextConfigImpl cfg(*loader);
-  return ClientContextPtr(new ClientContextImpl(name, store, cfg));
+  return ClientContextPtr(new ClientContextImpl(scope, cfg));
 }
 
 Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool alpn) {

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -16,8 +16,7 @@ namespace Ssl {
 
 class TestServerContextImpl : public ContextImpl, public ServerContext {
 public:
-  TestServerContextImpl(const std::string& name, Stats::Store& stats, ContextConfig& config)
-      : ContextImpl(name, stats, config) {}
+  TestServerContextImpl(Stats::Scope& scope, ContextConfig& config) : ContextImpl(scope, config) {}
 };
 
 class MockRuntimeIntegrationTestServer : public IntegrationTestServer {
@@ -49,9 +48,9 @@ public:
   static void SetUpTestCase() {
     test_server_ =
         MockRuntimeIntegrationTestServer::create("test/config/integration/server_ssl.json");
-    upstream_ssl_ctx_ = createUpstreamSslContext("upstream", store());
-    client_ssl_ctx_alpn_ = createClientSslContext("client", store(), true);
-    client_ssl_ctx_no_alpn_ = createClientSslContext("client", store(), false);
+    upstream_ssl_ctx_ = createUpstreamSslContext(store());
+    client_ssl_ctx_alpn_ = createClientSslContext(store(), true);
+    client_ssl_ctx_no_alpn_ = createClientSslContext(store(), false);
     fake_upstreams_.emplace_back(
         new FakeUpstream(upstream_ssl_ctx_.get(), 11000, FakeHttpConnection::Type::HTTP1));
     fake_upstreams_.emplace_back(
@@ -71,9 +70,8 @@ public:
 
   Network::ClientConnectionPtr makeSslClientConnection(bool alpn);
 
-  static ServerContextPtr createUpstreamSslContext(const std::string& name, Stats::Store& store);
-  static ClientContextPtr createClientSslContext(const std::string& name, Stats::Store& store,
-                                                 bool alpn);
+  static ServerContextPtr createUpstreamSslContext(Stats::Scope& store);
+  static ClientContextPtr createClientSslContext(Stats::Scope& scope, bool alpn);
 
   static Stats::Store& store() { return test_server_->server().stats(); }
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -13,12 +13,10 @@ public:
   MockContextManager();
   ~MockContextManager();
 
-  MOCK_METHOD3(createSslClientContext,
-               Ssl::ClientContext&(const std::string& name, Stats::Store& stats,
-                                   ContextConfig& config));
-  MOCK_METHOD3(createSslServerContext,
-               Ssl::ServerContext&(const std::string& name, Stats::Store& stats,
-                                   ContextConfig& config));
+  MOCK_METHOD2(createSslClientContext,
+               Ssl::ClientContext&(Stats::Scope& scope, ContextConfig& config));
+  MOCK_METHOD2(createSslServerContext,
+               Ssl::ServerContext&(Stats::Scope& stats, ContextConfig& config));
   MOCK_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_METHOD0(getContexts, std::vector<std::reference_wrapper<Ssl::Context>>());
 };

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -40,16 +40,15 @@ MockHost::MockHost() {}
 MockHost::~MockHost() {}
 
 MockClusterInfo::MockClusterInfo()
-    : stats_(ClusterInfoImpl::generateStats(stat_prefix_, stats_store_)),
+    : stats_(ClusterInfoImpl::generateStats(stats_store_)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1)) {
 
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
-  ON_CALL(*this, altStatName()).WillByDefault(ReturnRef(alt_stat_name_));
   ON_CALL(*this, maxRequestsPerConnection())
       .WillByDefault(ReturnPointee(&max_requests_per_connection_));
-  ON_CALL(*this, statPrefix()).WillByDefault(ReturnRef(stat_prefix_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
+  ON_CALL(*this, statsScope()).WillByDefault(ReturnRef(stats_store_));
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke([this](ResourcePriority)
                                 -> Upstream::ResourceManager& { return *resource_manager_; }));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -21,7 +21,6 @@ public:
   ~MockClusterInfo();
 
   // Upstream::ClusterInfo
-  MOCK_CONST_METHOD0(altStatName, const std::string&());
   MOCK_CONST_METHOD0(connectTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(features, uint64_t());
   MOCK_CONST_METHOD0(httpCodecOptions, uint64_t());
@@ -31,12 +30,10 @@ public:
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
   MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
-  MOCK_CONST_METHOD0(statPrefix, const std::string&());
   MOCK_CONST_METHOD0(stats, ClusterStats&());
+  MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
 
   std::string name_{"fake_cluster"};
-  std::string alt_stat_name_{"fake_alt_cluster"};
-  std::string stat_prefix_{"cluster.fake_cluster."};
   uint64_t max_requests_per_connection_{};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStats stats_;


### PR DESCRIPTION
Currently stats are allocated from a fix memory pool in shared memory
so that we can do hot restart. We have no facility to delete stats. This
is not going to work when we can add/remove clusters dynamically. This
commit adds a new scope concept and plumbs through a scope for all cluster
stats. The actual scope implementation doesn't do anything currently other
than just pass through to the main store. The actual shared memory
implementation of deletion is quite complicated so I will do that in a
dedicated smaller change.

A few other notes:
1) I got rid of alt_stat_prefix from cluster. This was used a long time ago
   when we were rolling out sds. It's hard to support in the new scheme so
   I'm just getting rid of it.
2) How we manage SSL contexts is also broken for cluster deletion. The contexts
   are currently global and not deleted. I will fix this in a follow up.