### PR TITLE
Add regular expression support in header match

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -198,7 +198,7 @@ The router can match a request to a route based on headers specified in the rout
 .. code-block:: json
 
   [
-    {"name": "...", "value": "..."}
+    {"name": "...", "value": "...", "regex": "..."}
   ]
 
 name
@@ -207,6 +207,10 @@ name
 value
   *(optional, string)* Specifies the value of the header. If the value is absent a request that has
   the *name* header will match, regardless of the header's value.
+
+regex
+  *(optional, boolean)* Specifies whether the header value is a regular
+  expression or not. Defaults to false.
 
 The router will check the request's headers against all the specified
 headers in the route config. A match will happen if all the headers in the route are present in

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -210,7 +210,8 @@ value
 
 regex
   *(optional, boolean)* Specifies whether the header value is a regular
-  expression or not. Defaults to false.
+  expression or not. Defaults to false. The regex grammar used in the value field
+  is defined `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
 
 The router will check the request's headers against all the specified
 headers in the route config. A match will happen if all the headers in the route are present in

--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -119,7 +119,7 @@ actual fault injection further depend on the values of *abort_percent* and
 .. code-block:: json
 
   [
-    {"name": "...", "value": "..."}
+    {"name": "...", "value": "...", "regex": "..."}
   ]
 
 name
@@ -129,6 +129,10 @@ value
   *(optional, string)* Specifies the value of the header. If the value is
   absent a request that has the *name* header will match, regardless of the
   header's value.
+
+regex
+  *(optional, boolean)* Specifies whether the header value is a regular expression
+  or not. Defaults to false.
 
 The filter will check the request's headers against all the specified
 headers in the filter config. A match will happen if all the headers in the

--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -132,7 +132,8 @@ value
 
 regex
   *(optional, boolean)* Specifies whether the header value is a regular expression
-  or not. Defaults to false.
+  or not. Defaults to false. The regex grammar used in the value field
+  is defined `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
 
 The filter will check the request's headers against all the specified
 headers in the filter config. A match will happen if all the headers in the

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -60,7 +60,8 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
     for (const Json::ObjectPtr& header_map : config_headers) {
       // allow header value to be empty, allows matching to be only based on header presence.
       fault_filter_headers_.emplace_back(Http::LowerCaseString(header_map->getString("name")),
-                                         header_map->getString("value", EMPTY_STRING));
+                                         header_map->getString("value", EMPTY_STRING),
+                                         header_map->getBoolean("regex", false));
     }
   }
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -55,13 +55,13 @@ bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
   if (!config_headers.empty()) {
     for (const HeaderData& cfg_header_data : config_headers) {
       const Http::HeaderEntry* header = request_headers.get(cfg_header_data.name_);
-      if (cfg_header_data.value_ == EMPTY_STRING) {
+      if (cfg_header_data.value_.empty()) {
         matches &= (header != nullptr);
-      } else if (cfg_header_data.isregex_) {
-        matches &= (header != nullptr) &&
-                   std::regex_match(header->value().c_str(), cfg_header_data.pattern_);
-      } else {
+      } else if (!cfg_header_data.is_regex_) {
         matches &= (header != nullptr) && (header->value() == cfg_header_data.value_.c_str());
+      } else {
+        matches &= (header != nullptr) &&
+                   std::regex_match(header->value().c_str(), cfg_header_data.regex_pattern_);
       }
       if (!matches) {
         break;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -48,17 +48,17 @@ Upstream::ResourcePriority ConfigUtility::parsePriority(const Json::Object& conf
   }
 }
 
-bool ConfigUtility::matchHeaders(const Http::HeaderMap& headers,
-                                 const std::vector<HeaderData> request_headers) {
+bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
+                                 const std::vector<HeaderData> config_headers) {
   bool matches = true;
 
-  if (!request_headers.empty()) {
-    for (const HeaderData& header_data : request_headers) {
-      const Http::HeaderEntry* header = headers.get(header_data.name_);
-      if (header_data.value_ == EMPTY_STRING) {
+  if (!config_headers.empty()) {
+    for (const HeaderData& cfg_header_data : config_headers) {
+      const Http::HeaderEntry* header = request_headers.get(cfg_header_data.name_);
+      if (cfg_header_data.value_ == EMPTY_STRING) {
         matches &= (header != nullptr);
       } else {
-        matches &= (header != nullptr) && (header->value() == header_data.value_.c_str());
+        matches &= (header != nullptr) && (header->value() == cfg_header_data.value_.c_str());
       }
       if (!matches) {
         break;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -58,7 +58,8 @@ bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
       if (cfg_header_data.value_ == EMPTY_STRING) {
         matches &= (header != nullptr);
       } else {
-        matches &= (header != nullptr) && (header->value() == cfg_header_data.value_.c_str());
+        matches &= (header != nullptr) &&
+                   std::regex_match(header->value().c_str(), cfg_header_data.pattern_);
       }
       if (!matches) {
         break;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -46,13 +46,14 @@ public:
 class ConfigUtility {
 public:
   struct HeaderData {
-    HeaderData(const Http::LowerCaseString& name, const std::string& value, const bool isregex)
-        : name_(name), value_(value), pattern_(value_, std::regex::optimize), isregex_(isregex) {}
+    HeaderData(const Http::LowerCaseString& name, const std::string& value, const bool is_regex)
+        : name_(name), value_(value), regex_pattern_(value_, std::regex::optimize),
+          is_regex_(is_regex) {}
 
     const Http::LowerCaseString name_;
     const std::string value_;
-    const std::regex pattern_;
-    const bool isregex_;
+    const std::regex regex_pattern_;
+    const bool is_regex_;
   };
 
   /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -47,10 +47,11 @@ class ConfigUtility {
 public:
   struct HeaderData {
     HeaderData(const Http::LowerCaseString& name, const std::string& value)
-        : name_(name), value_(value) {}
+        : name_(name), value_(value), pattern_(value_, std::regex::optimize) {}
 
     const Http::LowerCaseString name_;
     const std::string value_;
+    const std::regex pattern_;
   };
 
   /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -46,12 +46,13 @@ public:
 class ConfigUtility {
 public:
   struct HeaderData {
-    HeaderData(const Http::LowerCaseString& name, const std::string& value)
-        : name_(name), value_(value), pattern_(value_, std::regex::optimize) {}
+    HeaderData(const Http::LowerCaseString& name, const std::string& value, const bool isregex)
+        : name_(name), value_(value), pattern_(value_, std::regex::optimize), isregex_(isregex) {}
 
     const Http::LowerCaseString name_;
     const std::string value_;
     const std::regex pattern_;
+    const bool isregex_;
   };
 
   /**

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -438,9 +438,16 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
         },
         {
           "prefix": "/",
-          "cluster": "local_service_with_header_pattern",
+          "cluster": "local_service_with_header_pattern_set_regex",
           "headers" : [
-            {"name": "test_header_pattern", "value": "^user=test-\\d+$"}
+            {"name": "test_header_pattern", "value": "^user=test-\\d+$", "regex": true}
+          ]
+        },
+        {
+          "prefix": "/",
+          "cluster": "local_service_with_header_pattern_unset_regex",
+          "headers" : [
+            {"name": "test_header_pattern", "value": "^customer=test-\\d+$"}
           ]
         },
         {
@@ -495,8 +502,14 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
     headers.addViaCopy("test_header_pattern", "user=test-1223");
-    EXPECT_EQ("local_service_with_header_pattern",
+    EXPECT_EQ("local_service_with_header_pattern_set_regex",
               config.routeForRequest(headers, 0)->clusterName());
+  }
+
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addViaCopy("test_header_pattern", "customer=test-1223");
+    EXPECT_EQ("local_service_without_headers", config.routeForRequest(headers, 0)->clusterName());
   }
 }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3,8 +3,8 @@
 #include "common/json/json_loader.h"
 #include "common/router/config_impl.h"
 
-#include "test/mocks/upstream/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
 
 using testing::_;
@@ -438,6 +438,13 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
         },
         {
           "prefix": "/",
+          "cluster": "local_service_with_header_pattern",
+          "headers" : [
+            {"name": "test_header_pattern", "value": "^user=test-\\d+$"}
+          ]
+        },
+        {
+          "prefix": "/",
           "cluster": "local_service_without_headers"
         }
       ]
@@ -482,6 +489,13 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
     headers.addViaCopy("test_header_presence", "test");
     EXPECT_EQ("local_service_with_empty_headers",
+              config.routeForRequest(headers, 0)->clusterName());
+  }
+
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addViaCopy("test_header_pattern", "user=test-1223");
+    EXPECT_EQ("local_service_with_header_pattern",
               config.routeForRequest(headers, 0)->clusterName());
   }
 }


### PR DESCRIPTION
fixes #199 

This PR adds support for C++ style regexes while matching request headers. There are no config syntax changes.
