### PR TITLE
Refactor route matching

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -201,6 +201,24 @@ public:
 };
 
 /**
+ * An interface that holds a RedirectEntry or a RouteEntry for a request.
+ */
+class Route {
+public:
+  virtual ~Route() {}
+
+  /**
+   * @return the redirect entry or nullptr if there is no redirect needed for the request.
+   */
+  virtual const RedirectEntry* redirectEntry() const PURE;
+
+  /**
+   * @return the route entry or nullptr if there is no matching route for the request.
+   */
+  virtual const RouteEntry* routeEntry() const PURE;
+};
+
+/**
  * The router configuration.
  */
 class Config {
@@ -208,25 +226,15 @@ public:
   virtual ~Config() {}
 
   /**
-   * Based on the incoming HTTP request headers, determine whether a redirect should take place.
-   * @param headers supplies the request headers.
-   * @param random_value supplies the random seed to use if a runtime choice is required. This
-   *        allows stable choices between calls if desired.
-   * @return the redirect entry or nullptr if there is no redirect needed for the request.
-   */
-  virtual const RedirectEntry* redirectRequest(const Http::HeaderMap& headers,
-                                               uint64_t random_value) const PURE;
-
-  /**
-   * Based on the incoming HTTP request headers, choose the target route to send the remainder
-   * of the request to.
+   * Based on the incoming HTTP request headers, determine the target route (containing either a
+   * route entry or a redirect entry) for the request.
    * @param headers supplies the request headers.
    * @param random_value supplies the random seed to use if a runtime choice is required. This
    *        allows stable choices between calls if desired.
    * @return the route or nullptr if there is no matching route for the request.
    */
-  virtual const RouteEntry* routeForRequest(const Http::HeaderMap& headers,
-                                            uint64_t random_value) const PURE;
+  virtual const Route* getRouteForRequest(const Http::HeaderMap& headers,
+                                          uint64_t random_value) const PURE;
 
   /**
    * Return a list of headers that will be cleaned from any requests that are not from an internal
@@ -266,19 +274,12 @@ public:
   virtual ~StableRouteTable() {}
 
   /**
-   * Based on the incoming HTTP request headers, determine whether a redirect should take place.
-   * @param headers supplies the request headers.
-   * @return the redirect entry or nullptr if there is no redirect needed for the request.
-   */
-  virtual const RedirectEntry* redirectRequest(const Http::HeaderMap& headers) const PURE;
-
-  /**
-   * Based on the incoming HTTP request headers, choose the target route to send the remainder
-   * of the request to.
+   * Based on the incoming HTTP request headers, determine the target route (containing either a
+   * route entry or a redirect entry) for the request.
    * @param headers supplies the request headers.
    * @return the route or nullptr if there is no matching route for the request.
    */
-  virtual const RouteEntry* routeForRequest(const Http::HeaderMap& headers) const PURE;
+  virtual const Route* route(const Http::HeaderMap& headers) const PURE;
 };
 
 } // Router

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -233,8 +233,7 @@ public:
    *        allows stable choices between calls if desired.
    * @return the route or nullptr if there is no matching route for the request.
    */
-  virtual const Route* getRouteForRequest(const Http::HeaderMap& headers,
-                                          uint64_t random_value) const PURE;
+  virtual const Route* route(const Http::HeaderMap& headers, uint64_t random_value) const PURE;
 
   /**
    * Return a list of headers that will be cleaned from any requests that are not from an internal

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -110,7 +110,7 @@ void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
     return;
   }
 
-gg  // TODO: Cluster may not exist.
+  // TODO: Cluster may not exist.
   cluster_ = cm_.get(route_entry->clusterName());
   grpc_service_ = parts[0];
   grpc_method_ = parts[1];

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -95,8 +95,13 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::HeaderMap& tr
 }
 
 void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
-  const Router::RouteEntry* route = decoder_callbacks_->routeTable().routeForRequest(headers);
+  const Router::Route* route = decoder_callbacks_->routeTable().route(headers);
   if (!route) {
+    return;
+  }
+
+  const Router::RouteEntry* route_entry = route->routeEntry();
+  if (!route_entry) {
     return;
   }
 
@@ -105,8 +110,8 @@ void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
     return;
   }
 
-  // TODO: Cluster may not exist.
-  cluster_ = cm_.get(route->clusterName());
+gg  // TODO: Cluster may not exist.
+  cluster_ = cm_.get(route_entry->clusterName());
   grpc_service_ = parts[0];
   grpc_method_ = parts[1];
   do_stat_tracking_ = true;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -125,6 +125,17 @@ private:
     Optional<std::chrono::milliseconds> timeout_;
   };
 
+  struct RouteImpl : public Router::Route {
+    RouteImpl(const std::string& cluster_name, const Optional<std::chrono::milliseconds>& timeout)
+        : route_entry_(cluster_name, timeout) {}
+
+    // Router::Route
+    const Router::RedirectEntry* redirectEntry() const override { return nullptr; }
+    const Router::RouteEntry* routeEntry() const override { return &route_entry_; }
+
+    RouteEntryImpl route_entry_;
+  };
+
   void cleanup();
   void failDueToClientDestroy();
   void onComplete();
@@ -147,12 +158,7 @@ private:
   void encodeTrailers(HeaderMapPtr&& trailers) override;
 
   // Router::StableRouteTable
-  const Router::RedirectEntry* redirectRequest(const Http::HeaderMap&) const override {
-    return nullptr;
-  }
-  const Router::RouteEntry* routeForRequest(const Http::HeaderMap&) const override {
-    return &route_;
-  }
+  const Router::Route* route(const Http::HeaderMap&) const override { return &route_; }
 
   MessagePtr request_;
   AsyncClientImpl& parent_;
@@ -162,7 +168,7 @@ private:
   Router::ProdFilter router_;
   std::function<void()> reset_callback_;
   AccessLog::RequestInfoImpl request_info_;
-  RouteEntryImpl route_;
+  RouteImpl route_;
   bool complete_{};
 
   friend class AsyncClientImpl;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -252,8 +252,7 @@ private:
 
     // Router::StableRouteTable
     const Router::Route* route(const HeaderMap& headers) const {
-      return parent_.connection_manager_.config_.routeConfig().getRouteForRequest(
-          headers, parent_.stream_id_);
+      return parent_.connection_manager_.config_.routeConfig().route(headers, parent_.stream_id_);
     }
 
     ActiveStream& parent_;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -251,13 +251,9 @@ private:
     const std::string& downstreamAddress() override;
 
     // Router::StableRouteTable
-    const Router::RedirectEntry* redirectRequest(const HeaderMap& headers) const {
-      return parent_.connection_manager_.config_.routeConfig().redirectRequest(headers,
-                                                                               parent_.stream_id_);
-    }
-    const Router::RouteEntry* routeForRequest(const HeaderMap& headers) const {
-      return parent_.connection_manager_.config_.routeConfig().routeForRequest(headers,
-                                                                               parent_.stream_id_);
+    const Router::Route* route(const HeaderMap& headers) const {
+      return parent_.connection_manager_.config_.routeConfig().getRouteForRequest(
+          headers, parent_.stream_id_);
     }
 
     ActiveStream& parent_;

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -29,11 +29,11 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
     std::vector<::RateLimit::Descriptor> descriptors;
 
     // Get all applicable rate limit policy entries for the route.
-    populateRateLimitDescriptors(route_entry->rateLimitPolicy(), descriptors, route, headers);
+    populateRateLimitDescriptors(route_entry->rateLimitPolicy(), descriptors, route_entry, headers);
 
     // Get all applicable rate limit policy entries for the virtual host.
-    populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors, route,
-                                 headers);
+    populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors,
+                                 route_entry, headers);
 
     if (!descriptors.empty()) {
       state_ = State::Calling;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -329,10 +329,10 @@ const Route* VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& headers
                                                   uint64_t random_value) const {
   // First check for ssl redirect.
   if (ssl_requirements_ == SslRequirements::ALL && headers.ForwardedProto()->value() != "https") {
-    return &SSL_ROUTE;
+    return &SSL_REDIRECT_ROUTE;
   } else if (ssl_requirements_ == SslRequirements::EXTERNAL_ONLY &&
              headers.ForwardedProto()->value() != "https" && !headers.EnvoyInternalRequest()) {
-    return &SSL_ROUTE;
+    return &SSL_REDIRECT_ROUTE;
   }
 
   // Check for a route that matches the request.
@@ -361,8 +361,7 @@ const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::HeaderMap& head
   return nullptr;
 }
 
-const Route* RouteMatcher::getRouteForRequest(const Http::HeaderMap& headers,
-                                              uint64_t random_value) const {
+const Route* RouteMatcher::route(const Http::HeaderMap& headers, uint64_t random_value) const {
   const VirtualHostImpl* virtual_host = findVirtualHost(headers);
   if (virtual_host) {
     return virtual_host->getRouteFromEntries(headers, random_value);
@@ -372,8 +371,8 @@ const Route* RouteMatcher::getRouteForRequest(const Http::HeaderMap& headers,
 }
 
 const VirtualHostImpl::CatchAllVirtualCluster VirtualHostImpl::VIRTUAL_CLUSTER_CATCH_ALL;
-const SslRedirector SslRoute::SSL_REDIRECTOR;
-const SslRoute VirtualHostImpl::SSL_ROUTE;
+const SslRedirector SslRedirectRoute::SSL_REDIRECTOR;
+const SslRedirectRoute VirtualHostImpl::SSL_REDIRECT_ROUTE;
 
 const VirtualCluster*
 VirtualHostImpl::virtualClusterFromEntries(const Http::HeaderMap& headers) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -40,7 +40,7 @@ public:
   std::string newPath(const Http::HeaderMap& headers) const override;
 };
 
-class SslRoute : public Route {
+class SslRedirectRoute : public Route {
 public:
   // Router::Route
   const RedirectEntry* redirectEntry() const override { return &SSL_REDIRECTOR; }
@@ -125,7 +125,7 @@ private:
   };
 
   static const CatchAllVirtualCluster VIRTUAL_CLUSTER_CATCH_ALL;
-  static const SslRoute SSL_ROUTE;
+  static const SslRedirectRoute SSL_REDIRECT_ROUTE;
 
   const std::string name_;
   std::vector<RouteEntryImplBasePtr> routes_;
@@ -278,7 +278,7 @@ class RouteMatcher {
 public:
   RouteMatcher(const Json::Object& config, Runtime::Loader& runtime, Upstream::ClusterManager& cm);
 
-  const Route* getRouteForRequest(const Http::HeaderMap& headers, uint64_t random_value) const;
+  const Route* route(const Http::HeaderMap& headers, uint64_t random_value) const;
   bool usesRuntime() const { return uses_runtime_; }
 
 private:
@@ -297,9 +297,8 @@ public:
   ConfigImpl(const Json::Object& config, Runtime::Loader& runtime, Upstream::ClusterManager& cm);
 
   // Router::Config
-  const Route* getRouteForRequest(const Http::HeaderMap& headers,
-                                  uint64_t random_value) const override {
-    return route_matcher_->getRouteForRequest(headers, random_value);
+  const Route* route(const Http::HeaderMap& headers, uint64_t random_value) const override {
+    return route_matcher_->route(headers, random_value);
   }
 
   const std::list<Http::LowerCaseString>& internalOnlyHeaders() const override {
@@ -330,9 +329,7 @@ private:
 class NullConfigImpl : public Config {
 public:
   // Router::Config
-  const Route* getRouteForRequest(const Http::HeaderMap&, uint64_t) const override {
-    return nullptr;
-  }
+  const Route* route(const Http::HeaderMap&, uint64_t) const override { return nullptr; }
 
   const std::list<Http::LowerCaseString>& internalOnlyHeaders() const override {
     return internal_only_headers_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -278,8 +278,8 @@ class RouteMatcher {
 public:
   RouteMatcher(const Json::Object& config, Runtime::Loader& runtime, Upstream::ClusterManager& cm);
 
-  bool usesRuntime() const { return uses_runtime_; }
   const Route* getRouteForRequest(const Http::HeaderMap& headers, uint64_t random_value) const;
+  bool usesRuntime() const { return uses_runtime_; }
 
 private:
   const VirtualHostImpl* findVirtualHost(const Http::HeaderMap& headers) const;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -108,7 +108,7 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
 
     Http::CodeUtility::ResponseStatInfo info{
         config_.global_store_, cluster_->statsScope(), EMPTY_STRING, response_headers,
-        internal_request, route_->virtualHost().name(),
+        internal_request, route_entry_->virtualHost().name(),
         request_vcluster_ ? request_vcluster_->name() : EMPTY_STRING,
         config_.local_info_.zoneName(), upstreamZone(upstream_host), is_canary};
 
@@ -138,17 +138,11 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   // that get handled by earlier filters.
   config_.stats_.rq_total_.inc();
 
-  // First determine if we need to do a redirect before we do anything else.
-  const RedirectEntry* redirect = callbacks_->routeTable().redirectRequest(headers);
-  if (redirect) {
-    config_.stats_.rq_redirect_.inc();
-    Http::Utility::sendRedirect(*callbacks_, redirect->newPath(headers));
-    return Http::FilterHeadersStatus::StopIteration;
-  }
+  // Determine if there is a route entry or a redirect for the request.
+  const Route* route = callbacks_->routeTable().route(headers);
 
-  // Determine if there is a route match.
-  route_ = callbacks_->routeTable().routeForRequest(headers);
-  if (!route_) {
+  // There doesn't exist a redirect or route entry for the request.
+  if (!route) {
     config_.stats_.no_route_.inc();
     stream_log_debug("no cluster match for URL '{}'", *callbacks_, headers.Path()->value().c_str());
 
@@ -159,12 +153,22 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     return Http::FilterHeadersStatus::StopIteration;
   }
 
+  // Determine if there is a redirect for the request.
+  if (route->redirectEntry()) {
+    config_.stats_.rq_redirect_.inc();
+    Http::Utility::sendRedirect(*callbacks_, route->redirectEntry()->newPath(headers));
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  // A route entry matches for the request.
+  route_entry_ = route->routeEntry();
+
   // Set up stat prefixes, etc.
-  request_vcluster_ = route_->virtualCluster(headers);
-  stream_log_debug("cluster '{}' match for URL '{}'", *callbacks_, route_->clusterName(),
+  request_vcluster_ = route_entry_->virtualCluster(headers);
+  stream_log_debug("cluster '{}' match for URL '{}'", *callbacks_, route_entry_->clusterName(),
                    headers.Path()->value().c_str());
 
-  cluster_ = config_.cm_.get(route_->clusterName());
+  cluster_ = config_.cm_.get(route_entry_->clusterName());
 
   const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();
   if (request_alt_name) {
@@ -182,19 +186,19 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Fetch a connection pool for the upstream cluster.
   Http::ConnectionPool::Instance* conn_pool =
-      config_.cm_.httpConnPoolForCluster(route_->clusterName(), finalPriority());
+      config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), finalPriority());
   if (!conn_pool) {
     sendNoHealthyUpstreamResponse();
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  timeout_ = FilterUtility::finalTimeout(*route_, headers);
-  route_->finalizeRequestHeaders(headers);
+  timeout_ = FilterUtility::finalTimeout(*route_entry_, headers);
+  route_entry_->finalizeRequestHeaders(headers);
   FilterUtility::setUpstreamScheme(headers, *cluster_);
-  retry_state_ = createRetryState(route_->retryPolicy(), headers, *cluster_, config_.runtime_,
+  retry_state_ = createRetryState(route_entry_->retryPolicy(), headers, *cluster_, config_.runtime_,
                                   config_.random_, callbacks_->dispatcher(), finalPriority());
-  do_shadowing_ =
-      FilterUtility::shouldShadow(route_->shadowPolicy(), config_.runtime_, callbacks_->streamId());
+  do_shadowing_ = FilterUtility::shouldShadow(route_entry_->shadowPolicy(), config_.runtime_,
+                                              callbacks_->streamId());
 
 #ifndef NDEBUG
   headers.iterate([](const Http::HeaderEntry& header, void* context) -> void {
@@ -267,7 +271,7 @@ Upstream::ResourcePriority Filter::finalPriority() {
   if (request_vcluster_) {
     return request_vcluster_->priority();
   } else {
-    return route_->priority();
+    return route_entry_->priority();
   }
 }
 
@@ -276,7 +280,7 @@ void Filter::maybeDoShadowing() {
     return;
   }
 
-  ASSERT(!route_->shadowPolicy().cluster().empty());
+  ASSERT(!route_entry_->shadowPolicy().cluster().empty());
   Http::MessagePtr request(new Http::RequestMessageImpl(
       Http::HeaderMapPtr{new Http::HeaderMapImpl(*downstream_headers_)}));
   if (callbacks_->decodingBuffer()) {
@@ -286,7 +290,7 @@ void Filter::maybeDoShadowing() {
     request->trailers(Http::HeaderMapPtr{new Http::HeaderMapImpl(*downstream_trailers_)});
   }
 
-  config_.shadowWriter().shadow(route_->shadowPolicy().cluster(), std::move(request),
+  config_.shadowWriter().shadow(route_entry_->shadowPolicy().cluster(), std::move(request),
                                 timeout_.global_timeout_);
 }
 
@@ -319,7 +323,7 @@ void Filter::onResetStream() {
 
 void Filter::onResponseTimeout() {
   stream_log_debug("upstream timeout", *callbacks_);
-  config_.cm_.get(route_->clusterName())->stats().upstream_rq_timeout_.inc();
+  config_.cm_.get(route_entry_->clusterName())->stats().upstream_rq_timeout_.inc();
 
   // It's possible to timeout during a retry backoff delay when we have no upstream request. In
   // this case we fake a reset since onUpstreamReset() doesn't care.
@@ -477,7 +481,7 @@ void Filter::onUpstreamComplete() {
 
     Http::CodeUtility::ResponseTimingInfo info{
         config_.global_store_, cluster_->statsScope(), EMPTY_STRING, response_time,
-        upstream_request_->upstream_canary_, internal_request, route_->virtualHost().name(),
+        upstream_request_->upstream_canary_, internal_request, route_entry_->virtualHost().name(),
         request_vcluster_ ? request_vcluster_->name() : EMPTY_STRING,
         config_.local_info_.zoneName(), upstreamZone(upstream_request_->upstream_host_)};
 
@@ -517,7 +521,7 @@ bool Filter::setupRetry(bool end_stream) {
 
 void Filter::doRetry() {
   Http::ConnectionPool::Instance* conn_pool =
-      config_.cm_.httpConnPoolForCluster(route_->clusterName(), finalPriority());
+      config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), finalPriority());
   if (!conn_pool) {
     sendNoHealthyUpstreamResponse();
     cleanup();
@@ -641,7 +645,7 @@ void Filter::UpstreamRequest::setupPerTryTimeout() {
 
 void Filter::UpstreamRequest::onPerTryTimeout() {
   stream_log_debug("upstream per try timeout", *parent_.callbacks_);
-  parent_.config_.cm_.get(parent_.route_->clusterName())
+  parent_.config_.cm_.get(parent_.route_entry_->clusterName())
       ->stats()
       .upstream_rq_per_try_timeout_.inc();
   upstream_host_->stats().rq_timeout_.inc();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -140,8 +140,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Determine if there is a route entry or a redirect for the request.
   const Route* route = callbacks_->routeTable().route(headers);
-
-  // There doesn't exist a redirect or route entry for the request.
   if (!route) {
     config_.stats_.no_route_.inc();
     stream_log_debug("no cluster match for URL '{}'", *callbacks_, headers.Path()->value().c_str());

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -200,7 +200,7 @@ private:
 
   FilterConfig& config_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
-  const RouteEntry* route_;
+  const RouteEntry* route_entry_;
   Upstream::ClusterInfoPtr cluster_;
   std::string alt_stat_prefix_;
   const VirtualCluster* request_vcluster_;

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -74,7 +74,7 @@ public:
 TEST_F(HttpRateLimitFilterTest, NoRoute) {
   SetUpTest(filter_config);
 
-  EXPECT_CALL(filter_callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(filter_callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(nullptr));
 
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -84,7 +84,8 @@ TEST_F(HttpRateLimitFilterTest, NoRoute) {
 TEST_F(HttpRateLimitFilterTest, NoApplicableRateLimit) {
   SetUpTest(filter_config);
 
-  filter_callbacks_.route_table_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
+  filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
+      .clear();
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
@@ -114,7 +115,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
   SetUpTest(filter_config);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_entry_.rate_limit_policy_,
+  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0)).Times(1);
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -40,12 +40,13 @@ public:
     client_ = new ::RateLimit::MockClient();
     filter_.reset(new Filter(config_, ::RateLimit::ClientPtr{client_}));
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
-    filter_callbacks_.route_table_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
-    filter_callbacks_.route_table_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
+    filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
+        .clear();
+    filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
         .emplace_back(route_rate_limit_);
-    filter_callbacks_.route_table_.route_entry_.virtual_host_.rate_limit_policy_
+    filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_
         .rate_limit_policy_entry_.clear();
-    filter_callbacks_.route_table_.route_entry_.virtual_host_.rate_limit_policy_
+    filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_
         .rate_limit_policy_entry_.emplace_back(vh_rate_limit_);
   }
 
@@ -121,7 +122,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_entry_.virtual_host_.rate_limit_policy_,
+  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_,
               getApplicableRateLimit(0)).Times(1);
 
   EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<::RateLimit::Descriptor>{

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1013,15 +1013,6 @@ TEST(RouteMatcherTest, ExclusiveRouteEntryOrRedirectEntry) {
         {
           "prefix": "/foo",
           "host_redirect": "new.lyft.com"
-        },
-        {
-          "prefix": "/bar",
-          "path_redirect": "/new_bar"
-        },
-        {
-          "prefix": "/baz",
-          "host_redirect": "new.lyft.com",
-          "path_redirect": "/new_baz"
         }
       ]
     }

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -132,7 +132,8 @@ TEST_F(RateLimitConfiguration, NoRateLimit) {
 
   SetUpTest(json);
 
-  EXPECT_EQ(0U, config_->routeForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0)
+  EXPECT_EQ(0U, config_->getRouteForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0)
+                    ->routeEntry()
                     ->rateLimitPolicy()
                     .getApplicableRateLimit(0)
                     .size());
@@ -168,7 +169,7 @@ TEST_F(RateLimitConfiguration, TestGetApplicationRateLimit) {
   SetUpTest(json);
   std::string address = "10.0.0.1";
 
-  route_ = config_->routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0);
+  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(1U, rate_limits.size());

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -132,7 +132,7 @@ TEST_F(RateLimitConfiguration, NoRateLimit) {
 
   SetUpTest(json);
 
-  EXPECT_EQ(0U, config_->getRouteForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0)
+  EXPECT_EQ(0U, config_->route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
                     ->routeEntry()
                     ->rateLimitPolicy()
                     .getApplicableRateLimit(0)
@@ -169,7 +169,7 @@ TEST_F(RateLimitConfiguration, TestGetApplicationRateLimit) {
   SetUpTest(json);
   std::string address = "10.0.0.1";
 
-  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
+  route_ = config_->route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(1U, rate_limits.size());
@@ -211,7 +211,7 @@ TEST_F(RateLimitConfiguration, TestVirtualHost) {
 
   SetUpTest(json);
 
-  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry();
+  route_ = config_->route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->virtualHost().rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(1U, rate_limits.size());
@@ -263,7 +263,7 @@ TEST_F(RateLimitConfiguration, TestMultipleRateLimits) {
   SetUpTest(json);
   std::string address = "10.0.0.1";
 
-  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
+  route_ = config_->route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(2U, rate_limits.size());

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -211,7 +211,7 @@ TEST_F(RateLimitConfiguration, TestVirtualHost) {
 
   SetUpTest(json);
 
-  route_ = config_->routeForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0);
+  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->virtualHost().rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(1U, rate_limits.size());
@@ -263,7 +263,7 @@ TEST_F(RateLimitConfiguration, TestMultipleRateLimits) {
   SetUpTest(json);
   std::string address = "10.0.0.1";
 
-  route_ = config_->routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0);
+  route_ = config_->getRouteForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(2U, rate_limits.size());

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -83,14 +83,14 @@ TEST_F(RouterTest, RouteNotFound) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  EXPECT_CALL(callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(callbacks_.route_table_, route(_)).WillOnce(Return(nullptr));
 
   router_.decodeHeaders(headers, true);
 }
 
 TEST_F(RouterTest, PoolFailureWithPriority) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
   route_entry.virtual_cluster_.priority_ = Upstream::ResourcePriority::High;
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, Upstream::ResourcePriority::High));
 
@@ -603,8 +603,8 @@ TEST_F(RouterTest, RetryUpstream5xxNotComplete) {
 }
 
 TEST_F(RouterTest, Shadow) {
-  callbacks_.route_table_.route_entry_.shadow_policy_.cluster_ = "foo";
-  callbacks_.route_table_.route_entry_.shadow_policy_.runtime_key_ = "bar";
+  callbacks_.route_table_.route_.route_entry_.shadow_policy_.cluster_ = "foo";
+  callbacks_.route_table_.route_.route_entry_.shadow_policy_.runtime_key_ = "bar";
   ON_CALL(callbacks_, streamId()).WillByDefault(Return(43));
 
   NiceMock<Http::MockStreamEncoder> encoder;
@@ -644,7 +644,7 @@ TEST_F(RouterTest, Shadow) {
 TEST_F(RouterTest, AltStatName) {
   // Also test no upstream timeout here.
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 
@@ -688,7 +688,7 @@ TEST_F(RouterTest, AltStatName) {
 TEST_F(RouterTest, Redirect) {
   MockRedirectEntry redirect;
   EXPECT_CALL(redirect, newPath(_)).WillOnce(Return("hello"));
-  EXPECT_CALL(callbacks_.route_table_, redirectRequest(_)).WillOnce(Return(&redirect));
+  EXPECT_CALL(callbacks_.route_table_.route_, redirectEntry()).WillRepeatedly(Return(&redirect));
 
   Http::TestHeaderMapImpl response_headers{{":status", "301"}, {"location", "hello"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
@@ -805,7 +805,7 @@ TEST(RouterFilterUtilityTest, shouldShadow) {
 
 TEST_F(RouterTest, CanaryStatusTrue) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 
@@ -836,7 +836,7 @@ TEST_F(RouterTest, CanaryStatusTrue) {
 
 TEST_F(RouterTest, CanaryStatusFalse) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_, routeForRequest(_)).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -62,7 +62,6 @@ MockConfig::MockConfig() {
 MockConfig::~MockConfig() {}
 
 MockRoute::MockRoute() { ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_)); }
-
 MockRoute::~MockRoute() {}
 
 MockStableRouteTable::MockStableRouteTable() {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -61,8 +61,12 @@ MockConfig::MockConfig() {
 
 MockConfig::~MockConfig() {}
 
+MockRoute::MockRoute() { ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_)); }
+
+MockRoute::~MockRoute() {}
+
 MockStableRouteTable::MockStableRouteTable() {
-  ON_CALL(*this, routeForRequest(_)).WillByDefault(Return(&route_entry_));
+  ON_CALL(*this, route(_)).WillByDefault(Return(&route_));
 }
 
 MockStableRouteTable::~MockStableRouteTable() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -159,6 +159,8 @@ public:
                      const RedirectEntry*(const Http::HeaderMap& headers, uint64_t random_value));
   MOCK_CONST_METHOD2(routeForRequest,
                      const RouteEntry*(const Http::HeaderMap&, uint64_t random_value));
+  MOCK_CONST_METHOD2(getRouteForRequest,
+                     const Route*(const Http::HeaderMap&, uint64_t random_value));
   MOCK_CONST_METHOD0(internalOnlyHeaders, const std::list<Http::LowerCaseString>&());
   MOCK_CONST_METHOD0(responseHeadersToAdd,
                      const std::list<std::pair<Http::LowerCaseString, std::string>>&());
@@ -170,16 +172,27 @@ public:
   std::list<Http::LowerCaseString> response_headers_to_remove_;
 };
 
+class MockRoute : public Route {
+public:
+  MockRoute();
+  ~MockRoute();
+
+  // Router::Route
+  MOCK_CONST_METHOD0(redirectEntry, const RedirectEntry*());
+  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+
+  testing::NiceMock<MockRouteEntry> route_entry_;
+};
+
 class MockStableRouteTable : public StableRouteTable {
 public:
   MockStableRouteTable();
   ~MockStableRouteTable();
 
   // Router::StableRouteTable
-  MOCK_CONST_METHOD1(redirectRequest, const RedirectEntry*(const Http::HeaderMap& headers));
-  MOCK_CONST_METHOD1(routeForRequest, const RouteEntry*(const Http::HeaderMap&));
+  MOCK_CONST_METHOD1(route, const Route*(const Http::HeaderMap&));
 
-  testing::NiceMock<MockRouteEntry> route_entry_;
+  testing::NiceMock<MockRoute> route_;
 };
 
 } // Router

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -155,8 +155,7 @@ public:
   ~MockConfig();
 
   // Router::Config
-  MOCK_CONST_METHOD2(getRouteForRequest,
-                     const Route*(const Http::HeaderMap&, uint64_t random_value));
+  MOCK_CONST_METHOD2(route, const Route*(const Http::HeaderMap&, uint64_t random_value));
   MOCK_CONST_METHOD0(internalOnlyHeaders, const std::list<Http::LowerCaseString>&());
   MOCK_CONST_METHOD0(responseHeadersToAdd,
                      const std::list<std::pair<Http::LowerCaseString, std::string>>&());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -155,10 +155,6 @@ public:
   ~MockConfig();
 
   // Router::Config
-  MOCK_CONST_METHOD2(redirectRequest,
-                     const RedirectEntry*(const Http::HeaderMap& headers, uint64_t random_value));
-  MOCK_CONST_METHOD2(routeForRequest,
-                     const RouteEntry*(const Http::HeaderMap&, uint64_t random_value));
   MOCK_CONST_METHOD2(getRouteForRequest,
                      const Route*(const Http::HeaderMap&, uint64_t random_value));
   MOCK_CONST_METHOD0(internalOnlyHeaders, const std::list<Http::LowerCaseString>&());


### PR DESCRIPTION
Currently, when trying to find a route for a request, two calls are made to matches(). The code base is refactored to call matches only once and return a new object Route that can have a RouteEntry or RedirectEntry. 