### PR TITLE
Docs: Update access logs documentation to include equal operator.

### DIFF
--- a/docs/configuration/http_conn_man/access_log.rst
+++ b/docs/configuration/http_conn_man/access_log.rst
@@ -147,7 +147,7 @@ Status code
 Filters on HTTP response/status code.
 
 op
-  *(required, string)* Comparison operator. Currently *>=* is the only supported operator.
+  *(required, string)* Comparison operator. Currently *>=*  and *=* are the only supported operators.
 
 value
   *(required, integer)* Default value to compare against if runtime value is not available.


### PR DESCRIPTION
Envoy already supports the equal operator. This PR updates our documentation.