### PR TITLE
build: add libevent includes to server and test

### DIFF
--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(SYSTEM ${ENVOY_HTTP_PARSER_INCLUDE_DIR})
 include_directories(${ENVOY_NGHTTP2_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_OPENSSL_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR})
+include_directories(${ENVOY_LIBEVENT_INCLUDE_DIR})
 
 set_target_properties(envoy-server PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT
                       "../precompiled/precompiled.h")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(${PROJECT_BINARY_DIR})
 include_directories(SYSTEM ${ENVOY_OPENSSL_INCLUDE_DIR})
 include_directories(${ENVOY_NGHTTP2_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR})
+include_directories(${ENVOY_LIBEVENT_INCLUDE_DIR})
 
 add_executable(envoy-test
   $<TARGET_OBJECTS:envoy-server>


### PR DESCRIPTION
This is not required in the public CI but it does break our Lyft internal
build.