### PR TITLE
test: fix flaky Http2IntegrationTest.MaxHeadersInCodec test

### DIFF
--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -33,8 +33,10 @@ void IntegrationStreamDecoder::waitForEndStream() {
 }
 
 void IntegrationStreamDecoder::waitForReset() {
-  waiting_for_reset_ = true;
-  dispatcher_.run(Event::Dispatcher::RunType::Block);
+  if (!saw_reset_) {
+    waiting_for_reset_ = true;
+    dispatcher_.run(Event::Dispatcher::RunType::Block);
+  }
 }
 
 void IntegrationStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
@@ -73,6 +75,7 @@ void IntegrationStreamDecoder::decodeTrailers(Http::HeaderMapPtr&& trailers) {
 }
 
 void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason) {
+  saw_reset_ = true;
   if (waiting_for_reset_) {
     dispatcher_.exit();
   }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -39,6 +39,7 @@ private:
   std::string body_;
   uint64_t body_data_waiting_length_{};
   bool waiting_for_reset_{};
+  bool saw_reset_{};
 };
 
 typedef std::unique_ptr<IntegrationStreamDecoder> IntegrationStreamDecoderPtr;


### PR DESCRIPTION
Reset stream can arrive before we check for it.