### PR TITLE
hot restart: bump version

### DIFF
--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -14,7 +14,7 @@ namespace Server {
 
 // Increment this whenever there is a shared memory / RPC change that will prevent a hot restart
 // from working. Operations code can then cope with this and do a full restart.
-const uint64_t SharedMemory::VERSION = 3;
+const uint64_t SharedMemory::VERSION = 4;
 
 SharedMemory& SharedMemory::initialize(Options& options) {
   int flags = O_RDWR;


### PR DESCRIPTION
The stats change in https://github.com/lyft/envoy/pull/348 does not
actually change the size of the shared memory region due to compiler
alignment (at least on gcc 4.9). This will force a shared memory region
version bump.