### PR TITLE
cluster manager: implement CDS API

### DIFF
--- a/docs/configuration/cluster_manager/cds.rst
+++ b/docs/configuration/cluster_manager/cds.rst
@@ -21,7 +21,7 @@ clusters depending on what is required.
 
 refresh_delay_ms
   *(required, integer)* The delay, in milliseconds, between fetches to the CDS API for each
-  configured SDS cluster. Envoy will add an additional random jitter to the delay that is between
+  configured CDS cluster. Envoy will add an additional random jitter to the delay that is between
   zero and *refresh_delay_ms* milliseconds. Thus the longest possible refresh delay is
   2 \* *refresh_delay_ms*.
 

--- a/docs/configuration/cluster_manager/cds.rst
+++ b/docs/configuration/cluster_manager/cds.rst
@@ -10,7 +10,7 @@ clusters depending on what is required.
 .. code-block:: json
 
   {
-    "cluster_name": "{...}",
+    "cluster": "{...}",
     "refresh_delay_ms": "{...}"
   }
 

--- a/docs/configuration/cluster_manager/cds.rst
+++ b/docs/configuration/cluster_manager/cds.rst
@@ -1,0 +1,64 @@
+.. _config_cluster_manager_cds:
+
+Cluster discovery service
+=========================
+
+The cluster discovery service (CDS) is an optional API that Envoy will call to dynamically fetch
+cluster manager members. Envoy will reconcile the API response and add, modify, or remove known
+clusters depending on what is required.
+
+.. code-block:: json
+
+  {
+    "cluster_name": "{...}",
+    "refresh_delay_ms": "{...}"
+  }
+
+:ref:`cluster <config_cluster_manager_cluster>`
+  *(required, object)* A standard definition of an upstream cluster that hosts the cluster
+  discovery service. The cluster must run a REST service that implements the :ref:`CDS HTTP API
+  <config_cluster_manager_cds_api>`.
+
+refresh_delay_ms
+  *(required, integer)* The delay, in milliseconds, between fetches to the CDS API for each
+  configured SDS cluster. Envoy will add an additional random jitter to the delay that is between
+  zero and *refresh_delay_ms* milliseconds. Thus the longest possible refresh delay is
+  2 \* *refresh_delay_ms*.
+
+.. _config_cluster_manager_cds_api:
+
+REST API
+--------
+
+.. http:get:: /v1/clusters/(string: service_cluster)/(string: service_node)
+
+Asks the discovery service to return all clusters for a particular `service_cluster` and
+`service_node`. `service_cluster` corresponds to the :option:`--service-cluster` CLI option.
+`service_node` corresponds to the :option:`--service-node` CLI option. Responses use the following
+JSON schema:
+
+.. code-block:: json
+
+  {
+    "clusters": []
+  }
+
+clusters
+  *(Required, array)* A list of :ref:`clusters <config_cluster_manager_cluster>` that will be
+  dynamically added/modified within the cluster manager. Envoy will reconcile this list with the
+  clusters that are currently loaded and either add/modify/remove clusters as necessary. Note that
+  any clusters that are statically defined within the Envoy configuration cannot be modified via
+  the CDS API.
+
+Statistics
+----------
+
+CDS has a statistics tree rooted at *cluster_manager.cds.* with the following statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  update_attempt, Counter, Total API fetches attempted
+  update_success, Counter, Total API fetches completed successfully
+  update_failure, Counter, Total API fetches that failed (either network or schema errors)

--- a/docs/configuration/cluster_manager/cluster_manager.rst
+++ b/docs/configuration/cluster_manager/cluster_manager.rst
@@ -3,6 +3,15 @@
 Cluster manager
 ===============
 
+.. toctree::
+  :hidden:
+
+  cluster
+  sds
+  sds_api
+  outlier
+  cds
+
 Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.
 
 .. code-block:: json
@@ -11,7 +20,8 @@ Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.
     "clusters": [],
     "sds": "{...}",
     "local_cluster_name": "...",
-    "outlier_detection": "{...}"
+    "outlier_detection": "{...}",
+    "cds": "{...}"
   }
 
 .. _config_cluster_manager_clusters:
@@ -36,10 +46,20 @@ local_cluster_name
 :ref:`outlier_detection <config_cluster_manager_outlier_detection>`
   *(optional, object)* Optional global configuration for outlier detection.
 
-.. toctree::
-  :hidden:
+:ref:`cds <config_cluster_manager_cds>`
+  *(optional, object)* Optional configuration for the cluster discovery service (CDS) API.
 
-  cluster
-  sds
-  sds_api
-  outlier
+Statistics
+----------
+
+The cluster manager has a statistics tree rooted at *cluster_manager.* with the following
+statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  cluster_added, Counter, Total clusters added (either via static config or CDS)
+  cluster_modified, Counter, Total clusters modified (via CDS)
+  cluster_removed, Counter, Total clusters removed (via CDS)
+  total_clusters, Gauge, Number of currently loaded clusters

--- a/docs/intro/arch_overview/cluster_manager.rst
+++ b/docs/intro/arch_overview/cluster_manager.rst
@@ -9,12 +9,18 @@ clusters each with different service discovery, health checking, and other setti
 
 Upstream clusters and hosts are abstracted from the network/HTTP filter stack given that upstream
 clusters and hosts may be used for any number of different proxy tasks. The cluster manager exposes
-APIs to the filter stack that allow filters to obtain a L3/L4 connection to an upstream cluster, or 
-a handle to an abstract HTTP connection pool to an upstream cluster (whether the upstream host 
+APIs to the filter stack that allow filters to obtain a L3/L4 connection to an upstream cluster, or
+a handle to an abstract HTTP connection pool to an upstream cluster (whether the upstream host
 supports HTTP/1.1 or HTTP/2 is hidden). A filter stage determines whether it needs an L3/L4
 connection or a new HTTP stream and the cluster manager handles all of the complexity of knowing
 which hosts are available and healthy, load balancing, thread local storage of upstream connection
 data (since most Envoy code is written to be single threaded), upstream connection type (TCP/IP,
 UDS), upstream protocol where applicable (HTTP/1.1, HTTP/2), etc.
 
-Cluster manager :ref:`configuration <config_cluster_manager>`.
+Clusters known to the cluster manager can be configured either statically, or fetched dynamically
+via the cluster discovery service (CDS) API. Dynamic cluster fetches allow more configuration to
+be stored in a central configuration server and thus requires less Envoy restarts and configuration
+distribution.
+
+* Cluster manager :ref:`configuration <config_cluster_manager>`.
+* CDS :ref:`configuration <config_cluster_manager_cds>`.

--- a/docs/operations/cli.rst
+++ b/docs/operations/cli.rst
@@ -50,13 +50,15 @@ following are the command line options that Envoy supports.
   <config_cluster_manager_cluster_hc_service_name>`, :ref:`runtime override directory
   <config_runtime_override_subdirectory>`, :ref:`user agent addition
   <config_http_conn_man_add_user_agent>`, :ref:`HTTP global rate limiting
-  <config_http_filters_rate_limit>`, and :ref:`HTTP tracing <arch_overview_tracing>`.
+  <config_http_filters_rate_limit>`, :ref:`CDS <config_cluster_manager_cds>`, and
+  :ref:`HTTP tracing <arch_overview_tracing>`.
 
 .. option:: --service-node <string>
 
   *(optional)* Defines the local service node name where Envoy is running. Though optional,
   it should be set if any of the following features are used: :ref:`statsd
-  <arch_overview_statistics>`, and :ref:`HTTP tracing <arch_overview_tracing>`.
+  <arch_overview_statistics>`, :ref:`CDS <config_cluster_manager_cds>`, and
+  :ref:`HTTP tracing <arch_overview_tracing>`.
 
 .. option:: --service-zone <string>
 

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -95,6 +95,21 @@ struct SdsConfig {
 };
 
 /**
+ * Abstract interface for a CDS API provider.
+ */
+class CdsApi {
+public:
+  virtual ~CdsApi() {}
+
+  /**
+   * Start the first fetch of CDS data.
+   */
+  virtual void initialize() PURE;
+};
+
+typedef std::unique_ptr<CdsApi> CdsApiPtr;
+
+/**
  * Factory for objects needed during cluster manager operation.
  */
 class ClusterManagerFactory {
@@ -114,6 +129,11 @@ public:
   virtual ClusterPtr clusterFromJson(const Json::Object& cluster, ClusterManager& cm,
                                      const Optional<SdsConfig>& sds_config,
                                      Outlier::EventLoggerPtr outlier_event_logger) PURE;
+
+  /**
+   * Create a CDS API provider from configuration JSON.
+   */
+  virtual CdsApiPtr createCds(const Json::Object& config, ClusterManager& cm) PURE;
 };
 
 } // Upstream

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(
   stats/thread_local_store.cc
   thread_local/thread_local_impl.cc
   tracing/http_tracer_impl.cc
+  upstream/cds_api_impl.cc
   upstream/cluster_manager_impl.cc
   upstream/health_checker_impl.cc
   upstream/host_utility.cc

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -63,7 +63,7 @@ void Config::parseResponse(const Http::Message& message) {
   stats_.total_principals_.set(new_principals->size());
 }
 
-void Config::onFetchFailure(Http::AsyncClient::FailureReason) { stats_.update_failure_.inc(); }
+void Config::onFetchFailure(EnvoyException*) { stats_.update_failure_.inc(); }
 
 static const std::string Path = "/v1/certs/list/approved";
 

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -88,7 +88,7 @@ private:
   void createRequest(Http::Message& request) override;
   void parseResponse(const Http::Message& response) override;
   void onFetchComplete() override {}
-  void onFetchFailure(Http::AsyncClient::FailureReason reason) override;
+  void onFetchFailure(EnvoyException* e) override;
 
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -32,8 +32,6 @@ void RestApiFetcher::onSuccess(Http::MessagePtr&& response) {
     parseResponse(*response);
   } catch (EnvoyException& e) {
     onFetchFailure(&e);
-    requestComplete();
-    return;
   }
 
   requestComplete();

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -31,15 +31,16 @@ void RestApiFetcher::onSuccess(Http::MessagePtr&& response) {
   try {
     parseResponse(*response);
   } catch (EnvoyException& e) {
-    onFailure(Http::AsyncClient::FailureReason::Reset);
+    onFetchFailure(&e);
+    requestComplete();
     return;
   }
 
   requestComplete();
 }
 
-void RestApiFetcher::onFailure(Http::AsyncClient::FailureReason reason) {
-  onFetchFailure(reason);
+void RestApiFetcher::onFailure(Http::AsyncClient::FailureReason) {
+  onFetchFailure(nullptr);
   requestComplete();
 }
 

--- a/source/common/http/rest_api_fetcher.h
+++ b/source/common/http/rest_api_fetcher.h
@@ -41,11 +41,13 @@ protected:
 
   /**
    * This will be called if the fetch fails (either due to non-200 response, network error, etc.).
+   * @param e supplies any exception data on why the fetch failed. May be nullptr.
    */
-  virtual void onFetchFailure(AsyncClient::FailureReason reason) PURE;
+  virtual void onFetchFailure(EnvoyException* e) PURE;
 
 protected:
   const std::string remote_cluster_name_;
+  Upstream::ClusterManager& cm_;
 
 private:
   void refresh();
@@ -55,7 +57,6 @@ private:
   void onSuccess(Http::MessagePtr&& response) override;
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 
-  Upstream::ClusterManager& cm_;
   Runtime::RandomGenerator& random_;
   const std::chrono::milliseconds refresh_interval_;
   Event::TimerPtr refresh_timer_;

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -1,0 +1,71 @@
+#include "cds_api_impl.h"
+
+#include "common/common/assert.h"
+#include "common/http/headers.h"
+#include "common/json/json_loader.h"
+
+namespace Upstream {
+
+CdsApiPtr CdsApiImpl::create(const Json::Object& config, ClusterManager& cm,
+                             Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+                             const LocalInfo::LocalInfo& local_info, Stats::Scope& scope) {
+  if (!config.hasObject("cds")) {
+    return nullptr;
+  }
+
+  return CdsApiPtr{
+      new CdsApiImpl(*config.getObject("cds"), cm, dispatcher, random, local_info, scope)};
+}
+
+CdsApiImpl::CdsApiImpl(const Json::Object& config, ClusterManager& cm,
+                       Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+                       const LocalInfo::LocalInfo& local_info, Stats::Scope& scope)
+    : RestApiFetcher(cm, config.getObject("cluster")->getString("name"), dispatcher, random,
+                     std::chrono::milliseconds(config.getInteger("refresh_interval_ms", 30000))),
+      local_info_(local_info),
+      stats_({ALL_CDS_STATS(POOL_COUNTER_PREFIX(scope, "cluster_manager.cds."))}) {
+  if (local_info.clusterName().empty() || local_info.nodeName().empty()) {
+    throw EnvoyException("cds: setting --service-cluster and --service-node are required");
+  }
+}
+
+void CdsApiImpl::createRequest(Http::Message& request) {
+  log_debug("cds: starting request");
+  stats_.update_attempt_.inc();
+  request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
+  request.headers().insertPath().value(
+      fmt::format("/v1/clusters/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
+}
+
+void CdsApiImpl::parseResponse(const Http::Message& response) {
+  log_debug("cds: parsing response");
+  Json::ObjectPtr response_json = Json::Factory::LoadFromString(response.bodyAsString());
+  std::vector<Json::ObjectPtr> clusters = response_json->getObjectArray("clusters");
+
+  // We need to keep track of which clusters we might need to remove.
+  ClusterManager::ClusterInfoMap clusters_to_remove = cm_.clusters();
+  for (auto& cluster : clusters) {
+    std::string cluster_name = cluster->getString("name");
+    clusters_to_remove.erase(cluster_name);
+    log().info("cds: add/update cluster '{}'", cluster_name);
+    cm_.addOrUpdatePrimaryCluster(*cluster);
+  }
+
+  for (auto cluster : clusters_to_remove) {
+    log().info("cds: remove cluster '{}'", cluster.first);
+    cm_.removePrimaryCluster(cluster.first);
+  }
+
+  stats_.update_success_.inc();
+}
+
+void CdsApiImpl::onFetchFailure(EnvoyException* e) {
+  stats_.update_failure_.inc();
+  if (e) {
+    log().warn("cds: fetch failure: {}", e->what());
+  } else {
+    log().info("cds: fetch failure: network error");
+  }
+}
+
+} // Upstream

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/json/json_object.h"
+#include "envoy/local_info/local_info.h"
+
+#include "common/common/logger.h"
+#include "common/http/rest_api_fetcher.h"
+
+namespace Upstream {
+
+/**
+ * All CDS stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_CDS_STATS(COUNTER)                                                                     \
+  COUNTER(update_attempt)                                                                          \
+  COUNTER(update_success)                                                                          \
+  COUNTER(update_failure)
+// clang-format on
+
+/**
+ * Struct definition for all CDS stats. @see stats_macros.h
+ */
+struct CdsStats {
+  ALL_CDS_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * REST fetching implementation of the CDS API.
+ */
+class CdsApiImpl : public CdsApi, Http::RestApiFetcher, Logger::Loggable<Logger::Id::upstream> {
+public:
+  static CdsApiPtr create(const Json::Object& config, ClusterManager& cm,
+                          Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+                          const LocalInfo::LocalInfo& local_info, Stats::Scope& scope);
+
+  // Upstream::CdsApi
+  void initialize() override { RestApiFetcher::initialize(); }
+
+private:
+  CdsApiImpl(const Json::Object& config, ClusterManager& cm, Event::Dispatcher& dispatcher,
+             Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
+             Stats::Scope& scope);
+
+  // Http::RestApiFetcher
+  void createRequest(Http::Message& request) override;
+  void parseResponse(const Http::Message& response) override;
+  void onFetchComplete() override {}
+  void onFetchFailure(EnvoyException* e) override;
+
+  const LocalInfo::LocalInfo& local_info_;
+  CdsStats stats_;
+};
+
+} // Upstream

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -79,9 +79,12 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
   info_->stats().update_success_.inc();
 }
 
-void SdsClusterImpl::onFetchFailure(Http::AsyncClient::FailureReason) {
+void SdsClusterImpl::onFetchFailure(EnvoyException* e) {
   log_debug("sds refresh failure for cluster: {}", info_->name());
   info_->stats().update_failure_.inc();
+  if (e) {
+    log().warn("sds parsing error: {}", e->what());
+  }
 }
 
 void SdsClusterImpl::createRequest(Http::Message& message) {

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -27,7 +27,7 @@ private:
   void createRequest(Http::Message& request) override;
   void parseResponse(const Http::Message& response) override;
   void onFetchComplete() override;
-  void onFetchFailure(Http::AsyncClient::FailureReason reason) override;
+  void onFetchFailure(EnvoyException* e) override;
 
   const LocalInfo::LocalInfo& local_info_;
   const std::string service_name_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(envoy-test
   common/stats/statsd_test.cc
   common/stats/thread_local_store_test.cc
   common/tracing/http_tracer_impl_test.cc
+  common/upstream/cds_api_impl_test.cc
   common/upstream/cluster_manager_impl_test.cc
   common/upstream/health_checker_impl_test.cc
   common/upstream/host_utility_test.cc

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -38,7 +38,7 @@ public:
 
   void expectAdd(const std::string& cluster_name) {
     EXPECT_CALL(cm_, addOrUpdatePrimaryCluster(_))
-        .WillOnce(Invoke([&](const Json::Object& config) -> bool {
+        .WillOnce(Invoke([cluster_name](const Json::Object& config) -> bool {
           EXPECT_EQ(cluster_name, config.getString("name"));
           return true;
         }));

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -1,0 +1,185 @@
+#include "common/http/message_impl.h"
+#include "common/json/json_loader.h"
+#include "common/upstream/cds_api_impl.h"
+
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Upstream {
+
+class CdsApiImplTest : public testing::Test {
+public:
+  CdsApiImplTest() : request_(&cm_.async_client_) {}
+
+  void setup() {
+    std::string config_json = R"EOF(
+    {
+      "cds": {
+        "cluster": {
+          "name": "foo_cluster"
+        }
+      }
+    }
+    )EOF";
+
+    Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+    cds_ = CdsApiImpl::create(*config, cm_, dispatcher_, random_, local_info_, store_);
+
+    expectRequest();
+    cds_->initialize();
+  }
+
+  void expectAdd(const std::string& cluster_name) {
+    EXPECT_CALL(cm_, addOrUpdatePrimaryCluster(_))
+        .WillOnce(Invoke([&](const Json::Object& config) -> bool {
+          EXPECT_EQ(cluster_name, config.getString("name"));
+          return true;
+        }));
+  }
+
+  void expectRequest() {
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("foo_cluster"));
+    EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+                       const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              EXPECT_EQ((Http::TestHeaderMapImpl{{":method", "GET"},
+                                                 {":path", "/v1/clusters/cluster_name/node_name"},
+                                                 {":authority", "foo_cluster"}}),
+                        request->headers());
+              callbacks_ = &callbacks;
+              return &request_;
+            }));
+  }
+
+  ClusterManager::ClusterInfoMap makeClusterMap(std::vector<std::string> clusters) {
+    ClusterManager::ClusterInfoMap map;
+    for (auto cluster : clusters) {
+      map.emplace(cluster, cm_.cluster_);
+    }
+    return map;
+  }
+
+  MockClusterManager cm_;
+  Event::MockDispatcher dispatcher_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  Stats::IsolatedStoreImpl store_;
+  Http::MockAsyncClientRequest request_;
+  CdsApiPtr cds_;
+  Event::MockTimer* interval_timer_{new Event::MockTimer(&dispatcher_)};
+  Http::AsyncClient::Callbacks* callbacks_{};
+};
+
+TEST_F(CdsApiImplTest, InvalidOptions) {
+  std::string config_json = R"EOF(
+  {
+    "cds": {
+      "cluster": {
+        "name": "foo_cluster"
+      }
+    }
+  }
+  )EOF";
+
+  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  local_info_.cluster_name_ = "";
+  local_info_.node_name_ = "";
+  EXPECT_THROW(CdsApiImpl::create(*config, cm_, dispatcher_, random_, local_info_, store_),
+               EnvoyException);
+}
+
+TEST_F(CdsApiImplTest, Basic) {
+  InSequence s;
+
+  setup();
+
+  std::string response1_json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster1"
+    },
+    {
+      "name": "cluster2"
+    }
+    ]
+  }
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+
+  EXPECT_CALL(cm_, clusters()).WillOnce(Return(ClusterManager::ClusterInfoMap{}));
+  expectAdd("cluster1");
+  expectAdd("cluster2");
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  expectRequest();
+  interval_timer_->callback_();
+
+  std::string response2_json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster1"
+    },
+    {
+      "name": "cluster3"
+    }
+    ]
+  }
+  )EOF";
+
+  message.reset(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response2_json)});
+
+  EXPECT_CALL(cm_, clusters()).WillOnce(Return(makeClusterMap({"cluster1", "cluster2"})));
+  expectAdd("cluster1");
+  expectAdd("cluster3");
+  EXPECT_CALL(cm_, removePrimaryCluster("cluster2"));
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_success").value());
+}
+
+TEST_F(CdsApiImplTest, Failure) {
+  InSequence s;
+
+  setup();
+
+  std::string response1_json = R"EOF(
+  {
+  }
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  expectRequest();
+  interval_timer_->callback_();
+
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
+
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_failure").value());
+}
+
+} // Upstream

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -76,6 +76,7 @@ MockCluster::~MockCluster() {}
 
 MockClusterManager::MockClusterManager() {
   ON_CALL(*this, httpConnPoolForCluster(_, _)).WillByDefault(Return(&conn_pool_));
+  ON_CALL(*this, httpAsyncClientForCluster(_)).WillByDefault(ReturnRef(async_client_));
   ON_CALL(*this, get(_)).WillByDefault(Return(cluster_.info_));
 }
 
@@ -87,5 +88,8 @@ MockHealthChecker::MockHealthChecker() {
 }
 
 MockHealthChecker::~MockHealthChecker() {}
+
+MockCdsApi::MockCdsApi() {}
+MockCdsApi::~MockCdsApi() {}
 
 } // Upstream

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -118,4 +118,12 @@ public:
   std::list<HostStatusCb> callbacks_;
 };
 
+class MockCdsApi : public CdsApi {
+public:
+  MockCdsApi();
+  ~MockCdsApi();
+
+  MOCK_METHOD0(initialize, void());
+};
+
 } // Upstream


### PR DESCRIPTION
Fixes https://github.com/lyft/envoy/issues/144

The only remaining piece that is missing is more graceful initialization
of CDS clusters on boot. (Basically we should only start listening once
we have done an initial init pass on any loaded CDS clusters). I will do
this in a follow up a this change is enough for folks to start testing basic
functionality.