### PR TITLE
Support for multiple weighted clusters in routing

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -45,7 +45,7 @@ cluster
   should be forwarded to.
 
 :ref:`weighted_clusters <config_http_conn_man_route_table_route_weighted_clusters>`
-  *(sometimes required, string)* If the route is not a redirect (i.e., *host_redirect* and/or
+  *(sometimes required, string)* If the route is not a redirect (*host_redirect* and/or
   *path_redirect* is not specified), one of *cluster* or *weighted_clusters* must be specified. 
   With the *weighted_clusters*, multiple upstream clusters can be specified for a given route.
   The request is forwarded to one of the upstream clusters based on weights assigned

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -39,7 +39,7 @@ path
 .. _config_http_conn_man_route_table_route_cluster:
 
 cluster
-  *(sometimes required, string)* If the route is not a redirect (i.e., *host_redirect* and/or
+  *(sometimes required, string)* If the route is not a redirect (*host_redirect* and/or
   *path_redirect* is not specified), one of *cluster* or *weighted_clusters* must be specified.
   When a *cluster* is specified, its value indicates the upstream cluster to which the request
   should be forwarded to.

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -47,7 +47,7 @@ cluster
 :ref:`weighted_clusters <config_http_conn_man_route_table_route_weighted_clusters>`
   *(sometimes required, string)* If the route is not a redirect (*host_redirect* and/or
   *path_redirect* is not specified), one of *cluster* or *weighted_clusters* must be specified. 
-  With the *weighted_clusters*, multiple upstream clusters can be specified for a given route.
+  With the *weighted_clusters* option, multiple upstream clusters can be specified for a given route.
   The request is forwarded to one of the upstream clusters based on weights assigned
   to each cluster. See :ref:`traffic splitting <config_http_conn_man_route_table_weighted_routing>`
   for additional documentation.
@@ -233,7 +233,7 @@ Weighted Clusters
 -----------------
 
 Compared to the ``cluster`` field that specifies a single upstream cluster as the target
-of a request, the ``weighted_clusters`` allows for specification of multiple upstream clusters
+of a request, the ``weighted_clusters`` option allows for specification of multiple upstream clusters
 along with weights that indicate the **percentage** of traffic to be forwarded to each cluster.
 The router selects an upstream cluster based on the weights.
 
@@ -260,8 +260,8 @@ clusters
 
   weight
     *(required, integer)* An integer between 0-100. When a request matches the route,
-    choice of an upstream cluster is determined by its weight. The sum of
-    weights across all entries in the ``clusters`` array should add up to 100.
+    the choice of an upstream cluster is determined by its weight. The sum of
+    weights across all entries in the ``clusters`` array must add up to 100.
 
 runtime_key_prefix
   *(optional, string)* Specifies the runtime key prefix that should be used to construct the runtime

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -12,6 +12,7 @@ next (e.g., redirect, forward, rewrite, etc.).
     "prefix": "...",
     "path": "...",
     "cluster": "...",
+    "weighted_clusters" : "...",
     "host_redirect": "...",
     "path_redirect": "...",
     "prefix_rewrite": "...",
@@ -38,9 +39,18 @@ path
 .. _config_http_conn_man_route_table_route_cluster:
 
 cluster
-  *(sometimes required, string)* If the route is not a redirect (*host_redirect* and/or
-  *path_redirect* is specified), *cluster* must be specified and indicates which upstream cluster
-  the request should be forwarded to.
+  *(sometimes required, string)* If the route is not a redirect (i.e., *host_redirect* and/or
+  *path_redirect* is not specified), one of *cluster* or *weighted_clusters* must be specified.
+  When a *cluster* is specified, its value indicates the upstream cluster to which the request
+  should be forwarded to.
+
+:ref:`weighted_clusters <config_http_conn_man_route_table_route_weighted_clusters>`
+  *(sometimes required, string)* If the route is not a redirect (i.e., *host_redirect* and/or
+  *path_redirect* is not specified), one of *cluster* or *weighted_clusters* must be specified. 
+  With the *weighted_clusters*, multiple upstream clusters can be specified for a given route.
+  The request is forwarded to one of the upstream clusters based on weights assigned
+  to each cluster. See :ref:`traffic splitting <config_http_conn_man_route_table_weighted_routing>`
+  for additional documentation.
 
 .. _config_http_conn_man_route_table_route_host_redirect:
 
@@ -216,3 +226,52 @@ regex
 The router will check the request's headers against all the specified
 headers in the route config. A match will happen if all the headers in the route are present in
 the request with the same values (or based on presence if the ``value`` field is not in the config).
+
+.. _config_http_conn_man_route_table_route_weighted_clusters:
+
+Weighted Clusters
+-----------------
+
+Compared to the ``cluster`` field that specifies a single upstream cluster as the target
+of a request, the ``weighted_clusters`` allows for specification of multiple upstream clusters
+along with weights that indicate the **percentage** of traffic to be forwarded to each cluster.
+The router selects an upstream cluster based on the weights.
+
+.. code-block:: json
+
+   {
+     "clusters": [],
+     "runtime_key_prefix" : "..."
+   }
+
+clusters
+  *(required, array)* Specifies one or more upstream clusters associated with the route. 
+
+  .. code-block:: json
+
+     {
+       "name" : "...",
+       "weight": "..."
+     }
+
+  name
+    *(required, string)* Name of the upstream cluster. The cluster must exist in the
+    :ref:`cluster manager configuration <config_cluster_manager>`.
+
+  weight
+    *(required, integer)* An integer between 0-100. When a request matches the route,
+    choice of an upstream cluster is determined by its weight. The sum of
+    weights across all entries in the ``clusters`` array should add up to 100.
+
+runtime_key_prefix
+  *(optional, string)* Specifies the runtime key prefix that should be used to construct the runtime
+  keys associated with each cluster. When the ``runtime_key_prefix`` is specified, the router will
+  look for weights associated with each upstream cluster under the key 
+  ``runtime_key_prefix + "." + cluster[i].name`` where ``cluster[i]``  denotes an entry in the
+  ``clusters`` array field. If the runtime key for the cluster does not exist, the value specified
+  in the configuration file will be used as the default weight.
+  See the :ref:`runtime documentation <operations_runtime>` for how key names map to the
+  underlying implementation.
+
+  **Note:** If the sum of runtime weights exceed 100, the traffic splitting behavior
+  is undefined (although the request will be routed to one of the clusters).

--- a/docs/configuration/http_conn_man/route_config/route_config.rst
+++ b/docs/configuration/http_conn_man/route_config/route_config.rst
@@ -56,3 +56,4 @@ response_headers_to_remove
   rate_limits
   route_matching
   traffic_shifting
+  weighted_routing

--- a/docs/configuration/http_conn_man/route_config/weighted_routing.rst
+++ b/docs/configuration/http_conn_man/route_config/weighted_routing.rst
@@ -1,0 +1,109 @@
+.. _config_http_conn_man_route_table_weighted_routing:
+
+Traffic splitting across multiple upstreams
+===========================================
+
+Envoy's router can split traffic to a route in a virtual host across
+multiple upstream clusters. A common use case is A/B testing or
+multivariate testing, where two or more versions of the same service are
+tested simultaneously. In this case, the traffic to the route has to be
+*split* between clusters running different versions of the same
+service.
+
+Consider a simple example ``service`` with three versions (v1, v2 and
+v3). Envoy provides two ways to split traffic evenly across the three
+versions (i.e., ``33%, 33%, 34%``):
+
+.. _config_http_conn_man_route_table_weighted_routing_percentages:
+
+(a) Weight-based cluster selection
+----------------------------------
+
+The first option is to use a **single** :ref:`route <config_http_conn_man_route_table_route>` with 
+:ref:`weighted_clusters <config_http_conn_man_route_table_route_weighted_clusters>`,
+where multiple upstream cluster targets are specified for a single route,
+along with weights that indicate the **percentage** of traffic to be sent
+to each upstream cluster.
+
+.. code-block:: json
+
+    {
+      "route_config": {
+        "virtual_hosts": [
+          {
+            "name": "service",
+            "domains": ["*"],
+            "routes": [
+              {
+                "prefix": "/",
+                "weighted_clusters": {
+                  "clusters" : [
+                    { "name" : "service_v1", "weight" : 33 },
+                    { "name" : "service_v2", "weight" : 33 },
+                    { "name" : "service_v3", "weight" : 34 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+
+.. _config_http_conn_man_route_table_weighted_routing_probabilities:
+
+(b) Probabilistic route selection
+---------------------------------
+
+The second option is to use **multiple** :ref:`routes <config_http_conn_man_route_table_route>`
+with :ref:`runtimes <config_http_conn_man_route_table_route_runtime>` that specify the
+**probability** of selecting a route.
+Since Envoy matches routes with a :ref:`first match <config_http_conn_man_route_table_route_matching>`
+policy, the related routes (one for each upstream cluster) are placed back-to-back,
+along with a runtime in all but the last route.
+
+.. code-block:: json
+
+    {
+      "route_config": {
+        "virtual_hosts": [
+          {
+            "name": "service",
+            "domains": ["*"],
+            "routes": [
+              {
+                "prefix": "/",
+                "cluster": "service_v1",
+                "runtime": {
+                  "key": "routing.traffic_split.service.service_v1",
+                  "default": 33
+                }
+              },
+              {
+                "prefix": "/",
+                "cluster": "service_v2",
+                "runtime": {
+                  "key": "routing.traffic_split.service.service_v2",
+                  "default": 50
+                }
+              },
+              {
+                "prefix": "/",
+                "cluster": "service_v3",
+              }
+            ]
+          }
+        ]
+      }
+    }
+
+In the configuration above,
+
+1. ``routing.traffic_split.service.service_v1`` is set to ``33``, so that there is a
+   *33\% probability* that the v1 route will be selected by Envoy.
+2. ``routing.traffic_split.service.service_v2`` is set to ``50``, so that if the v1 route
+   is not selected, between v2 and v3, there is a *50\% probability* that the v2 route will
+   be selected by Envoy. If v2 is not selected the traffic falls through to the v3 route.
+
+This distribution of probabilities ensures that the traffic will be split evenly across
+all three routes (i.e. ``33%, 33%, 34%``).

--- a/docs/configuration/http_conn_man/route_config/weighted_routing.rst
+++ b/docs/configuration/http_conn_man/route_config/weighted_routing.rst
@@ -59,7 +59,7 @@ The second option is to use **multiple** :ref:`routes <config_http_conn_man_rout
 with :ref:`runtimes <config_http_conn_man_route_table_route_runtime>` that specify the
 **probability** of selecting a route.
 Since Envoy matches routes with a :ref:`first match <config_http_conn_man_route_table_route_matching>`
-policy, the related routes (one for each upstream cluster) are placed back-to-back,
+policy, the related routes (one for each upstream cluster) must be placed back-to-back,
 along with a runtime in all but the last route.
 
 .. code-block:: json

--- a/docs/configuration/http_conn_man/route_config/weighted_routing.rst
+++ b/docs/configuration/http_conn_man/route_config/weighted_routing.rst
@@ -4,11 +4,16 @@ Traffic splitting across multiple upstreams
 ===========================================
 
 Envoy's router can split traffic to a route in a virtual host across
-multiple upstream clusters. A common use case is A/B testing or
-multivariate testing, where two or more versions of the same service are
-tested simultaneously. In this case, the traffic to the route has to be
-*split* between clusters running different versions of the same
-service.
+multiple upstream clusters. There are two common use cases. The first use
+case is version upgrades, where traffic to a route is shifted gradually
+from one cluster to another. The
+:ref:`traffic shifting <config_http_conn_man_route_table_traffic_shifting>`
+describes this scenario in more detail.
+
+The second use case, discussed in this section, is A/B testing or multivariate
+testing, where ``two or more versions`` of the same service are tested simultaneously.
+The traffic to the route has to be *split* between clusters running different versions
+of the same service.
 
 Consider a simple example ``service`` with three versions (v1, v2 and
 v3). Envoy provides two ways to split traffic evenly across the three
@@ -37,6 +42,7 @@ to each upstream cluster.
               {
                 "prefix": "/",
                 "weighted_clusters": {
+                  "runtime_key_prefix" : "routing.traffic_split.service",
                   "clusters" : [
                     { "name" : "service_v1", "weight" : 33 },
                     { "name" : "service_v2", "weight" : 33 },
@@ -49,6 +55,11 @@ to each upstream cluster.
         ]
       }
     }
+
+The weights assigned to each cluster can be dynamically adjusted using the
+following runtime variables: ``routing.traffic_split.service.service_v1``,
+``routing.traffic_split.service.service_v2`` and
+``routing.traffic_split.service.service_v3``.
 
 .. _config_http_conn_man_route_table_weighted_routing_probabilities:
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -72,7 +72,7 @@ bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
   return matches;
 }
 
-static const std::string WEIGHTED_CLUSTERS_RUNTIME_KEY = "weighted_clusters";
+const uint64_t RouteEntryImplBase::WeightedClusterEntry::MAX_CLUSTER_WEIGHT = 100UL;
 
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json::Object& route,
                                        Runtime::Loader& loader)
@@ -89,6 +89,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
 
   bool have_weighted_clusters = route.hasObject("weighted_clusters");
   bool have_cluster = !cluster_name_.empty() || have_weighted_clusters;
+
   // Check to make sure that we are either a redirect route or we have a cluster.
   if (!(isRedirect() ^ have_cluster)) {
     throw EnvoyException("routes must be either redirects or cluster targets");

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <chrono>
 #include "router_ratelimit.h"
 
 #include "envoy/common/optional.h"
@@ -23,13 +25,17 @@ public:
    * @param headers supplies the headers to match.
    * @param random_value supplies the random seed to use if a runtime choice is required. This
    *        allows stable choices between calls if desired.
-   * @return true if input headers match this object.
+   * @return Pointer to object implementing Route interface if input headers match this object,
+   *         else nullptr.
    */
-  virtual RouteEntry* matches(const Http::HeaderMap &headers, uint64_t random_value) const PURE;
+  virtual const Route* matches(const Http::HeaderMap& headers, uint64_t random_value) const PURE;
 };
 
 class RouteEntryImplBase;
 typedef std::shared_ptr<RouteEntryImplBase> RouteEntryImplBasePtr;
+
+class WeightedClusterEntry;
+typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntryPtr;
 
 /**
  * Redirect entry that does an SSL redirect.
@@ -196,14 +202,15 @@ public:
   std::string newPath(const Http::HeaderMap& headers) const override;
 
   // Router::Matchable
-  RouteEntry* matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
+  const Route* matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
 
   // Router::Route
   const RedirectEntry* redirectEntry() const override;
   const RouteEntry* routeEntry() const override;
 
-  // gets the route object associated with this entry (choose based on Weighted Clusters)
-  const Route* getRoute(uint64_t random_value) const;
+  const std::vector<WeightedClusterEntryPtr>& weightedClusters() const {
+    return weighted_clusters_;
+  }
 
 protected:
   const bool case_sensitive_;
@@ -220,12 +227,13 @@ private:
 
   static Optional<RuntimeData> loadRuntimeData(const Json::Object& route);
 
+  // gets the route object associated with this entry (choose based on Weighted Clusters)
+  const Route* getEntry(uint64_t random_value) const;
   // Default timeout is 15s if nothing is specified in the route config.
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;
 
   const VirtualHostImpl& vhost_;
   const std::string cluster_name_;
-  const uint64_t cluster_weight_;
   const std::chrono::milliseconds timeout_;
   const Optional<RuntimeData> runtime_;
   Runtime::Loader& loader_;
@@ -236,7 +244,7 @@ private:
   const ShadowPolicyImpl shadow_policy_;
   const Upstream::ResourcePriority priority_;
   std::vector<ConfigUtility::HeaderData> config_headers_;
-  std::vector<RouteEntryImplBasePtr> weighted_clusters_;
+  std::vector<WeightedClusterEntryPtr> weighted_clusters_;
 };
 
 /**
@@ -251,7 +259,7 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
 
   // Router::Matchable
-  bool matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
+  const Route* matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
 
 private:
   const std::string prefix_;
@@ -269,12 +277,62 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
 
   // Router::Matchable
-  bool matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
+  const Route* matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
 
 private:
   const std::string path_;
 };
 
+/**
+ * Route entry implementation for weighted clusters.
+ * RouteEntryImplBase holds one or more weighted cluster objects, where each object has a back
+ * pointer to the parent RouteEntryImplBase object. Almost all functions in this class forward calls
+ * back to the parent, with the exception of clusterName and routeEntry.
+ */
+class WeightedClusterEntry : public RouteEntry, public Route {
+public:
+  WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string name, uint64_t weight)
+      : parent_(parent), cluster_name_(name), cluster_weight_(weight) {}
+
+  const std::string& clusterName() const override { return cluster_name_; }
+
+  void finalizeRequestHeaders(Http::HeaderMap& headers) const override {
+    return parent_->finalizeRequestHeaders(headers);
+  }
+
+  Upstream::ResourcePriority priority() const override { return parent_->priority(); }
+
+  const RateLimitPolicy& rateLimitPolicy() const override { return parent_->rateLimitPolicy(); }
+
+  const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
+
+  const ShadowPolicy& shadowPolicy() const override { return parent_->shadowPolicy(); }
+
+  std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
+
+  const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
+    return parent_->virtualCluster(headers);
+  }
+
+  const VirtualHost& virtualHost() const override { return parent_->virtualHost(); }
+
+  const RedirectEntry* redirectEntry() const override { return parent_->redirectEntry(); }
+
+  const RouteEntry* routeEntry() const override {
+    if (parent_->isRedirect()) {
+      return nullptr;
+    } else {
+      return this;
+    }
+  }
+
+  uint64_t cluster_weight() const { return cluster_weight_; }
+
+private:
+  const RouteEntryImplBase* parent_;
+  const std::string cluster_name_;
+  uint64_t cluster_weight_;
+};
 /**
  * Wraps the route configuration which matches an incoming request headers to a backend cluster.
  * This is split out mainly to help with unit testing.

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -217,12 +217,10 @@ private:
   };
 
   /**
-   * Route entry implementation for weighted clusters.
-   * RouteEntryImplBase holds one or more weighted cluster objects,
-   * where each object has a back pointer to the parent
-   * RouteEntryImplBase object. Almost all functions in this class
-   * forward calls back to the parent, with the exception of
-   * clusterName and routeEntry.
+   * Route entry implementation for weighted clusters. The RouteEntryImplBase object holds
+   * one or more weighted cluster objects, where each object has a back pointer to the parent
+   * RouteEntryImplBase object. Almost all functions in this class forward calls back to the
+   * parent, with the exception of clusterName and routeEntry.
    */
   struct WeightedClusterEntry : public RouteEntry, public Route {
   public:
@@ -234,8 +232,6 @@ private:
     uint64_t clusterWeight() const {
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
     }
-
-    static const uint64_t MAX_CLUSTER_WEIGHT;
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
@@ -260,13 +256,16 @@ private:
     const RedirectEntry* redirectEntry() const override { return nullptr; }
     const RouteEntry* routeEntry() const override { return this; }
 
+    static const uint64_t MAX_CLUSTER_WEIGHT;
+
   private:
     const RouteEntryImplBase* parent_;
     const std::string runtime_key_;
     Runtime::Loader& loader_;
     const std::string cluster_name_;
-    uint64_t cluster_weight_;
+    const uint64_t cluster_weight_;
   };
+
   typedef std::unique_ptr<WeightedClusterEntry> WeightedClusterEntryPtr;
 
   static Optional<RuntimeData> loadRuntimeData(const Json::Object& route);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -235,6 +235,8 @@ private:
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
     }
 
+    static const uint64_t MAX_CLUSTER_WEIGHT = 100;
+
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -210,9 +210,11 @@ public:
   // the vector.
   void validateClusters(Upstream::ClusterManager& cm) const;
 
-  // gets the route object associated with this entry (choose based on
-  // Weighted Clusters)
-  const Route* getEntry(uint64_t random_value) const;
+  // Check if this Route Entry has a weighted cluster
+  bool isWeightedCluster() const { return !weighted_clusters_.empty(); }
+
+  // gets the route object chosen from the list of weighted clusters
+  const Route* weightedClusterEntry(uint64_t random_value) const;
 
 protected:
   const bool case_sensitive_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -239,8 +239,10 @@ private:
    */
   struct WeightedClusterEntry : public RouteEntry, public Route {
   public:
-    WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string name, uint64_t weight)
-        : parent_(parent), cluster_name_(name), cluster_weight_(weight) {}
+    WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string runtime_key,
+                         Runtime::Loader& loader, const std::string name, uint64_t weight)
+        : parent_(parent), runtime_key_(runtime_key), loader_(loader), cluster_name_(name),
+          cluster_weight_(weight) {}
 
     const std::string& clusterName() const override { return cluster_name_; }
 
@@ -268,10 +270,15 @@ private:
       }
     }
 
-    uint64_t clusterWeight() const { return cluster_weight_; }
+    uint64_t clusterWeight() const {
+      return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
+    }
 
   private:
     const RouteEntryImplBase* parent_;
+    const std::string runtime_key_;
+    Runtime::Loader& loader_;
+
     const std::string cluster_name_;
     uint64_t cluster_weight_;
   };

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -235,7 +235,7 @@ private:
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
     }
 
-    static const uint64_t MAX_CLUSTER_WEIGHT = 100;
+    static const uint64_t MAX_CLUSTER_WEIGHT;
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -25,7 +25,7 @@ public:
    *        allows stable choices between calls if desired.
    * @return true if input headers match this object.
    */
-  virtual bool matches(const Http::HeaderMap& headers, uint64_t random_value) const PURE;
+  virtual RouteEntry* matches(const Http::HeaderMap &headers, uint64_t random_value) const PURE;
 };
 
 class RouteEntryImplBase;
@@ -196,11 +196,14 @@ public:
   std::string newPath(const Http::HeaderMap& headers) const override;
 
   // Router::Matchable
-  bool matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
+  RouteEntry* matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
 
   // Router::Route
   const RedirectEntry* redirectEntry() const override;
   const RouteEntry* routeEntry() const override;
+
+  // gets the route object associated with this entry (choose based on Weighted Clusters)
+  const Route* getRoute(uint64_t random_value) const;
 
 protected:
   const bool case_sensitive_;
@@ -222,6 +225,7 @@ private:
 
   const VirtualHostImpl& vhost_;
   const std::string cluster_name_;
+  const uint64_t cluster_weight_;
   const std::chrono::milliseconds timeout_;
   const Optional<RuntimeData> runtime_;
   Runtime::Loader& loader_;
@@ -232,6 +236,7 @@ private:
   const ShadowPolicyImpl shadow_policy_;
   const Upstream::ResourcePriority priority_;
   std::vector<ConfigUtility::HeaderData> config_headers_;
+  std::vector<RouteEntryImplBasePtr> weighted_clusters_;
 };
 
 /**

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1207,6 +1207,33 @@ TEST(RouteMatcherTest, WeightedClustersMissingClusterList) {
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm), EnvoyException);
 }
 
+TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
+  std::string json = R"EOF(
+{
+  "virtual_hosts": [
+    {
+      "name": "www2",
+      "domains": ["www.lyft.com"],
+      "routes": [
+        {
+          "prefix": "/",
+          "weighted_clusters": {
+            "runtime_key_prefix" : "www2",
+            "clusters" : []
+          }
+        }
+      ]
+    }
+  ]
+}
+  )EOF";
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  EXPECT_THROW(ConfigImpl(*loader, runtime, cm), EnvoyException);
+}
+
 TEST(RouteMatcherTest, WeightedClustersSumOFWeightsNotEqualToMax) {
   std::string json = R"EOF(
 {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1047,6 +1047,7 @@ TEST(RouteMatcherTest, ExclusiveWeightedClustersEntryOrRedirectEntry) {
     EXPECT_EQ(nullptr, config.route(headers, 0)->redirectEntry());
     EXPECT_EQ("www2", config.route(headers, 0)->routeEntry()->clusterName());
   }
+
   {
     Http::TestHeaderMapImpl headers = genRedirectHeaders("redirect.lyft.com", "/foo", false, false);
     EXPECT_EQ("http://new.lyft.com/foo",
@@ -1109,9 +1110,9 @@ TEST(RouteMatcherTest, WeightedClusters) {
   // Weighted Cluster with no runtime
   {
     Http::TestHeaderMapImpl headers = genHeaders("www1.lyft.com", "/foo", "GET");
-    EXPECT_EQ("cluster1", config.route(headers, 15)->routeEntry()->clusterName());
-    EXPECT_EQ("cluster2", config.route(headers, 45)->routeEntry()->clusterName());
-    EXPECT_EQ("cluster3", config.route(headers, 60)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster1", config.route(headers, 115)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 445)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster3", config.route(headers, 560)->routeEntry()->clusterName());
   }
 
   // Weighted Cluster with valid runtime values
@@ -1144,7 +1145,7 @@ TEST(RouteMatcherTest, WeightedClusters) {
     EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster3", 40))
         .WillRepeatedly(Return(10));
 
-    EXPECT_EQ("cluster1", config.route(headers, 5)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster1", config.route(headers, 1005)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 82)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 92)->routeEntry()->clusterName());
   }


### PR DESCRIPTION
[apologies for the delayed turn around for this feature].

This PR provides an intuitive way of specifying cluster weights, when a particular route is backed by two or more clusters. Instead of using the existing Runtime style probability specification, users can group related clusters under a single weighted_clusters block with % weights assigned to each cluster.

Please refer to #247 for more details.

The current PR is missing documentation. Will add that in a day or so. TLDR:
In the routing config, you can have either the `cluster` key or the `weighted_clusters` key.
The `weighted_clusters` is of the following format:
```json
"weighted_clusters" : {
"runtime_key_prefix" : "foo",
"clusters" : [{ "name" : "cluster-name", "weight" : N },
...
]}
```
where N is an integer from 0 to 100. It determines the proportion of request traffic to be sent to the target cluster. The sum of all weights in the weighted cluster should be equal to 100. 

*On runtime support for weighted clusters:* If we wish to validate the weights provided by the user (as we do it currently), it is not exactly clear how the weights would be validated (i.e. sum of weights == 100) if runtime support were to be enabled for a weighted cluster. My current inclination is to skip runtime support altogether for weighted_clusters. With the addition of RDS, a user can combine weighted cluster and RDS to dynamically change weights. It may not occur instantaneously (as it depends on the RDS poll interval).

Fixes #247 

@mattklein123 @ccaraman 

p.s.: For reviewing this PR, please do not look at the individual commits. Instead, I suggest looking at config_impl.h|cc as one change set and then config_impl_test.cc as another change set.
