### PR TITLE
close connections with no filter chains

### DIFF
--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -153,8 +153,10 @@ public:
   /**
    * Called to create the filter chain.
    * @param connection supplies the connection to create the chain on.
+   * @return true if filter chain was created successfully. Otherwise
+   *   false, e.g. filter chain is empty.
    */
-  virtual void createFilterChain(Connection& connection) PURE;
+  virtual bool createFilterChain(Connection& connection) PURE;
 };
 
 } // Network

--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -139,8 +139,9 @@ public:
   /**
    * Initialize all of the installed read filters. This effectively calls onNewConnection() on
    * each of them.
+   * @return true if read filters were initialized successfully, otherwise false.
    */
-  virtual void initializeReadFilters() PURE;
+  virtual bool initializeReadFilters() PURE;
 };
 
 /**

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -63,7 +63,7 @@ void ConnectionImpl::addFilter(FilterPtr filter) { filter_manager_.addFilter(fil
 
 void ConnectionImpl::addReadFilter(ReadFilterPtr filter) { filter_manager_.addReadFilter(filter); }
 
-void ConnectionImpl::initializeReadFilters() { filter_manager_.initializeReadFilters(); }
+bool ConnectionImpl::initializeReadFilters() { return filter_manager_.initializeReadFilters(); }
 
 void ConnectionImpl::close(ConnectionCloseType type) {
   if (fd_ == -1) {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -44,7 +44,7 @@ public:
   void addWriteFilter(WriteFilterPtr filter) override;
   void addFilter(FilterPtr filter) override;
   void addReadFilter(ReadFilterPtr filter) override;
-  void initializeReadFilters() override;
+  bool initializeReadFilters() override;
 
   // Network::Connection
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -28,9 +28,12 @@ void FilterManagerImpl::destroyFilters() {
   downstream_filters_.clear();
 }
 
-void FilterManagerImpl::initializeReadFilters() {
-  ASSERT(!upstream_filters_.empty());
+bool FilterManagerImpl::initializeReadFilters() {
+  if (upstream_filters_.empty()) {
+    return false;
+  }
   onContinueReading(nullptr);
+  return true;
 }
 
 void FilterManagerImpl::onContinueReading(ActiveReadFilter* filter) {

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -36,7 +36,7 @@ public:
   void addFilter(FilterPtr filter);
   void addReadFilter(ReadFilterPtr filter);
   void destroyFilters();
-  void initializeReadFilters();
+  bool initializeReadFilters();
   void onRead();
   FilterStatus onWrite();
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -14,13 +14,14 @@
 namespace Server {
 namespace Configuration {
 
-void FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager,
+bool FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager,
                                           const std::list<NetworkFilterFactoryCb>& factories) {
   for (const NetworkFilterFactoryCb& factory : factories) {
     factory(filter_manager);
   }
 
   filter_manager.initializeReadFilters();
+  return factories.size() > 0;
 }
 
 MainImpl::MainImpl(Server::Instance& server) : server_(server) {}
@@ -170,8 +171,8 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json)
   }
 }
 
-void MainImpl::ListenerConfig::createFilterChain(Network::Connection& connection) {
-  FilterChainUtility::buildFilterChain(connection, filter_factories_);
+bool MainImpl::ListenerConfig::createFilterChain(Network::Connection& connection) {
+  return FilterChainUtility::buildFilterChain(connection, filter_factories_);
 }
 
 InitialImpl::InitialImpl(const Json::Object& json) {

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -20,8 +20,7 @@ bool FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager
     factory(filter_manager);
   }
 
-  filter_manager.initializeReadFilters();
-  return factories.size() > 0;
+  return filter_manager.initializeReadFilters();
 }
 
 MainImpl::MainImpl(Server::Instance& server) : server_(server) {}

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -43,7 +43,7 @@ public:
    * Given a connection and a list of factories, create a new filter chain. Chain creation will
    * exit early if any filters immediately close the connection.
    */
-  static void buildFilterChain(Network::FilterManager& filter_manager,
+  static bool buildFilterChain(Network::FilterManager& filter_manager,
                                const std::list<NetworkFilterFactoryCb>& factories);
 };
 
@@ -97,7 +97,7 @@ private:
     bool useOriginalDst() override { return use_original_dst_; }
 
     // Network::FilterChainFactory
-    void createFilterChain(Network::Connection& connection) override;
+    bool createFilterChain(Network::Connection& connection) override;
 
   private:
     MainImpl& parent_;

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -93,13 +93,13 @@ Network::Listener* ConnectionHandlerImpl::findListener(const std::string& socket
 void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     Network::ConnectionPtr&& new_connection) {
   conn_log(parent_.logger_, info, "new connection", *new_connection);
-  auto badFilterChain = !factory_.createFilterChain(*new_connection);
+  bool empty_filter_chain = !factory_.createFilterChain(*new_connection);
 
   // If the connection is already closed, we can just let this connection immediately die.
   if (new_connection->state() != Network::Connection::State::Closed) {
-    // Close the connection if the filter chain is bad (e.g. empty) to avoid
+    // Close the connection if the filter chain is empty to avoid
     // leaving open connections with nothing to do.
-    if (badFilterChain) {
+    if (empty_filter_chain) {
       conn_log(parent_.logger_, info, "closing connection - no filters", *new_connection);
       new_connection->close(Network::ConnectionCloseType::NoFlush);
     } else {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -97,10 +97,10 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
 
   // If the connection is already closed, we can just let this connection immediately die.
   if (new_connection->state() != Network::Connection::State::Closed) {
-    // Close the connection if the filter chain is empty to avoid
-    // leaving open connections with nothing to do.
+    // Close the connection if the filter chain is empty to avoid leaving open connections
+    // with nothing to do.
     if (empty_filter_chain) {
-      conn_log(parent_.logger_, info, "closing connection - no filters", *new_connection);
+      conn_log(parent_.logger_, info, "closing connection: no filters", *new_connection);
       new_connection->close(Network::ConnectionCloseType::NoFlush);
     } else {
       ActiveConnectionPtr active_connection(

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -93,14 +93,21 @@ Network::Listener* ConnectionHandlerImpl::findListener(const std::string& socket
 void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     Network::ConnectionPtr&& new_connection) {
   conn_log(parent_.logger_, info, "new connection", *new_connection);
-  factory_.createFilterChain(*new_connection);
+  auto badFilterChain = !factory_.createFilterChain(*new_connection);
 
   // If the connection is already closed, we can just let this connection immediately die.
   if (new_connection->state() != Network::Connection::State::Closed) {
-    ActiveConnectionPtr active_connection(
-        new ActiveConnection(parent_, std::move(new_connection), stats_));
-    active_connection->moveIntoList(std::move(active_connection), parent_.connections_);
-    parent_.num_connections_++;
+    // Close the connection if the filter chain is bad (e.g. empty) to avoid
+    // leaving open connections with nothing to do.
+    if (badFilterChain) {
+      conn_log(parent_.logger_, info, "closing connection - no filters", *new_connection);
+      new_connection->close(Network::ConnectionCloseType::NoFlush);
+    } else {
+      ActiveConnectionPtr active_connection(
+          new ActiveConnection(parent_, std::move(new_connection), stats_));
+      active_connection->moveIntoList(std::move(active_connection), parent_.connections_);
+      parent_.num_connections_++;
+    }
   }
 }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -323,9 +323,10 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
   return Http::ServerConnectionPtr{new Http::Http1::ServerConnectionImpl(connection, callbacks)};
 }
 
-void AdminImpl::createFilterChain(Network::Connection& connection) {
+bool AdminImpl::createFilterChain(Network::Connection& connection) {
   connection.addReadFilter(Network::ReadFilterPtr{new Http::ConnectionManagerImpl(
       *this, server_.drainManager(), server_.random(), server_.httpTracer(), server_.runtime())});
+  return true;
 }
 
 void AdminImpl::createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -34,7 +34,7 @@ public:
   }
 
   // Network::FilterChainFactory
-  void createFilterChain(Network::Connection& connection) override;
+  bool createFilterChain(Network::Connection& connection) override;
 
   // Http::FilterChainFactory
   void createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) override;

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -60,7 +60,7 @@ TEST_F(NetworkFilterManagerTest, All) {
   EXPECT_EQ(read_filter->callbacks_->upstreamHost(), filter->callbacks_->upstreamHost());
 
   EXPECT_CALL(*read_filter, onNewConnection()).WillOnce(Return(FilterStatus::StopIteration));
-  manager.initializeReadFilters();
+  EXPECT_EQ(manager.initializeReadFilters(), true);
 
   EXPECT_CALL(*filter, onNewConnection()).WillOnce(Return(FilterStatus::Continue));
   read_filter->callbacks_->continueReading();
@@ -140,7 +140,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
       .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks)
                                        -> void { request_callbacks = &callbacks; })));
 
-  manager.initializeReadFilters();
+  EXPECT_EQ(manager.initializeReadFilters(), true);
 
   NiceMock<Network::MockClientConnection>* upstream_connection =
       new NiceMock<Network::MockClientConnection>();

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -212,11 +212,12 @@ FakeUpstream::~FakeUpstream() {
   thread_->join();
 }
 
-void FakeUpstream::createFilterChain(Network::Connection& connection) {
+bool FakeUpstream::createFilterChain(Network::Connection& connection) {
   std::unique_lock<std::mutex> lock(lock_);
   connection.readDisable(true);
   new_connections_.push_back(&connection);
   new_connection_event_.notify_one();
+  return true;
 }
 
 void FakeUpstream::threadRoutine() {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -157,7 +157,7 @@ public:
   FakeRawConnectionPtr waitForRawConnection();
 
   // Network::FilterChainFactory
-  void createFilterChain(Network::Connection& connection) override;
+  bool createFilterChain(Network::Connection& connection) override;
 
 private:
   FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr&& connection,

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -46,7 +46,7 @@ public:
   MOCK_METHOD1(close, void(ConnectionCloseType type));
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(id, uint64_t());
-  MOCK_METHOD0(initializeReadFilters, void());
+  MOCK_METHOD0(initializeReadFilters, bool());
   MOCK_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
@@ -75,7 +75,7 @@ public:
   MOCK_METHOD1(close, void(ConnectionCloseType type));
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(id, uint64_t());
-  MOCK_METHOD0(initializeReadFilters, void());
+  MOCK_METHOD0(initializeReadFilters, bool());
   MOCK_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -180,7 +180,7 @@ public:
   MockFilterChainFactory();
   ~MockFilterChainFactory();
 
-  MOCK_METHOD1(createFilterChain, void(Connection& connection));
+  MOCK_METHOD1(createFilterChain, bool(Connection& connection));
 };
 
 class MockListenSocket : public ListenSocket {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -19,8 +19,15 @@ TEST(FilterChainUtility, buildFilterChain) {
   factories.push_back(factory);
 
   EXPECT_CALL(watcher, ready()).Times(2);
-  EXPECT_CALL(connection, initializeReadFilters());
-  FilterChainUtility::buildFilterChain(connection, factories);
+  EXPECT_CALL(connection, initializeReadFilters()).WillOnce(Return(true));
+  EXPECT_EQ(FilterChainUtility::buildFilterChain(connection, factories), true);
+}
+
+TEST(FilterChainUtility, buildFilterChainFailWithBadFilters) {
+  Network::MockConnection connection;
+  std::list<NetworkFilterFactoryCb> factories;
+  EXPECT_CALL(connection, initializeReadFilters()).WillOnce(Return(false));
+  EXPECT_EQ(FilterChainUtility::buildFilterChain(connection, factories), false);
 }
 
 TEST(ConfigurationImplTest, DefaultStatsFlushInterval) {


### PR DESCRIPTION
This fixes a bug where a listener is configured with an empty network
filter list and the connection remains open with no subsequent filter
action.

I can make a similar fix for the HTTP filters if that makes sense and this approach looks okay. 