### PR TITLE
Destination-cluster based fault injection

### DIFF
--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -9,7 +9,8 @@ inject delays and abort requests with user-specified error codes, thereby
 providing the ability to stage different failure scenarios such as service
 failures, service overloads, high network latency, network partitions,
 etc. Faults injection can be limited to a specific set of requests based on
-a set of pre-defined request headers.
+the (destination) upstream cluster of a request and/or a set of pre-defined
+request headers. 
 
 The scope of failures is restricted to those that are observable by an
 application communicating over the network. CPU and disk failures on the
@@ -17,7 +18,6 @@ local host cannot be emulated.
 
 Currently, the fault injection filter has the following limitations:
 
-* Faults will be injected on all configured routes in the Envoy instance
 * Abort codes are restricted to HTTP status codes only
 * Delays are restricted to fixed duration.
 
@@ -46,6 +46,7 @@ including the router filter.*
           "fixed_delay_percent" : "...",
           "fixed_duration_ms" : "..."
         },
+        "upstream_cluster" : "...",
         "headers" : []
       }
     }
@@ -71,6 +72,11 @@ delay.fixed_delay_percent:
 delay.fixed_duration_ms:
   *(required, integer)* The delay duration in
   milliseconds. Must be greater than 0.
+
+upstream_cluster:
+  *(optional, string)* Specifies the name of the (destination) upstream
+  cluster that the filter should match on. Fault injection will be
+  restricted to requests bound to the specific upstream cluster.
 
 :ref:`headers <config_http_filters_fault_injection_headers>`
   *(optional, array)* Specifies a set of headers that the filter should match on.

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -80,7 +80,6 @@ FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
 
   if (!matchesTargetCluster(headers)) {
-    std::cerr << "in decodeHeaders got false, continuing filter\n";
     return FilterHeadersStatus::Continue;
   }
 
@@ -155,18 +154,12 @@ bool FaultFilter::matchesTargetCluster(HeaderMap& headers) {
   bool matches = true;
 
   if (!config_->targetCluster().empty()) {
-    std::cerr << "in matchesTargetCluster with targetCluster " << config_->targetCluster() << "\n";
     // TODO PERF Eliminate repeated route matching
     const Router::Route* route = callbacks_->routeTable().route(headers);
 
     matches &= ((nullptr != route) && (nullptr != route->routeEntry()));
-    std::cerr << "in matchesTargetCluster after route match, matches= " << matches << "\n";
     if (matches) {
-      std::cerr << "in matchesTargetCluster with routeEntry->clusterName "
-                << route->routeEntry()->clusterName() << "\n";
       matches &= (route->routeEntry()->clusterName() == config_->targetCluster());
-      std::cerr << "in matchesTargetCluster with after string compare, matches "
-                << matches << "\n";
     }
   }
   return matches;

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -78,7 +78,6 @@ FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 // if we inject a delay, then we will inject the abort in the delay timer
 // callback.
 FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
-
   if (!matchesTargetCluster(headers)) {
     return FilterHeadersStatus::Continue;
   }

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -40,7 +40,7 @@ public:
   uint64_t delayPercent() { return fixed_delay_percent_; }
   uint64_t delayDuration() { return fixed_duration_ms_; }
   uint64_t abortCode() { return http_status_; }
-  const std::string& targetCluster() { return target_cluster_; }
+  const std::string& upstreamCluster() { return upstream_cluster_; }
   Runtime::Loader& runtime() { return runtime_; }
   FaultFilterStats& stats() { return stats_; }
 
@@ -51,7 +51,7 @@ private:
   uint64_t http_status_{};         // HTTP or gRPC return codes
   uint64_t fixed_delay_percent_{}; // 0-100
   uint64_t fixed_duration_ms_{};   // in milliseconds
-  std::string target_cluster_;     // restrict faults to specific upstream cluster
+  std::string upstream_cluster_;   // restrict faults to specific upstream cluster
   std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers_;
   Runtime::Loader& runtime_;
   FaultFilterStats stats_;
@@ -77,7 +77,7 @@ private:
   void resetTimerState();
   void postDelayInjection();
   void abortWithHTTPStatus();
-  bool matchesTargetCluster(HeaderMap& headers);
+  bool matchesTargetCluster(const HeaderMap& headers);
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -40,6 +40,7 @@ public:
   uint64_t delayPercent() { return fixed_delay_percent_; }
   uint64_t delayDuration() { return fixed_duration_ms_; }
   uint64_t abortCode() { return http_status_; }
+  const std::string& targetCluster() { return target_cluster_; }
   Runtime::Loader& runtime() { return runtime_; }
   FaultFilterStats& stats() { return stats_; }
 
@@ -50,6 +51,7 @@ private:
   uint64_t http_status_{};         // HTTP or gRPC return codes
   uint64_t fixed_delay_percent_{}; // 0-100
   uint64_t fixed_duration_ms_{};   // in milliseconds
+  std::string target_cluster_;     // restrict faults to specific upstream cluster
   std::vector<Router::ConfigUtility::HeaderData> fault_filter_headers_;
   Runtime::Loader& runtime_;
   FaultFilterStats stats_;
@@ -75,6 +77,7 @@ private:
   void resetTimerState();
   void postDelayInjection();
   void abortWithHTTPStatus();
+  bool matchesTargetCluster(HeaderMap& headers);
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};


### PR DESCRIPTION
This PR adds the ability to a restrict fault injection filter to a specific upstream cluster. Requests that are bound for other clusters or requests that do not match any route will not be affected.