### PR TITLE
access log: option to log upstream cluster

### DIFF
--- a/docs/configuration/http_conn_man/access_log.rst
+++ b/docs/configuration/http_conn_man/access_log.rst
@@ -90,6 +90,9 @@ The following command operators are supported:
 %UPSTREAM_HOST%
   Upstream host URL (e.g., tcp://ip:port for TCP connections).
 
+%UPSTREAM_CLUSTER%
+  Upstream cluster to which the upstream host belongs to.
+
 %REQ(X?Y):Z%
   An HTTP request header where X is the main HTTP header, Y is the alternative one, and Z is an
   optional parameter denoting string truncation up to Z characters long. The value is taken from the

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -258,6 +258,15 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
 
       return upstream_host_url.empty() ? "-" : upstream_host_url;
     };
+  } else if (field_name == "UPSTREAM_CLUSTER") {
+    field_extractor_ = [](const RequestInfo& request_info) {
+      std::string upstream_cluster_name;
+      if (nullptr != request_info.upstreamHost()) {
+        upstream_cluster_name = request_info.upstreamHost()->cluster().name();
+      }
+
+      return upstream_cluster_name.empty() ? "-" : upstream_cluster_name;
+    };
   } else {
     throw EnvoyException(fmt::format("Not supported field in RequestInfo: {}", field_name));
   }

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -129,17 +129,9 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
-    std::shared_ptr<Upstream::MockHostDescription> host(new Upstream::MockHostDescription());
-    EXPECT_CALL(requestInfo, upstreamHost()).WillRepeatedly(Return(host));
     const std::string host_url = "name";
-    EXPECT_CALL(*host, url()).WillOnce(ReturnRef(host_url));
+    EXPECT_CALL(*requestInfo.host_, url()).WillOnce(ReturnRef(host_url));
     EXPECT_EQ("name", upstream_format.format(header, header, requestInfo));
-  }
-
-  {
-    RequestInfoFormatter upstream_format("UPSTREAM_HOST");
-    EXPECT_CALL(requestInfo, upstreamHost()).WillOnce(Return(nullptr));
-    EXPECT_EQ("-", upstream_format.format(header, header, requestInfo));
   }
 
   {
@@ -147,6 +139,12 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
     const std::string upstream_cluster_name = "cluster_name";
     EXPECT_CALL(requestInfo.host_->cluster_, name()).WillOnce(ReturnRef(upstream_cluster_name));
     EXPECT_EQ("cluster_name", upstream_format.format(header, header, requestInfo));
+  }
+
+  {
+    RequestInfoFormatter upstream_format("UPSTREAM_HOST");
+    EXPECT_CALL(requestInfo, upstreamHost()).WillOnce(Return(nullptr));
+    EXPECT_EQ("-", upstream_format.format(header, header, requestInfo));
   }
 
   {

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -71,138 +71,138 @@ TEST(AccessLogFormatterTest, plainStringFormatter) {
 TEST(AccessLogFormatterTest, requestInfoFormatter) {
   EXPECT_THROW(RequestInfoFormatter formatter("unknown_field"), EnvoyException);
 
-  NiceMock<MockRequestInfo> requestInfo;
+  NiceMock<MockRequestInfo> request_info;
   TestHeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
 
   {
     RequestInfoFormatter start_time_format("START_TIME");
     SystemTime time;
-    EXPECT_CALL(requestInfo, startTime()).WillOnce(Return(time));
+    EXPECT_CALL(request_info, startTime()).WillOnce(Return(time));
     EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
-              start_time_format.format(header, header, requestInfo));
+              start_time_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter bytes_received_format("BYTES_RECEIVED");
-    EXPECT_CALL(requestInfo, bytesReceived()).WillOnce(Return(1));
-    EXPECT_EQ("1", bytes_received_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(1));
+    EXPECT_EQ("1", bytes_received_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter protocol_format("PROTOCOL");
-    EXPECT_CALL(requestInfo, protocol()).WillOnce(Return(Protocol::Http11));
-    EXPECT_EQ("HTTP/1.1", protocol_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, protocol()).WillOnce(Return(Protocol::Http11));
+    EXPECT_EQ("HTTP/1.1", protocol_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_format("RESPONSE_CODE");
     Optional<uint32_t> response_code{200};
-    EXPECT_CALL(requestInfo, responseCode()).WillRepeatedly(ReturnRef(response_code));
-    EXPECT_EQ("200", response_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
+    EXPECT_EQ("200", response_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_code_format("RESPONSE_CODE");
     Optional<uint32_t> response_code;
-    EXPECT_CALL(requestInfo, responseCode()).WillRepeatedly(ReturnRef(response_code));
-    EXPECT_EQ("0", response_code_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
+    EXPECT_EQ("0", response_code_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter bytes_sent_format("BYTES_SENT");
-    EXPECT_CALL(requestInfo, bytesSent()).WillOnce(Return(1));
-    EXPECT_EQ("1", bytes_sent_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(1));
+    EXPECT_EQ("1", bytes_sent_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter duration_format("DURATION");
     std::chrono::milliseconds time{2};
-    EXPECT_CALL(requestInfo, duration()).WillOnce(Return(time));
-    EXPECT_EQ("2", duration_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, duration()).WillOnce(Return(time));
+    EXPECT_EQ("2", duration_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_flags_format("RESPONSE_FLAGS");
-    ON_CALL(requestInfo, getResponseFlag(ResponseFlag::LocalReset)).WillByDefault(Return(true));
-    EXPECT_EQ("LR", response_flags_format.format(header, header, requestInfo));
+    ON_CALL(request_info, getResponseFlag(ResponseFlag::LocalReset)).WillByDefault(Return(true));
+    EXPECT_EQ("LR", response_flags_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
     const std::string host_url = "name";
-    EXPECT_CALL(*requestInfo.host_, url()).WillOnce(ReturnRef(host_url));
-    EXPECT_EQ("name", upstream_format.format(header, header, requestInfo));
+    EXPECT_CALL(*request_info.host_, url()).WillOnce(ReturnRef(host_url));
+    EXPECT_EQ("name", upstream_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_CLUSTER");
     const std::string upstream_cluster_name = "cluster_name";
-    EXPECT_CALL(requestInfo.host_->cluster_, name()).WillOnce(ReturnRef(upstream_cluster_name));
-    EXPECT_EQ("cluster_name", upstream_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info.host_->cluster_, name()).WillOnce(ReturnRef(upstream_cluster_name));
+    EXPECT_EQ("cluster_name", upstream_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
-    EXPECT_CALL(requestInfo, upstreamHost()).WillOnce(Return(nullptr));
-    EXPECT_EQ("-", upstream_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
+    EXPECT_EQ("-", upstream_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_CLUSTER");
-    EXPECT_CALL(requestInfo, upstreamHost()).WillOnce(Return(nullptr));
-    EXPECT_EQ("-", upstream_format.format(header, header, requestInfo));
+    EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
+    EXPECT_EQ("-", upstream_format.format(header, header, request_info));
   }
 }
 
 TEST(AccessLogFormatterTest, requestHeaderFormatter) {
-  MockRequestInfo requestInfo;
+  MockRequestInfo request_info;
   TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
   TestHeaderMapImpl response_header{{":method", "PUT"}};
 
   {
     RequestHeaderFormatter formatter(":Method", "", Optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("GET", formatter.format(request_header, response_header, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":path", ":method", Optional<size_t>());
-    EXPECT_EQ("/", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("/", formatter.format(request_header, response_header, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":TEST", ":METHOD", Optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("GET", formatter.format(request_header, response_header, request_info));
   }
 
   {
     RequestHeaderFormatter formatter("does_not_exist", "", Optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("-", formatter.format(request_header, response_header, request_info));
   }
 }
 
 TEST(AccessLogFormatterTest, responseHeaderFormatter) {
-  MockRequestInfo requestInfo;
+  MockRequestInfo request_info;
   TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
   TestHeaderMapImpl response_header{{":method", "PUT"}, {"test", "test"}};
 
   {
     ResponseHeaderFormatter formatter(":method", "", Optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("PUT", formatter.format(request_header, response_header, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("test", ":method", Optional<size_t>());
-    EXPECT_EQ("test", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("test", formatter.format(request_header, response_header, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter(":path", ":method", Optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("PUT", formatter.format(request_header, response_header, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("does_not_exist", "", Optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, requestInfo));
+    EXPECT_EQ("-", formatter.format(request_header, response_header, request_info));
   }
 }
 

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -144,12 +144,8 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_CLUSTER");
-    std::shared_ptr<Upstream::MockHostDescription> host(new Upstream::MockHostDescription());
-    Upstream::MockClusterInfo cluster;
-    EXPECT_CALL(requestInfo, upstreamHost()).WillRepeatedly(Return(host));
-    EXPECT_CALL(*host, cluster()).WillRepeatedly(ReturnRef(cluster));
     const std::string upstream_cluster_name = "cluster_name";
-    EXPECT_CALL(cluster, name()).WillOnce(ReturnRef(upstream_cluster_name));
+    EXPECT_CALL(requestInfo.host_->cluster_, name()).WillOnce(ReturnRef(upstream_cluster_name));
     EXPECT_EQ("cluster_name", upstream_format.format(header, header, requestInfo));
   }
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -135,7 +135,8 @@ namespace AccessLog {
 MockInstance::MockInstance() {}
 MockInstance::~MockInstance() {}
 
-MockRequestInfo::MockRequestInfo() {}
+MockRequestInfo::MockRequestInfo() { ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_)); }
+
 MockRequestInfo::~MockRequestInfo() {}
 
 } // AccessLog

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -46,6 +46,9 @@ public:
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
+
+  std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
+      new testing::NiceMock<Upstream::MockHostDescription>()};
 };
 
 } // AccessLog

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "envoy/upstream/cluster_manager.h"
+#include "envoy/upstream/upstream.h"
+
+#include "common/stats/stats_impl.h"
+
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/stats/mocks.h"
+
+using testing::NiceMock;
+
+namespace Upstream {
+
+class MockClusterInfo : public ClusterInfo {
+public:
+  MockClusterInfo();
+  ~MockClusterInfo();
+
+  // Upstream::ClusterInfo
+  MOCK_CONST_METHOD0(connectTimeout, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(features, uint64_t());
+  MOCK_CONST_METHOD0(httpCodecOptions, uint64_t());
+  MOCK_CONST_METHOD0(lbType, LoadBalancerType());
+  MOCK_CONST_METHOD0(maintenanceMode, bool());
+  MOCK_CONST_METHOD0(maxRequestsPerConnection, uint64_t());
+  MOCK_CONST_METHOD0(name, const std::string&());
+  MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
+  MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
+  MOCK_CONST_METHOD0(stats, ClusterStats&());
+  MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
+
+  std::string name_{"fake_cluster"};
+  uint64_t max_requests_per_connection_{};
+  NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  ClusterStats stats_;
+  NiceMock<Runtime::MockLoader> runtime_;
+  std::unique_ptr<Upstream::ResourceManager> resource_manager_;
+};
+
+} // Upstream

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -58,6 +58,7 @@ public:
 
   std::string url_{"tcp://10.0.0.1:443"};
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
+  testing::NiceMock<MockClusterInfo> cluster_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))};
 };

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -3,6 +3,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/stats/stats_impl.h"
+#include "cluster_info.h"
 
 namespace Upstream {
 namespace Outlier {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "cluster_info.h"
+
 #include "envoy/upstream/upstream.h"
 
 #include "common/stats/stats_impl.h"
-#include "cluster_info.h"
 
 namespace Upstream {
 namespace Outlier {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -33,7 +33,7 @@ MockHostDescription::MockHostDescription() {
   ON_CALL(*this, url()).WillByDefault(ReturnRef(url_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
-  ON_CALL(*this, cluster()).WillByDefault(ReturnRef(*cluster_));
+  ON_CALL(*this, cluster()).WillByDefault(ReturnRef(cluster_));
 }
 
 MockHostDescription::~MockHostDescription() {}

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -33,6 +33,7 @@ MockHostDescription::MockHostDescription() {
   ON_CALL(*this, url()).WillByDefault(ReturnRef(url_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
+  ON_CALL(*this, cluster()).WillByDefault(ReturnRef(*cluster_));
 }
 
 MockHostDescription::~MockHostDescription() {}

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -10,36 +10,11 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "cluster_info.h"
 
 using testing::NiceMock;
 
 namespace Upstream {
-
-class MockClusterInfo : public ClusterInfo {
-public:
-  MockClusterInfo();
-  ~MockClusterInfo();
-
-  // Upstream::ClusterInfo
-  MOCK_CONST_METHOD0(connectTimeout, std::chrono::milliseconds());
-  MOCK_CONST_METHOD0(features, uint64_t());
-  MOCK_CONST_METHOD0(httpCodecOptions, uint64_t());
-  MOCK_CONST_METHOD0(lbType, LoadBalancerType());
-  MOCK_CONST_METHOD0(maintenanceMode, bool());
-  MOCK_CONST_METHOD0(maxRequestsPerConnection, uint64_t());
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
-  MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
-  MOCK_CONST_METHOD0(stats, ClusterStats&());
-  MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
-
-  std::string name_{"fake_cluster"};
-  uint64_t max_requests_per_connection_{};
-  NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
-  ClusterStats stats_;
-  NiceMock<Runtime::MockLoader> runtime_;
-  std::unique_ptr<Upstream::ResourceManager> resource_manager_;
-};
 
 class MockCluster : public Cluster {
 public:

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cluster_info.h"
+
 #include "envoy/http/async_client.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/health_checker.h"
@@ -10,7 +12,6 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
-#include "cluster_info.h"
 
 using testing::NiceMock;
 


### PR DESCRIPTION
Added a separate UPSTREAM_CLUSTER field to access log. For egress access logs, this is very useful to identify the destination cluster.