### PR TITLE
build: add ccache option to envoy build

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -34,5 +34,14 @@ endif()
 
 option(ENVOY_STRIP "strip symbols from binaries" OFF)
 
+option(ENVOY_USE_CCACHE "build with ccache" OFF)
+if (ENVOY_USE_CCACHE)
+  find_program(CCACHE_FOUND ccache)
+  if (CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif()
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ENVOY_COTIRE_MODULE_DIR}")
 include(cotire)


### PR DESCRIPTION
At least on my machine, ccache set via CC and CXX env variables is no
longer working and breaks the boringssl build. This allows ccache to
be turned on via cmake for the envoy code only.