### PR TITLE
cluster manager: gracefully handle static/cds cluster manager init

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -105,6 +105,12 @@ public:
    * Start the first fetch of CDS data.
    */
   virtual void initialize() PURE;
+
+  /**
+   * Set a callback that will be called when the CDS API has done an initial load from the remote
+   * server. If the initial load fails, the callback will also be called.
+   */
+  virtual void setInitializedCb(std::function<void()> callback) PURE;
 };
 
 typedef std::unique_ptr<CdsApi> CdsApiPtr;

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -59,6 +59,13 @@ void CdsApiImpl::parseResponse(const Http::Message& response) {
   stats_.update_success_.inc();
 }
 
+void CdsApiImpl::onFetchComplete() {
+  if (initialize_callback_) {
+    initialize_callback_();
+    initialize_callback_ = nullptr;
+  }
+}
+
 void CdsApiImpl::onFetchFailure(EnvoyException* e) {
   stats_.update_failure_.inc();
   if (e) {

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -37,6 +37,9 @@ public:
 
   // Upstream::CdsApi
   void initialize() override { RestApiFetcher::initialize(); }
+  void setInitializedCb(std::function<void()> callback) override {
+    initialize_callback_ = callback;
+  }
 
 private:
   CdsApiImpl(const Json::Object& config, ClusterManager& cm, Event::Dispatcher& dispatcher,
@@ -46,11 +49,12 @@ private:
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override;
   void parseResponse(const Http::Message& response) override;
-  void onFetchComplete() override {}
+  void onFetchComplete() override;
   void onFetchFailure(EnvoyException* e) override;
 
   const LocalInfo::LocalInfo& local_info_;
   CdsStats stats_;
+  std::function<void()> initialize_callback_;
 };
 
 } // Upstream

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -41,12 +41,12 @@ void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
 }
 
 void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
-  // There is a remote edge case where we can remove a cluster via CDS that has not yet been
-  // initialized. This catches that case.
   if (state_ == State::AllClustersInitialized) {
     return;
   }
 
+  // There is a remote edge case where we can remove a cluster via CDS that has not yet been
+  // initialized. When called via the remove cluster API this code catches that case.
   std::list<Cluster*>* cluster_list;
   if (cluster.initializePhase() == Cluster::InitializePhase::Primary) {
     cluster_list = &primary_init_clusters_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -15,11 +15,6 @@
 
 namespace Upstream {
 
-ClusterManagerInitHelper::~ClusterManagerInitHelper() {
-  ASSERT(primary_init_clusters_.empty());
-  ASSERT(secondary_init_clusters_.empty());
-}
-
 void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
   if (state_ == State::AllClustersInitialized) {
     cluster.initialize();

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -15,6 +15,117 @@
 
 namespace Upstream {
 
+ClusterManagerInitHelper::~ClusterManagerInitHelper() {
+  ASSERT(primary_init_clusters_.empty());
+  ASSERT(secondary_init_clusters_.empty());
+}
+
+void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
+  if (state_ == State::AllClustersInitialized) {
+    cluster.initialize();
+    return;
+  }
+
+  if (cluster.initializePhase() == Cluster::InitializePhase::Primary) {
+    primary_init_clusters_.push_back(&cluster);
+    cluster.initialize();
+  } else {
+    ASSERT(cluster.initializePhase() == Cluster::InitializePhase::Secondary);
+    secondary_init_clusters_.push_back(&cluster);
+  }
+
+  cluster.setInitializedCb([&cluster, this]() -> void {
+    ASSERT(state_ != State::AllClustersInitialized);
+    removeCluster(cluster);
+  });
+}
+
+void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
+  // There is a remote edge case where we can remove a cluster via CDS that has not yet been
+  // initialized. This catches that case.
+  if (state_ == State::AllClustersInitialized) {
+    return;
+  }
+
+  std::list<Cluster*>* cluster_list;
+  if (cluster.initializePhase() == Cluster::InitializePhase::Primary) {
+    cluster_list = &primary_init_clusters_;
+  } else {
+    ASSERT(cluster.initializePhase() == Cluster::InitializePhase::Secondary);
+    cluster_list = &secondary_init_clusters_;
+  }
+
+  ASSERT(std::find(cluster_list->begin(), cluster_list->end(), &cluster) != cluster_list->end());
+  cluster_list->remove(&cluster);
+  maybeFinishInitialize();
+}
+
+void ClusterManagerInitHelper::maybeFinishInitialize() {
+  // Do not do anything if we are still doing the initial static load or if we are waiting for
+  // CDS initialize.
+  if (state_ == State::Loading || state_ == State::WaitingForCdsInitialize) {
+    return;
+  }
+
+  // If we are still waiting for primary clusters to initialize, do nothing.
+  ASSERT(state_ == State::WaitingForStaticInitialize || state_ == State::CdsInitialized);
+  if (!primary_init_clusters_.empty()) {
+    return;
+  }
+
+  // If we are still waiting for secondary clusters to initialize, see if we need to first call
+  // initialize on them. This is only done once.
+  if (!secondary_init_clusters_.empty()) {
+    if (!started_secondary_initialize_) {
+      started_secondary_initialize_ = true;
+      for (Cluster* cluster : secondary_init_clusters_) {
+        cluster->initialize();
+      }
+    }
+
+    return;
+  }
+
+  // At this point, if we are doing static init, and we have CDS, start CDS init. Otherwise, move
+  // directly to initialized.
+  started_secondary_initialize_ = false;
+  if (state_ == State::WaitingForStaticInitialize && cds_) {
+    state_ = State::WaitingForCdsInitialize;
+    cds_->initialize();
+  } else {
+    state_ = State::AllClustersInitialized;
+    if (initialized_callback_) {
+      initialized_callback_();
+    }
+  }
+}
+
+void ClusterManagerInitHelper::onStaticLoadComplete() {
+  ASSERT(state_ == State::Loading);
+  state_ = State::WaitingForStaticInitialize;
+  maybeFinishInitialize();
+}
+
+void ClusterManagerInitHelper::setCds(CdsApi* cds) {
+  ASSERT(state_ == State::Loading);
+  cds_ = cds;
+  if (cds_) {
+    cds_->setInitializedCb([this]() -> void {
+      ASSERT(state_ == State::WaitingForCdsInitialize);
+      state_ = State::CdsInitialized;
+      maybeFinishInitialize();
+    });
+  }
+}
+
+void ClusterManagerInitHelper::setInitializedCb(std::function<void()> callback) {
+  if (state_ == State::AllClustersInitialized) {
+    callback();
+  } else {
+    initialized_callback_ = callback;
+  }
+}
+
 ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManagerFactory& factory,
                                        Stats::Store& stats, ThreadLocal::Instance& tls,
                                        Runtime::Loader& runtime, Runtime::RandomGenerator& random,
@@ -23,9 +134,6 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
     : factory_(factory), runtime_(runtime), stats_(stats), tls_(tls), random_(random),
       thread_local_slot_(tls.allocateSlot()), local_info_(local_info),
       cm_stats_(generateStats(stats)) {
-
-  std::vector<Json::ObjectPtr> clusters = config.getObjectArray("clusters");
-  pending_cluster_init_ = clusters.size();
 
   if (config.hasObject("outlier_detection")) {
     std::string event_log_file_path =
@@ -37,7 +145,6 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
   }
 
   if (config.hasObject("sds")) {
-    pending_cluster_init_++;
     loadCluster(*config.getObject("sds")->getObject("cluster"), false);
 
     SdsConfig sds_config{
@@ -48,11 +155,14 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
   }
 
   if (config.hasObject("cds")) {
-    pending_cluster_init_++;
     loadCluster(*config.getObject("cds")->getObject("cluster"), false);
   }
 
-  for (const Json::ObjectPtr& cluster : clusters) {
+  // We can now potentially create the CDS API once the backing cluster exists.
+  cds_api_ = factory_.createCds(config, *this);
+  init_helper_.setCds(cds_api_.get());
+
+  for (const Json::ObjectPtr& cluster : config.getObjectArray("clusters")) {
     loadCluster(*cluster, false);
   }
 
@@ -78,12 +188,7 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
     postInitializeCluster(*cluster.second.cluster_);
   }
 
-  // Once all clusters are initiailized we can attempt to initialize the CDS API if configured.
-  // TODO: Graceful initialize of CDS on initial load.
-  cds_api_ = factory_.createCds(config, *this);
-  if (cds_api_) {
-    cds_api_->initialize();
-  }
+  init_helper_.onStaticLoadComplete();
 }
 
 ClusterManagerStats ClusterManagerImpl::generateStats(Stats::Scope& scope) {
@@ -131,7 +236,8 @@ bool ClusterManagerImpl::removePrimaryCluster(const std::string& cluster_name) {
     return false;
   }
 
-  primary_clusters_.erase(cluster_name);
+  init_helper_.removeCluster(*existing_cluster->second.cluster_);
+  primary_clusters_.erase(existing_cluster);
   cm_stats_.cluster_removed_.inc();
   cm_stats_.total_clusters_.set(primary_clusters_.size());
   tls_.runOnAllThreads([this, cluster_name]() -> void {
@@ -148,35 +254,12 @@ void ClusterManagerImpl::loadCluster(const Json::Object& cluster, bool added_via
   ClusterPtr new_cluster =
       factory_.clusterFromJson(cluster, *this, sds_config_, outlier_event_logger_);
 
+  init_helper_.addCluster(*new_cluster);
   if (!added_via_api) {
     if (primary_clusters_.find(new_cluster->info()->name()) != primary_clusters_.end()) {
       throw EnvoyException(
           fmt::format("cluster manager: duplicate cluster '{}'", new_cluster->info()->name()));
     }
-
-    if (new_cluster->initializePhase() == Cluster::InitializePhase::Primary) {
-      new_cluster->initialize();
-    } else {
-      ASSERT(new_cluster->initializePhase() == Cluster::InitializePhase::Secondary);
-      secondary_init_clusters_.push_back(new_cluster.get());
-    }
-
-    ASSERT(pending_cluster_init_ > 0);
-    new_cluster->setInitializedCb([this]() -> void {
-      ASSERT(pending_cluster_init_ > 0);
-      if (--pending_cluster_init_ == 0) {
-        if (initialized_callback_) {
-          initialized_callback_();
-        }
-      } else if (pending_cluster_init_ == secondary_init_clusters_.size()) {
-        // All primary clusters have initialized. Now we start up the secondary clusters.
-        for (Cluster* cluster : secondary_init_clusters_) {
-          cluster->initialize();
-        }
-      }
-    });
-  } else {
-    new_cluster->initialize();
   }
 
   const Cluster& primary_cluster_reference = *new_cluster;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -54,7 +54,6 @@ private:
  */
 class ClusterManagerInitHelper {
 public:
-  ~ClusterManagerInitHelper();
   void addCluster(Cluster& cluster);
   void onStaticLoadComplete();
   void removeCluster(Cluster& cluster);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -16,7 +16,6 @@
 
 #include "common/common/enum_to_int.h"
 #include "common/common/logger.h"
-#include "common/json/json_loader.h"
 #include "common/stats/stats_impl.h"
 
 namespace Upstream {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -9,6 +9,7 @@ using testing::Invoke;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
+using testing::SaveArg;
 
 namespace Upstream {
 namespace Outlier {
@@ -90,7 +91,10 @@ MockHealthChecker::MockHealthChecker() {
 
 MockHealthChecker::~MockHealthChecker() {}
 
-MockCdsApi::MockCdsApi() {}
+MockCdsApi::MockCdsApi() {
+  ON_CALL(*this, setInitializedCb(_)).WillByDefault(SaveArg<0>(&initialized_callback_));
+}
+
 MockCdsApi::~MockCdsApi() {}
 
 } // Upstream

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -124,6 +124,9 @@ public:
   ~MockCdsApi();
 
   MOCK_METHOD0(initialize, void());
+  MOCK_METHOD1(setInitializedCb, void(std::function<void()> callback));
+
+  std::function<void()> initialized_callback_;
 };
 
 } // Upstream


### PR DESCRIPTION
This change refactors CM init so that we can properly do initialization
across static clusters as well as CDS clusters. The normal init flow
looks like this:
1) Initialize static primary clusters
2) Initialize static secondary clusters
3) Start CDS fetch
4) Initialize CDS primary clusters
5) Initialize CDS secondary clusters

This should now work correectly if any of the phases are absent or
immediately complete (as in the case of static clusters).

fixes https://github.com/lyft/envoy/issues/367
fixes https://github.com/lyft/envoy/issues/330