### PR TITLE
perf: cache HTTP route when looked up by filters

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -87,10 +87,10 @@ public:
    * Returns the route for the current request. The assumption is that the implementation can do
    * caching where applicable to avoid multiple lookups.
    *
-   * NOTE: This breaks down a bit if the caller knows it has modified something that would effect
+   * NOTE: This breaks down a bit if the caller knows it has modified something that would affect
    *       routing (such as the request headers). In practice, we don't do this anywhere currently,
    *       but in the future we might need to provide the ability to clear the cache if a filter
-   *       knows that it has modified the headers in a way that would effect routing. In the future
+   *       knows that it has modified the headers in a way that would affect routing. In the future
    *       we may also want to allow the filter to override the route entry.
    */
   virtual const Router::Route* route() PURE;

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -84,12 +84,16 @@ public:
   virtual void resetStream() PURE;
 
   /**
-   * @return const Router::StableRouteTable& the route table used for HTTP routing decisions.
-   *         The most important consumer of this information is the router filter. However,
-   *         other filters may wish to know the route that will be taken for various reasons so
-   *         the information is supplied to all filters. The table may be empty.
+   * Returns the route for the current request. The assumption is that the implementation can do
+   * caching where applicable to avoid multiple lookups.
+   *
+   * NOTE: This breaks down a bit if the caller knows it has modified something that would effect
+   *       routing (such as the request headers). In practice, we don't do this anywhere currently,
+   *       but in the future we might need to provide the ability to clear the cache if a filter
+   *       knows that it has modified the headers in a way that would effect routing. In the future
+   *       we may also want to allow the filter to override the route entry.
    */
-  virtual const Router::StableRouteTable& routeTable() PURE;
+  virtual const Router::Route* route() PURE;
 
   /**
    * @return uint64_t the ID of the originating stream for logging purposes.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -264,21 +264,4 @@ public:
 
 typedef std::unique_ptr<Config> ConfigPtr;
 
-/**
- * An interface into the config that removes the random value parameters. An implementation is
- * expected to pass the same random_value for all wrapped calls.
- */
-class StableRouteTable {
-public:
-  virtual ~StableRouteTable() {}
-
-  /**
-   * Based on the incoming HTTP request headers, determine the target route (containing either a
-   * route entry or a redirect entry) for the request.
-   * @param headers supplies the request headers.
-   * @return the route or nullptr if there is no matching route for the request.
-   */
-  virtual const Route* route(const Http::HeaderMap& headers) const PURE;
-};
-
 } // Router

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -95,7 +95,7 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::HeaderMap& tr
 }
 
 void Http1BridgeFilter::setupStatTracking(const Http::HeaderMap& headers) {
-  const Router::Route* route = decoder_callbacks_->routeTable().route(headers);
+  const Router::Route* route = decoder_callbacks_->route();
   if (!route) {
     return;
   }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -47,7 +47,6 @@ private:
  */
 class AsyncRequestImpl final : public AsyncClient::Request,
                                StreamDecoderFilterCallbacks,
-                               Router::StableRouteTable,
                                Logger::Loggable<Logger::Id::http>,
                                LinkedObject<AsyncRequestImpl> {
 public:
@@ -147,7 +146,7 @@ private:
   uint64_t connectionId() override { return 0; }
   Event::Dispatcher& dispatcher() override { return parent_.dispatcher_; }
   void resetStream() override;
-  const Router::StableRouteTable& routeTable() { return *this; }
+  const Router::Route* route() override { return &route_; }
   uint64_t streamId() override { return stream_id_; }
   AccessLog::RequestInfo& requestInfo() override { return request_info_; }
   const std::string& downstreamAddress() override { return EMPTY_STRING; }
@@ -156,9 +155,6 @@ private:
   void encodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(HeaderMapPtr&& trailers) override;
-
-  // Router::StableRouteTable
-  const Router::Route* route(const Http::HeaderMap&) const override { return &route_; }
 
   MessagePtr request_;
   AsyncClientImpl& parent_;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -802,6 +802,15 @@ AccessLog::RequestInfo& ConnectionManagerImpl::ActiveStreamFilterBase::requestIn
   return parent_.request_info_;
 }
 
+const Router::Route* ConnectionManagerImpl::ActiveStreamFilterBase::route() {
+  if (!cached_route_.valid()) {
+    cached_route_.value(parent_.connection_manager_.config_.routeConfig().route(
+        *parent_.request_headers_, parent_.stream_id_));
+  }
+
+  return cached_route_.value();
+}
+
 void ConnectionManagerImpl::ActiveStreamDecoderFilter::continueDecoding() { commonContinue(); }
 
 void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeHeaders(HeaderMapPtr&& headers,

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -242,8 +242,7 @@ private:
   /**
    * Base class wrapper for both stream encoder and decoder filters.
    */
-  struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
-                                  public Router::StableRouteTable {
+  struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks {
     ActiveStreamFilterBase(ActiveStream& parent) : parent_(parent) {}
 
     bool commonHandleAfterHeadersCallback(FilterHeadersStatus status);
@@ -264,19 +263,15 @@ private:
     uint64_t connectionId() override;
     Event::Dispatcher& dispatcher() override;
     void resetStream() override;
-    const Router::StableRouteTable& routeTable() override { return *this; }
+    const Router::Route* route() override;
     uint64_t streamId() override;
     AccessLog::RequestInfo& requestInfo() override;
     const std::string& downstreamAddress() override;
 
-    // Router::StableRouteTable
-    const Router::Route* route(const HeaderMap& headers) const {
-      return parent_.connection_manager_.config_.routeConfig().route(headers, parent_.stream_id_);
-    }
-
     ActiveStream& parent_;
     bool headers_continued_{};
     bool stopped_{};
+    Optional<const Router::Route*> cached_route_;
   };
 
   /**

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -149,11 +149,11 @@ void FaultFilter::abortWithHTTPStatus() {
   callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected);
 }
 
-bool FaultFilter::matchesTargetCluster(const HeaderMap& headers) {
+bool FaultFilter::matchesTargetCluster(const HeaderMap&) {
   bool matches = true;
 
   if (!config_->upstreamCluster().empty()) {
-    const Router::Route* route = callbacks_->routeTable().route(headers);
+    const Router::Route* route = callbacks_->route();
     matches = route && route->routeEntry() &&
               (route->routeEntry()->clusterName() == config_->upstreamCluster());
   }

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -78,7 +78,7 @@ FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 // if we inject a delay, then we will inject the abort in the delay timer
 // callback.
 FilterHeadersStatus FaultFilter::decodeHeaders(HeaderMap& headers, bool) {
-  if (!matchesTargetCluster(headers)) {
+  if (!matchesTargetCluster()) {
     return FilterHeadersStatus::Continue;
   }
 
@@ -149,7 +149,7 @@ void FaultFilter::abortWithHTTPStatus() {
   callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::FaultInjected);
 }
 
-bool FaultFilter::matchesTargetCluster(const HeaderMap&) {
+bool FaultFilter::matchesTargetCluster() {
   bool matches = true;
 
   if (!config_->upstreamCluster().empty()) {

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -77,7 +77,7 @@ private:
   void resetTimerState();
   void postDelayInjection();
   void abortWithHTTPStatus();
-  bool matchesTargetCluster(const HeaderMap& headers);
+  bool matchesTargetCluster();
 
   FaultFilterConfigPtr config_;
   StreamDecoderFilterCallbacks* callbacks_{};

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -19,7 +19,7 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
     return FilterHeadersStatus::Continue;
   }
 
-  const Router::Route* route = callbacks_->routeTable().route(headers);
+  const Router::Route* route = callbacks_->route();
   if (route && route->routeEntry()) {
     const Router::RouteEntry* route_entry = route->routeEntry();
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -139,7 +139,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   config_.stats_.rq_total_.inc();
 
   // Determine if there is a route entry or a redirect for the request.
-  const Route* route = callbacks_->routeTable().route(headers);
+  const Route* route = callbacks_->route();
   if (!route) {
     config_.stats_.no_route_.inc();
     stream_log_debug("no cluster match for URL '{}'", *callbacks_, headers.Path()->value().c_str());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -120,6 +120,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
       new NiceMock<Http::MockStreamDecoderFilter>());
 
   EXPECT_CALL(filter->reset_stream_called_, ready()).Times(0);
+  EXPECT_CALL(route_config_, route(_, _)).Times(2);
   EXPECT_CALL(*filter, decodeHeaders(_, true))
       .Times(2)
       .WillRepeatedly(Invoke([&](HeaderMap& headers, bool) -> FilterHeadersStatus {
@@ -128,6 +129,10 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
         if (headers.Path()->value() == "/healthcheck") {
           filter->callbacks_->requestInfo().healthCheck(true);
         }
+
+        // Test route caching.
+        EXPECT_EQ(&route_config_.route_, filter->callbacks_->route());
+        EXPECT_EQ(&route_config_.route_, filter->callbacks_->route());
 
         return FilterHeadersStatus::StopIteration;
       }));

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -450,7 +450,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
   SetUpTest(fault_with_target_cluster_json);
   const std::string upstream_cluster("www1");
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_, clusterName())
+  EXPECT_CALL(filter_callbacks_.route_.route_entry_, clusterName())
       .WillOnce(ReturnRef(upstream_cluster));
 
   // Delay related calls
@@ -490,7 +490,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchFail) {
   SetUpTest(fault_with_target_cluster_json);
   const std::string upstream_cluster("mismatch");
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_, clusterName())
+  EXPECT_CALL(filter_callbacks_.route_.route_entry_, clusterName())
       .WillOnce(ReturnRef(upstream_cluster));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", _))
       .Times(0);
@@ -513,7 +513,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterNullRoute) {
   SetUpTest(fault_with_target_cluster_json);
   const std::string upstream_cluster("www1");
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(nullptr));
+  EXPECT_CALL(filter_callbacks_.route_, routeEntry()).WillOnce(Return(nullptr));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("fault.http.delay.fixed_delay_percent", _))
       .Times(0);
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", _)).Times(0);

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -40,14 +40,13 @@ public:
     client_ = new ::RateLimit::MockClient();
     filter_.reset(new Filter(config_, ::RateLimit::ClientPtr{client_}));
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
-    filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
+    filter_callbacks_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
+    filter_callbacks_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_.emplace_back(
+        route_rate_limit_);
+    filter_callbacks_.route_.route_entry_.virtual_host_.rate_limit_policy_.rate_limit_policy_entry_
         .clear();
-    filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
-        .emplace_back(route_rate_limit_);
-    filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_
-        .rate_limit_policy_entry_.clear();
-    filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_
-        .rate_limit_policy_entry_.emplace_back(vh_rate_limit_);
+    filter_callbacks_.route_.route_entry_.virtual_host_.rate_limit_policy_.rate_limit_policy_entry_
+        .emplace_back(vh_rate_limit_);
   }
 
   const std::string filter_config = R"EOF(
@@ -75,7 +74,7 @@ public:
 TEST_F(HttpRateLimitFilterTest, NoRoute) {
   SetUpTest(filter_config);
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(nullptr));
+  EXPECT_CALL(filter_callbacks_.route_, routeEntry()).WillOnce(Return(nullptr));
 
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -85,8 +84,7 @@ TEST_F(HttpRateLimitFilterTest, NoRoute) {
 TEST_F(HttpRateLimitFilterTest, NoApplicableRateLimit) {
   SetUpTest(filter_config);
 
-  filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_
-      .clear();
+  filter_callbacks_.route_.route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
@@ -116,13 +114,13 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
   SetUpTest(filter_config);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_.rate_limit_policy_,
-              getApplicableRateLimit(0)).Times(1);
+  EXPECT_CALL(filter_callbacks_.route_.route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
+      .Times(1);
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(filter_callbacks_.route_table_.route_.route_entry_.virtual_host_.rate_limit_policy_,
+  EXPECT_CALL(filter_callbacks_.route_.route_entry_.virtual_host_.rate_limit_policy_,
               getApplicableRateLimit(0)).Times(1);
 
   EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<::RateLimit::Descriptor>{

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -83,14 +83,14 @@ TEST_F(RouterTest, RouteNotFound) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  EXPECT_CALL(callbacks_.route_table_, route(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(callbacks_, route()).WillOnce(Return(nullptr));
 
   router_.decodeHeaders(headers, true);
 }
 
 TEST_F(RouterTest, PoolFailureWithPriority) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_, routeEntry()).WillOnce(Return(&route_entry));
   route_entry.virtual_cluster_.priority_ = Upstream::ResourcePriority::High;
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, Upstream::ResourcePriority::High));
 
@@ -603,8 +603,8 @@ TEST_F(RouterTest, RetryUpstream5xxNotComplete) {
 }
 
 TEST_F(RouterTest, Shadow) {
-  callbacks_.route_table_.route_.route_entry_.shadow_policy_.cluster_ = "foo";
-  callbacks_.route_table_.route_.route_entry_.shadow_policy_.runtime_key_ = "bar";
+  callbacks_.route_.route_entry_.shadow_policy_.cluster_ = "foo";
+  callbacks_.route_.route_entry_.shadow_policy_.runtime_key_ = "bar";
   ON_CALL(callbacks_, streamId()).WillByDefault(Return(43));
 
   NiceMock<Http::MockStreamEncoder> encoder;
@@ -644,7 +644,7 @@ TEST_F(RouterTest, Shadow) {
 TEST_F(RouterTest, AltStatName) {
   // Also test no upstream timeout here.
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 
@@ -688,7 +688,7 @@ TEST_F(RouterTest, AltStatName) {
 TEST_F(RouterTest, Redirect) {
   MockRedirectEntry redirect;
   EXPECT_CALL(redirect, newPath(_)).WillOnce(Return("hello"));
-  EXPECT_CALL(callbacks_.route_table_.route_, redirectEntry()).WillRepeatedly(Return(&redirect));
+  EXPECT_CALL(callbacks_.route_, redirectEntry()).WillRepeatedly(Return(&redirect));
 
   Http::TestHeaderMapImpl response_headers{{":status", "301"}, {"location", "hello"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
@@ -805,7 +805,7 @@ TEST(RouterFilterUtilityTest, shouldShadow) {
 
 TEST_F(RouterTest, CanaryStatusTrue) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 
@@ -836,7 +836,7 @@ TEST_F(RouterTest, CanaryStatusTrue) {
 
 TEST_F(RouterTest, CanaryStatusFalse) {
   NiceMock<MockRouteEntry> route_entry;
-  EXPECT_CALL(callbacks_.route_table_.route_, routeEntry()).WillOnce(Return(&route_entry));
+  EXPECT_CALL(callbacks_.route_, routeEntry()).WillOnce(Return(&route_entry));
   EXPECT_CALL(route_entry, timeout()).WillOnce(Return(std::chrono::milliseconds(0)));
   EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(0);
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -72,7 +72,7 @@ template <class T> static void initializeMockStreamFilterCallbacks(T& callbacks)
       .WillByDefault(SaveArg<0>(&callbacks.reset_callback_));
   ON_CALL(callbacks, dispatcher()).WillByDefault(ReturnRef(callbacks.dispatcher_));
   ON_CALL(callbacks, requestInfo()).WillByDefault(ReturnRef(callbacks.request_info_));
-  ON_CALL(callbacks, routeTable()).WillByDefault(ReturnRef(callbacks.route_table_));
+  ON_CALL(callbacks, route()).WillByDefault(Return(&callbacks.route_));
   ON_CALL(callbacks, downstreamAddress()).WillByDefault(ReturnRef(callbacks.downstream_address_));
 }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -197,7 +197,7 @@ public:
   std::function<void()> reset_callback_;
   Event::MockDispatcher dispatcher_;
   testing::NiceMock<AccessLog::MockRequestInfo> request_info_;
-  testing::NiceMock<Router::MockStableRouteTable> route_table_;
+  testing::NiceMock<Router::MockRoute> route_;
   std::string downstream_address_;
 };
 
@@ -212,7 +212,7 @@ public:
   MOCK_METHOD0(connectionId, uint64_t());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(routeTable, Router::StableRouteTable&());
+  MOCK_METHOD0(route, const Router::Route*());
   MOCK_METHOD0(streamId, uint64_t());
   MOCK_METHOD0(requestInfo, Http::AccessLog::RequestInfo&());
   MOCK_METHOD0(downstreamAddress, const std::string&());
@@ -241,7 +241,7 @@ public:
   MOCK_METHOD0(connectionId, uint64_t());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(resetStream, void());
-  MOCK_METHOD0(routeTable, Router::StableRouteTable&());
+  MOCK_METHOD0(route, const Router::Route*());
   MOCK_METHOD0(streamId, uint64_t());
   MOCK_METHOD0(requestInfo, Http::AccessLog::RequestInfo&());
   MOCK_METHOD0(downstreamAddress, const std::string&());

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -54,6 +54,7 @@ MockRouteEntry::MockRouteEntry() {
 MockRouteEntry::~MockRouteEntry() {}
 
 MockConfig::MockConfig() {
+  ON_CALL(*this, route(_, _)).WillByDefault(Return(&route_));
   ON_CALL(*this, internalOnlyHeaders()).WillByDefault(ReturnRef(internal_only_headers_));
   ON_CALL(*this, responseHeadersToAdd()).WillByDefault(ReturnRef(response_headers_to_add_));
   ON_CALL(*this, responseHeadersToRemove()).WillByDefault(ReturnRef(response_headers_to_remove_));
@@ -63,11 +64,5 @@ MockConfig::~MockConfig() {}
 
 MockRoute::MockRoute() { ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_)); }
 MockRoute::~MockRoute() {}
-
-MockStableRouteTable::MockStableRouteTable() {
-  ON_CALL(*this, route(_)).WillByDefault(Return(&route_));
-}
-
-MockStableRouteTable::~MockStableRouteTable() {}
 
 } // Router

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -149,6 +149,18 @@ public:
   testing::NiceMock<MockVirtualHost> virtual_host_;
 };
 
+class MockRoute : public Route {
+public:
+  MockRoute();
+  ~MockRoute();
+
+  // Router::Route
+  MOCK_CONST_METHOD0(redirectEntry, const RedirectEntry*());
+  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+
+  testing::NiceMock<MockRouteEntry> route_entry_;
+};
+
 class MockConfig : public Config {
 public:
   MockConfig();
@@ -162,32 +174,10 @@ public:
   MOCK_CONST_METHOD0(responseHeadersToRemove, const std::list<Http::LowerCaseString>&());
   MOCK_CONST_METHOD0(usesRuntime, bool());
 
+  testing::NiceMock<MockRoute> route_;
   std::list<Http::LowerCaseString> internal_only_headers_;
   std::list<std::pair<Http::LowerCaseString, std::string>> response_headers_to_add_;
   std::list<Http::LowerCaseString> response_headers_to_remove_;
-};
-
-class MockRoute : public Route {
-public:
-  MockRoute();
-  ~MockRoute();
-
-  // Router::Route
-  MOCK_CONST_METHOD0(redirectEntry, const RedirectEntry*());
-  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
-
-  testing::NiceMock<MockRouteEntry> route_entry_;
-};
-
-class MockStableRouteTable : public StableRouteTable {
-public:
-  MockStableRouteTable();
-  ~MockStableRouteTable();
-
-  // Router::StableRouteTable
-  MOCK_CONST_METHOD1(route, const Route*(const Http::HeaderMap&));
-
-  testing::NiceMock<MockRoute> route_;
 };
 
 } // Router


### PR DESCRIPTION
If multiple filters consult the route table, the same route can be looked
up many times. With large route tables, this can become quite expensive.
This change adds caching for the route lookup and changes the interfaces
so that headers are no longer passed when getting a stable route. In
the future we may need to add route cache clearing, but for now this is
fine.

fixes https://github.com/lyft/envoy/issues/372