### PR TITLE
Open config file read-only.

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -205,7 +205,7 @@ private:
 
 ObjectPtr Factory::LoadFromFile(const std::string& file_path) {
   rapidjson::Document document;
-  std::fstream file_stream(file_path);
+  std::ifstream file_stream(file_path);
   rapidjson::IStreamWrapper stream_wrapper(file_stream);
   if (document.ParseStream(stream_wrapper).HasParseError()) {
     throw Exception(fmt::format("Error(offset {}): {}\n", document.GetErrorOffset(),


### PR DESCRIPTION
Prior to this change, Envoy would fail to open config files that were
not writable.