### PR TITLE
JSON Schema: HTTP Filter schemas

### DIFF
--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -10,7 +10,7 @@ providing the ability to stage different failure scenarios such as service
 failures, service overloads, high network latency, network partitions,
 etc. Faults injection can be limited to a specific set of requests based on
 the (destination) upstream cluster of a request and/or a set of pre-defined
-request headers. 
+request headers.
 
 The scope of failures is restricted to those that are observable by an
 application communicating over the network. CPU and disk failures on the
@@ -37,34 +37,33 @@ including the router filter.*
       "type" : "decoder",
       "name" : "fault",
       "config" : {
-        "abort" : {
-          "abort_percent" : "...",
-          "http_status" : "..."
-        },
-        "delay" : {
-          "type" : "...",
-          "fixed_delay_percent" : "...",
-          "fixed_duration_ms" : "..."
-        },
+        "abort" : "{...}",
+        "delay" : "{...}",
         "upstream_cluster" : "...",
         "headers" : []
       }
     }
 
-abort.abort_percent
+abort
+  *(sometimes required, object)*
+
+delay
+  *(sometimes required, object)*
+
+abort_percent
   *(required, integer)* The percentage of requests that
   should be aborted with the specified *http_status* code. Valid values
   range from 0 to 100.
 
-abort.http_status
+http_status
   *(required, integer)* The HTTP status code that will be used as the
   response code for the request being aborted.
 
-delay.type:
+type:
   *(required, string)* Specifies the type of delay being
   injected. Currently only *fixed* delay type (step function) is supported.
 
-delay.fixed_delay_percent:
+fixed_delay_percent:
   *(required, integer)* The percentage of requests that will
   be delayed for the duration specified by *fixed_duration_ms*. Valid
   values range from 0 to 100.
@@ -72,6 +71,8 @@ delay.fixed_delay_percent:
 delay.fixed_duration_ms:
   *(required, integer)* The delay duration in
   milliseconds. Must be greater than 0.
+
+**Note:** The filter expects at least *abort* or *delay* objects to be specified in the config.
 
 upstream_cluster:
   *(optional, string)* Specifies the name of the (destination) upstream
@@ -158,4 +159,3 @@ prefix <config_http_conn_man_stat_prefix>` comes from the owning HTTP connection
 
   delays_injected, Counter, Total requests that were delayed
   aborts_injected, Counter, Total requests that were aborted
-

--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -33,46 +33,24 @@ including the router filter.*
 
 .. code-block:: json
 
-    {
-      "type" : "decoder",
-      "name" : "fault",
-      "config" : {
-        "abort" : "{...}",
-        "delay" : "{...}",
-        "upstream_cluster" : "...",
-        "headers" : []
-      }
+  {
+    "type" : "decoder",
+    "name" : "fault",
+    "config" : {
+      "abort" : "{...}",
+      "delay" : "{...}",
+      "upstream_cluster" : "...",
+      "headers" : []
     }
+  }
 
-abort
-  *(sometimes required, object)*
+:ref:`abort <config_http_filters_fault_injection_abort>`
+  *(sometimes required, object)* If specified, the filter will abort requests based on
+  the values in the object. At least *abort* or *delay* must be specified.
 
-delay
-  *(sometimes required, object)*
-
-abort_percent
-  *(required, integer)* The percentage of requests that
-  should be aborted with the specified *http_status* code. Valid values
-  range from 0 to 100.
-
-http_status
-  *(required, integer)* The HTTP status code that will be used as the
-  response code for the request being aborted.
-
-type:
-  *(required, string)* Specifies the type of delay being
-  injected. Currently only *fixed* delay type (step function) is supported.
-
-fixed_delay_percent:
-  *(required, integer)* The percentage of requests that will
-  be delayed for the duration specified by *fixed_duration_ms*. Valid
-  values range from 0 to 100.
-
-delay.fixed_duration_ms:
-  *(required, integer)* The delay duration in
-  milliseconds. Must be greater than 0.
-
-**Note:** The filter expects at least *abort* or *delay* objects to be specified in the config.
+:ref:`delay <config_http_filters_fault_injection_delay>`
+  *(sometimes required, object)* If specified, the filter will inject delays based on the values
+  in the object. At least *abort* or *delay* must be specified.
 
 upstream_cluster:
   *(optional, string)* Specifies the name of the (destination) upstream
@@ -85,6 +63,50 @@ upstream_cluster:
 The abort and delay blocks can be omitted. If they are not specified in the
 configuration file, their respective values will be obtained from the
 runtime.
+
+.. _config_http_filters_fault_injection_abort:
+
+Abort
+-----
+.. code-block:: json
+
+  {
+    "abort_percent" : "...",
+    "http_status" : "..."
+  }
+
+abort_percent
+  *(required, integer)* The percentage of requests that
+  should be aborted with the specified *http_status* code. Valid values
+  range from 0 to 100.
+
+http_status
+  *(required, integer)* The HTTP status code that will be used as the
+  response code for the request being aborted.
+
+.. _config_http_filters_fault_injection_delay:
+
+Delay
+-----
+.. code-block:: json
+
+  {
+    "type" : "...",
+    "fixed_delay_percent" : "...",
+    "fixed_duration_ms" : "..."
+  }
+
+type:
+  *(required, string)* Specifies the type of delay being
+  injected. Currently only *fixed* delay type (step function) is supported.
+
+fixed_delay_percent:
+  *(required, integer)* The percentage of requests that will
+  be delayed for the duration specified by *fixed_duration_ms*. Valid
+  values range from 0 to 100.
+
+fixed_duration_ms:
+  *(required, integer)* The delay duration in milliseconds. Must be greater than 0.
 
 Runtime
 -------

--- a/include/envoy/json/json_object.h
+++ b/include/envoy/json/json_object.h
@@ -141,6 +141,11 @@ public:
    *        valid.
    */
   virtual void validateSchema(const std::string& schema) const PURE;
+
+  /**
+   * @return true if the JSON object is empty;
+   */
+  virtual bool empty() const PURE;
 };
 
 } // Json

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -25,7 +25,7 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
   const Json::ObjectPtr& delay = json_config.getObject("delay", true);
 
   if (abort->empty() && delay->empty()) {
-    throw EnvoyException("fault filter must have either abort or delay specified in the config.");
+    throw EnvoyException("fault filter must have at least abort or delay specified in the config.");
   }
 
   if (!abort->empty()) {

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -46,7 +46,6 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
   }
 
   if (!delay->empty()) {
-    const Json::ObjectPtr& delay = json_config.getObject("delay");
     const std::string type = delay->getString("type", "empty");
     if (type == "fixed") {
       fixed_delay_percent_ = static_cast<uint64_t>(delay->getInteger("fixed_delay_percent", 0));

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -21,8 +21,8 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
 
   json_config.validateSchema(Json::Schema::FAULT_HTTP_FILTER_SCHEMA);
 
-  const Json::ObjectPtr& abort = json_config.getObject("abort", true);
-  const Json::ObjectPtr& delay = json_config.getObject("delay", true);
+  const Json::ObjectPtr abort = json_config.getObject("abort", true);
+  const Json::ObjectPtr delay = json_config.getObject("delay", true);
 
   if (abort->empty() && delay->empty()) {
     throw EnvoyException("fault filter must have at least abort or delay specified in the config.");

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -6,10 +6,19 @@
 #include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/http/codes.h"
+#include "common/json/config_schemas.h"
 #include "common/router/config_impl.h"
 
 namespace Http {
 namespace RateLimit {
+
+FilterConfig::FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
+                           Stats::Store& global_store, Runtime::Loader& runtime,
+                           Upstream::ClusterManager& cm)
+    : domain_(config.getString("domain")), stage_(config.getInteger("stage", 0)),
+      local_info_(local_info), global_store_(global_store), runtime_(runtime), cm_(cm) {
+  config.validateSchema(Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA);
+}
 
 const Http::HeaderMapPtr Filter::TOO_MANY_REQUESTS_HEADER{new Http::HeaderMapImpl{
     {Http::Headers::get().Status, std::to_string(enumToInt(Code::TooManyRequests))}}};

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -18,9 +18,7 @@ namespace RateLimit {
 class FilterConfig {
 public:
   FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
-               Stats::Store& global_store, Runtime::Loader& runtime, Upstream::ClusterManager& cm)
-      : domain_(config.getString("domain")), stage_(config.getInteger("stage", 0)),
-        local_info_(local_info), global_store_(global_store), runtime_(runtime), cm_(cm) {}
+               Stats::Store& global_store, Runtime::Loader& runtime, Upstream::ClusterManager& cm);
 
   const std::string& domain() const { return domain_; }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -482,11 +482,11 @@ const std::string Json::Schema::FAULT_HTTP_FILTER_SCHEMA(R"EOF(
         "minItems" : 1,
         "items" : {
           "type" : "object",
-            "properties" : {
-              "name" : {"type" : "string"},
-              "value" : {"type" : "string"},
-              "regex" : {"type" : "boolean"}
-            },
+          "properties" : {
+            "name" : {"type" : "string"},
+            "value" : {"type" : "string"},
+            "regex" : {"type" : "boolean"}
+          },
           "required" : ["name"],
           "additionalProperties" : false
         }
@@ -510,23 +510,23 @@ const std::string Json::Schema::HEALTH_CHECK_HTTP_FILTER_SCHEMA(R"EOF(
   )EOF");
 
 const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
-{
-  "$schema": "http://json-schema.org/schema#",
-  "properties" : {
-    "domain" : {"type" : "string"},
-    "stage" : {"type" : "integer"}
-  },
-  "required" : ["domain"],
-  "additionalProperties" : false
-}
-)EOF");
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "properties" : {
+      "domain" : {"type" : "string"},
+      "stage" : {"type" : "integer"}
+    },
+    "required" : ["domain"],
+    "additionalProperties" : false
+  }
+  )EOF");
 
 const std::string Json::Schema::ROUTER_HTTP_FILTER_SCHEMA(R"EOF(
-{
-  "$schema": "http://json-schema.org/schema#",
-  "properties" : {
-    "dynamic_stats" : {"type" : "boolean"}
-  },
-  "additionalProperties" : false
-}
-)EOF");
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "properties" : {
+      "dynamic_stats" : {"type" : "boolean"}
+    },
+    "additionalProperties" : false
+  }
+  )EOF");

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -425,3 +425,15 @@ const std::string Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA(R"EOF(
     "additionalProperties" : false
   }
   )EOF");
+
+const std::string Json::Schema::BUFFER_HTTP_FILTER_SCHEMA(R"EOF(
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "properties" : {
+      "max_request_bytes" : {"type" : "integer"},
+      "max_request_time_s" : {"type" : "integer"}
+    },
+    "required" : ["max_request_bytes", "max_request_time_s"],
+    "additionalProperties" : false
+  }
+  )EOF");

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -187,12 +187,12 @@ const std::string Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA(R"EOF(
 
 const std::string Json::Schema::REDIS_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
   {
-      "$schema": "http://json-schema.org/schema#",
-      "properties":{
-        "cluster_name" : {"type" : "string"}
-      },
-      "required": ["cluster_name"],
-      "additionalProperties": false
+    "$schema": "http://json-schema.org/schema#",
+    "properties":{
+      "cluster_name" : {"type" : "string"}
+    },
+    "required": ["cluster_name"],
+    "additionalProperties": false
   }
   )EOF");
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -437,3 +437,96 @@ const std::string Json::Schema::BUFFER_HTTP_FILTER_SCHEMA(R"EOF(
     "additionalProperties" : false
   }
   )EOF");
+
+const std::string Json::Schema::FAULT_HTTP_FILTER_SCHEMA(R"EOF(
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "properties" : {
+      "abort": {
+        "type" : "object",
+        "properties" : {
+          "abort_percent" : {
+            "type" : "integer",
+            "minimum" : 0,
+            "maximum" : 100
+          },
+          "http_status" : {"type" : "integer"}
+        },
+        "required" : ["abort_percent", "http_status"],
+        "additionalProperties" : false
+      },
+      "delay" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : ["fixed"]
+          },
+          "fixed_delay_percent" : {
+            "type" : "integer",
+            "minimum" : 0,
+            "maximum" : 100
+          },
+          "fixed_duration_ms" : {
+            "type" : "integer",
+            "minimum" : 0,
+            "exclusiveMinimum" : true
+          }
+        },
+        "required" : ["type", "fixed_delay_percent", "fixed_duration_ms"],
+        "additionalProperties" : false
+      },
+      "upstream_cluster" : {"type" : "string"},
+      "headers" : {
+        "type" : "array",
+        "minItems" : 1,
+        "items" : {
+          "type" : "object",
+            "properties" : {
+              "name" : {"type" : "string"},
+              "value" : {"type" : "string"},
+              "regex" : {"type" : "boolean"}
+            },
+          "required" : ["name"],
+          "additionalProperties" : false
+        }
+      }
+    },
+    "additionalProperties" : false
+  }
+  )EOF");
+
+const std::string Json::Schema::HEALTH_CHECK_HTTP_FILTER_SCHEMA(R"EOF(
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "properties" : {
+      "pass_through_mode" : {"type" : "boolean"},
+      "endpoint" : {"type" : "string"},
+      "cache_time_ms" : {"type" : "integer"}
+    },
+    "required" : ["pass_through_mode", "endpoint"],
+    "additionalProperties" : false
+  }
+  )EOF");
+
+const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties" : {
+    "domain" : {"type" : "string"},
+    "stage" : {"type" : "integer"}
+  },
+  "required" : ["domain"],
+  "additionalProperties" : false
+}
+)EOF");
+
+const std::string Json::Schema::ROUTER_HTTP_FILTER_SCHEMA(R"EOF(
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties" : {
+    "dynamic_stats" : {"type" : "boolean"}
+  },
+  "additionalProperties" : false
+}
+)EOF");

--- a/source/common/json/config_schemas.h
+++ b/source/common/json/config_schemas.h
@@ -24,7 +24,6 @@ public:
   // HTTP Filter Schemas
   static const std::string BUFFER_HTTP_FILTER_SCHEMA;
   static const std::string FAULT_HTTP_FILTER_SCHEMA;
-  static const std::string DYNAMO_HTTP_FILTER_SCHEMA;
   static const std::string HEALTH_CHECK_HTTP_FILTER_SCHEMA;
   static const std::string RATE_LIMIT_HTTP_FILTER_SCHEMA;
   static const std::string ROUTER_HTTP_FILTER_SCHEMA;

--- a/source/common/json/config_schemas.h
+++ b/source/common/json/config_schemas.h
@@ -20,6 +20,14 @@ public:
   static const std::string VIRTUAL_HOST_CONFIGURATION_SCHEMA;
   static const std::string ROUTE_ENTRY_CONFIGURATION_SCHEMA;
   static const std::string HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA;
+
+  // HTTP Filter Schemas
+  static const std::string BUFFER_HTTP_FILTER_SCHEMA;
+  static const std::string FAULT_HTTP_FILTER_SCHEMA;
+  static const std::string DYNAMO_HTTP_FILTER_SCHEMA;
+  static const std::string HEALTH_CHECK_HTTP_FILTER_SCHEMA;
+  static const std::string RATE_LIMIT_HTTP_FILTER_SCHEMA;
+  static const std::string ROUTER_HTTP_FILTER_SCHEMA;
 };
 
 } // Json

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -182,6 +182,8 @@ public:
     }
   }
 
+  bool empty() const override { return value_.IsObject() && value_.ObjectEmpty(); }
+
 private:
   const std::string name_;
   const rapidjson::Value& value_;

--- a/source/server/config/http/buffer.cc
+++ b/source/server/config/http/buffer.cc
@@ -1,34 +1,30 @@
-#include "envoy/server/instance.h"
+#include "buffer.h"
 
 #include "common/http/filter/buffer_filter.h"
-#include "server/config/network/http_connection_manager.h"
+#include "common/json/config_schemas.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for the buffer filter. @see HttpFilterConfigFactory.
- */
-class BufferFilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object& json_config,
-                                             const std::string& stats_prefix,
-                                             Server::Instance& server) override {
-    if (type != HttpFilterType::Decoder || name != "buffer") {
-      return nullptr;
-    }
-
-    Http::BufferFilterConfigPtr config(new Http::BufferFilterConfig{
-        Http::BufferFilter::generateStats(stats_prefix, server.stats()),
-        static_cast<uint64_t>(json_config.getInteger("max_request_bytes")),
-        std::chrono::seconds(json_config.getInteger("max_request_time_s"))});
-    return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterPtr{new Http::BufferFilter(config)});
-    };
+HttpFilterFactoryCb BufferFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                               const std::string& name,
+                                                               const Json::Object& json_config,
+                                                               const std::string& stats_prefix,
+                                                               Server::Instance& server) {
+  if (type != HttpFilterType::Decoder || name != "buffer") {
+    return nullptr;
   }
-};
+
+  json_config.validateSchema(Json::Schema::BUFFER_HTTP_FILTER_SCHEMA);
+
+  Http::BufferFilterConfigPtr config(new Http::BufferFilterConfig{
+      Http::BufferFilter::generateStats(stats_prefix, server.stats()),
+      static_cast<uint64_t>(json_config.getInteger("max_request_bytes")),
+      std::chrono::seconds(json_config.getInteger("max_request_time_s"))});
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::BufferFilter(config)});
+  };
+}
 
 /**
  * Static registration for the buffer filter. @see RegisterHttpFilterConfigFactory.

--- a/source/server/config/http/buffer.h
+++ b/source/server/config/http/buffer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the buffer filter. @see HttpFilterConfigFactory.
+ */
+class BufferFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object& json_config,
+                                             const std::string& stats_prefix,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/config/http/dynamo.cc
+++ b/source/server/config/http/dynamo.cc
@@ -1,28 +1,24 @@
-#include "server/config/network/http_connection_manager.h"
+#include "dynamo.h"
 
 #include "common/dynamo/dynamo_filter.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for http dynamodb filter.
- */
-class DynamoFilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object&, const std::string& stat_prefix,
-                                             Server::Instance& server) override {
-    if (type != HttpFilterType::Both || name != "http_dynamo_filter") {
-      return nullptr;
-    }
-
-    return [&server, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamFilter(Http::StreamFilterPtr{
-          new Dynamo::DynamoFilter(server.runtime(), stat_prefix, server.stats())});
-    };
+HttpFilterFactoryCb DynamoFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                               const std::string& name,
+                                                               const Json::Object&,
+                                                               const std::string& stat_prefix,
+                                                               Server::Instance& server) {
+  if (type != HttpFilterType::Both || name != "http_dynamo_filter") {
+    return nullptr;
   }
-};
+
+  return [&server, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(Http::StreamFilterPtr{
+        new Dynamo::DynamoFilter(server.runtime(), stat_prefix, server.stats())});
+  };
+}
 
 /**
  * Static registration for the http dynamodb filter. @see RegisterHttpFilterConfigFactory.

--- a/source/server/config/http/dynamo.h
+++ b/source/server/config/http/dynamo.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for http dynamodb filter.
+ */
+class DynamoFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object&, const std::string& stat_prefix,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -1,32 +1,26 @@
-#include "envoy/server/instance.h"
+#include "fault.h"
 
 #include "common/http/filter/fault_filter.h"
-#include "common/router/config_impl.h"
-#include "server/config/network/http_connection_manager.h"
+#include "common/json/config_schemas.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for the fault injection filter. @see HttpFilterConfigFactory.
- */
-class FaultFilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object& json_config,
-                                             const std::string& stats_prefix,
-                                             Server::Instance& server) override {
-    if (type != HttpFilterType::Decoder || name != "fault") {
-      return nullptr;
-    }
-
-    Http::FaultFilterConfigPtr config(
-        new Http::FaultFilterConfig(json_config, server.runtime(), stats_prefix, server.stats()));
-    return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
-    };
+HttpFilterFactoryCb FaultFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                              const std::string& name,
+                                                              const Json::Object& json_config,
+                                                              const std::string& stats_prefix,
+                                                              Server::Instance& server) {
+  if (type != HttpFilterType::Decoder || name != "fault") {
+    return nullptr;
   }
-};
+
+  Http::FaultFilterConfigPtr config(
+      new Http::FaultFilterConfig(json_config, server.runtime(), stats_prefix, server.stats()));
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::FaultFilter(config)});
+  };
+}
 
 /**
  * Static registration for the fault filter. @see RegisterHttpFilterConfigFactory.

--- a/source/server/config/http/fault.h
+++ b/source/server/config/http/fault.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the fault injection filter. @see HttpFilterConfigFactory.
+ */
+class FaultFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object& json_config,
+                                             const std::string& stats_prefix,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/config/http/grpc_http1_bridge.cc
+++ b/source/server/config/http/grpc_http1_bridge.cc
@@ -1,29 +1,24 @@
-#include "envoy/server/instance.h"
+#include "grpc_http1_bridge.h"
 
 #include "common/grpc/http1_bridge_filter.h"
-#include "server/config/network/http_connection_manager.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for the grpc HTTP1 bridge filter. @see HttpFilterConfigFactory.
- */
-class GrpcHttp1BridgeFilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object&, const std::string&,
-                                             Server::Instance& server) override {
-    if (type != HttpFilterType::Both || name != "grpc_http1_bridge") {
-      return nullptr;
-    }
-
-    return [&server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamFilter(
-          Http::StreamFilterPtr{new Grpc::Http1BridgeFilter(server.clusterManager())});
-    };
+HttpFilterFactoryCb GrpcHttp1BridgeFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                                        const std::string& name,
+                                                                        const Json::Object&,
+                                                                        const std::string&,
+                                                                        Server::Instance& server) {
+  if (type != HttpFilterType::Both || name != "grpc_http1_bridge") {
+    return nullptr;
   }
-};
+
+  return [&server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(
+        Http::StreamFilterPtr{new Grpc::Http1BridgeFilter(server.clusterManager())});
+  };
+}
 
 /**
  * Static registration for the grpc HTTP1 bridge filter. @see RegisterHttpFilterConfigFactory.

--- a/source/server/config/http/grpc_http1_bridge.h
+++ b/source/server/config/http/grpc_http1_bridge.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the grpc HTTP1 bridge filter. @see HttpFilterConfigFactory.
+ */
+class GrpcHttp1BridgeFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object&, const std::string&,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -1,31 +1,26 @@
-#include "envoy/server/instance.h"
+#include "ratelimit.h"
 
 #include "common/http/filter/ratelimit.h"
-#include "server/config/network/http_connection_manager.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for the rate limit filter. @see HttpFilterConfigFactory.
- */
-class RateLimitFilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object& config, const std::string&,
-                                             Server::Instance& server) override {
-    if (type != HttpFilterType::Decoder || name != "rate_limit") {
-      return nullptr;
-    }
-
-    Http::RateLimit::FilterConfigPtr filter_config(new Http::RateLimit::FilterConfig(
-        config, server.localInfo(), server.stats(), server.runtime(), server.clusterManager()));
-    return [filter_config, &server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::RateLimit::Filter(
-          filter_config, server.rateLimitClient(std::chrono::milliseconds(20)))});
-    };
+HttpFilterFactoryCb RateLimitFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                                  const std::string& name,
+                                                                  const Json::Object& config,
+                                                                  const std::string&,
+                                                                  Server::Instance& server) {
+  if (type != HttpFilterType::Decoder || name != "rate_limit") {
+    return nullptr;
   }
-};
+
+  Http::RateLimit::FilterConfigPtr filter_config(new Http::RateLimit::FilterConfig(
+      config, server.localInfo(), server.stats(), server.runtime(), server.clusterManager()));
+  return [filter_config, &server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterPtr{new Http::RateLimit::Filter(
+        filter_config, server.rateLimitClient(std::chrono::milliseconds(20)))});
+  };
+}
 
 /**
  * Static registration for the rate limit filter. @see RegisterHttpFilterConfigFactory.

--- a/source/server/config/http/ratelimit.h
+++ b/source/server/config/http/ratelimit.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the rate limit filter. @see HttpFilterConfigFactory.
+ */
+class RateLimitFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object& config, const std::string&,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -1,39 +1,37 @@
+#include "router.h"
+
+#include "common/json/config_schemas.h"
 #include "common/router/router.h"
 #include "common/router/shadow_writer_impl.h"
-#include "server/config/network/http_connection_manager.h"
 
 namespace Server {
 namespace Configuration {
 
-/**
- * Config registration for the router filter. @see HttpFilterConfigFactory.
- */
-class FilterConfig : public HttpFilterConfigFactory {
-public:
-  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
-                                             const Json::Object& json_config,
-                                             const std::string& stat_prefix,
-                                             Instance& server) override {
-    if (type != HttpFilterType::Decoder || name != "router") {
-      return nullptr;
-    }
-
-    Router::FilterConfigPtr config(new Router::FilterConfig(
-        stat_prefix, server.localInfo(), server.stats(), server.clusterManager(), server.runtime(),
-        server.random(),
-        Router::ShadowWriterPtr{new Router::ShadowWriterImpl(server.clusterManager())},
-        json_config.getBoolean("dynamic_stats", true)));
-
-    return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(std::make_shared<Router::ProdFilter>(*config));
-    };
+HttpFilterFactoryCb RouterFilterConfig::tryCreateFilterFactory(HttpFilterType type,
+                                                               const std::string& name,
+                                                               const Json::Object& json_config,
+                                                               const std::string& stat_prefix,
+                                                               Server::Instance& server) {
+  if (type != HttpFilterType::Decoder || name != "router") {
+    return nullptr;
   }
-};
+
+  json_config.validateSchema(Json::Schema::ROUTER_HTTP_FILTER_SCHEMA);
+
+  Router::FilterConfigPtr config(new Router::FilterConfig(
+      stat_prefix, server.localInfo(), server.stats(), server.clusterManager(), server.runtime(),
+      server.random(),
+      Router::ShadowWriterPtr{new Router::ShadowWriterImpl(server.clusterManager())},
+      json_config.getBoolean("dynamic_stats", true)));
+
+  return [config](Http::FilterChainFactoryCallbacks& callbacks)
+      -> void { callbacks.addStreamDecoderFilter(std::make_shared<Router::ProdFilter>(*config)); };
+}
 
 /**
  * Static registration for the router filter. @see RegisterHttpFilterConfigFactory.
  */
-static RegisterHttpFilterConfigFactory<FilterConfig> register_;
+static RegisterHttpFilterConfigFactory<RouterFilterConfig> register_;
 
 } // Configuration
 } // Server

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Server {
+namespace Configuration {
+
+/**
+ * Config registration for the router filter. @see HttpFilterConfigFactory.
+ */
+class RouterFilterConfig : public HttpFilterConfigFactory {
+public:
+  HttpFilterFactoryCb tryCreateFilterFactory(HttpFilterType type, const std::string& name,
+                                             const Json::Object& json_config,
+                                             const std::string& stat_prefix,
+                                             Server::Instance& server) override;
+};
+
+} // Configuration
+} // Server

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -11,6 +11,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
+#include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
 
 namespace Server {
@@ -27,6 +28,8 @@ HttpFilterFactoryCb HealthCheckFilterConfig::tryCreateFilterFactory(HttpFilterTy
   if (type != HttpFilterType::Both || name != "health_check") {
     return nullptr;
   }
+
+  config.validateSchema(Json::Schema::HEALTH_CHECK_HTTP_FILTER_SCHEMA);
 
   bool pass_through_mode = config.getBoolean("pass_through_mode");
   int64_t cache_time_ms = config.getInteger("cache_time_ms", 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,6 +137,7 @@ add_executable(envoy-test
   mocks/thread_local/mocks.cc
   mocks/tracing/mocks.cc
   mocks/upstream/mocks.cc
+  server/config/http/config_test.cc
   server/config/network/config_test.cc
   server/config/network/http_connection_manager_test.cc
   server/configuration_impl_test.cc

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -112,7 +112,6 @@ public:
 TEST(FaultFilterBadConfigTest, EmptyConfig) {
   const std::string json = R"EOF(
   {
-
   }
   )EOF";
 

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -109,6 +109,19 @@ public:
   Event::MockTimer* timer_{};
 };
 
+TEST(FaultFilterBadConfigTest, EmptyConfig) {
+  const std::string json = R"EOF(
+  {
+
+  }
+  )EOF";
+
+  Stats::IsolatedStoreImpl stats;
+  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
+}
+
 TEST(FaultFilterBadConfigTest, BadAbortPercent) {
   const std::string json = R"EOF(
     {
@@ -118,6 +131,7 @@ TEST(FaultFilterBadConfigTest, BadAbortPercent) {
       }
     }
   )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
@@ -132,6 +146,7 @@ TEST(FaultFilterBadConfigTest, MissingHTTPStatus) {
       }
     }
   )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
@@ -148,6 +163,7 @@ TEST(FaultFilterBadConfigTest, BadDelayType) {
       }
     }
   )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
@@ -164,6 +180,7 @@ TEST(FaultFilterBadConfigTest, BadDelayPercent) {
       }
     }
   )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
@@ -180,6 +197,7 @@ TEST(FaultFilterBadConfigTest, BadDelayDuration) {
       }
     }
    )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
@@ -195,6 +213,7 @@ TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
       }
     }
    )EOF";
+
   Stats::IsolatedStoreImpl stats;
   Json::ObjectPtr config = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -71,6 +71,18 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
+TEST_F(HttpRateLimitFilterTest, BadConfig) {
+  const std::string filter_config = R"EOF(
+  {
+    "domain": "foo",
+    "route_key" : "my_route"
+  }
+  )EOF";
+
+  Json::ObjectPtr config = Json::Factory::LoadFromString(filter_config);
+  EXPECT_THROW(FilterConfig(*config, local_info_, stats_store_, runtime_, cm_), Json::Exception);
+}
+
 TEST_F(HttpRateLimitFilterTest, NoRoute) {
   SetUpTest(filter_config);
 

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -10,6 +10,7 @@ TEST(JsonLoaderTest, Basic) {
     ObjectPtr json = Factory::LoadFromString("{\"hello\":123}");
     EXPECT_TRUE(json->hasObject("hello"));
     EXPECT_FALSE(json->hasObject("world"));
+    EXPECT_FALSE(json->empty());
     EXPECT_THROW(json->getObject("world"), Exception);
     EXPECT_THROW(json->getBoolean("hello"), Exception);
     EXPECT_THROW(json->getObjectArray("hello"), Exception);
@@ -114,6 +115,7 @@ TEST(JsonLoaderTest, Basic) {
     ObjectPtr config = Factory::LoadFromString(json);
     ObjectPtr object = config->getObject("foo", true);
     EXPECT_EQ(2, object->getInteger("bar", 2));
+    EXPECT_TRUE(object->empty());
   }
 }
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -115,6 +115,9 @@ MockAsyncClientCallbacks::~MockAsyncClientCallbacks() {}
 MockAsyncClientRequest::MockAsyncClientRequest(MockAsyncClient* client) : client_(client) {}
 MockAsyncClientRequest::~MockAsyncClientRequest() { client_->onRequestDestroy(); }
 
+MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() {}
+MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() {}
+
 } // Http
 
 namespace Http {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -330,6 +330,7 @@ public:
   MOCK_METHOD1(addStreamDecoderFilter, void(Http::StreamDecoderFilterPtr filter));
   MOCK_METHOD1(addStreamEncoderFilter, void(Http::StreamEncoderFilterPtr filter));
   MOCK_METHOD1(addStreamFilter, void(Http::StreamFilterPtr filter));
+  MOCK_METHOD1(addAccessLogHandler, void(Http::AccessLog::InstancePtr handler));
 };
 } // Http
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -331,7 +331,6 @@ public:
   MOCK_METHOD1(addStreamEncoderFilter, void(Http::StreamEncoderFilterPtr filter));
   MOCK_METHOD1(addStreamFilter, void(Http::StreamFilterPtr filter));
 };
-
 } // Http
 
 namespace Http {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -321,6 +321,17 @@ public:
 
   MockAsyncClient* client_;
 };
+
+class MockFilterChainFactoryCallbacks : public Http::FilterChainFactoryCallbacks {
+public:
+  MockFilterChainFactoryCallbacks();
+  ~MockFilterChainFactoryCallbacks();
+
+  MOCK_METHOD1(addStreamDecoderFilter, void(Http::StreamDecoderFilterPtr filter));
+  MOCK_METHOD1(addStreamEncoderFilter, void(Http::StreamEncoderFilterPtr filter));
+  MOCK_METHOD1(addStreamFilter, void(Http::StreamFilterPtr filter));
+};
+
 } // Http
 
 namespace Http {

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -1,0 +1,173 @@
+#include "server/config/http/buffer.h"
+#include "server/config/http/dynamo.h"
+#include "server/config/http/fault.h"
+#include "server/config/http/grpc_http1_bridge.h"
+#include "server/config/http/ratelimit.h"
+#include "server/config/http/router.h"
+#include "server/http/health_check.h"
+
+#include "test/mocks/server/mocks.h"
+
+using testing::_;
+using testing::NiceMock;
+
+namespace Server {
+namespace Configuration {
+
+TEST(HttpFilterConfigTest, BufferFilter) {
+  std::string json_string = R"EOF(
+  {
+    "max_request_bytes" : 1028,
+    "max_request_time_s" : 2
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  BufferFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "buffer",
+                                                          *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, BadBufferFilterConfig) {
+  std::string json_string = R"EOF(
+  {
+    "max_request_bytes" : 1028,
+    "max_request_time_s" : "2"
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  BufferFilterConfig factory;
+  EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Decoder, "buffer", *json_config,
+                                              "stats", server),
+               Json::Exception);
+}
+
+TEST(HttpFilterConfigTest, DynamoFilter) {
+  std::string json_string = R"EOF(
+  {
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  DynamoFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(
+      HttpFilterType::Both, "http_dynamo_filter", *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, FaultFilter) {
+  std::string json_string = R"EOF(
+  {
+    "delay" : {
+      "type" : "fixed",
+      "fixed_delay_percent" : 100,
+      "fixed_duration_ms" : 5000
+    }
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  FaultFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "fault",
+                                                          *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, GrpcHttp1BridgeFilter) {
+  std::string json_string = R"EOF(
+  {
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  GrpcHttp1BridgeFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Both, "grpc_http1_bridge",
+                                                          *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, HealthCheckFilter) {
+  std::string json_string = R"EOF(
+  {
+    "pass_through_mode" : true,
+    "endpoint" : "/hc"
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  HealthCheckFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Both, "health_check",
+                                                          *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, BadHealthCheckFilterConfig) {
+  std::string json_string = R"EOF(
+  {
+    "pass_through_mode" : true,
+    "endpoint" : "/hc",
+    "status" : 500
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  HealthCheckFilterConfig factory;
+  EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Both, "health_check", *json_config,
+                                              "stats", server),
+               Json::Exception);
+}
+
+TEST(HttpFilterConfigTest, RouterFilter) {
+  std::string json_string = R"EOF(
+  {
+    "dynamic_stats" : true
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  RouterFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "router",
+                                                          *json_config, "stats", server);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, BadRouterFilterConfig) {
+  std::string json_string = R"EOF(
+  {
+    "dynamic_stats" : true,
+    "route" : {}
+  }
+  )EOF";
+
+  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  NiceMock<MockInstance> server;
+  RouterFilterConfig factory;
+  EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Decoder, "router", *json_config,
+                                              "stats", server),
+               Json::Exception);
+}
+
+} // Configuration
+} // Server


### PR DESCRIPTION
-Breaks http configs into h/cc
-Increases tests coverage for http configs by adding server/config/http/config_test.cc
-Adds schema validation for applicable HTTP filters. 
-Updates Fault Filter documentation to specify at least abort or delay must be specified in the config. The implementation has been updated to reflect expected behaviour.
-Added empty() method on JSON Objects.  
