### PR TITLE
Automatic dockerhub builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ env:
   - TEST_TYPE=docs
 script:
   - travis lint .travis.yml --skip-completion-check
-  - docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+  - docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:4c887e005b129b28d815d59f9983b1ed3eb9568f /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
   - ./ci/docker_push.sh
   - ./ci/verify_examples.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ env:
 script:
   - travis lint .travis.yml --skip-completion-check
   - docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+  - ./ci/docker_push.sh
+  - ./ci/verify_examples.sh

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -4,4 +4,4 @@ ADD build/source/exe/envoy /usr/local/bin/envoy
 RUN apt-get update && apt-get install -y \
     build-essential
 RUN strip /usr/local/bin/envoy
-RUN apt-get remove -y build-essential
+RUN apt-get purge -y build-essential

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -2,5 +2,6 @@ FROM ubuntu:14.04
 
 ADD build/source/exe/envoy /usr/local/bin/envoy
 RUN apt-get update && apt-get install -y \
-    curl \
-    python-pip
+    build-essential
+RUN strip /usr/local/bin/envoy
+RUN apt-get remove -y build-essential

--- a/ci/build_container/README.md
+++ b/ci/build_container/README.md
@@ -1,6 +1,6 @@
 ## Steps to publish new image for Envoy 3rd party dependencies
 
-Currently this can be done only by Envoy team.
+*Currently this can be done only by Envoy team*
 
 * Modify [build_container.sh](build_container.sh) to include steps for building 3rd party library.
 * Build image locally by running `docker build --rm -t lyft/envoy-build:latest .` from this directory.

--- a/ci/build_container/README.md
+++ b/ci/build_container/README.md
@@ -2,7 +2,12 @@
 
 *Currently this can be done only by Envoy team*
 
-* Modify [build_container.sh](build_container.sh) to include steps for building 3rd party library.
-* Build image locally by running `docker build --rm -t lyft/envoy-build:latest .` from this directory.
-* Login into docker hub by running `docker login`. Make sure to create account beforehand and get that added to Lyft team.
-* Publish image by running `docker push lyft/envoy-build:latest`.
+After you have made changes to `build_container.sh` and merge them to master:
+
+1.  Checkout master and pull latest changes.
+2.  Get the SHA of the master commit of your changes to `build_container.sh`.
+3.  From `~/envoy/ci/build_container` run `update_build_container.sh`. **Make sure to have
+    DOCKER_USERNAME and DOCKER_PASSWORD environment variables set**. This script will build
+    the envoy-build container with the current state of `build_container.sh`, tag the image
+    with the SHA provided, and push it to Dockerhub.
+4.  After you have done that, update `.travis.yml` to pull the new tagged version of `lyft/envoy-build`.

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ev
+read -r -p "Are you on master and have a clean branch? [y/N] " response
+if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+  read -r -p "What SHA do you want to tag the envoy-build with? [y/N] " tag
+  docker-machine start default
+  eval $(docker-machine env default)
+  docker build --rm -t lyft/envoy-build:$tag .
+  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  docker push lyft/envoy-build:$tag
+fi

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -8,7 +8,7 @@ then
   docker build --rm -t lyft/envoy-build:$TAG .
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   docker push lyft/envoy-build:$TAG
-  echo 'Pushed lyft/envoy-build:${TAG}'
+  echo Pushed lyft/envoy-build:$TAG
   docker tag lyft/envoy-build:$TAG lyft/envoy-build:latest
   docker push lyft/envoy-build:latest
 fi

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 read -r -p "Do you have master checked out with most recent changes? [y/N] " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
 then
@@ -9,6 +8,7 @@ then
   docker build --rm -t lyft/envoy-build:$TAG .
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   docker push lyft/envoy-build:$TAG
+  echo 'Pushed lyft/envoy-build:${TAG}'
   docker tag lyft/envoy-build:$TAG lyft/envoy-build:latest
   docker push lyft/envoy-build:latest
 fi

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-set -ev
-read -r -p "Are you on master and have a clean branch? [y/N] " response
+set -e
+read -r -p "Do you have master checked out with most recent changes? [y/N] " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-  read -r -p "What SHA do you want to tag the envoy-build with? [y/N] " tag
+  TAG="$(git rev-parse origin/master)"
   docker-machine start default
   eval $(docker-machine env default)
-  docker build --rm -t lyft/envoy-build:$tag .
+  docker build --rm -t lyft/envoy-build:$TAG .
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  docker push lyft/envoy-build:$tag
+  docker push lyft/envoy-build:$TAG
+  docker tag lyft/envoy-build:$TAG lyft/envoy-build:latest
+  docker push lyft/envoy-build:latest
 fi

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -2,7 +2,7 @@
 read -r -p "Do you have master checked out with most recent changes? [y/N] " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-  TAG="$(git rev-parse origin/master)"
+  TAG="$(git rev-parse master)"
   docker-machine start default
   eval $(docker-machine env default)
   docker build --rm -t lyft/envoy-build:$TAG .

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ev
+
+if [ "$TEST_TYPE" == "normal" ]
+then
+  # this is needed to verify the example images
+  docker build -f ci/Dockerfile-envoy-image -t lyft/envoy:latest .
+
+  # push the envoy image on merge to master
+  want_push='false'
+  for branch in "master"
+  do
+     if [ "$TRAVIS_BRANCH" == "$branch" ]
+     then
+         want_push='true'
+     fi
+  done
+  if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$want_push" == "true" ]
+  then
+      docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      docker push lyft/envoy:latest
+  else
+      echo 'Ignoring PR branch for docker push.'
+  fi
+fi

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -ev
+verify() {
+  echo $1
+  CONTAINER_ID="$(docker ps -aqf name=$1)"
+  if [ "false" == "$(docker inspect -f {{.State.Running}} ${CONTAINER_ID})" ]
+  then
+    echo "error: $1 not running"
+    exit 1
+  fi
+}
+
+if [ "$TEST_TYPE" == "normal" ]
+then
+    # Test front proxy example
+    cd examples/front-proxy
+    docker-compose up --build -d
+    for CONTAINER_NAME in "frontproxy_front-envoy" "frontproxy_service1" "frontproxy_service2"
+    do
+      verify $CONTAINER_NAME
+    done
+    cd ../
+
+    # Test grpc bridge example
+    # install go
+    curl -O https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
+    tar -xf go1.7.1.linux-amd64.tar.gz
+    sudo mv go /usr/local
+    export PATH=$PATH:/usr/local/go/bin
+    export GOPATH=$HOME/go
+    mkdir -p $GOPATH/src/github.com/lyft/envoy/examples/
+    cp -r grpc-bridge $GOPATH/src/github.com/lyft/envoy/examples/
+    # build example
+    cd $GOPATH/src/github.com/lyft/envoy/examples/grpc-bridge
+    ./script/bootstrap
+    ./script/build
+    # verify example works
+    docker-compose up --build -d
+    for CONTAINER_NAME in "grpcbridge_python" "grpcbridge_grpc"
+    do
+      verify $CONTAINER_NAME
+    done
+else
+    echo 'Ignoring non-normal build branch'
+fi

--- a/docs/install/sandboxes.rst
+++ b/docs/install/sandboxes.rst
@@ -308,7 +308,7 @@ of the software used to build it.::
 
   $ pwd
   src/envoy/
-  $ docker build -f examples/Dockerfile-envoy-image -t envoy .
+  $ docker build -f ci/Dockerfile-envoy-image -t envoy .
 
 Now you can use this ``envoy`` image to build the any of the sandboxes if you change
 the ``FROM`` line in any dockerfile.

--- a/examples/front-proxy/Dockerfile-frontenvoy
+++ b/examples/front-proxy/Dockerfile-frontenvoy
@@ -1,3 +1,5 @@
 FROM lyft/envoy:latest
 
+RUN apt-get update && apt-get -q install -y \
+    curl
 CMD /usr/local/bin/envoy -c /etc/front-envoy.json

--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,6 +1,9 @@
 FROM lyft/envoy:latest
 
-RUN pip install Flask==0.11.1
+RUN apt-get update && apt-get -q install -y \
+    curl \
+    python-pip
+RUN pip install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/examples/grpc-bridge/Dockerfile-python
+++ b/examples/grpc-bridge/Dockerfile-python
@@ -1,8 +1,9 @@
 FROM lyft/envoy:latest
 
 RUN apt-get update
-RUN apt-get install -y python-dev
-RUN pip install grpcio requests
+RUN apt-get -q install -y python-dev \
+    python-pip
+RUN pip install -q grpcio requests
 ADD ./client /client
 RUN chmod a+x /client/client.py
 RUN mkdir /var/log/envoy/


### PR DESCRIPTION
@lyft/network-team 

I have added two new scripts to CI: 

1. `ci/docker_push.sh`: this file creates a `lyft/envoy:latest` image that is used by script 2. and gets push to dockerhub if the current branch is master. This will cause our lyft/envoy:latest image to be updated every time a PR is merged to master.
2. `ci/verify_examples.sh`: this file builds our examples and verifies that all the containers run. This is the way I devised to verify that our examples build and run on every PR. The grpc-bridge example is a little convoluted because travis does not allow multi-lingual environments so I had to install go, and setup the project on a gopath.

Both scripts are part of the script portion of CI so that their failure causes test failure and people notice them. Both scripts only run on the `normal` env.