### PR TITLE
Change types to not assume an arch

### DIFF
--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -144,7 +144,7 @@ void AccessLogFormatParser::parseCommand(const std::string& token, const size_t 
     }
 
     std::string length_str = token.substr(end_request + 2);
-    size_t length_value;
+    uint64_t length_value;
 
     if (!StringUtil::atoul(length_str.c_str(), length_value)) {
       throw EnvoyException(fmt::format("Length must be an integer, given: {}", length_str));

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -99,7 +99,8 @@ bool RuntimeFilter::evaluate(const RequestInfo&, const HeaderMap& request_header
   const HeaderEntry* uuid = request_header.RequestId();
   uint16_t sampled_value;
   if (uuid && UuidUtils::uuidModBy(uuid->value().c_str(), sampled_value, 100)) {
-    uint64_t runtime_value = std::min(runtime_.snapshot().getInteger(runtime_key_, 0), 100UL);
+    uint64_t runtime_value =
+        std::min<uint64_t>(runtime_.snapshot().getInteger(runtime_key_, 0), 100);
 
     return sampled_value < static_cast<uint16_t>(runtime_value);
   } else {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -51,7 +51,7 @@ private:
  * ConnectionPool asynchronously.
  */
 class AsyncStreamImpl : public AsyncClient::Stream,
-                        StreamDecoderFilterCallbacks,
+                        public StreamDecoderFilterCallbacks,
                         Logger::Loggable<Logger::Id::http>,
                         LinkedObject<AsyncStreamImpl> {
 public:

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -161,7 +161,7 @@ void ConnectionImpl::reserveBuffer(uint64_t size) {
 
   // TODO PERF: It would be better to allow a split reservation. That will make fill code more
   //            complicated.
-  output_buffer_.reserve(std::max(4096UL, size), &reserved_iovec_, 1);
+  output_buffer_.reserve(std::max<uint64_t>(4096, size), &reserved_iovec_, 1);
   reserved_current_ = static_cast<char*>(reserved_iovec_.mem_);
 }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -113,7 +113,7 @@ void ConnectionImpl::StreamImpl::submitTrailers(const HeaderMap& trailers) {
   UNREFERENCED_PARAMETER(rc);
 }
 
-ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(size_t length, uint32_t* data_flags) {
+ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* data_flags) {
   if (pending_send_data_.length() == 0 && !local_end_stream_) {
     ASSERT(!data_deferred_);
     data_deferred_ = true;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -104,7 +104,7 @@ protected:
     ~StreamImpl();
 
     StreamImpl* base() { return this; }
-    ssize_t onDataSourceRead(size_t length, uint32_t* data_flags);
+    ssize_t onDataSourceRead(uint64_t length, uint32_t* data_flags);
     int onDataSourceSend(const uint8_t* framehd, size_t length);
     void resetStreamWorker(StreamResetReason reason);
     void buildHeaders(std::vector<nghttp2_nv>& final_headers, const HeaderMap& headers);

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -7,13 +7,13 @@
 namespace Memory {
 
 uint64_t Stats::totalCurrentlyAllocated() {
-  uint64_t value = 0;
+  size_t value = 0;
   MallocExtension::instance()->GetNumericProperty("generic.current_allocated_bytes", &value);
   return value;
 }
 
 uint64_t Stats::totalCurrentlyReserved() {
-  uint64_t value = 0;
+  size_t value = 0;
   MallocExtension::instance()->GetNumericProperty("generic.heap_size", &value);
   return value;
 }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -117,7 +117,7 @@ bool LoadBalancerBase::earlyExitNonZoneRouting() {
 
 bool LoadBalancerBase::isGlobalPanic(const HostSet& host_set) {
   uint64_t global_panic_threshold =
-      std::min(100UL, runtime_.snapshot().getInteger(RuntimePanicThreshold, 50));
+      std::min<uint64_t>(100, runtime_.snapshot().getInteger(RuntimePanicThreshold, 50));
   double healthy_percent = 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
 
   // If the % of healthy hosts in the cluster is less than our panic threshold, we use all hosts.

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -133,8 +133,8 @@ void DetectorImpl::checkHostForUneject(HostPtr host, DetectorHostSinkImpl* sink,
 }
 
 void DetectorImpl::ejectHost(HostPtr host, EjectionType type) {
-  uint64_t max_ejection_percent =
-      std::min(100UL, runtime_.snapshot().getInteger("outlier_detection.max_ejection_percent", 10));
+  uint64_t max_ejection_percent = std::min<uint64_t>(
+      100, runtime_.snapshot().getInteger("outlier_detection.max_ejection_percent", 10));
   double ejected_percent = 100.0 * stats_.ejections_active_.value() / host_sinks_.size();
   if (ejected_percent < max_ejection_percent) {
     stats_.ejections_total_.inc();

--- a/source/precompiled/precompiled.h
+++ b/source/precompiled/precompiled.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <arpa/inet.h>
 #include <chrono>
 #include <cmath>
@@ -12,8 +14,10 @@
 #include <memory>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <random>
 #include <regex>
 #include <signal.h>
+#include <sstream>
 #include <string.h>
 #include <sys/signalfd.h>
 #include <unistd.h>


### PR DESCRIPTION
Some of these types were assuming that `size_t == uint64_t` or that `uint64_t == unsigned long` but that's not universally true, some BSDs such as Darwin define uint64_t as unsigned long long which warns on literals that are defined as `UL`.

Additionally there was also some assumptions made on the pch as to forward declaration. So I explicitly added some needed ones.