### PR TITLE
Remove unused properties

### DIFF
--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -12,7 +12,7 @@
 namespace Filesystem {
 
 WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher)
-    : dispatcher_(dispatcher), inotify_fd_(inotify_init1(IN_NONBLOCK)),
+    : inotify_fd_(inotify_init1(IN_NONBLOCK)),
       inotify_event_(dispatcher.createFileEvent(inotify_fd_, [this](uint32_t events) -> void {
         if (events & Event::FileReadyType::Read) {
           onInotifyEvent();

--- a/source/common/filesystem/watcher_impl.h
+++ b/source/common/filesystem/watcher_impl.h
@@ -33,7 +33,6 @@ private:
 
   void onInotifyEvent();
 
-  Event::Dispatcher& dispatcher_;
   int inotify_fd_;
   Event::FileEventPtr inotify_event_;
   std::unordered_map<int, DirectoryWatch> callback_map_;

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -72,7 +72,7 @@ FilterPtr FilterImpl::fromJson(Json::Object& json, Runtime::Loader& runtime) {
   }
 }
 
-TraceableRequestFilter::TraceableRequestFilter(Runtime::Loader& runtime) : runtime_(runtime) {}
+TraceableRequestFilter::TraceableRequestFilter(Runtime::Loader&) {}
 
 bool TraceableRequestFilter::evaluate(const RequestInfo& info, const HeaderMap& request_headers) {
   Tracing::Decision decision = Tracing::HttpTracerUtility::isTracing(info, request_headers);

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -66,13 +66,11 @@ FilterPtr FilterImpl::fromJson(Json::Object& json, Runtime::Loader& runtime) {
   } else if (type == "not_healthcheck") {
     return FilterPtr{new NotHealthCheckFilter()};
   } else if (type == "traceable_request") {
-    return FilterPtr{new TraceableRequestFilter(runtime)};
+    return FilterPtr{new TraceableRequestFilter()};
   } else {
     throw EnvoyException(fmt::format("invalid access log filter type '{}'", type));
   }
 }
-
-TraceableRequestFilter::TraceableRequestFilter(Runtime::Loader&) {}
 
 bool TraceableRequestFilter::evaluate(const RequestInfo& info, const HeaderMap& request_headers) {
   Tracing::Decision decision = Tracing::HttpTracerUtility::isTracing(info, request_headers);

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -110,9 +110,6 @@ public:
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
-
-private:
-  Runtime::Loader& runtime_;
 };
 
 /**

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -106,8 +106,6 @@ public:
  */
 class TraceableRequestFilter : public Filter {
 public:
-  TraceableRequestFilter(Runtime::Loader& runtime);
-
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
 };

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -146,7 +146,7 @@ private:
  */
 class NullLoaderImpl : public Loader {
 public:
-  NullLoaderImpl(RandomGenerator& generator) : generator_(generator), snapshot_(generator) {}
+  NullLoaderImpl(RandomGenerator& generator) : snapshot_(generator) {}
 
   // Runtime::Loader
   Snapshot& snapshot() override { return snapshot_; }
@@ -186,7 +186,6 @@ private:
     RandomGenerator& generator_;
   };
 
-  RandomGenerator& generator_;
   NullSnapshotImpl snapshot_;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,6 +149,12 @@ add_executable(envoy-test
   test_common/printers.cc
   test_common/utility.cc)
 
+# The MOCK_METHOD* macros from gtest triggers this clang warning and it's hard
+# to work around, so we just ignore it.
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set_target_properties(envoy-test PROPERTIES COMPILE_FLAGS "-Wno-inconsistent-missing-override")
+endif()
+
 if (ENVOY_TCMALLOC)
   target_link_libraries(envoy-test tcmalloc_and_profiler)
 endif()

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -32,14 +32,11 @@ public:
 
 class LocalMockFilter : public MockFilter {
 public:
-  LocalMockFilter(const Upstream::HostDescription* host) : host_(host) {}
+  LocalMockFilter(const Upstream::HostDescription*) {}
   ~LocalMockFilter() {
     // Make sure the upstream host is still valid in the filter destructor.
     callbacks_->upstreamHost()->url();
   }
-
-private:
-  const Upstream::HostDescription* host_;
 };
 
 TEST_F(NetworkFilterManagerTest, All) {

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -32,7 +32,6 @@ public:
 
 class LocalMockFilter : public MockFilter {
 public:
-  LocalMockFilter(const Upstream::HostDescription*) {}
   ~LocalMockFilter() {
     // Make sure the upstream host is still valid in the filter destructor.
     callbacks_->upstreamHost()->url();
@@ -45,7 +44,7 @@ TEST_F(NetworkFilterManagerTest, All) {
   Upstream::HostDescription* host_description(new NiceMock<Upstream::MockHostDescription>());
   MockReadFilter* read_filter(new MockReadFilter());
   MockWriteFilter* write_filter(new MockWriteFilter());
-  MockFilter* filter(new LocalMockFilter(host_description));
+  MockFilter* filter(new LocalMockFilter());
 
   NiceMock<MockConnection> connection;
   FilterManagerImpl manager(connection, *this);


### PR DESCRIPTION
Not sure if this was intended but they are unused.

Also added a fix for some compilation warnings on the test target when compiling with clang.