### PR TITLE
Move asynchronous DNS implementation to use c-ares

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -129,3 +129,10 @@ wget -O gcovr-3.3.tar.gz https://github.com/gcovr/gcovr/archive/3.3.tar.gz
 tar xf gcovr-3.3.tar.gz
 rm gcovr-3.3.tar.gz
 
+# libcares
+wget https://c-ares.haxx.se/download/c-ares-1.12.0.tar.gz
+tar xf c-ares-1.12.0.tar.gz
+rm c-ares-1.12.0.tar.gz
+cd c-ares-1.12.0
+./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no
+make install

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -46,6 +46,7 @@ $EXTRA_CMAKE_FLAGS \
 -DENVOY_GTEST_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_HTTP_PARSER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_LIBEVENT_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+-DENVOY_LIBCARES_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_NGHTTP2_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_SPDLOG_INCLUDE_DIR:FILEPATH=/thirdparty/spdlog-0.11.0/include \
 -DENVOY_TCLAP_INCLUDE_DIR:FILEPATH=/thirdparty/tclap-1.2.1/include \

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -124,6 +124,7 @@ endif()
 
 include_directories(${ENVOY_LIBEVENT_INCLUDE_DIR})
 include_directories(${ENVOY_NGHTTP2_INCLUDE_DIR})
+include_directories(${ENVOY_LIBCARES_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_OPENSSL_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR})
 

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -7,22 +7,11 @@
 namespace Event {
 namespace Libevent {
 
-const int Global::DNS_SIGNAL_ID = SIGRTMIN;
-
 void Global::initialize() {
   evthread_use_pthreads();
 
   // Ignore SIGPIPE and allow errors to propagate through error codes.
   signal(SIGPIPE, SIG_IGN);
-
-  // Block the DNS signal so we can use it with signalfd().
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, DNS_SIGNAL_ID);
-
-  int rc = pthread_sigmask(SIG_BLOCK, &mask, nullptr);
-  RELEASE_ASSERT(-1 != rc);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 } // Libevent

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -34,8 +34,6 @@ public:
    * Initialize the library globally.
    */
   static void initialize();
-
-  static const int DNS_SIGNAL_ID;
 };
 
 typedef CSmartPtr<event_base, event_base_free> BasePtr;

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -4,92 +4,100 @@
 #include "common/event/libevent.h"
 #include "common/network/utility.h"
 
-#include "event2/event.h"
 
 namespace Network {
 
-DnsResolverImpl::DnsResolverImpl(Event::DispatcherImpl& dispatcher) : dispatcher_(dispatcher) {
-  // This sets us up to receive signals on an fd when async DNS resolved are completed.
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, Event::Libevent::Global::DNS_SIGNAL_ID);
-  signal_fd_ = signalfd(-1, &mask, SFD_NONBLOCK);
-  RELEASE_ASSERT(-1 != signal_fd_);
-
-  event_assign(&signal_read_event_, &dispatcher_.base(), signal_fd_,
-               EV_READ | EV_PERSIST, [](evutil_socket_t, short, void* arg) -> void {
-                 static_cast<DnsResolverImpl*>(arg)->onSignal();
-               }, this);
-
-  event_add(&signal_read_event_, nullptr);
-}
+DnsResolverImpl::DnsResolverImpl(Event::DispatcherImpl& dispatcher) : dispatcher_(dispatcher) {}
 
 DnsResolverImpl::~DnsResolverImpl() {
-  close(signal_fd_);
-  event_del(&signal_read_event_);
+  pending_resolutions_.empty();
 }
 
-void DnsResolverImpl::onSignal() {
-  while (true) {
-    signalfd_siginfo signal_info;
-    ssize_t rc = read(signal_fd_, &signal_info, sizeof(signal_info));
-    if (rc == -1 && errno == EAGAIN) {
-      break;
-    }
-
-    RELEASE_ASSERT(rc == sizeof(signal_info));
-    PendingResolution* pending_resolution =
-        reinterpret_cast<PendingResolution*>(signal_info.ssi_ptr);
-
-    std::list<std::string> address_list;
-    addrinfo* result = pending_resolution->async_cb_data_.ar_result;
-    while (result != nullptr) {
-      ASSERT(result->ai_family == AF_INET);
-      sockaddr_in* address = reinterpret_cast<sockaddr_in*>(result->ai_addr);
-      address_list.emplace_back(Network::Utility::getAddressName(address));
-      result = result->ai_next;
-    }
-
-    freeaddrinfo(pending_resolution->async_cb_data_.ar_result);
-    if (!pending_resolution->cancelled_) {
-      // TODO: There is no good way to cancel a DNS request with the terrible getaddrinfo_a() API.
-      //       We just mark it cancelled and ignore raising a callback. In the future when we switch
-      //       this out for a better library we can actually cancel.
-      pending_resolution->callback_(std::move(address_list));
-    }
-    pending_resolution->removeFromList(pending_resolutions_);
+void DnsResolverImpl::onDNSResult(PendingResolution *resolution, int status, hostent* hostent) {
+  if (status == ARES_EDESTRUCTION) {
+    return;
   }
+
+  std::list<std::string> address_list;
+  if (status == ARES_SUCCESS && hostent->h_addr_list) {
+    for (char** paddr = hostent->h_addr_list; *paddr != NULL; paddr++) {
+      ASSERT(resolution->hints_.ai_family == hostent->h_addrtype);
+
+      sockaddr_in address;
+      address.sin_addr = *reinterpret_cast<in_addr*>(*paddr);
+      address_list.emplace_back(Network::Utility::getAddressName(&address));
+    }
+  }
+
+  if (status != ARES_ECANCELLED) {
+    resolution->callback_(std::move(address_list));
+  }
+
+  resolution->resolved = true;
+
+  auto removed = resolution->removeFromList(pending_resolutions_);
+  dispatcher_.deferredDelete(std::move(removed));
+}
+
+void DnsResolverImpl::dispatchEvent(PendingResolution *pending_resolution) {
+  int fd;
+  timeval tv;
+
+  if (ares_getsock(pending_resolution->channel_, &fd, 1) == 0) {
+    return;
+  }
+
+  event_assign(
+    &pending_resolution->fd_event_, &dispatcher_.base(), fd, EV_READ | EV_TIMEOUT,
+    [](int fd, short event, void *arg) -> void {
+      if (event & EV_READ) {
+        auto resolution = reinterpret_cast<PendingResolution *>(arg);
+        ares_process_fd(resolution->channel_, fd, ARES_SOCKET_BAD);
+      }
+    },
+    static_cast<void *>(pending_resolution));
+
+  auto tvp = ares_timeout(pending_resolution->channel_, NULL, &tv);
+  event_add(&pending_resolution->fd_event_, tvp);
+}
+
+DnsResolverImpl::PendingResolutionPtr DnsResolverImpl::makePendingResolution(ResolveCb callback) {
+  PendingResolutionPtr pending_resolution(new PendingResolution());
+  pending_resolution->hints_.ai_family = AF_INET;
+  pending_resolution->hints_.ai_socktype = SOCK_STREAM;
+  pending_resolution->callback_ = callback;
+
+  static char lookups[] = "fb";
+  ares_options opts;
+  opts.lookups = lookups;
+
+  int rc = ares_init_options(&pending_resolution->channel_, &opts, ARES_OPT_LOOKUPS);
+  RELEASE_ASSERT(rc == ARES_SUCCESS);
+
+  return pending_resolution;
 }
 
 ActiveDnsQuery& DnsResolverImpl::resolve(const std::string& dns_name, ResolveCb callback) {
-  // This initializes the getaddrinfo_a callback data.
-  PendingResolutionPtr pending_resolution(new PendingResolution());
-  ActiveDnsQuery& ret = *pending_resolution;
-  pending_resolution->host_ = dns_name;
-  pending_resolution->async_cb_data_.ar_name = pending_resolution->host_.c_str();
-  pending_resolution->async_cb_data_.ar_service = nullptr;
-  pending_resolution->async_cb_data_.ar_request = &pending_resolution->hints_;
-  pending_resolution->callback_ = callback;
+  auto pending_resolution_ptr = makePendingResolution(callback);
+  auto pending_resolution = pending_resolution_ptr.get();
+  auto pair = new ResolverPendingPair(this, pending_resolution);
 
-  // This initializes the hints for the lookup.
-  memset(&pending_resolution->hints_, 0, sizeof(pending_resolution->hints_));
-  pending_resolution->hints_.ai_family = AF_INET;
-  pending_resolution->hints_.ai_socktype = SOCK_STREAM;
+  pending_resolution_ptr->moveIntoList(std::move(pending_resolution_ptr), pending_resolutions_);
 
-  // This initializes the async signal data.
-  sigevent signal_info;
-  signal_info.sigev_notify = SIGEV_SIGNAL;
-  signal_info.sigev_signo = Event::Libevent::Global::DNS_SIGNAL_ID;
-  signal_info.sigev_value.sival_ptr = pending_resolution.get();
+  ares_gethostbyname(
+   pending_resolution->channel_, dns_name.c_str(), pending_resolution->hints_.ai_family,
+   [](void* arg, int status, int, hostent* hostent) -> void {
+     auto pair = reinterpret_cast<ResolverPendingPair*>(arg);
+     pair->first->onDNSResult(pair->second, status, hostent);
+     delete pair;
+   },
+   static_cast<void*>(pair));
 
-  gaicb* list[1];
-  list[0] = &pending_resolution->async_cb_data_;
-  pending_resolution->moveIntoList(std::move(pending_resolution), pending_resolutions_);
-  int rc = getaddrinfo_a(GAI_NOWAIT, list, 1, &signal_info);
-  RELEASE_ASSERT(0 == rc);
-  UNREFERENCED_PARAMETER(rc);
+  if (!pending_resolution->resolved) {
+    dispatchEvent(pending_resolution);
+  }
 
-  return ret;
+  return *pending_resolution;
 }
 
 } // Network

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -1,18 +1,21 @@
 #pragma once
 
+#include "ares.h"
+
 #include "envoy/network/dns.h"
+#include "envoy/event/deferred_deletable.h"
 
 #include "common/common/linked_object.h"
 #include "common/event/dispatcher_impl.h"
 
 #include "event2/event_struct.h"
+#include "event2/event.h"
 
 namespace Network {
 
 /**
- * Implementation of DnsResolver that uses getaddrinfo_a. All calls and callbacks are assumed to
- * happen on the thread that owns the creating dispatcher. Also, since results come in via signal
- * only one of these can exist at a time.
+ * Implementation of DnsResolver that uses c-ares. All calls and callbacks are assumed to
+ * happen on the thread that owns the creating dispatcher.
  */
 class DnsResolverImpl : public DnsResolver {
 public:
@@ -23,24 +26,40 @@ public:
   ActiveDnsQuery& resolve(const std::string& dns_name, ResolveCb callback) override;
 
 private:
-  struct PendingResolution : LinkedObject<PendingResolution>, public ActiveDnsQuery {
-    // Network::ActiveDnsQuery
-    void cancel() override { cancelled_ = true; }
+  struct PendingResolution : LinkedObject<PendingResolution>,
+                             public ActiveDnsQuery,
+                             public Event::DeferredDeletable {
+    ~PendingResolution() {
+      if (channel_) {
+        ares_destroy(channel_);
+        channel_ = nullptr;
+      }
 
-    std::string host_;
-    addrinfo hints_;
-    gaicb async_cb_data_;
+      // Some resolutions don't need an event (e.g. localhost) and are resolved synchronously
+      if (NULL != fd_event_.ev_base) {
+        event_del(&fd_event_);
+      }
+    }
+
+    // Network::ActiveDnsQuery
+    void cancel() override { ares_cancel(channel_); }
+
     ResolveCb callback_;
-    bool cancelled_{};
+    ares_channel channel_;
+    event fd_event_;
+    addrinfo hints_;
+    bool resolved;
   };
 
   typedef std::unique_ptr<PendingResolution> PendingResolutionPtr;
+  typedef std::pair<DnsResolverImpl*, PendingResolution*> ResolverPendingPair;
 
-  void onSignal();
+  // Network::DnsResolverImpl
+  void dispatchEvent(PendingResolution *pending_resolution);
+  PendingResolutionPtr makePendingResolution(ResolveCb callback);
+  void onDNSResult(PendingResolution *resolution, int status, hostent* hostent);
 
   Event::DispatcherImpl& dispatcher_;
-  int signal_fd_;
-  event signal_read_event_;
   std::list<PendingResolutionPtr> pending_resolutions_;
 };
 

--- a/source/exe/CMakeLists.txt
+++ b/source/exe/CMakeLists.txt
@@ -4,6 +4,7 @@ if (ENVOY_TCMALLOC)
   target_link_libraries(envoy tcmalloc_and_profiler)
 endif()
 
+target_link_libraries(envoy cares)
 target_link_libraries(envoy event)
 target_link_libraries(envoy event_pthreads)
 target_link_libraries(envoy http_parser)

--- a/source/precompiled/precompiled.h
+++ b/source/precompiled/precompiled.h
@@ -15,7 +15,6 @@
 #include <regex>
 #include <signal.h>
 #include <string.h>
-#include <sys/signalfd.h>
 #include <unistd.h>
 #include <unordered_set>
 

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(envoy-server OBJECT
 include_directories(SYSTEM ${ENVOY_TCLAP_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_HTTP_PARSER_INCLUDE_DIR})
 include_directories(${ENVOY_NGHTTP2_INCLUDE_DIR})
+include_directories(${ENVOY_LIBCARES_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_OPENSSL_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR})
 include_directories(${ENVOY_LIBEVENT_INCLUDE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(
 set_source_files_properties(generated/helloworld.pb.cc PROPERTIES COMPILE_FLAGS -Wno-unused-parameter)
 
 include_directories(${ENVOY_GMOCK_INCLUDE_DIR})
+include_directories(${ENVOY_LIBCARES_INCLUDE_DIR})
 include_directories(${ENVOY_GTEST_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_HTTP_PARSER_INCLUDE_DIR})
 include_directories(${PROJECT_SOURCE_DIR})
@@ -152,6 +153,7 @@ if (ENVOY_TCMALLOC)
   target_link_libraries(envoy-test tcmalloc_and_profiler)
 endif()
 
+target_link_libraries(envoy-test cares)
 target_link_libraries(envoy-test event)
 target_link_libraries(envoy-test event_pthreads)
 target_link_libraries(envoy-test http_parser)

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -28,24 +28,49 @@ TEST(DnsImplTest, LocalAsyncLookup) {
   EXPECT_THAT(address_list, testing::Contains("127.0.0.1"));
 }
 
+TEST(DnsImplTest, MultipleResolvers) {
+  Api::Impl api(std::chrono::milliseconds(10000));
+  Event::DispatcherPtr dispatcher = api.allocateDispatcher();
+  DnsResolverPtr resolver1 = dispatcher->createDnsResolver();
+  DnsResolverPtr resolver2 = dispatcher->createDnsResolver();
+
+  std::list<std::string> address_list;
+  resolver1->resolve("localhost", [&](std::list<std::string>&& results) -> void {
+    address_list.splice(address_list.end(), results);
+  });
+  resolver2->resolve("localhost", [&](std::list<std::string>&& results) -> void {
+    address_list.splice(address_list.end(), results);
+  });
+
+  dispatcher->run(Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(address_list.size(), 2UL);
+}
+
+TEST(DnsImplTest, CancelInflightLookups) {
+  Api::Impl api(std::chrono::milliseconds(10000));
+  Event::DispatcherPtr dispatcher = api.allocateDispatcher();
+  DnsResolverPtr resolver = dispatcher->createDnsResolver();
+
+  resolver->resolve("lyft.com", [](std::list<std::string> && ) -> void { FAIL(); });
+  resolver->resolve("lyft.com", [](std::list<std::string> && ) -> void { FAIL(); });
+  resolver->resolve("lyft.com", [](std::list<std::string> && ) -> void { FAIL(); });
+
+  resolver.reset();
+  dispatcher->run(Event::Dispatcher::RunType::Block);
+}
+
 TEST(DnsImplTest, Cancel) {
   Api::Impl api(std::chrono::milliseconds(10000));
   Event::DispatcherPtr dispatcher = api.allocateDispatcher();
   DnsResolverPtr resolver = dispatcher->createDnsResolver();
-  Event::TimerPtr stop_timer = dispatcher->createTimer([&]() -> void {
-    // TODO: This is an absurd hack, but right now the DNS resolver uses signalfd, which means
-    //       that we can get delivery when a new resolver comes up later in the test. We will
-    //       get rid of all of this when we switch this out for c-ares.
-    dispatcher->exit();
-  });
 
   ActiveDnsQuery& query =
-      resolver->resolve("localhost", [](std::list<std::string> && ) -> void { FAIL(); });
+      resolver->resolve("lyft.com", [](std::list<std::string> && ) -> void { FAIL(); });
 
   std::list<std::string> address_list;
   resolver->resolve("localhost", [&](std::list<std::string>&& results) -> void {
     address_list = results;
-    stop_timer->enableTimer(std::chrono::milliseconds(250));
+    dispatcher->exit();
   });
 
   query.cancel();

--- a/thirdparty.cmake
+++ b/thirdparty.cmake
@@ -47,6 +47,10 @@ set(ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR "" CACHE FILEPATH "location of lighstep t
 # Last tested with 1.1.0
 set(ENVOY_RAPIDJSON_INCLUDE_DIR "" CACHE FILEPATH "location of rapidjson includes")
 
+# https://c-ares.haxx.se/
+# Last tested with 1.12.0
+set(ENVOY_LIBCARES_INCLUDE_DIR "" CACHE STRING "location of libcares includes")
+
 # Extra linker flags required to properly link envoy with all of the above libraries.
 set(ENVOY_EXE_EXTRA_LINKER_FLAGS "" CACHE STRING "envoy extra linker flags")
 


### PR DESCRIPTION
This is a first attempt to get feedback on the approach. I'm using libevent and the existing dispatching loop. The motivation for this change was:

- Move away from `getaddrinfo_a` which has a terrible API *and* uses POSIX signal handling.
- `getaddrinfo_a` is a GNU extension and only available on Linux
- c-ares support SRV (not implemented yet on this PR but shouldn't be hard)