### PR TITLE
address refactor

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -33,19 +33,21 @@ public:
 
   /**
    * Create a client connection.
-   * @param url supplies the URL to connect to.
+   * @param address supplies the address to connect to.
    * @return Network::ClientConnectionPtr a client connection that is owned by the caller.
    */
-  virtual Network::ClientConnectionPtr createClientConnection(const std::string& url) PURE;
+  virtual Network::ClientConnectionPtr
+  createClientConnection(Network::Address::InstancePtr address) PURE;
 
   /**
    * Create an SSL client connection.
    * @param ssl_ctx supplies the SSL context to use.
-   * @param url supplies the URL to connect to.
+   * @param address supplies the address to connect to.
    * @return Network::ClientConnectionPtr a client connection that is owned by the caller.
    */
-  virtual Network::ClientConnectionPtr createSslClientConnection(Ssl::ClientContext& ssl_ctx,
-                                                                 const std::string& url) PURE;
+  virtual Network::ClientConnectionPtr
+  createSslClientConnection(Ssl::ClientContext& ssl_ctx,
+                            Network::Address::InstancePtr address) PURE;
 
   /**
    * Create an async DNS resolver. Only a single resolver can exist in the process at a time and it

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/pure.h"
+#include "envoy/network/address.h"
 
 namespace LocalInfo {
 
@@ -12,9 +13,9 @@ public:
   virtual ~LocalInfo() {}
 
   /**
-   * Human readable network address. E.g., "127.0.0.1".
+   * @return the local (non-loopback) address of the server.
    */
-  virtual const std::string& address() const PURE;
+  virtual Network::Address::InstancePtr address() const PURE;
 
   /**
    * Human readable zone name. E.g., "us-east-1a".

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -71,8 +71,8 @@ public:
   virtual const std::string& asString() const PURE;
 
   /**
-   * Bind a socket to to this address. The socket should have been created with a call to socket()
-   * on this object.
+   * Bind a socket to this address. The socket should have been created with a call to socket() on
+   * this object.
    * @param fd supplies the platform socket handle.
    * @return the platform error code.
    */

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "envoy/common/optional.h"
+#include "envoy/common/pure.h"
+
+namespace Network {
+namespace Address {
+
+/**
+ * Interface for an Ipv4 address.
+ */
+class Ipv4 {
+public:
+  virtual ~Ipv4() {}
+
+  /**
+   * @return the 32-bit IPv4 address in network byte order.
+   */
+  virtual uint32_t address() const PURE;
+};
+
+enum class IpVersion { v4 };
+
+/**
+ * Interface for a generic IP address.
+ */
+class Ip {
+public:
+  virtual ~Ip() {}
+
+  /**
+   * @return the address as a string. E.g., "1.2.3.4" for an IPv4 address.
+   */
+  virtual const std::string& addressAsString() const PURE;
+
+  /**
+   * @return Ipv4 address data IFF type() == IpVersion::v4, otherwise nullptr.
+   */
+  virtual const Ipv4* ipv4() const PURE;
+
+  /**
+   * @return the port associated with the address. Port may be zero if not specified or applicable.
+   *         The port is in host byte order.
+   */
+  virtual uint32_t port() const PURE;
+
+  /**
+   * @return the version of IP address.
+   */
+  virtual IpVersion version() const PURE;
+};
+
+enum class Type { Ip, Pipe };
+enum class SocketType { Stream, Datagram };
+
+/**
+ * Interface for all network addresses.
+ */
+class Instance {
+public:
+  virtual ~Instance() {}
+
+  virtual bool operator==(const Instance& rhs) const PURE;
+
+  /**
+   * @return a human readable string for the address.
+   *
+   * This string will be in the following format:
+   * For IP addresses: "1.2.3.4:80"
+   * For pipe addresses: "/foo"
+   */
+  virtual const std::string& asString() const PURE;
+
+  /**
+   * Bind a socket to to this address. The socket should have been created with a call to socket()
+   * on this object.
+   * @param fd supplies the platform socket handle.
+   * @return the platform error code.
+   */
+  virtual int bind(int fd) const PURE;
+
+  /**
+   * Connect a socket to this address. The socket should have been created with a call to socket()
+   * on this object.
+   * @param fd supplies the platform socket handle.
+   * @return the platform error code.
+   */
+  virtual int connect(int fd) const PURE;
+
+  /**
+   * @return the IP address information IFF type() == Type::Ip, otherwise nullptr.
+   */
+  virtual const Ip* ip() const PURE;
+
+  /**
+   * Create a socket for this address.
+   * @param type supplies the socket type to create.
+   * @return the platform error code.
+   */
+  virtual int socket(SocketType type) const PURE;
+
+  /**
+   * @return the type of address.
+   */
+  virtual Type type() const PURE;
+};
+
+typedef std::shared_ptr<const Instance> InstancePtr;
+
+} // Address
+} // Network

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 
 namespace Network {

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -3,6 +3,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"
+#include "envoy/network/address.h"
 #include "envoy/network/filter.h"
 #include "envoy/ssl/connection.h"
 
@@ -113,7 +114,7 @@ public:
   /**
    * @return The address of the remote client.
    */
-  virtual const std::string& remoteAddress() PURE;
+  virtual const Address::Instance& remoteAddress() PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin
@@ -121,7 +122,7 @@ public:
    * it can be different from the proxy address if the downstream connection has been redirected or
    * the proxy is operating in transparent mode.
    */
-  virtual const std::string& localAddress() PURE;
+  virtual const Address::Instance& localAddress() PURE;
 
   /**
    * Set the buffer stats to update when the connection's read/write buffers change. Note that

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/pure.h"
+#include "envoy/network/address.h"
 
 namespace Network {
 
@@ -29,7 +30,7 @@ public:
    * @param address_list supplies the list of resolved IP addresses. The list will be empty if
    *                     the resolution failed.
    */
-  typedef std::function<void(std::list<std::string>&& address_list)> ResolveCb;
+  typedef std::function<void(std::list<Address::InstancePtr>&& address_list)> ResolveCb;
 
   /**
    * Initiate an async DNS resolution.

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/pure.h"
+#include "envoy/network/address.h"
 
 namespace Network {
 
@@ -12,9 +13,9 @@ public:
   virtual ~ListenSocket() {}
 
   /**
-   * @return a name used for stats.  For TCP listen sockets, this is the port.
+   * @return the address that the socket is listening on.
    */
-  virtual const std::string name() PURE;
+  virtual Address::InstancePtr localAddress() PURE;
 
   /**
    * @return fd the listen socket's file descriptor.

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/network/address.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/upstream/outlier_detection.h"
 
@@ -50,9 +51,9 @@ public:
   virtual Outlier::DetectorHostSink& outlierDetector() const PURE;
 
   /**
-   * @return the URL used to connect to the host.
+   * @return the address used to connect to the host.
    */
-  virtual const std::string& url() const PURE;
+  virtual Network::Address::InstancePtr address() const PURE;
 
   /**
    * @return host specific stats.

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(
   mongo/codec_impl.cc
   mongo/proxy.cc
   mongo/utility.cc
+  network/address_impl.cc
   network/connection_impl.cc
   network/dns_impl.cc
   network/filter_manager_impl.cc

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -55,13 +55,15 @@ void DispatcherImpl::clearDeferredDeleteList() {
   deferred_deleting_ = false;
 }
 
-Network::ClientConnectionPtr DispatcherImpl::createClientConnection(const std::string& url) {
-  return Network::ClientConnectionImpl::create(*this, url);
+Network::ClientConnectionPtr
+DispatcherImpl::createClientConnection(Network::Address::InstancePtr address) {
+  return Network::ClientConnectionPtr{new Network::ClientConnectionImpl(*this, address)};
 }
 
-Network::ClientConnectionPtr DispatcherImpl::createSslClientConnection(Ssl::ClientContext& ssl_ctx,
-                                                                       const std::string& url) {
-  return Network::ClientConnectionPtr{new Ssl::ClientConnectionImpl(*this, ssl_ctx, url)};
+Network::ClientConnectionPtr
+DispatcherImpl::createSslClientConnection(Ssl::ClientContext& ssl_ctx,
+                                          Network::Address::InstancePtr address) {
+  return Network::ClientConnectionPtr{new Ssl::ClientConnectionImpl(*this, ssl_ctx, address)};
 }
 
 Network::DnsResolverPtr DispatcherImpl::createDnsResolver() {

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -25,9 +25,11 @@ public:
 
   // Event::Dispatcher
   void clearDeferredDeleteList() override;
-  Network::ClientConnectionPtr createClientConnection(const std::string& url) override;
-  Network::ClientConnectionPtr createSslClientConnection(Ssl::ClientContext& ssl_ctx,
-                                                         const std::string& url) override;
+  Network::ClientConnectionPtr
+  createClientConnection(Network::Address::InstancePtr address) override;
+  Network::ClientConnectionPtr
+  createSslClientConnection(Ssl::ClientContext& ssl_ctx,
+                            Network::Address::InstancePtr address) override;
   Network::DnsResolverPtr createDnsResolver() override;
   FileEventPtr createFileEvent(int fd, FileReadyCb cb) override;
   Filesystem::WatcherPtr createFilesystemWatcher() override;

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -98,8 +98,7 @@ void Instance::onEvent(uint32_t events) {
   }
 
   ASSERT(read_callbacks_->connection().ssl());
-  if (config_->ipWhiteList().contains(
-          Network::Utility::hostFromUrl(read_callbacks_->connection().remoteAddress()))) {
+  if (config_->ipWhiteList().contains(read_callbacks_->connection().remoteAddress())) {
     config_->stats().auth_ip_white_list_.inc();
     read_callbacks_->continueReading();
     return;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -61,34 +61,23 @@ TcpProxyConfig::TcpProxyConfig(const Json::Object& config,
 const std::string& TcpProxyConfig::getRouteFromEntries(Network::Connection& connection) {
   for (const TcpProxyConfig::Route& route : routes_) {
     if (!route.source_port_ranges_.empty() &&
-        !Network::Utility::portInRangeList(
-            Network::Utility::portFromUrl(connection.remoteAddress()), route.source_port_ranges_)) {
-      continue; // no match, try next route
+        !Network::Utility::portInRangeList(connection.remoteAddress(), route.source_port_ranges_)) {
+      continue;
     }
 
-    if (!route.source_ips_.empty() &&
-        !route.source_ips_.contains(Network::Utility::hostFromUrl(connection.remoteAddress()))) {
-      continue; // no match, try next route
-    }
-
-    // If the route needs to match on destination address and port but they are not available
-    // (localAddress is empty), we skip it. The connection has a chance to match a different
-    // route that does not depend on destination address and port.
-    if ((!route.destination_port_ranges_.empty() || !route.destination_ips_.empty()) &&
-        connection.localAddress().empty()) {
+    if (!route.source_ips_.empty() && !route.source_ips_.contains(connection.remoteAddress())) {
       continue;
     }
 
     if (!route.destination_port_ranges_.empty() &&
-        !Network::Utility::portInRangeList(Network::Utility::portFromUrl(connection.localAddress()),
+        !Network::Utility::portInRangeList(connection.localAddress(),
                                            route.destination_port_ranges_)) {
-      continue; // no match, try next route
+      continue;
     }
 
     if (!route.destination_ips_.empty() &&
-        !route.destination_ips_.contains(
-            Network::Utility::hostFromUrl(connection.localAddress()))) {
-      continue; // no match, try next route
+        !route.destination_ips_.contains(connection.localAddress())) {
+      continue;
     }
 
     // if we made it past all checks, the route matches

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -251,12 +251,11 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "UPSTREAM_HOST") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      std::string upstream_host_url;
-      if (nullptr != request_info.upstreamHost()) {
-        upstream_host_url = request_info.upstreamHost()->url();
+      if (request_info.upstreamHost()) {
+        return request_info.upstreamHost()->address()->asString();
+      } else {
+        return std::string("-");
       }
-
-      return upstream_host_url.empty() ? "-" : upstream_host_url;
     };
   } else if (field_name == "UPSTREAM_CLUSTER") {
     field_extractor_ = [](const RequestInfo& request_info) {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -1,4 +1,5 @@
 #include "async_client_impl.h"
+#include "utility.h"
 
 namespace Http {
 
@@ -94,7 +95,7 @@ void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
 
 void AsyncStreamImpl::sendHeaders(HeaderMap& headers, bool end_stream) {
   headers.insertEnvoyInternalRequest().value(Headers::get().EnvoyInternalRequestValues.True);
-  headers.insertForwardedFor().value(parent_.config_.local_info_.address());
+  Utility::appendXff(headers, *parent_.config_.local_info_.address());
   router_.decodeHeaders(headers, end_stream);
   closeLocal(end_stream);
 }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -188,7 +188,7 @@ public:
    * @return local address.
    * Gives richer information in case of internal requests.
    */
-  virtual const std::string& localAddress() PURE;
+  virtual const Network::Address::Instance& localAddress() PURE;
 
   /**
    * @return custom user agent for internal requests for better debugging. Must be configured to

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -39,11 +39,10 @@ void ConnectionManagerUtility::mutateRequestHeaders(Http::HeaderMap& request_hea
   // peer. Cases where we don't "use remote address" include trusted double proxy where we expect
   // our peer to have already properly set XFF, etc.
   if (config.useRemoteAddress()) {
-    const std::string remote_address = Network::Utility::hostFromUrl(connection.remoteAddress());
-    if (Network::Utility::isLoopbackAddress(remote_address.c_str())) {
+    if (Network::Utility::isLoopbackAddress(connection.remoteAddress())) {
       Utility::appendXff(request_headers, config.localAddress());
     } else {
-      Utility::appendXff(request_headers, remote_address);
+      Utility::appendXff(request_headers, connection.remoteAddress());
     }
     request_headers.insertForwardedProto().value(
         connection.ssl() ? Headers::get().SchemeValues.Https : Headers::get().SchemeValues.Http);
@@ -95,9 +94,9 @@ void ConnectionManagerUtility::mutateRequestHeaders(Http::HeaderMap& request_hea
 
   // If we are an external request, AND we are "using remote address" (see above), we set
   // x-envoy-external-address since this is our first ingress point into the trusted network.
-  if (edge_request) {
+  if (edge_request && connection.remoteAddress().type() == Network::Address::Type::Ip) {
     request_headers.insertEnvoyExternalAddress().value(
-        Network::Utility::hostFromUrl(connection.remoteAddress()));
+        connection.remoteAddress().ip()->addressAsString());
   }
 
   // Generate x-request-id for all edge requests, or if there is none.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -14,7 +14,11 @@
 
 namespace Http {
 
-void Utility::appendXff(HeaderMap& headers, const std::string& remote_address) {
+void Utility::appendXff(HeaderMap& headers, const Network::Address::Instance& remote_address) {
+  if (remote_address.type() != Network::Address::Type::Ip) {
+    return;
+  }
+
   // TODO PERF: Append and do not copy.
   HeaderEntry* header = headers.ForwardedFor();
   std::string forwarded_for = header ? header->value().c_str() : "";
@@ -22,7 +26,7 @@ void Utility::appendXff(HeaderMap& headers, const std::string& remote_address) {
     forwarded_for += ", ";
   }
 
-  forwarded_for += remote_address;
+  forwarded_for += remote_address.ip()->addressAsString();
   headers.insertForwardedFor().value(forwarded_for);
 }
 

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -19,7 +19,7 @@ public:
    * @param headers supplies the headers to append to.
    * @param remote_address supplies the remote address to append.
    */
-  static void appendXff(HeaderMap& headers, const std::string& remote_address);
+  static void appendXff(HeaderMap& headers, const Network::Address::Instance& remote_address);
 
   /**
    * Creates an SSL (https) redirect path based on the input host and path headers.

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -6,18 +6,18 @@ namespace LocalInfo {
 
 class LocalInfoImpl : public LocalInfo {
 public:
-  LocalInfoImpl(const std::string address, const std::string zone_name,
+  LocalInfoImpl(Network::Address::InstancePtr address, const std::string zone_name,
                 const std::string cluster_name, const std::string node_name)
       : address_(address), zone_name_(zone_name), cluster_name_(cluster_name),
         node_name_(node_name) {}
 
-  const std::string& address() const override { return address_; }
+  Network::Address::InstancePtr address() const override { return address_; }
   const std::string& zoneName() const override { return zone_name_; }
   const std::string& clusterName() const override { return cluster_name_; }
   const std::string& nodeName() const override { return node_name_; }
 
 private:
-  const std::string address_;
+  Network::Address::InstancePtr address_;
   const std::string zone_name_;
   const std::string cluster_name_;
   const std::string node_name_;

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -22,7 +22,7 @@ void AccessLog::logMessage(const Message& message, const std::string&, bool full
   SystemTime now = std::chrono::system_clock::now();
   std::string log_line =
       fmt::format(log_format, AccessLogDateTimeFormatter::fromTime(now), message.toString(full),
-                  upstream_host ? upstream_host->url() : "-");
+                  upstream_host ? upstream_host->address()->asString() : "-");
 
   file_->write(log_line);
 }

--- a/source/common/network/addr_info.h
+++ b/source/common/network/addr_info.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "common/common/c_smart_ptr.h"
-
-namespace Network {
-
-typedef CSmartPtr<addrinfo, freeaddrinfo> AddrInfoPtr;
-
-} // Network

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,5 +1,7 @@
 #include "address_impl.h"
 
+#include "envoy/common/exception.h"
+
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,0 +1,90 @@
+#include "address_impl.h"
+
+#include "common/common/assert.h"
+#include "common/common/utility.h"
+
+namespace Network {
+namespace Address {
+
+int InstanceBase::flagsFromSocketType(SocketType type) const {
+  int flags = SOCK_NONBLOCK;
+  if (type == SocketType::Stream) {
+    flags |= SOCK_STREAM;
+  } else {
+    flags |= SOCK_DGRAM;
+  }
+  return flags;
+}
+
+Ipv4Instance::Ipv4Instance(const sockaddr_in* address) : InstanceBase(Type::Ip) {
+  ip_.ipv4_.address_ = *address;
+  char str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &address->sin_addr, str, INET_ADDRSTRLEN);
+  friendly_name_ = fmt::format("{}:{}", str, ntohs(address->sin_port));
+  ip_.friendly_address_ = str;
+}
+
+Ipv4Instance::Ipv4Instance(const std::string& address) : Ipv4Instance(address, 0) {}
+
+Ipv4Instance::Ipv4Instance(const std::string& address, uint32_t port) : InstanceBase(Type::Ip) {
+  memset(&ip_.ipv4_.address_, 0, sizeof(ip_.ipv4_.address_));
+  ip_.ipv4_.address_.sin_family = AF_INET;
+  ip_.ipv4_.address_.sin_port = htons(port);
+  int rc = inet_pton(AF_INET, address.c_str(), &ip_.ipv4_.address_.sin_addr);
+  if (1 != rc) {
+    throw EnvoyException(fmt::format("invalid ipv4 address '{}'", address));
+  }
+
+  friendly_name_ = fmt::format("{}:{}", address, port);
+  ip_.friendly_address_ = address;
+}
+
+Ipv4Instance::Ipv4Instance(uint32_t port) : InstanceBase(Type::Ip) {
+  memset(&ip_.ipv4_.address_, 0, sizeof(ip_.ipv4_.address_));
+  ip_.ipv4_.address_.sin_family = AF_INET;
+  ip_.ipv4_.address_.sin_port = htons(port);
+  ip_.ipv4_.address_.sin_addr.s_addr = INADDR_ANY;
+  friendly_name_ = fmt::format("0.0.0.0:{}", port);
+  ip_.friendly_address_ = "0.0.0.0";
+}
+
+int Ipv4Instance::bind(int fd) const {
+  return ::bind(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv4_.address_),
+                sizeof(ip_.ipv4_.address_));
+}
+
+int Ipv4Instance::connect(int fd) const {
+  return ::connect(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv4_.address_),
+                   sizeof(ip_.ipv4_.address_));
+}
+
+int Ipv4Instance::socket(SocketType type) const {
+  return ::socket(AF_INET, flagsFromSocketType(type), 0);
+}
+
+PipeInstance::PipeInstance(const sockaddr_un* address) : InstanceBase(Type::Pipe) {
+  address_ = *address;
+  friendly_name_ = address_.sun_path;
+}
+
+PipeInstance::PipeInstance(const std::string& pipe_path) : InstanceBase(Type::Pipe) {
+  memset(&address_, 0, sizeof(address_));
+  address_.sun_family = AF_UNIX;
+  StringUtil::strlcpy(&address_.sun_path[0], pipe_path.c_str(), sizeof(address_.sun_path));
+  friendly_name_ = address_.sun_path;
+}
+
+int PipeInstance::bind(int fd) const {
+  return ::bind(fd, reinterpret_cast<const sockaddr*>(&address_), sizeof(address_));
+}
+
+int PipeInstance::connect(int fd) const {
+  return ::connect(fd, reinterpret_cast<const sockaddr*>(&address_), sizeof(address_));
+}
+
+int PipeInstance::socket(SocketType type) const {
+  return ::socket(AF_UNIX, flagsFromSocketType(type), 0);
+}
+
+} // Address
+} // Network

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "envoy/network/address.h"
+
+#include <sys/un.h>
+
+namespace Network {
+namespace Address {
+
+/**
+ * Base class for all address types.
+ */
+class InstanceBase : public Instance {
+public:
+  // Network::Address::Instance
+  bool operator==(const Instance& rhs) const override { return asString() == rhs.asString(); }
+  const std::string& asString() const override { return friendly_name_; }
+  Type type() const override { return type_; }
+
+protected:
+  InstanceBase(Type type) : type_(type) {}
+  int flagsFromSocketType(SocketType type) const;
+
+  std::string friendly_name_;
+
+private:
+  const Type type_;
+};
+
+/**
+ * Implementation of an IPv4 address.
+ */
+class Ipv4Instance : public InstanceBase {
+public:
+  /**
+   * Construct from an existing unix IPv4 address.
+   */
+  Ipv4Instance(const sockaddr_in* address);
+
+  /**
+   * Construct from a string IPv4 address such as "1.2.3.4". Port will be unset/0.
+   */
+  Ipv4Instance(const std::string& address);
+
+  /**
+   * Construct from a string IPv4 address such as "1.2.3.4" as well as a port.
+   */
+  Ipv4Instance(const std::string& address, uint32_t port);
+
+  /**
+   * Construct from a port. The IPv4 address will be set to "any" and is suitable for binding
+   * a port to any available address.
+   */
+  Ipv4Instance(uint32_t port);
+
+  // Network::Address::Instance
+  int bind(int fd) const override;
+  int connect(int fd) const override;
+  const Ip* ip() const override { return &ip_; }
+  int socket(SocketType type) const override;
+
+private:
+  struct Ipv4Helper : public Ipv4 {
+    uint32_t address() const override { return address_.sin_addr.s_addr; }
+
+    sockaddr_in address_;
+  };
+
+  struct IpHelper : public Ip {
+    const std::string& addressAsString() const override { return friendly_address_; }
+    const Ipv4* ipv4() const override { return &ipv4_; }
+    uint32_t port() const override { return ntohs(ipv4_.address_.sin_port); }
+    IpVersion version() const override { return IpVersion::v4; }
+
+    Ipv4Helper ipv4_;
+    std::string friendly_address_;
+  };
+
+  IpHelper ip_;
+};
+
+/**
+ * Implementation of a pipe address (unix domain socket on unix).
+ */
+class PipeInstance : public InstanceBase {
+public:
+  /**
+   * Construct from an existing unix address.
+   */
+  PipeInstance(const sockaddr_un* address);
+
+  /**
+   * Construct from a string pipe path.
+   */
+  PipeInstance(const std::string& pipe_path);
+
+  // Network::Address::Instance
+  int bind(int fd) const override;
+  int connect(int fd) const override;
+  const Ip* ip() const override { return nullptr; }
+  int socket(SocketType type) const override;
+
+private:
+  sockaddr_un address_;
+};
+
+} // Address
+} // Network

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -2,6 +2,7 @@
 
 #include "common/common/assert.h"
 #include "common/event/libevent.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
 #include "event2/event.h"
@@ -41,12 +42,13 @@ void DnsResolverImpl::onSignal() {
     PendingResolution* pending_resolution =
         reinterpret_cast<PendingResolution*>(signal_info.ssi_ptr);
 
-    std::list<std::string> address_list;
+    std::list<Address::InstancePtr> address_list;
     addrinfo* result = pending_resolution->async_cb_data_.ar_result;
     while (result != nullptr) {
+      // TODO: IPv6 support.
       ASSERT(result->ai_family == AF_INET);
       sockaddr_in* address = reinterpret_cast<sockaddr_in*>(result->ai_addr);
-      address_list.emplace_back(Network::Utility::getAddressName(address));
+      address_list.emplace_back(new Address::Ipv4Instance(address));
       result = result->ai_next;
     }
 

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -4,12 +4,14 @@
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
+#include "common/network/address_impl.h"
 
 namespace Network {
 
-TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) : port_(port) {
-  AddrInfoPtr address = Utility::resolveTCP("", port);
-  fd_ = socket(address->ai_addr->sa_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) {
+  // TODO: IPv6 support.
+  local_address_.reset(new Address::Ipv4Instance(port));
+  fd_ = local_address_->socket(Address::SocketType::Stream);
   RELEASE_ASSERT(fd_ != -1);
 
   int on = 1;
@@ -17,7 +19,7 @@ TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) : port_(port)
   RELEASE_ASSERT(rc != -1);
 
   if (bind_to_port) {
-    rc = bind(fd_, address->ai_addr, address->ai_addrlen);
+    rc = local_address_->bind(fd_);
     if (rc == -1) {
       close();
       throw EnvoyException(fmt::format("cannot bind on port {}: {}", port, strerror(errno)));
@@ -25,13 +27,18 @@ TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) : port_(port)
   }
 }
 
+TcpListenSocket::TcpListenSocket(int fd, uint32_t port) {
+  fd_ = fd;
+  local_address_.reset(new Address::Ipv4Instance(port));
+}
+
 UdsListenSocket::UdsListenSocket(const std::string& uds_path) {
   remove(uds_path.c_str());
-  sockaddr_un address = Utility::resolveUnixDomainSocket(uds_path);
-  fd_ = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+  local_address_.reset(new Address::PipeInstance(uds_path));
+  fd_ = local_address_->socket(Address::SocketType::Stream);
   RELEASE_ASSERT(fd_ != -1);
 
-  int rc = bind(fd_, reinterpret_cast<sockaddr*>(&address), sizeof(sockaddr_un));
+  int rc = local_address_->bind(fd_);
   if (rc == -1) {
     close();
     throw EnvoyException(

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -22,6 +22,8 @@ public:
   }
 
 protected:
+  void doBind();
+
   int fd_;
   Address::InstancePtr local_address_;
 };

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -8,14 +8,13 @@ namespace Network {
 
 class ListenSocketImpl : public ListenSocket {
 public:
-  ListenSocketImpl() {}
-  ListenSocketImpl(int fd) : fd_(fd) {}
-  virtual ~ListenSocketImpl() { close(); }
+  ~ListenSocketImpl() { close(); }
 
   // Network::ListenSocket
-  int fd() { return fd_; }
+  Address::InstancePtr localAddress() override { return local_address_; }
+  int fd() override { return fd_; }
 
-  void close() {
+  void close() override {
     if (fd_ != -1) {
       ::close(fd_);
       fd_ = -1;
@@ -24,6 +23,7 @@ public:
 
 protected:
   int fd_;
+  Address::InstancePtr local_address_;
 };
 
 /**
@@ -32,15 +32,7 @@ protected:
 class TcpListenSocket : public ListenSocketImpl {
 public:
   TcpListenSocket(uint32_t port, bool bind_to_port);
-  TcpListenSocket(int fd, uint32_t port) : ListenSocketImpl(fd), port_(port) {}
-
-  uint32_t port() { return port_; }
-
-  // Network::ListenSocket
-  const std::string name() { return std::to_string(port_); }
-
-private:
-  uint32_t port_;
+  TcpListenSocket(int fd, uint32_t port);
 };
 
 typedef std::unique_ptr<TcpListenSocket> TcpListenSocketPtr;
@@ -48,9 +40,6 @@ typedef std::unique_ptr<TcpListenSocket> TcpListenSocketPtr;
 class UdsListenSocket : public ListenSocketImpl {
 public:
   UdsListenSocket(const std::string& uds_path);
-
-  // Network::ListenSocket
-  const std::string name() { return "uds"; }
 };
 
 } // Network

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -28,16 +28,8 @@ public:
    * @param remote_address supplies the remote address for the new connection.
    * @param local_address supplies the local address for the new connection.
    */
-  virtual void newConnection(int fd, sockaddr* remote_address, sockaddr* local_address);
-
-  /**
-   * Accept/process a new connection with the given remote address.
-   * @param fd supplies the new connection's fd.
-   * @param remote_address supplies the remote address for the new connection.
-   * @param local_address supplies the local address for the new connection.
-   */
-  virtual void newConnection(int fd, const std::string& remote_address,
-                             const std::string& local_address);
+  virtual void newConnection(int fd, Address::InstancePtr remote_address,
+                             Address::InstancePtr local_address);
 
   /**
    * @return the socket supplied to the listener at construction time
@@ -45,8 +37,7 @@ public:
   ListenSocket& socket() { return socket_; }
 
 protected:
-  const std::string getAddressName(sockaddr* addr);
-  virtual uint16_t getAddressPort(sockaddr* addr);
+  virtual Address::InstancePtr getOriginalDst(int fd);
 
   Network::ConnectionHandler& connection_handler_;
   Event::DispatcherImpl& dispatcher_;
@@ -75,9 +66,8 @@ public:
         ssl_ctx_(ssl_ctx) {}
 
   // ListenerImpl
-  void newConnection(int fd, sockaddr* remote_addr, sockaddr* local_addr) override;
-  void newConnection(int fd, const std::string& remote_address,
-                     const std::string& local_address) override;
+  void newConnection(int fd, Address::InstancePtr remote_address,
+                     Address::InstancePtr local_address) override;
 
 private:
   Ssl::Context& ssl_ctx_;

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -1,3 +1,4 @@
+#include "address_impl.h"
 #include "listener_impl.h"
 #include "proxy_protocol.h"
 
@@ -71,8 +72,11 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   removeFromList(parent_.connections_);
 
-  // TODO: pass in something more meaningful than 0 as remote port and EMPTY_STRING as local_address
-  listener.newConnection(fd, Network::Utility::urlForTcp(remote_address, 0), EMPTY_STRING);
+  // TODO: Parse the remote port instead of passing zero.
+  // TODO: IPv6 support.
+  listener.newConnection(
+      fd, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(remote_address, 0)},
+      listener.socket().localAddress());
 }
 
 void ProxyProtocol::ActiveConnection::close() {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -77,9 +77,8 @@ const std::string Utility::UNIX_SCHEME = "unix://";
 
 Address::InstancePtr Utility::resolveUrl(const std::string& url) {
   // TODO: IPv6 support.
-  // TODO: We have switched to ip:// for IP addresses and pipe:// for unix/pipe addresses, but we
-  //       still support the legacy tcp:// and unix:// names. Actually support/parse ip:// and
-  //       pipe:// and document it.
+  // TODO: We still support the legacy tcp:// and unix:// names. We should support/parse ip:// and
+  //       pipe:// as better names.
   if (url.find(TCP_SCHEME) == 0) {
     return Address::InstancePtr{
         new Address::Ipv4Instance(hostFromTcpUrl(url), portFromTcpUrl(url))};

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -83,7 +83,7 @@ Address::InstancePtr Utility::resolveUrl(const std::string& url) {
     return Address::InstancePtr{
         new Address::Ipv4Instance(hostFromTcpUrl(url), portFromTcpUrl(url))};
   } else if (url.find(UNIX_SCHEME) == 0) {
-    return Address::InstancePtr{new Address::PipeInstance(pathFromUnixUrl(url))};
+    return Address::InstancePtr{new Address::PipeInstance(url.substr(UNIX_SCHEME.size()))};
   } else {
     throw EnvoyException(fmt::format("unknown protocol scheme: {}", url));
   }
@@ -119,14 +119,6 @@ uint32_t Utility::portFromTcpUrl(const std::string& url) {
   } catch (const std::invalid_argument& e) {
     throw EnvoyException(e.what());
   }
-}
-
-std::string Utility::pathFromUnixUrl(const std::string& url) {
-  if (url.find(UNIX_SCHEME) != 0) {
-    throw EnvoyException(fmt::format("unknown protocol scheme: {}", url));
-  }
-
-  return url.substr(UNIX_SCHEME.size());
 }
 
 Address::InstancePtr Utility::getLocalAddress() {

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -74,13 +74,6 @@ public:
   static uint32_t portFromTcpUrl(const std::string& url);
 
   /**
-   * Parses a path from a Unix URL
-   * @param the URL to parse port from
-   * @return std::string the parsed path
-   */
-  static std::string pathFromUnixUrl(const std::string& url);
-
-  /**
    * @return the local IP address of the server
    */
   static Address::InstancePtr getLocalAddress();

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -1,14 +1,8 @@
 #pragma once
 
+#include "envoy/json/json_object.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
-
-#include "common/json/json_loader.h"
-#include "common/network/addr_info.h"
-
-#include <sys/un.h>
-
-#include <linux/netfilter_ipv4.h>
 
 namespace Network {
 
@@ -22,7 +16,7 @@ public:
   IpList(const Json::Object& config, const std::string& member_name);
   IpList(){};
 
-  bool contains(const std::string& address) const;
+  bool contains(const Address::Instance& address) const;
   bool empty() const { return ipv4_list_.empty(); }
 
 private:
@@ -59,74 +53,37 @@ public:
   static const std::string UNIX_SCHEME;
 
   /**
-   * Resolve a TCP address.
-   * @param host supplies the host name.
-   * @param port supplies the port.
-   * @return EventAddrInfoPtr the resolved address.
-   */
-  static AddrInfoPtr resolveTCP(const std::string& host, uint32_t port);
-
-  /**
-   * Resolve a unix domain socket.
-   * @param path supplies the path to resolve.
-   * @return EventAddrInfoPtr the resolved address.
-   */
-  static sockaddr_un resolveUnixDomainSocket(const std::string& path);
-
-  /**
-   * Resolve an address.
+   * Resolve a URL.
    * @param url supplies the url to resolve.
-   * @return EventAddrInfoPtr the resolved address.
+   * @return a resolved address.
    */
-  static void resolve(const std::string& url);
+  static Address::InstancePtr resolveUrl(const std::string& url);
 
   /**
-   * Parses the host from a URL
+   * Parses the host from a TCP URL
    * @param the URL to parse host from
    * @return std::string the parsed host
    */
-  static std::string hostFromUrl(const std::string& url);
+  static std::string hostFromTcpUrl(const std::string& url);
 
   /**
-   * Parses the port from a URL
+   * Parses the port from a TCP URL
    * @param the URL to parse port from
    * @return uint32_t the parsed port
    */
-  static uint32_t portFromUrl(const std::string& url);
+  static uint32_t portFromTcpUrl(const std::string& url);
 
   /**
-   * Parses a path from a URL
+   * Parses a path from a Unix URL
    * @param the URL to parse port from
    * @return std::string the parsed path
    */
-  static std::string pathFromUrl(const std::string& url);
-
-  /**
-   * Converts an address and port into a TCP URL
-   * @param address the address to include
-   * @param port the port to include
-   * @return URL a URL of the form tcp://address:port
-   */
-  static std::string urlForTcp(const std::string& address, uint32_t port);
+  static std::string pathFromUnixUrl(const std::string& url);
 
   /**
    * @return the local IP address of the server
    */
-  static std::string getLocalAddress();
-
-  /**
-   * Converts a sockaddr_in to a human readable string.
-   * @param addr the address to convert to a string
-   * @return the string IP address representation for 'addr'
-   */
-  static std::string getAddressName(sockaddr_in* addr);
-
-  /**
-   * Extract port information from a sockaddr_in.
-   * @param addr the address from which to extract the port number
-   * @return the port number
-   */
-  static uint16_t getAddressPort(sockaddr_in* addr);
+  static Address::InstancePtr getLocalAddress();
 
   /**
    * Determine whether this is an internal (RFC1918) address.
@@ -138,17 +95,16 @@ public:
    * Check if address is loopback address.
    * @return true if so, otherwise false
    */
-  static bool isLoopbackAddress(const char* address);
+  static bool isLoopbackAddress(const Address::Instance& address);
 
   /**
    * Retrieve the original destination address from an accepted fd.
    * The address (IP and port) may be not local and the port may differ from
    * the listener port if the packets were redirected using iptables
    * @param fd is the descriptor returned by accept()
-   * @param orig_addr is the data structure that contains the original address
-   * @return true if the operation succeeded, false otherwise
+   * @return the original destination or nullptr not available.
    */
-  static bool getOriginalDst(int fd, sockaddr_storage* orig_addr);
+  static Address::InstancePtr getOriginalDst(int fd);
 
   /**
    * Parses a string containing a comma-separated list of port numbers and/or
@@ -162,11 +118,11 @@ public:
 
   /**
    * Checks whether a given port number appears in at least one of the port ranges in a list
-   * @param port is the port number to search
+   * @param address supplies the IP address to compare.
    * @param list the list of port ranges in which the port may appear
    * @return whether the port appears in at least one of the ranges in the list
    */
-  static bool portInRangeList(uint32_t port, const std::list<PortRange>& list);
+  static bool portInRangeList(const Address::Instance& address, const std::list<PortRange>& list);
 };
 
 } // Network

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -55,7 +55,7 @@ public:
   /**
    * Resolve a URL.
    * @param url supplies the url to resolve.
-   * @return a resolved address.
+   * @return Address::InstancePtr the resolved address.
    */
   static Address::InstancePtr resolveUrl(const std::string& url);
 
@@ -95,7 +95,7 @@ public:
    * The address (IP and port) may be not local and the port may differ from
    * the listener port if the packets were redirected using iptables
    * @param fd is the descriptor returned by accept()
-   * @return the original destination or nullptr not available.
+   * @return the original destination or nullptr if not available.
    */
   static Address::InstancePtr getOriginalDst(int fd);
 

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -10,8 +10,9 @@
 namespace Ssl {
 
 ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
-                               const std::string& remote_address, const std::string& local_address,
-                               Context& ctx, InitialState state)
+                               Network::Address::InstancePtr remote_address,
+                               Network::Address::InstancePtr local_address, Context& ctx,
+                               InitialState state)
     : Network::ConnectionImpl(dispatcher, fd, remote_address, local_address),
       ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
   BIO* bio = BIO_new_socket(fd, 0);
@@ -186,18 +187,12 @@ std::string ConnectionImpl::sha256PeerCertificateDigest() {
   return Hex::encode(computed_hash);
 }
 
-// TODO: see if we can pass something more meaningful than EMPTY_STRING as localAddress
 ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Context& ctx,
-                                           const std::string& url)
-    : ConnectionImpl(dispatcher, socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0), url, EMPTY_STRING,
-                     ctx, InitialState::Client) {}
+                                           Network::Address::InstancePtr address)
+    : ConnectionImpl(dispatcher, address->socket(Network::Address::SocketType::Stream), address,
+                     null_local_address_, ctx, InitialState::Client) {}
 
-void ClientConnectionImpl::connect() {
-  Network::AddrInfoPtr addr_info =
-      Network::Utility::resolveTCP(Network::Utility::hostFromUrl(remote_address_),
-                                   Network::Utility::portFromUrl(remote_address_));
-  doConnect(addr_info->ai_addr, addr_info->ai_addrlen);
-}
+void ClientConnectionImpl::connect() { doConnect(); }
 
 void ConnectionImpl::closeSocket(uint32_t close_type) {
   if (handshake_complete_ && state() != State::Closed) {

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -10,8 +10,9 @@ class ConnectionImpl : public Network::ConnectionImpl, public Connection {
 public:
   enum class InitialState { Client, Server };
 
-  ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd, const std::string& remote_address,
-                 const std::string& local_address, Context& ctx, InitialState state);
+  ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
+                 Network::Address::InstancePtr remote_address,
+                 Network::Address::InstancePtr local_address, Context& ctx, InitialState state);
   ~ConnectionImpl();
 
   // Network::Connection
@@ -38,7 +39,8 @@ private:
 
 class ClientConnectionImpl final : public ConnectionImpl, public Network::ClientConnection {
 public:
-  ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Context& ctx, const std::string& url);
+  ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Context& ctx,
+                       Network::Address::InstancePtr address);
 
   // Network::ClientConnection
   void connect() override;

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -6,17 +6,18 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
 namespace Stats {
 namespace Statsd {
 
 Writer::Writer(uint32_t port) {
-  Network::AddrInfoPtr resolved(Network::Utility::resolveTCP("", port));
-  fd_ = socket(AF_INET, SOCK_DGRAM, 0);
+  Network::Address::InstancePtr address(new Network::Address::Ipv4Instance(port));
+  fd_ = address->socket(Network::Address::SocketType::Datagram);
   ASSERT(fd_ != -1);
 
-  int rc = connect(fd_, resolved->ai_addr, resolved->ai_addrlen);
+  int rc = address->connect(fd_);
   ASSERT(rc != -1);
   UNREFERENCED_PARAMETER(rc);
 }

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -66,7 +66,7 @@ void LogicalDnsCluster::startResolve() {
             // TODO: The logical host is only used in /clusters admin output. We used to show
             //       the friendly DNS name in that output, but currently there is no way to
             //       express a DNS name inside of an Address::Instance. For now this is OK but
-            //       we might want to do better agan later.
+            //       we might want to do better again later.
             logical_host_.reset(
                 new LogicalHost(info_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -1,5 +1,6 @@
 #include "logical_dns_cluster.h"
 
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
 namespace Upstream {
@@ -20,8 +21,8 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
   }
 
   dns_url_ = hosts_json[0]->getString("url");
-  Network::Utility::hostFromUrl(dns_url_);
-  Network::Utility::portFromUrl(dns_url_);
+  Network::Utility::hostFromTcpUrl(dns_url_);
+  Network::Utility::portFromTcpUrl(dns_url_);
   startResolve();
 
   tls.set(tls_slot_, [](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectPtr {
@@ -36,29 +37,38 @@ LogicalDnsCluster::~LogicalDnsCluster() {
 }
 
 void LogicalDnsCluster::startResolve() {
-  std::string dns_address = Network::Utility::hostFromUrl(dns_url_);
+  std::string dns_address = Network::Utility::hostFromTcpUrl(dns_url_);
   log_debug("starting async DNS resolution for {}", dns_address);
   info_->stats().update_attempt_.inc();
 
   active_dns_query_ = &dns_resolver_.resolve(
-      dns_address, [this, dns_address](std::list<std::string>&& address_list) -> void {
+      dns_address,
+      [this, dns_address](std::list<Network::Address::InstancePtr>&& address_list) -> void {
         active_dns_query_ = nullptr;
         log_debug("async DNS resolution complete for {}", dns_address);
         info_->stats().update_success_.inc();
 
         if (!address_list.empty()) {
-          std::string url = Network::Utility::urlForTcp(address_list.front(),
-                                                        Network::Utility::portFromUrl(dns_url_));
-          if (url != current_resolved_url_) {
-            current_resolved_url_ = url;
+          // TODO: IPv6 support as well as moving port handling into the DNS interface.
+          Network::Address::InstancePtr new_address(
+              new Network::Address::Ipv4Instance(address_list.front()->ip()->addressAsString(),
+                                                 Network::Utility::portFromTcpUrl(dns_url_)));
+          if (!current_resolved_address_ || !(*new_address == *current_resolved_address_)) {
+            current_resolved_address_ = new_address;
             // Capture URL to avoid a race with another update.
-            tls_.runOnAllThreads([this, url]() -> void {
-              tls_.getTyped<PerThreadCurrentHostData>(tls_slot_).current_resolved_url_ = url;
+            tls_.runOnAllThreads([this, new_address]() -> void {
+              tls_.getTyped<PerThreadCurrentHostData>(tls_slot_).current_resolved_address_ =
+                  new_address;
             });
           }
 
           if (!logical_host_) {
-            logical_host_.reset(new LogicalHost(info_, dns_url_, *this));
+            // TODO: The logical host is only used in /clusters admin output. We used to show
+            //       the friendly DNS name in that output, but currently there is no way to
+            //       express a DNS name inside of an Address::Instance. For now this is OK but
+            //       we might want to do better agan later.
+            logical_host_.reset(
+                new LogicalHost(info_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());
             new_hosts->emplace_back(logical_host_);
             updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
@@ -79,10 +89,10 @@ Upstream::Host::CreateConnectionData
 LogicalDnsCluster::LogicalHost::createConnection(Event::Dispatcher& dispatcher) const {
   PerThreadCurrentHostData& data =
       parent_.tls_.getTyped<PerThreadCurrentHostData>(parent_.tls_slot_);
-  ASSERT(!data.current_resolved_url_.empty());
-  return {
-      HostImpl::createConnection(dispatcher, *parent_.info_, data.current_resolved_url_),
-      HostDescriptionPtr{new RealHostDescription(data.current_resolved_url_, shared_from_this())}};
+  ASSERT(data.current_resolved_address_);
+  return {HostImpl::createConnection(dispatcher, *parent_.info_, data.current_resolved_address_),
+          HostDescriptionPtr{
+              new RealHostDescription(data.current_resolved_address_, shared_from_this())}};
 }
 
 } // Upstream

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -38,8 +38,9 @@ public:
 
 private:
   struct LogicalHost : public HostImpl {
-    LogicalHost(ClusterInfoPtr cluster, const std::string& url, LogicalDnsCluster& parent)
-        : HostImpl(cluster, url, false, 1, ""), parent_(parent) {}
+    LogicalHost(ClusterInfoPtr cluster, Network::Address::InstancePtr address,
+                LogicalDnsCluster& parent)
+        : HostImpl(cluster, address, false, 1, ""), parent_(parent) {}
 
     // Upstream::Host
     CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const override;
@@ -48,8 +49,8 @@ private:
   };
 
   struct RealHostDescription : public HostDescription {
-    RealHostDescription(const std::string& url, ConstHostPtr logical_host)
-        : url_(url), logical_host_(logical_host) {}
+    RealHostDescription(Network::Address::InstancePtr address, ConstHostPtr logical_host)
+        : address_(address), logical_host_(logical_host) {}
 
     // Upstream:HostDescription
     bool canary() const override { return false; }
@@ -58,10 +59,10 @@ private:
       return logical_host_->outlierDetector();
     }
     const HostStats& stats() const override { return logical_host_->stats(); }
-    const std::string& url() const override { return url_; }
+    Network::Address::InstancePtr address() const override { return address_; }
     const std::string& zone() const override { return EMPTY_STRING; }
 
-    const std::string url_;
+    Network::Address::InstancePtr address_;
     ConstHostPtr logical_host_;
   };
 
@@ -69,7 +70,7 @@ private:
     // ThreadLocal::ThreadLocalObject
     void shutdown() override {}
 
-    std::string current_resolved_url_;
+    Network::Address::InstancePtr current_resolved_address_;
   };
 
   void startResolve();
@@ -81,7 +82,7 @@ private:
   std::function<void()> initialize_callback_;
   Event::TimerPtr resolve_timer_;
   std::string dns_url_;
-  std::string current_resolved_url_;
+  Network::Address::InstancePtr current_resolved_address_;
   HostPtr logical_host_;
   Network::ActiveDnsQuery* active_dns_query_{};
 };

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -224,7 +224,7 @@ void EventLoggerImpl::logEject(HostDescriptionPtr host, EjectionType type) {
 
   file_->write(fmt::format(json,
                            AccessLogDateTimeFormatter::fromTime(time_source_.currentSystemTime()),
-                           host->cluster().name(), host->url(), typeToString(type),
+                           host->cluster().name(), host->address()->asString(), typeToString(type),
                            host->outlierDetector().numEjections()));
 }
 
@@ -241,9 +241,9 @@ void EventLoggerImpl::logUneject(HostDescriptionPtr host) {
     "}}\n";
   // clang-format on
 
-  file_->write(
-      fmt::format(json, AccessLogDateTimeFormatter::fromTime(time_source_.currentSystemTime()),
-                  host->cluster().name(), host->url(), host->outlierDetector().numEjections()));
+  file_->write(fmt::format(
+      json, AccessLogDateTimeFormatter::fromTime(time_source_.currentSystemTime()),
+      host->cluster().name(), host->address()->asString(), host->outlierDetector().numEjections()));
 }
 
 std::string EventLoggerImpl::typeToString(EjectionType type) {

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -1,6 +1,7 @@
 #include "sds.h"
 
 #include "common/http/headers.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
 namespace Upstream {
@@ -28,9 +29,10 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
       zone = host->getObject("tags")->getString("az", zone);
     }
 
-    new_hosts.emplace_back(new HostImpl(
-        info_, Network::Utility::urlForTcp(host->getString("ip_address"), host->getInteger("port")),
-        canary, weight, zone));
+    new_hosts.emplace_back(
+        new HostImpl(info_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+                                host->getString("ip_address"), host->getInteger("port"))},
+                     canary, weight, zone));
   }
 
   HostVectorPtr current_hosts_copy(new std::vector<HostPtr>(hosts()));

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -13,6 +13,7 @@
 #include "common/common/utility.h"
 #include "common/http/utility.h"
 #include "common/json/json_loader.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 #include "common/ssl/connection_impl.h"
 #include "common/ssl/context_config_impl.h"
@@ -22,17 +23,17 @@ namespace Upstream {
 Outlier::DetectorHostSinkNullImpl HostDescriptionImpl::null_outlier_detector_;
 
 Host::CreateConnectionData HostImpl::createConnection(Event::Dispatcher& dispatcher) const {
-  return {createConnection(dispatcher, *cluster_, url_), shared_from_this()};
+  return {createConnection(dispatcher, *cluster_, address_), shared_from_this()};
 }
 
 Network::ClientConnectionPtr HostImpl::createConnection(Event::Dispatcher& dispatcher,
                                                         const ClusterInfo& cluster,
-                                                        const std::string& url) {
+                                                        Network::Address::InstancePtr address) {
   if (cluster.sslContext()) {
     return Network::ClientConnectionPtr{
-        dispatcher.createSslClientConnection(*cluster.sslContext(), url)};
+        dispatcher.createSslClientConnection(*cluster.sslContext(), address)};
   } else {
-    return Network::ClientConnectionPtr{dispatcher.createClientConnection(url)};
+    return Network::ClientConnectionPtr{dispatcher.createClientConnection(address)};
   }
 }
 
@@ -260,10 +261,8 @@ StaticClusterImpl::StaticClusterImpl(const Json::Object& config, Runtime::Loader
   std::vector<Json::ObjectPtr> hosts_json = config.getObjectArray("hosts");
   HostVectorPtr new_hosts(new std::vector<HostPtr>());
   for (Json::ObjectPtr& host : hosts_json) {
-    std::string url = host->getString("url");
-    // resolve the URL to make sure it's valid
-    Network::Utility::resolve(url);
-    new_hosts->emplace_back(HostPtr{new HostImpl(info_, url, false, 1, "")});
+    new_hosts->emplace_back(HostPtr{
+        new HostImpl(info_, Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
   }
 
   updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
@@ -286,7 +285,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostPtr>& n
     for (auto i = current_hosts.begin(); i != current_hosts.end();) {
       // If we find a host matched based on URL, we keep it. However we do change weight inline so
       // do that here.
-      if ((*i)->url() == host->url()) {
+      if (*(*i)->address() == *host->address()) {
         if (host->weight() > max_host_weight) {
           max_host_weight = host->weight();
         }
@@ -375,8 +374,8 @@ void StrictDnsClusterImpl::updateAllHosts(const std::vector<HostPtr>& hosts_adde
 StrictDnsClusterImpl::ResolveTarget::ResolveTarget(StrictDnsClusterImpl& parent,
                                                    Event::Dispatcher& dispatcher,
                                                    const std::string& url)
-    : parent_(parent), dns_address_(Network::Utility::hostFromUrl(url)),
-      port_(Network::Utility::portFromUrl(url)),
+    : parent_(parent), dns_address_(Network::Utility::hostFromTcpUrl(url)),
+      port_(Network::Utility::portFromTcpUrl(url)),
       resolve_timer_(dispatcher.createTimer([this]() -> void { startResolve(); })) {
 
   startResolve();
@@ -393,15 +392,21 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
   parent_.info_->stats().update_attempt_.inc();
 
   active_query_ = &parent_.dns_resolver_.resolve(
-      dns_address_, [this](std::list<std::string>&& address_list) -> void {
+      dns_address_, [this](std::list<Network::Address::InstancePtr>&& address_list) -> void {
         active_query_ = nullptr;
         log_debug("async DNS resolution complete for {}", dns_address_);
         parent_.info_->stats().update_success_.inc();
 
         std::vector<HostPtr> new_hosts;
-        for (const std::string& address : address_list) {
+        for (Network::Address::InstancePtr address : address_list) {
+          // TODO: Currently the DNS interface does not consider port. We need to make a new
+          //       address that has port in it. We need to both support IPv6 as well as potentially
+          //       move port handling into the DNS interface itself, which would work better for
+          //       SRV.
           new_hosts.emplace_back(new HostImpl(
-              parent_.info_, Network::Utility::urlForTcp(address, port_), false, 1, ""));
+              parent_.info_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+                                 address->ip()->addressAsString(), port_)},
+              false, 1, ""));
         }
 
         std::vector<HostPtr> hosts_added;
@@ -422,17 +427,6 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
 
         resolve_timer_->enableTimer(parent_.dns_refresh_rate_ms_);
       });
-}
-
-void HostDescriptionImpl::checkUrl() {
-  if (url_.find(Network::Utility::TCP_SCHEME) == 0) {
-    Network::Utility::hostFromUrl(url_);
-    Network::Utility::portFromUrl(url_);
-  } else if (url_.find(Network::Utility::UNIX_SCHEME) == 0) {
-    Network::Utility::pathFromUrl(url_);
-  } else {
-    throw EnvoyException(fmt::format("malformed url: {}", url_));
-  }
 }
 
 } // Upstream

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -184,8 +184,8 @@ HttpFilterType HttpConnectionManagerConfig::stringToType(const std::string& type
   }
 }
 
-const std::string& HttpConnectionManagerConfig::localAddress() {
-  return server_.localInfo().address();
+const Network::Address::Instance& HttpConnectionManagerConfig::localAddress() {
+  return *server_.localInfo().address();
 }
 
 } // Configuration

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -89,7 +89,7 @@ public:
   const Optional<Http::TracingConnectionManagerConfig>& tracingConfig() override {
     return tracing_config_;
   }
-  const std::string& localAddress() override;
+  const Network::Address::Instance& localAddress() override;
   const Optional<std::string>& userAgent() override { return user_agent_; }
 
   static void registerHttpFilterConfigFactory(HttpFilterConfigFactory& factory) {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -23,7 +23,7 @@ void ConnectionHandlerImpl::addListener(Network::FilterChainFactory& factory,
                                         bool use_proxy_proto, bool use_orig_dst) {
   ActiveListenerPtr l(
       new ActiveListener(*this, socket, factory, bind_to_port, use_proxy_proto, use_orig_dst));
-  listeners_.insert(std::make_pair(socket.name(), std::move(l)));
+  listeners_.insert(std::make_pair(socket.localAddress()->asString(), std::move(l)));
 }
 
 void ConnectionHandlerImpl::addSslListener(Network::FilterChainFactory& factory,
@@ -32,7 +32,7 @@ void ConnectionHandlerImpl::addSslListener(Network::FilterChainFactory& factory,
                                            bool use_proxy_proto, bool use_orig_dst) {
   ActiveListenerPtr l(new SslActiveListener(*this, ssl_ctx, socket, factory, bind_to_port,
                                             use_proxy_proto, use_orig_dst));
-  listeners_.insert(std::make_pair(socket.name(), std::move(l)));
+  listeners_.insert(std::make_pair(socket.localAddress()->asString(), std::move(l)));
 }
 
 void ConnectionHandlerImpl::closeConnections() {
@@ -64,7 +64,7 @@ ConnectionHandlerImpl::ActiveListener::ActiveListener(ConnectionHandlerImpl& par
     : ActiveListener(parent, parent.dispatcher_->createListener(parent, socket, *this,
                                                                 parent.stats_store_, bind_to_port,
                                                                 use_proxy_proto, use_orig_dst),
-                     factory, socket.name()) {}
+                     factory, socket.localAddress()->asString()) {}
 
 ConnectionHandlerImpl::ActiveListener::ActiveListener(ConnectionHandlerImpl& parent,
                                                       Network::ListenerPtr&& listener,
@@ -83,7 +83,7 @@ ConnectionHandlerImpl::SslActiveListener::SslActiveListener(ConnectionHandlerImp
     : ActiveListener(parent, parent.dispatcher_->createSslListener(
                                  parent, ssl_ctx, socket, *this, parent.stats_store_, bind_to_port,
                                  use_proxy_proto, use_orig_dst),
-                     factory, socket.name()) {}
+                     factory, socket.localAddress()->asString()) {}
 
 Network::Listener* ConnectionHandlerImpl::findListener(const std::string& socket_name) {
   auto l = listeners_.find(socket_name);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -135,17 +135,18 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
 
       for (auto stat : all_stats) {
         response.add(fmt::format("{}::{}::{}::{}\n", cluster.second.get().info()->name(),
-                                 host->url(), stat.first, stat.second));
+                                 host->address()->asString(), stat.first, stat.second));
       }
 
       response.add(fmt::format("{}::{}::health_flags::{}\n", cluster.second.get().info()->name(),
-                               host->url(), Upstream::HostUtility::healthFlagsToString(*host)));
+                               host->address()->asString(),
+                               Upstream::HostUtility::healthFlagsToString(*host)));
       response.add(fmt::format("{}::{}::weight::{}\n", cluster.second.get().info()->name(),
-                               host->url(), host->weight()));
+                               host->address()->asString(), host->weight()));
       response.add(fmt::format("{}::{}::zone::{}\n", cluster.second.get().info()->name(),
-                               host->url(), host->zone()));
+                               host->address()->asString(), host->zone()));
       response.add(fmt::format("{}::{}::canary::{}\n", cluster.second.get().info()->name(),
-                               host->url(), host->canary()));
+                               host->address()->asString(), host->canary()));
     }
   }
 
@@ -364,6 +365,8 @@ Http::Code AdminImpl::runCallback(const std::string& path, Buffer::Instance& res
   return code;
 }
 
-const std::string& AdminImpl::localAddress() { return server_.localInfo().address(); }
+const Network::Address::Instance& AdminImpl::localAddress() {
+  return *server_.localInfo().address();
+}
 
 } // Server

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -56,7 +56,7 @@ public:
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return true; }
-  const std::string& localAddress() override;
+  const Network::Address::Instance& localAddress() override;
   const Optional<std::string>& userAgent() override { return user_agent_; }
   const Optional<Http::TracingConnectionManagerConfig>& tracingConfig() override {
     return tracing_config_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -38,7 +38,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   }
   server_stats_.version_.set(version_int);
 
-  if (local_info_.address().empty()) {
+  if (!local_info_.address()) {
     throw EnvoyException("could not resolve local address");
   }
 
@@ -107,7 +107,8 @@ void InstanceImpl::flushStats() {
 
 int InstanceImpl::getListenSocketFd(uint32_t port) {
   for (const auto& entry : socket_map_) {
-    if (entry.second->port() == port) {
+    // TODO: UDS listeners.
+    if (entry.second->localAddress()->ip()->port() == port) {
       return entry.second->fd();
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(envoy-test
   common/mongo/codec_impl_test.cc
   common/mongo/proxy_test.cc
   common/mongo/utility_test.cc
+  common/network/address_impl_test.cc
   common/network/connection_impl_test.cc
   common/network/dns_impl_test.cc
   common/network/filter_manager_impl_test.cc

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -1,5 +1,6 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/filter/tcp_proxy.h"
+#include "common/network/address_impl.h"
 #include "common/stats/stats_impl.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -12,7 +13,7 @@
 using testing::_;
 using testing::NiceMock;
 using testing::Return;
-using testing::ReturnRefOfCopy;
+using testing::ReturnRef;
 using testing::SaveArg;
 
 namespace Filter {
@@ -125,138 +126,138 @@ TEST(TcpProxyConfigTest, Routes) {
   {
     // hit route with destination_ip (10.10.10.10/32)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.10.10.10:0")));
+    Network::Address::Ipv4Instance local_address("10.10.10.10");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.10.10.11:0")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:0")));
+    Network::Address::Ipv4Instance local_address("10.10.10.11");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0");
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.10.11.0/24)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.10.11.11:0")));
+    Network::Address::Ipv4Instance local_address("10.10.11.11");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.10.12.12:0")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:0")));
+    Network::Address::Ipv4Instance local_address("10.10.12.12");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0");
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.11.0.0/16)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.11.11.11:0")));
+    Network::Address::Ipv4Instance local_address("10.11.11.11");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.12.12.12:0")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:0")));
+    Network::Address::Ipv4Instance local_address("10.12.12.12");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0");
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (11.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://11.11.11.11:0")));
+    Network::Address::Ipv4Instance local_address("11.11.11.11");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://12.12.12.12:0")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:0")));
+    Network::Address::Ipv4Instance local_address("12.12.12.12");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0");
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (128.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://128.255.255.255:0")));
+    Network::Address::Ipv4Instance local_address("128.255.255.255");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination port range
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:12345")));
+    Network::Address::Ipv4Instance local_address("1.2.3.4", 12345);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_EQ(std::string("with_destination_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:23456")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:0")));
+    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0");
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with source port range
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:23456")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:23459")));
+    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0", 23459);
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("with_source_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:23456")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://0.0.0.0:23458")));
+    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("0.0.0.0", 23458);
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit the route with all criterias present
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.0.0.0:10000")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://20.0.0.0:20000")));
+    Network::Address::Ipv4Instance local_address("10.0.0.0", 10000);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("20.0.0.0", 20000);
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("with_everything"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://10.0.0.0:10000")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://30.0.0.0:20000")));
+    Network::Address::Ipv4Instance local_address("10.0.0.0", 10000);
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    Network::Address::Ipv4Instance remote_address("30.0.0.0", 20000);
+    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 }
@@ -310,8 +311,9 @@ public:
       upstream_connection_ = new NiceMock<Network::MockClientConnection>();
       Upstream::MockHost::MockCreateConnectionData conn_info;
       conn_info.connection_ = upstream_connection_;
-      conn_info.host_.reset(new Upstream::HostImpl(cluster_manager_.cluster_.info_,
-                                                   "tcp://127.0.0.1:80", false, 1, ""));
+      conn_info.host_.reset(
+          new Upstream::HostImpl(cluster_manager_.cluster_.info_,
+                                 Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
       EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
       EXPECT_CALL(*upstream_connection_, addReadFilter(_))
           .WillOnce(SaveArg<0>(&upstream_read_filter_));
@@ -489,8 +491,8 @@ TEST_F(TcpProxyRoutingTest, NonRoutableConnection) {
   setup();
 
   // port 10000 is outside the specified destination port range
-  EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:10000")));
+  Network::Address::Ipv4Instance local_address("1.2.3.4", 10000);
+  EXPECT_CALL(connection_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
   // getRouteFromEntries() returns an empty string if no route matches
   EXPECT_CALL(cluster_manager_, get("")).WillRepeatedly(Return(nullptr));
@@ -510,8 +512,8 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
   setup();
 
   // port 9999 is within the specified destination port range
-  EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(ReturnRefOfCopy(std::string("tcp://1.2.3.4:9999")));
+  Network::Address::Ipv4Instance local_address("1.2.3.4", 9999);
+  EXPECT_CALL(connection_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
   // Expect filter to try to open a connection to specified cluster
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster"));

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -129,9 +129,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
-    const std::string host_url = "name";
-    EXPECT_CALL(*request_info.host_, url()).WillOnce(ReturnRef(host_url));
-    EXPECT_EQ("name", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("10.0.0.1:443", upstream_format.format(header, header, request_info));
   }
 
   {

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -5,6 +5,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
+#include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/runtime/uuid_util.h"
 #include "common/stats/stats_impl.h"
@@ -138,8 +139,8 @@ TEST_F(AccessLogImplTest, NoFilter) {
 
 TEST_F(AccessLogImplTest, UpstreamHost) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new Upstream::MockClusterInfo()};
-  request_info_.upstream_host_ =
-      std::make_shared<Upstream::HostDescriptionImpl>(cluster, "tcp://10.0.0.5:1234", false, "");
+  request_info_.upstream_host_ = std::make_shared<Upstream::HostDescriptionImpl>(
+      cluster, Network::Utility::resolveUrl("tcp://10.0.0.5:1234"), false, "");
 
   std::string json = R"EOF(
       {
@@ -153,7 +154,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
   EXPECT_CALL(*file_, write(_));
   log->log(&request_headers_, &response_headers_, request_info_);
   EXPECT_EQ("[1900-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
-            "\"tcp://10.0.0.5:1234\"\n",
+            "\"10.0.0.5:1234\"\n",
             output_);
 }
 

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -1,6 +1,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/http/codec_client.h"
 #include "common/http/exception.h"
+#include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
@@ -47,8 +48,8 @@ public:
   Network::ConnectionCallbacks* connection_cb_;
   Network::ReadFilterPtr filter_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
-  Upstream::HostDescriptionPtr host_{
-      new Upstream::HostDescriptionImpl(cluster_, "tcp://127.0.0.1:80", false, "")};
+  Upstream::HostDescriptionPtr host_{new Upstream::HostDescriptionImpl(
+      cluster_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
 };
 
 TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1,5 +1,6 @@
 #include "common/http/conn_manager_utility.h"
 #include "common/http/headers.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/runtime/uuid_util.h"
@@ -47,7 +48,7 @@ TEST_F(ConnectionManagerUtilityTest, generateStreamId) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddress) {
-  const std::string not_local_host_remote_address = "tcp://12.12.12.12:0";
+  Network::Address::Ipv4Instance not_local_host_remote_address("12.12.12.12");
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress())
       .WillRepeatedly(ReturnRef(not_local_host_remote_address));
@@ -56,13 +57,13 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddre
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(Network::Utility::hostFromUrl(not_local_host_remote_address),
+  EXPECT_EQ(not_local_host_remote_address.ip()->addressAsString(),
             headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) {
-  const std::string local_host_remote_address = "tcp://127.0.0.1:0";
-  const std::string local_address = "10.3.2.1";
+  Network::Address::Ipv4Instance local_host_remote_address("127.0.0.1");
+  Network::Address::Ipv4Instance local_address("10.3.2.1");
 
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_host_remote_address));
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
@@ -72,11 +73,11 @@ TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) 
   ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_, runtime_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(local_address, headers.get_(Headers::get().ForwardedFor));
+  EXPECT_EQ(local_address.ip()->addressAsString(), headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
-  const std::string internal_remote_address = "tcp://10.0.0.1:0";
+  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
@@ -90,7 +91,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
-  const std::string internal_remote_address = "tcp://10.0.0.1:0";
+  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
@@ -105,17 +106,14 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
-  const std::string external_remote_address = "34.0.0.1";
-  const std::string internal_remote_address = "10.0.0.1";
   const std::string uuid = "f4dca0a9-12c7-4307-8002-969403baf480";
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
   {
     // Internal request, make traceable
-    TestHeaderMapImpl headers{{"x-forwarded-for", internal_remote_address},
-                              {"x-request-id", uuid},
-                              {"x-envoy-force-trace", "true"}};
+    TestHeaderMapImpl headers{
+        {"x-forwarded-for", "10.0.0.1"}, {"x-request-id", uuid}, {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
@@ -126,9 +124,8 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 
   {
     // Not internal request, force trace header should be cleaned.
-    TestHeaderMapImpl headers{{"x-forwarded-for", external_remote_address},
-                              {"x-request-id", uuid},
-                              {"x-envoy-force-trace", "true"}};
+    TestHeaderMapImpl headers{
+        {"x-forwarded-for", "34.0.0.1"}, {"x-request-id", uuid}, {"x-envoy-force-trace", "true"}};
     EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
     ConnectionManagerUtility::mutateRequestHeaders(headers, connection_, config_, random_,
@@ -139,7 +136,7 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownstream) {
-  const std::string external_remote_address = "tcp://34.0.0.1:0";
+  Network::Address::Ipv4Instance external_remote_address("34.0.0.1");
   const std::string generated_uuid = "f4dca0a9-12c7-4307-8002-969403baf480";
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
@@ -210,7 +207,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalRequestPreserveRequestIdAndDownstre
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
-  const std::string internal_remote_address = "tcp://10.0.0.1:0";
+  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
@@ -225,7 +222,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
-  const std::string internal_remote_address = "tcp://10.0.0.1:0";
+  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
@@ -265,7 +262,7 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternalRequest) {
-  std::string local_remote_address = "tcp://10.0.0.1:0";
+  Network::Address::Ipv4Instance local_remote_address("10.0.0.1");
   EXPECT_CALL(config_, useRemoteAddress()).WillOnce(Return(true));
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_remote_address));
 
@@ -277,7 +274,7 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
 }
 
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
-  std::string external_ip = "tcp://134.2.2.11:0";
+  Network::Address::Ipv4Instance external_ip("134.2.2.11");
   EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(external_ip));
   TestHeaderMapImpl headers{{"x-request-id", "original"}};
 
@@ -289,8 +286,8 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
-  ON_CALL(connection_, remoteAddress())
-      .WillByDefault(ReturnRefOfCopy(std::string("tcp://50.0.0.1:0")));
+  Network::Address::Ipv4Instance external_ip("50.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   config_.route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
@@ -313,8 +310,8 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote) {
-  ON_CALL(connection_, remoteAddress())
-      .WillByDefault(ReturnRefOfCopy(std::string("tcp://50.0.0.1:0")));
+  Network::Address::Ipv4Instance external_ip("60.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
@@ -326,8 +323,8 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
-  ON_CALL(connection_, remoteAddress())
-      .WillByDefault(ReturnRefOfCopy(std::string("tcp://10.0.0.1:0")));
+  Network::Address::Ipv4Instance local_remote_address("10.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(local_remote_address));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -1,6 +1,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/http/codec_client.h"
 #include "common/http/http1/conn_pool.h"
+#include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
@@ -30,7 +31,8 @@ class ConnPoolImplForTest : public ConnPoolImpl {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::ClusterInfoPtr cluster)
       : ConnPoolImpl(dispatcher, Upstream::HostPtr{new Upstream::HostImpl(
-                                     cluster, "tcp://127.0.0.1:9000", false, 1, "")},
+                                     cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:9000"),
+                                     false, 1, "")},
                      Upstream::ResourcePriority::Default),
         mock_dispatcher_(dispatcher) {}
 

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1,4 +1,5 @@
 #include "common/http/http2/conn_pool.h"
+#include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
@@ -86,7 +87,8 @@ public:
 
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
-  Upstream::HostPtr host_{new Upstream::HostImpl(cluster_, "tcp://127.0.0.1:80", false, 1, "")};
+  Upstream::HostPtr host_{new Upstream::HostImpl(
+      cluster_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")};
   TestConnPoolImpl pool_;
   std::vector<TestCodecClient> test_clients_;
   NiceMock<Runtime::MockLoader> runtime_;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -1,6 +1,7 @@
 #include "common/http/exception.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/utility.h"
+#include "common/network/address_impl.h"
 
 #include "test/test_common/utility.h"
 
@@ -54,13 +55,15 @@ TEST(HttpUtility, isInternalRequest) {
 TEST(HttpUtility, appendXff) {
   {
     TestHeaderMapImpl headers;
-    Utility::appendXff(headers, "127.0.0.1");
+    Network::Address::Ipv4Instance address("127.0.0.1");
+    Utility::appendXff(headers, address);
     EXPECT_EQ("127.0.0.1", headers.get_("x-forwarded-for"));
   }
 
   {
     TestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
-    Utility::appendXff(headers, "127.0.0.1");
+    Network::Address::Ipv4Instance address("127.0.0.1");
+    Utility::appendXff(headers, address);
     EXPECT_EQ("10.0.0.1, 127.0.0.1", headers.get_("x-forwarded-for"));
   }
 }

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -1,0 +1,27 @@
+#include "envoy/common/exception.h"
+
+#include "common/network/address_impl.h"
+
+namespace Network {
+namespace Address {
+
+TEST(Ipv4InstanceTest, Basic) {
+  Ipv4Instance address("127.0.0.1", 80);
+  EXPECT_EQ("127.0.0.1:80", address.asString());
+  EXPECT_EQ(Type::Ip, address.type());
+  EXPECT_EQ("127.0.0.1", address.ip()->addressAsString());
+  EXPECT_EQ(80U, address.ip()->port());
+  EXPECT_EQ(IpVersion::v4, address.ip()->version());
+}
+
+TEST(Ipv4InstanceTest, BadAddress) { EXPECT_THROW(Ipv4Instance("foo"), EnvoyException); }
+
+TEST(PipeInstanceTest, Basic) {
+  PipeInstance address("/foo");
+  EXPECT_EQ("/foo", address.asString());
+  EXPECT_EQ(Type::Pipe, address.type());
+  EXPECT_EQ(nullptr, address.ip());
+}
+
+} // Address
+} // Network

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -5,27 +5,36 @@
 
 namespace Network {
 
+static bool hasAddress(const std::list<Address::InstancePtr>& results, const std::string& address) {
+  for (auto result : results) {
+    if (result->ip()->addressAsString() == address) {
+      return true;
+    }
+  }
+  return false;
+}
+
 TEST(DnsImplTest, LocalAsyncLookup) {
   Api::Impl api(std::chrono::milliseconds(10000));
   Event::DispatcherPtr dispatcher = api.allocateDispatcher();
   DnsResolverPtr resolver = dispatcher->createDnsResolver();
 
-  std::list<std::string> address_list;
-  resolver->resolve("", [&](std::list<std::string>&& results) -> void {
+  std::list<Address::InstancePtr> address_list;
+  resolver->resolve("", [&](std::list<Address::InstancePtr>&& results) -> void {
     address_list = results;
     dispatcher->exit();
   });
 
   dispatcher->run(Event::Dispatcher::RunType::Block);
-  EXPECT_THAT(std::list<std::string>{}, testing::ContainerEq(address_list));
+  EXPECT_TRUE(address_list.empty());
 
-  resolver->resolve("localhost", [&](std::list<std::string>&& results) -> void {
+  resolver->resolve("localhost", [&](std::list<Address::InstancePtr>&& results) -> void {
     address_list = results;
     dispatcher->exit();
   });
 
   dispatcher->run(Event::Dispatcher::RunType::Block);
-  EXPECT_THAT(address_list, testing::Contains("127.0.0.1"));
+  EXPECT_TRUE(hasAddress(address_list, "127.0.0.1"));
 }
 
 TEST(DnsImplTest, Cancel) {
@@ -40,17 +49,17 @@ TEST(DnsImplTest, Cancel) {
   });
 
   ActiveDnsQuery& query =
-      resolver->resolve("localhost", [](std::list<std::string> && ) -> void { FAIL(); });
+      resolver->resolve("localhost", [](std::list<Address::InstancePtr> && ) -> void { FAIL(); });
 
-  std::list<std::string> address_list;
-  resolver->resolve("localhost", [&](std::list<std::string>&& results) -> void {
+  std::list<Address::InstancePtr> address_list;
+  resolver->resolve("localhost", [&](std::list<Address::InstancePtr>&& results) -> void {
     address_list = results;
     stop_timer->enableTimer(std::chrono::milliseconds(250));
   });
 
   query.cancel();
   dispatcher->run(Event::Dispatcher::RunType::Block);
-  EXPECT_THAT(address_list, testing::Contains("127.0.0.1"));
+  EXPECT_TRUE(hasAddress(address_list, "127.0.0.1"));
 }
 
 } // Network

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -35,7 +35,7 @@ public:
   LocalMockFilter(const Upstream::HostDescription* host) : host_(host) {}
   ~LocalMockFilter() {
     // Make sure the upstream host is still valid in the filter destructor.
-    callbacks_->upstreamHost()->url();
+    callbacks_->upstreamHost()->address();
   }
 
 private:
@@ -152,8 +152,8 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = upstream_connection;
-  conn_info.host_.reset(
-      new Upstream::HostImpl(cm.cluster_.info_, "tcp://127.0.0.1:80", false, 1, ""));
+  conn_info.host_.reset(new Upstream::HostImpl(
+      cm.cluster_.info_, Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
   EXPECT_CALL(cm, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -7,12 +7,12 @@ namespace Network {
 TEST(ListenSocket, All) {
   TcpListenSocket socket1(uint32_t(15000), true);
   listen(socket1.fd(), 0);
-  EXPECT_EQ(15000U, socket1.port());
+  EXPECT_EQ(15000U, socket1.localAddress()->ip()->port());
 
   EXPECT_THROW(Network::TcpListenSocket socket2(uint32_t(15000), true), EnvoyException);
 
   TcpListenSocket socket2(dup(socket1.fd()), 15000);
-  EXPECT_EQ(15000U, socket2.port());
+  EXPECT_EQ(15000U, socket2.localAddress()->ip()->port());
 }
 
 } // Network

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -1,4 +1,6 @@
 #include "common/network/listener_impl.h"
+#include "common/network/address_impl.h"
+#include "common/network/utility.h"
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/network/mocks.h"
@@ -22,7 +24,7 @@ static void errorCallbackTest() {
       connection_handler, socket, listener_callbacks, stats_store, true, false, false);
 
   Network::ClientConnectionPtr client_connection =
-      dispatcher.createClientConnection("tcp://127.0.0.1:10000");
+      dispatcher.createClientConnection(Utility::resolveUrl("tcp://127.0.0.1:10000"));
   client_connection->connect();
 
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
@@ -45,22 +47,18 @@ public:
                    ListenSocket& socket, ListenerCallbacks& cb, Stats::Store& stats_store,
                    bool bind_to_port, bool use_proxy_proto, bool use_orig_dst)
       : ListenerImpl(conn_handler, dispatcher, socket, cb, stats_store, bind_to_port,
-                     use_proxy_proto, use_orig_dst) {}
-  ~TestListenerImpl() {}
+                     use_proxy_proto, use_orig_dst) {
+    ON_CALL(*this, newConnection(_, _, _))
+        .WillByDefault(Invoke(
+            [this](int fd, Address::InstancePtr remote_address, Address::InstancePtr local_address)
+                -> void { ListenerImpl::newConnection(fd, remote_address, local_address); }
 
-  MOCK_METHOD1(getAddressPort_, uint16_t(sockaddr*));
-  MOCK_METHOD3(newConnection_, void(int, sockaddr*, sockaddr*));
-
-  void newConnection(int fd, sockaddr* remote_addr, sockaddr* local_addr) override {
-    newConnection_(fd, remote_addr, local_addr);
-  }
-  void newConnection(int fd, const std::string& remote_addr,
-                     const std::string& local_addr) override {
-    ListenerImpl::newConnection(fd, remote_addr, local_addr);
+            ));
   }
 
-protected:
-  uint16_t getAddressPort(sockaddr* sock) override { return getAddressPort_(sock); }
+  MOCK_METHOD1(getOriginalDst, Address::InstancePtr(int fd));
+  MOCK_METHOD3(newConnection, void(int fd, Address::InstancePtr remote_address,
+                                   Address::InstancePtr local_address));
 };
 
 TEST(ListenerImplTest, UseOriginalDst) {
@@ -76,16 +74,17 @@ TEST(ListenerImplTest, UseOriginalDst) {
                                         listener_callbacks, stats_store, false, false, false);
 
   Network::ClientConnectionPtr client_connection =
-      dispatcher.createClientConnection("tcp://127.0.0.1:10000");
+      dispatcher.createClientConnection(Utility::resolveUrl("tcp://127.0.0.1:10000"));
   client_connection->connect();
 
-  EXPECT_CALL(listener, getAddressPort_(_)).WillRepeatedly(Return(10001));
-  EXPECT_CALL(connection_handler, findListener("10001")).WillRepeatedly(Return(&listenerDst));
+  Address::InstancePtr alt_address(new Address::Ipv4Instance("127.0.0.1", 10001));
+  EXPECT_CALL(listener, getOriginalDst(_)).WillRepeatedly(Return(alt_address));
+  EXPECT_CALL(connection_handler, findListener("127.0.0.1:10001"))
+      .WillRepeatedly(Return(&listenerDst));
 
-  EXPECT_CALL(listener, newConnection_(_, _, _)).Times(0);
-  EXPECT_CALL(listenerDst, newConnection_(_, _, _))
-      .Times(1)
-      .WillOnce(Invoke([&](int, sockaddr*, sockaddr*) -> void {
+  EXPECT_CALL(listener, newConnection(_, _, _)).Times(0);
+  EXPECT_CALL(listenerDst, newConnection(_, _, _))
+      .WillOnce(Invoke([&](int, Address::InstancePtr, Address::InstancePtr) -> void {
         client_connection->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
       }));

--- a/test/common/network/proxy_protocol_test.cc
+++ b/test/common/network/proxy_protocol_test.cc
@@ -19,7 +19,7 @@ public:
   ProxyProtocolTest()
       : socket_(uint32_t(1234), true), listener_(connection_handler_, dispatcher_, socket_,
                                                  callbacks_, stats_store_, true, true, false) {
-    conn_ = dispatcher_.createClientConnection("tcp://127.0.0.1:1234");
+    conn_ = dispatcher_.createClientConnection(Utility::resolveUrl("tcp://127.0.0.1:1234"));
     conn_->addConnectionCallbacks(connection_callbacks_);
     conn_->connect();
   }
@@ -48,7 +48,7 @@ TEST_F(ProxyProtocolTest, Basic) {
 
   EXPECT_CALL(callbacks_, onNewConnection_(_))
       .WillOnce(Invoke([&](ConnectionPtr& conn) -> void {
-        ASSERT_EQ("1.2.3.4", Network::Utility::hostFromUrl(conn->remoteAddress()));
+        ASSERT_EQ("1.2.3.4", conn->remoteAddress().ip()->addressAsString());
         conn->addReadFilter(read_filter_);
         accepted_connection = std::move(conn);
       }));
@@ -72,7 +72,7 @@ TEST_F(ProxyProtocolTest, Fragmented) {
 
   EXPECT_CALL(callbacks_, onNewConnection_(_))
       .WillOnce(Invoke([&](ConnectionPtr& conn) -> void {
-        ASSERT_EQ("255.255.255.255", Network::Utility::hostFromUrl(conn->remoteAddress()));
+        ASSERT_EQ("255.255.255.255", conn->remoteAddress().ip()->addressAsString());
         read_filter_.reset(new MockReadFilter());
         conn->addReadFilter(read_filter_);
         conn->close(ConnectionCloseType::NoFlush);
@@ -88,7 +88,7 @@ TEST_F(ProxyProtocolTest, PartialRead) {
 
   EXPECT_CALL(callbacks_, onNewConnection_(_))
       .WillOnce(Invoke([&](ConnectionPtr& conn) -> void {
-        ASSERT_EQ("255.255.255.255", Network::Utility::hostFromUrl(conn->remoteAddress()));
+        ASSERT_EQ("255.255.255.255", conn->remoteAddress().ip()->addressAsString());
         read_filter_.reset(new MockReadFilter());
         conn->addReadFilter(read_filter_);
         conn->close(ConnectionCloseType::NoFlush);

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/common/exception.h"
 
+#include "common/json/json_loader.h"
+#include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
 namespace Network {
@@ -64,23 +66,23 @@ TEST(IpListTest, Normal) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   IpList wl(*loader, "ip_white_list");
 
-  EXPECT_TRUE(wl.contains("192.168.3.0"));
-  EXPECT_TRUE(wl.contains("192.168.3.3"));
-  EXPECT_TRUE(wl.contains("192.168.3.255"));
-  EXPECT_FALSE(wl.contains("192.168.2.255"));
-  EXPECT_FALSE(wl.contains("192.168.4.0"));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.0")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.3")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.255")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("192.168.2.255")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("192.168.4.0")));
 
-  EXPECT_TRUE(wl.contains("50.1.2.3"));
-  EXPECT_FALSE(wl.contains("50.1.2.2"));
-  EXPECT_FALSE(wl.contains("50.1.2.4"));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("50.1.2.3")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("50.1.2.2")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("50.1.2.4")));
 
-  EXPECT_TRUE(wl.contains("10.15.0.0"));
-  EXPECT_TRUE(wl.contains("10.15.90.90"));
-  EXPECT_TRUE(wl.contains("10.15.255.255"));
-  EXPECT_FALSE(wl.contains("10.14.255.255"));
-  EXPECT_FALSE(wl.contains("10.16.0.0"));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("10.15.0.0")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("10.15.90.90")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("10.15.255.255")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("10.14.255.255")));
+  EXPECT_FALSE(wl.contains(Address::Ipv4Instance("10.16.0.0")));
 
-  EXPECT_FALSE(wl.contains(""));
+  EXPECT_FALSE(wl.contains(Address::PipeInstance("foo")));
 }
 
 TEST(IpListTest, MatchAny) {
@@ -95,46 +97,39 @@ TEST(IpListTest, MatchAny) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   IpList wl(*loader, "ip_white_list");
 
-  EXPECT_TRUE(wl.contains("192.168.3.3"));
-  EXPECT_TRUE(wl.contains("192.168.3.0"));
-  EXPECT_TRUE(wl.contains("192.168.3.255"));
-  EXPECT_TRUE(wl.contains("192.168.0.0"));
-  EXPECT_TRUE(wl.contains("192.0.0.0"));
-  EXPECT_TRUE(wl.contains("1.1.1.1"));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.3")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.0")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.255")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.0.0")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.0.0.0")));
+  EXPECT_TRUE(wl.contains(Address::Ipv4Instance("1.1.1.1")));
 
-  EXPECT_FALSE(wl.contains(""));
-}
-
-TEST(NetworkUtility, NonNumericResolve) {
-  EXPECT_THROW(Utility::resolveTCP("localhost", 80), EnvoyException);
+  EXPECT_FALSE(wl.contains(Address::PipeInstance("foo")));
 }
 
 TEST(NetworkUtility, Url) {
-  EXPECT_EQ("foo", Utility::hostFromUrl("tcp://foo:1234"));
-  EXPECT_EQ(1234U, Utility::portFromUrl("tcp://foo:1234"));
-  EXPECT_THROW(Utility::hostFromUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromUrl("abc://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUrl("abc://foo"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromUrl("tcp://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUrl("tcp://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUrl("tcp://foo:bar"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromUrl(""), EnvoyException);
+  EXPECT_EQ("foo", Utility::hostFromTcpUrl("tcp://foo:1234"));
+  EXPECT_EQ(1234U, Utility::portFromTcpUrl("tcp://foo:1234"));
+  EXPECT_THROW(Utility::hostFromTcpUrl("bogus://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("bogus://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("abc://foo"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("abc://foo"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("tcp://foo"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:bar"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
 }
 
-TEST(NetworkUtility, GetLocalAddress) {
-  std::string addr = Utility::getLocalAddress();
-  Utility::resolveTCP(addr, 80);
-}
+TEST(NetworkUtility, GetLocalAddress) { EXPECT_NE(nullptr, Utility::getLocalAddress()); }
 
 TEST(NetworkUtility, loopbackAddress) {
   {
-    std::string address = "127.0.0.1";
-    EXPECT_TRUE(Utility::isLoopbackAddress(address.c_str()));
+    Address::Ipv4Instance address("127.0.0.1");
+    EXPECT_TRUE(Utility::isLoopbackAddress(address));
   }
   {
-    std::string address = "10.0.0.1";
-    EXPECT_FALSE(Utility::isLoopbackAddress(address.c_str()));
+    Address::Ipv4Instance address("10.0.0.1");
+    EXPECT_FALSE(Utility::isLoopbackAddress(address));
   }
 }
 
@@ -170,14 +165,18 @@ TEST(PortRangeListTest, Errors) {
   }
 }
 
+static Address::Ipv4Instance makeFromPort(uint32_t port) {
+  return Address::Ipv4Instance("0.0.0.0", port);
+}
+
 TEST(PortRangeListTest, Normal) {
   {
     std::string port_range_str = "1";
     std::list<PortRange> port_range_list;
 
     Utility::parsePortRangeList(port_range_str, port_range_list);
-    EXPECT_TRUE(Utility::portInRangeList(1, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(2, port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(1), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(2), port_range_list));
   }
 
   {
@@ -185,12 +184,12 @@ TEST(PortRangeListTest, Normal) {
     std::list<PortRange> port_range_list;
 
     Utility::parsePortRangeList(port_range_str, port_range_list);
-    EXPECT_TRUE(Utility::portInRangeList(1024, port_range_list));
-    EXPECT_TRUE(Utility::portInRangeList(2048, port_range_list));
-    EXPECT_TRUE(Utility::portInRangeList(1536, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(1023, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(2049, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(0, port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(1024), port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(2048), port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(1536), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(1023), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(2049), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(0), port_range_list));
   }
 
   {
@@ -198,13 +197,13 @@ TEST(PortRangeListTest, Normal) {
     std::list<PortRange> port_range_list;
 
     Utility::parsePortRangeList(port_range_str, port_range_list);
-    EXPECT_TRUE(Utility::portInRangeList(1, port_range_list));
-    EXPECT_TRUE(Utility::portInRangeList(50, port_range_list));
-    EXPECT_TRUE(Utility::portInRangeList(5000, port_range_list));
-    EXPECT_TRUE(Utility::portInRangeList(65535, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(2, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(200, port_range_list));
-    EXPECT_FALSE(Utility::portInRangeList(20000, port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(1), port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(50), port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(5000), port_range_list));
+    EXPECT_TRUE(Utility::portInRangeList(makeFromPort(65535), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(2), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(200), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(makeFromPort(20000), port_range_list));
   }
 }
 

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -131,6 +131,10 @@ TEST(NetworkUtility, loopbackAddress) {
     Address::Ipv4Instance address("10.0.0.1");
     EXPECT_FALSE(Utility::isLoopbackAddress(address));
   }
+  {
+    Address::PipeInstance address("/foo");
+    EXPECT_FALSE(Utility::isLoopbackAddress(address));
+  }
 }
 
 TEST(PortRangeListTest, Errors) {
@@ -177,6 +181,7 @@ TEST(PortRangeListTest, Normal) {
     Utility::parsePortRangeList(port_range_str, port_range_list);
     EXPECT_TRUE(Utility::portInRangeList(makeFromPort(1), port_range_list));
     EXPECT_FALSE(Utility::portInRangeList(makeFromPort(2), port_range_list));
+    EXPECT_FALSE(Utility::portInRangeList(Address::PipeInstance("/foo"), port_range_list));
   }
 
   {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -118,9 +118,12 @@ TEST(NetworkUtility, Url) {
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo"), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:bar"), EnvoyException);
   EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("foo"), EnvoyException);
 }
 
-TEST(NetworkUtility, GetLocalAddress) { EXPECT_NE(nullptr, Utility::getLocalAddress()); }
+TEST(NetworkUtility, getLocalAddress) { EXPECT_NE(nullptr, Utility::getLocalAddress()); }
+
+TEST(NetworkUtlity, getOriginalDst) { EXPECT_EQ(nullptr, Utility::getOriginalDst(-1)); }
 
 TEST(NetworkUtility, loopbackAddress) {
   {

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/redis/conn_pool_impl.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -28,8 +29,8 @@ public:
     upstream_connection_ = new NiceMock<Network::MockClientConnection>();
     Upstream::MockHost::MockCreateConnectionData conn_info;
     conn_info.connection_ = upstream_connection_;
-    conn_info.host_.reset(
-        new Upstream::HostImpl(cm_.cluster_.info_, "tcp://127.0.0.1:80", false, 1, ""));
+    conn_info.host_.reset(new Upstream::HostImpl(
+        cm_.cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
     EXPECT_CALL(cm_, tcpConnForCluster_("foo")).WillOnce(Return(conn_info));
     EXPECT_CALL(*upstream_connection_, addReadFilter(_))
         .WillOnce(SaveArg<0>(&upstream_read_filter_));

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -1,6 +1,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/json/json_loader.h"
 #include "common/network/listen_socket_impl.h"
+#include "common/network/utility.h"
 #include "common/ssl/connection_impl.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/ssl/context_impl.h"
@@ -49,8 +50,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
   Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
-  Network::ClientConnectionPtr client_connection =
-      dispatcher.createSslClientConnection(*client_ctx, "tcp://127.0.0.1:10000");
+  Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
+      *client_ctx, Network::Utility::resolveUrl("tcp://127.0.0.1:10000"));
   client_connection->connect();
 
   Network::ConnectionPtr server_connection;
@@ -109,8 +110,8 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
   Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
-  Network::ClientConnectionPtr client_connection =
-      dispatcher.createSslClientConnection(*client_ctx, "tcp://127.0.0.1:10000");
+  Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
+      *client_ctx, Network::Utility::resolveUrl("tcp://127.0.0.1:10000"));
   client_connection->connect();
 
   Network::ConnectionPtr server_connection;
@@ -156,7 +157,7 @@ TEST(SslConnectionImplTest, SslError) {
       connection_handler, *server_ctx, socket, callbacks, stats_store, true, false, false);
 
   Network::ClientConnectionPtr client_connection =
-      dispatcher.createClientConnection("tcp://127.0.0.1:10000");
+      dispatcher.createClientConnection(Network::Utility::resolveUrl("tcp://127.0.0.1:10000"));
   client_connection->connect();
   Buffer::OwnedImpl bad_data("bad_handshake_data");
   client_connection->write(bad_data);

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/stats/statsd.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -31,8 +32,9 @@ TEST_F(TcpStatsdSinkTest, All) {
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = connection;
-  conn_info.host_.reset(new Upstream::HostImpl(
-      Upstream::ClusterInfoPtr{new Upstream::MockClusterInfo}, "tcp://127.0.0.1:80", false, 1, ""));
+  conn_info.host_.reset(
+      new Upstream::HostImpl(Upstream::ClusterInfoPtr{new Upstream::MockClusterInfo},
+                             Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
 
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("statsd")).WillOnce(Return(conn_info));
   EXPECT_CALL(*connection, connect());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1,6 +1,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
+#include "common/network/utility.h"
 #include "common/upstream/health_checker_impl.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -160,7 +161,8 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -181,7 +183,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
 
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -203,7 +206,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
 
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -226,7 +230,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
 
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -248,7 +253,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
 
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -267,7 +273,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
   setupNoServiceValidationHC();
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(true));
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -298,7 +305,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -310,7 +318,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -327,7 +336,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -355,7 +365,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 
 TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -383,7 +394,8 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -403,7 +415,8 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
 
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
   setupNoServiceValidationHC();
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -429,7 +442,8 @@ TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
 
   expectSessionCreate();
   expectStreamCreate(0);
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   std::vector<HostPtr> removed{cluster_->hosts_.back()};
@@ -442,7 +456,8 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false));
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -460,7 +475,8 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(2);
 
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -611,7 +627,8 @@ public:
 };
 
 TEST_F(TcpHealthCheckerImplTest, Success) {
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectClientCreate();
   health_checker_->start();
@@ -628,7 +645,8 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
 
   expectSessionCreate();
   expectClientCreate();
-  cluster_->hosts_ = {HostPtr{new HostImpl(cluster_->info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_->hosts_ = {HostPtr{new HostImpl(
+      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   Buffer::OwnedImpl response;

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/upstream/host_utility.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -7,7 +8,7 @@ namespace Upstream {
 
 TEST(HostUtilityTest, All) {
   ClusterInfoPtr cluster{new MockClusterInfo()};
-  HostImpl host(cluster, "tcp://127.0.0.1:80", false, 1, "");
+  HostImpl host(cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "");
   EXPECT_EQ("healthy", HostUtility::healthFlagsToString(host));
 
   host.healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -11,7 +12,7 @@ namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
                            uint32_t weight = 1) {
-  return HostPtr{new HostImpl(cluster, url, false, weight, "")};
+  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, weight, "")};
 }
 
 class RoundRobinLoadBalancerTest : public testing::Test {

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/upstream_impl.h"
@@ -12,7 +13,7 @@ namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
                            uint32_t weight = 1, const std::string& zone = "") {
-  return HostPtr{new HostImpl(cluster, url, false, weight, zone)};
+  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, weight, zone)};
 }
 
 /**
@@ -84,7 +85,7 @@ public:
                                    per_zone_local, empty_vector_, empty_vector_);
 
       ConstHostPtr selected = lb.chooseHost();
-      hits[selected->url()]++;
+      hits[selected->address()->asString()]++;
     }
 
     double mean = total_number_of_requests * 1.0 / hits.size();

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1,3 +1,4 @@
+#include "common/network/utility.h"
 #include "common/upstream/outlier_detection_impl.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -62,7 +63,8 @@ public:
 
 TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -91,7 +93,8 @@ TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
 
 TEST_F(OutlierDetectorImplTest, DestroyHostInUse) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -108,14 +111,15 @@ TEST_F(OutlierDetectorImplTest, DestroyHostInUse) {
 
 TEST_F(OutlierDetectorImplTest, BasicFlow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
-  cluster_.hosts_.push_back(
-      HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:81", false, 1, "")});
+  cluster_.hosts_.push_back(HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:81"), false, 1, "")});
   cluster_.runCallbacks({cluster_.hosts_[1]}, {});
 
   // Cause a consecutive 5xx error.
@@ -164,7 +168,8 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
 
 TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -199,8 +204,11 @@ TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
 
 TEST_F(OutlierDetectorImplTest, Overflow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")},
-                     HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:81", false, 1, "")}};
+  cluster_.hosts_ = {
+      HostPtr{new HostImpl(cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
+                           false, 1, "")},
+      HostPtr{new HostImpl(cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:81"),
+                           false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -237,7 +245,8 @@ TEST_F(OutlierDetectorImplTest, Overflow) {
 
 TEST_F(OutlierDetectorImplTest, NotEnforcing) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -261,7 +270,8 @@ TEST_F(OutlierDetectorImplTest, NotEnforcing) {
 
 TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -286,7 +296,8 @@ TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
 
 TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -312,7 +323,8 @@ TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
 
 TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -344,7 +356,8 @@ TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
 
 TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
-  cluster_.hosts_ = {HostPtr{new HostImpl(cluster_.info_, "tcp://127.0.0.1:80", false, 1, "")}};
+  cluster_.hosts_ = {HostPtr{new HostImpl(
+      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -386,10 +399,9 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   EventLoggerImpl event_logger(log_manager, "foo", time_source);
 
   std::string log1;
-  EXPECT_CALL(*file,
-              write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"cluster\": "
-                    "\"fake_cluster\", \"upstream_url\": \"tcp://10.0.0.1:443\", \"action\": "
-                    "\"eject\", \"type\": \"5xx\", \"num_ejections\": 0}\n"))
+  EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"cluster\": "
+                           "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
+                           "\"eject\", \"type\": \"5xx\", \"num_ejections\": 0}\n"))
       .WillOnce(SaveArg<0>(&log1));
   event_logger.logEject(host, EjectionType::Consecutive5xx);
   Json::Factory::LoadFromString(log1);
@@ -397,7 +409,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   std::string log2;
   EXPECT_CALL(*file,
               write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"cluster\": \"fake_cluster\", "
-                    "\"upstream_url\": \"tcp://10.0.0.1:443\", \"action\": \"uneject\", "
+                    "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
                     "\"num_ejections\": 0}\n")).WillOnce(SaveArg<0>(&log2));
   event_logger.logUneject(host);
   Json::Factory::LoadFromString(log2);

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -44,7 +44,7 @@ protected:
 
   HostPtr findHost(const std::string& address) {
     for (HostPtr host : cluster_->hosts()) {
-      if (Network::Utility::hostFromUrl(host->url()) == address) {
+      if (host->address()->ip()->addressAsString() == address) {
         return host;
       }
     }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2,6 +2,7 @@
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/json/json_loader.h"
+#include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/common.h"
@@ -9,6 +10,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
 
 using testing::_;
 using testing::ContainerEq;
@@ -17,13 +19,13 @@ using testing::NiceMock;
 
 namespace Upstream {
 
-static std::list<std::string> hostListToURLs(const std::vector<HostPtr>& hosts) {
-  std::list<std::string> urls;
+static std::list<std::string> hostListToAddresses(const std::vector<HostPtr>& hosts) {
+  std::list<std::string> addresses;
   for (const HostPtr& host : hosts) {
-    urls.push_back(host->url());
+    addresses.push_back(host->address()->asString());
   }
 
-  return urls;
+  return addresses;
 }
 
 struct ResolverData {
@@ -114,36 +116,36 @@ TEST(StrictDnsClusterImplTest, Basic) {
   resolver1.expectResolve(dns_resolver);
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
-  resolver1.dns_callback_({"127.0.0.1", "127.0.0.2"});
-  EXPECT_THAT(std::list<std::string>({"tcp://127.0.0.1:11001", "tcp://127.0.0.2:11001"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
+  EXPECT_THAT(std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
 
   resolver1.expectResolve(dns_resolver);
   resolver1.timer_->callback_();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
-  resolver1.dns_callback_({"127.0.0.2", "127.0.0.1"});
-  EXPECT_THAT(std::list<std::string>({"tcp://127.0.0.1:11001", "tcp://127.0.0.2:11001"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
+  EXPECT_THAT(std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
 
   resolver1.expectResolve(dns_resolver);
   resolver1.timer_->callback_();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
-  resolver1.dns_callback_({"127.0.0.2", "127.0.0.1"});
-  EXPECT_THAT(std::list<std::string>({"tcp://127.0.0.1:11001", "tcp://127.0.0.2:11001"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
+  EXPECT_THAT(std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
 
   resolver1.timer_->callback_();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
-  resolver1.dns_callback_({"127.0.0.3"});
-  EXPECT_THAT(std::list<std::string>({"tcp://127.0.0.3:11001"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3"}));
+  EXPECT_THAT(std::list<std::string>({"127.0.0.3:11001"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
 
   EXPECT_CALL(*resolver2.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
-  resolver2.dns_callback_({"10.0.0.1"});
-  EXPECT_THAT(std::list<std::string>({"tcp://127.0.0.3:11001", "tcp://10.0.0.1:11002"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  resolver2.dns_callback_(TestUtility::makeDnsResponse({"10.0.0.1"}));
+  EXPECT_THAT(std::list<std::string>({"127.0.0.3:11001", "10.0.0.1:11002"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
 
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
   EXPECT_EQ(0UL, cluster.hostsPerZone().size());
@@ -165,7 +167,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
 
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
-  HostImpl host(cluster.info_, "tcp://10.0.0.1:1234", false, 1, "");
+  HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1, "");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_FALSE(host.canary());
   EXPECT_EQ("", host.zone());
@@ -175,17 +177,19 @@ TEST(HostImplTest, Weight) {
   MockCluster cluster;
 
   {
-    HostImpl host(cluster.info_, "tcp://10.0.0.1:1234", false, 0, "");
+    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 0, "");
     EXPECT_EQ(1U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info_, "tcp://10.0.0.1:1234", false, 101, "");
+    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 101,
+                  "");
     EXPECT_EQ(100U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info_, "tcp://10.0.0.1:1234", false, 50, "");
+    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 50,
+                  "");
     EXPECT_EQ(50U, host.weight());
     host.weight(51);
     EXPECT_EQ(51U, host.weight());
@@ -198,15 +202,11 @@ TEST(HostImplTest, Weight) {
 
 TEST(HostImplTest, CanaryAndZone) {
   MockCluster cluster;
-  HostImpl host(cluster.info_, "tcp://10.0.0.1:1234", true, 1, "hello");
+  HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), true, 1,
+                "hello");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_TRUE(host.canary());
   EXPECT_EQ("hello", host.zone());
-}
-
-TEST(HostImplTest, MalformedUrl) {
-  MockCluster cluster;
-  EXPECT_THROW(HostImpl(cluster.info_, "fake\\10.0.0.1:1234", false, 1, ""), EnvoyException);
 }
 
 TEST(StaticClusterImplTest, OutlierDetector) {
@@ -337,8 +337,8 @@ TEST(StaticClusterImplTest, UrlConfig) {
   EXPECT_EQ(0U, cluster.info()->maxRequestsPerConnection());
   EXPECT_EQ(0U, cluster.info()->httpCodecOptions());
   EXPECT_EQ(LoadBalancerType::Random, cluster.info()->lbType());
-  EXPECT_THAT(std::list<std::string>({"tcp://10.0.0.1:11001", "tcp://10.0.0.2:11002"}),
-              ContainerEq(hostListToURLs(cluster.hosts())));
+  EXPECT_THAT(std::list<std::string>({"10.0.0.1:11001", "10.0.0.2:11002"}),
+              ContainerEq(hostListToAddresses(cluster.hosts())));
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
   EXPECT_EQ(0UL, cluster.hostsPerZone().size());
   EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -2,6 +2,7 @@
   "listeners": [
   {
     "port": 10000,
+    "use_original_dst": true,
     "filters": [
       { "type": "read", "name": "ratelimit",
         "config": {

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -6,6 +6,7 @@
 #include "envoy/server/hot_restart.h"
 
 #include "common/local_info/local_info_impl.h"
+#include "common/network/utility.h"
 
 namespace Server {
 
@@ -102,7 +103,8 @@ void IntegrationTestServer::threadRoutine() {
   Server::TestHotRestart restarter;
   Thread::MutexBasicLockable lock;
   Stats::TestIsolatedStoreImpl stats_store;
-  LocalInfo::LocalInfoImpl local_info("127.0.0.1", "zone_name", "cluster_name", "node_name");
+  LocalInfo::LocalInfoImpl local_info(Network::Utility::getLocalAddress(), "zone_name",
+                                      "cluster_name", "node_name");
   server_.reset(
       new Server::InstanceImpl(options, *this, restarter, stats_store, lock, *this, local_info));
   server_->run();

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -3,6 +3,7 @@
 #include "utility.h"
 
 #include "common/event/dispatcher_impl.h"
+#include "common/network/utility.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/ssl/context_manager_impl.h"
 
@@ -75,9 +76,9 @@ ClientContextPtr SslIntegrationTest::createClientSslContext(bool alpn) {
 }
 
 Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool alpn) {
-  return dispatcher_->createSslClientConnection(alpn ? *client_ssl_ctx_alpn_
-                                                     : *client_ssl_ctx_no_alpn_,
-                                                fmt::format("tcp://127.0.0.1:10001"));
+  return dispatcher_->createSslClientConnection(
+      alpn ? *client_ssl_ctx_alpn_ : *client_ssl_ctx_no_alpn_,
+      Network::Utility::resolveUrl("tcp://127.0.0.1:10001"));
 }
 
 void SslIntegrationTest::checkStats() {

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -10,6 +10,11 @@
 ACTION_P(SaveArgAddress, target) { *target = &arg0; }
 
 /**
+ * Matcher that matches on whether the pointee of both lhs and rhs are equal.
+ */
+MATCHER_P(PointeesEq, rhs, "") { return *arg == *rhs; }
+
+/**
  * Simple mock that just lets us make sure a method gets called or not called form a lambda.
  */
 class ReadyWatcher {

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -18,13 +18,15 @@ public:
   MockDispatcher();
   ~MockDispatcher();
 
-  Network::ClientConnectionPtr createClientConnection(const std::string& url) override {
-    return Network::ClientConnectionPtr{createClientConnection_(url)};
+  Network::ClientConnectionPtr
+  createClientConnection(Network::Address::InstancePtr address) override {
+    return Network::ClientConnectionPtr{createClientConnection_(address)};
   }
 
-  Network::ClientConnectionPtr createSslClientConnection(Ssl::ClientContext& ssl_ctx,
-                                                         const std::string& url) override {
-    return Network::ClientConnectionPtr{createSslClientConnection_(ssl_ctx, url)};
+  Network::ClientConnectionPtr
+  createSslClientConnection(Ssl::ClientContext& ssl_ctx,
+                            Network::Address::InstancePtr address) override {
+    return Network::ClientConnectionPtr{createSslClientConnection_(ssl_ctx, address)};
   }
 
   Network::DnsResolverPtr createDnsResolver() override {
@@ -72,9 +74,11 @@ public:
 
   // Event::Dispatcher
   MOCK_METHOD0(clearDeferredDeleteList, void());
-  MOCK_METHOD1(createClientConnection_, Network::ClientConnection*(const std::string& url));
+  MOCK_METHOD1(createClientConnection_,
+               Network::ClientConnection*(Network::Address::InstancePtr address));
   MOCK_METHOD2(createSslClientConnection_,
-               Network::ClientConnection*(Ssl::ClientContext& ssl_ctx, const std::string& url));
+               Network::ClientConnection*(Ssl::ClientContext& ssl_ctx,
+                                          Network::Address::InstancePtr address));
   MOCK_METHOD0(createDnsResolver_, Network::DnsResolver*());
   MOCK_METHOD2(createFileEvent_, FileEvent*(int fd, FileReadyCb cb));
   MOCK_METHOD0(createFilesystemWatcher_, Filesystem::Watcher*());

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -77,7 +77,7 @@ public:
   MOCK_METHOD0(stats, ConnectionManagerStats&());
   MOCK_METHOD0(tracingStats, ConnectionManagerTracingStats&());
   MOCK_METHOD0(useRemoteAddress, bool());
-  MOCK_METHOD0(localAddress, const std::string&());
+  MOCK_METHOD0(localAddress, const Network::Address::Instance&());
   MOCK_METHOD0(userAgent, const Optional<std::string>&());
   MOCK_METHOD0(tracingConfig, const Optional<Http::TracingConnectionManagerConfig>&());
 

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -1,11 +1,14 @@
 #include "mocks.h"
 
+#include "common/network/address_impl.h"
+
+using testing::Return;
 using testing::ReturnRef;
 
 namespace LocalInfo {
 
-MockLocalInfo::MockLocalInfo() {
-  ON_CALL(*this, address()).WillByDefault(ReturnRef(address_));
+MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("127.0.0.1")) {
+  ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(zone_name_));
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
   ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_name_));

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -9,12 +9,12 @@ public:
   MockLocalInfo();
   ~MockLocalInfo();
 
-  MOCK_CONST_METHOD0(address, std::string&());
+  MOCK_CONST_METHOD0(address, Network::Address::InstancePtr());
   MOCK_CONST_METHOD0(zoneName, std::string&());
   MOCK_CONST_METHOD0(clusterName, std::string&());
   MOCK_CONST_METHOD0(nodeName, std::string&());
 
-  std::string address_{"127.0.0.1"};
+  Network::Address::InstancePtr address_;
   std::string zone_name_{"zone_name"};
   std::string cluster_name_{"cluster_name"};
   std::string node_name_{"node_name"};

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -2,6 +2,9 @@
 
 #include "envoy/buffer/buffer.h"
 
+#include "common/network/address_impl.h"
+#include "common/network/utility.h"
+
 using testing::_;
 using testing::Invoke;
 using testing::Return;
@@ -41,7 +44,7 @@ template <class T> static void initializeMockConnection(T& connection) {
       .WillByDefault(Invoke([&connection](ConnectionCloseType) -> void {
         connection.raiseEvents(Network::ConnectionEvent::LocalClose);
       }));
-  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnRef(connection.remote_address_));
+  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnPointee(connection.remote_address_));
   ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
   ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
 
@@ -55,7 +58,7 @@ MockConnection::MockConnection() { initializeMockConnection(*this); }
 MockConnection::~MockConnection() {}
 
 MockClientConnection::MockClientConnection() {
-  remote_address_ = "tcp://10.0.0.1:443";
+  remote_address_ = Utility::resolveUrl("tcp://10.0.0.1:443");
   initializeMockConnection(*this);
 }
 
@@ -107,7 +110,10 @@ MockDrainDecision::~MockDrainDecision() {}
 MockFilterChainFactory::MockFilterChainFactory() {}
 MockFilterChainFactory::~MockFilterChainFactory() {}
 
-MockListenSocket::MockListenSocket() {}
+MockListenSocket::MockListenSocket() : local_address_(new Address::Ipv4Instance(80)) {
+  ON_CALL(*this, localAddress()).WillByDefault(Return(local_address_));
+}
+
 MockListenSocket::~MockListenSocket() {}
 
 MockListener::MockListener() {}

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -28,7 +28,7 @@ public:
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   std::list<Network::ConnectionCallbacks*> callbacks_;
   uint64_t id_{next_id_++};
-  std::string remote_address_;
+  Address::InstancePtr remote_address_;
   bool read_enabled_{true};
   Connection::State state_{Connection::State::Open};
 };
@@ -51,8 +51,8 @@ public:
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD0(readEnabled, bool());
-  MOCK_METHOD0(remoteAddress, const std::string&());
-  MOCK_METHOD0(localAddress, const std::string&());
+  MOCK_METHOD0(remoteAddress, const Address::Instance&());
+  MOCK_METHOD0(localAddress, const Address::Instance&());
   MOCK_METHOD1(setBufferStats, void(const BufferStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_METHOD0(state, State());
@@ -81,8 +81,8 @@ public:
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD0(readEnabled, bool());
-  MOCK_METHOD0(remoteAddress, const std::string&());
-  MOCK_METHOD0(localAddress, const std::string&());
+  MOCK_METHOD0(remoteAddress, const Address::Instance&());
+  MOCK_METHOD0(localAddress, const Address::Instance&());
   MOCK_METHOD1(setBufferStats, void(const BufferStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_METHOD0(state, State());
@@ -190,9 +190,11 @@ public:
   MockListenSocket();
   ~MockListenSocket();
 
-  MOCK_METHOD0(name, const std::string());
+  MOCK_METHOD0(localAddress, Address::InstancePtr());
   MOCK_METHOD0(fd, int());
   MOCK_METHOD0(close, void());
+
+  Address::InstancePtr local_address_;
 };
 
 class MockListener : public Listener {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -54,11 +54,11 @@ public:
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
-  MOCK_CONST_METHOD0(url, const std::string&());
+  MOCK_CONST_METHOD0(address, Network::Address::InstancePtr());
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());
 
-  std::string url_{"tcp://10.0.0.1:443"};
+  Network::Address::InstancePtr address_;
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
   testing::NiceMock<MockClusterInfo> cluster_;
   Stats::IsolatedStoreImpl stats_store_;
@@ -76,7 +76,6 @@ public:
   ~MockHost();
 
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
-  MOCK_CONST_METHOD0(url, const std::string&());
   MOCK_CONST_METHOD0(counters, std::list<Stats::CounterPtr>());
   MOCK_CONST_METHOD0(gauges, std::list<Stats::GaugePtr>());
   MOCK_CONST_METHOD0(healthy, bool());

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/upstream/load_balancer.h"
 
+#include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 using testing::_;
@@ -29,8 +30,9 @@ MockDetector::~MockDetector() {}
 
 } // Outlier
 
-MockHostDescription::MockHostDescription() {
-  ON_CALL(*this, url()).WillByDefault(ReturnRef(url_));
+MockHostDescription::MockHostDescription()
+    : address_(Network::Utility::resolveUrl("tcp://10.0.0.1:443")) {
+  ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   ON_CALL(*this, cluster()).WillByDefault(ReturnRef(cluster_));

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -3,6 +3,7 @@
 #include "envoy/buffer/buffer.h"
 
 #include "common/common/empty_string.h"
+#include "common/network/address_impl.h"
 
 bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instance& rhs) {
   if (lhs.length() != rhs.length()) {
@@ -42,6 +43,15 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
   }
 
   return output;
+}
+
+std::list<Network::Address::InstancePtr>
+TestUtility::makeDnsResponse(const std::list<std::string>& addresses) {
+  std::list<Network::Address::InstancePtr> ret;
+  for (auto address : addresses) {
+    ret.emplace_back(new Network::Address::Ipv4Instance(address));
+  }
+  return ret;
 }
 
 namespace Http {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/network/address.h"
+
 #include "common/http/header_map_impl.h"
 
 class TestUtility {
@@ -18,6 +20,13 @@ public:
    * @return std::string the converted string.
    */
   static std::string bufferToString(const Buffer::Instance& buffer);
+
+  /**
+   * Convert a string list of IP addresses into a list of network addresses usable for DNS
+   * response testing.
+   */
+  static std::list<Network::Address::InstancePtr>
+  makeDnsResponse(const std::list<std::string>& addresses);
 };
 
 namespace Http {


### PR DESCRIPTION
This is a large refactor that moves away from representing addresses
internally as strings of "URL" form into proper objects. With this
change in place, it should be very straightforward to add IPv6
support, as most places in the code no longer need to understand
anything about the underlying address. Additionally, adding NT support
in the future should also be easier.

There are still some unfortunate legacy aspects, such as the fact that
when loading from configuration we still parse tcp:// as well as unix://
style addresses. In the future this should likely become ip:// as well
as pipe:// but we will probably need to continue to support both.

Note that although this change is huge in number of lines, most of it is
very straightforward, and certain portions of the code have become
substantially simpler such as listener handling and client connection
handling.

Fixes https://github.com/lyft/envoy/issues/390