### PR TITLE
Add pprof to lyft/envoy-build for heap leak stack traces and symbols.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -4,7 +4,7 @@ set -e
 
 # Setup basic requirements and install them.
 apt-get update
-apt-get install -y wget software-properties-common make cmake git python python-pip clang-format-3.6 bc
+apt-get install -y wget software-properties-common make cmake git python python-pip clang-format-3.6 bc google-perftools
 apt-get install -y golang
 add-apt-repository -y ppa:ubuntu-toolchain-r/test
 apt-get update

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -4,7 +4,7 @@ set -e
 
 # Setup basic requirements and install them.
 apt-get update
-apt-get install -y wget software-properties-common make cmake git python python-pip clang-format-3.6 bc google-perftools
+apt-get install -y wget software-properties-common make cmake git python python-pip clang-format-3.6 bc
 apt-get install -y golang
 add-apt-repository -y ppa:ubuntu-toolchain-r/test
 apt-get update

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -5,7 +5,7 @@ set -e
 export CC=gcc-4.9
 export CXX=g++-4.9
 export HEAPCHECK=normal
-export PPROF_PATH=/usr/bin/google-pprof
+export PPROF_PATH=/thirdparty_build/bin/pprof
 
 NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 echo "building using $NUM_CPUS CPUs"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -5,6 +5,7 @@ set -e
 export CC=gcc-4.9
 export CXX=g++-4.9
 export HEAPCHECK=normal
+export PPROF_PATH=/usr/bin/google-pprof
 
 NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 echo "building using $NUM_CPUS CPUs"


### PR DESCRIPTION
do_ci.sh runs tests with heapcheck enabled. This can discover heap leaks
but requires pprof (in google-perftools) to perform the symbolization
and printing of allocation site stack traces.

With this PR, a failed run will produce output such as:

Have memory regions w/o callers: might report false leaks
Leak check _main_ detected leaks of 16 bytes in 1 objects
The 1 largest leaks:
Using local file /source/build/test/envoy-test.
Leak of 16 bytes in 1 objects allocated from:
        @ 15d6b6f Network::DnsImplTest_Cancel_Test::TestBody
        @ 1e91e66 testing::internal::HandleSehExceptionsInMethodIfSupported
        @ 1e8cba8 testing::internal::HandleExceptionsInMethodIfSupported
        @ 1e73af5 testing::Test::Run
        @ 1e74381 testing::TestInfo::Run
        @ 1e74a12 testing::TestCase::Run
        @ 1e7b1bd testing::internal::UnitTestImpl::RunAllTests
        @ 1e92f66 testing::internal::HandleSehExceptionsInMethodIfSupported
        @ 1e8d86a testing::internal::HandleExceptionsInMethodIfSupported
        @ 1e79e47 testing::UnitTest::Run
        @ 181925a RUN_ALL_TESTS
        @ 181844d main