### PR TITLE
Strip leading and trailing double quotes from cookies.

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -88,7 +88,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
           // Cookie values may be wrapped in double quotes.
           // https://tools.ietf.org/html/rfc6265#section-4.1.1
           if (s.size() >= 2 && s.back() == '"' && s[0] == '"') {
-              s = s.substr(1, s.size() - 1);
+            s = s.substr(1, s.size() - 1);
           }
           state->ret_ = s;
           return;

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -83,14 +83,14 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         std::string k = s.substr(first_non_space, equals_index - first_non_space);
         State* state = static_cast<State*>(context);
         if (k == state->key_) {
-          s = s.substr(equals_index + 1, s.size() - 1);
+          std::string v = s.substr(equals_index + 1, s.size() - 1);
 
           // Cookie values may be wrapped in double quotes.
           // https://tools.ietf.org/html/rfc6265#section-4.1.1
-          if (s.size() >= 2 && s.back() == '"' && s[0] == '"') {
-            s = s.substr(1, s.size() - 1);
+          if (v.size() >= 2 && v.back() == '"' && v[0] == '"') {
+            v = v.substr(1, v.size() - 1);
           }
-          state->ret_ = s;
+          state->ret_ = v;
           return;
         }
       }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -83,7 +83,14 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         std::string k = s.substr(first_non_space, equals_index - first_non_space);
         State* state = static_cast<State*>(context);
         if (k == state->key_) {
-          state->ret_ = s.substr(equals_index + 1, s.size() - 1);
+          s = s.substr(equals_index + 1, s.size() - 1);
+
+          // Cookie values may be wrapped in double quotes.
+          // https://tools.ietf.org/html/rfc6265#section-4.1.1
+          if (s.size() >= 2 && s.back() == '"' && s[0] == '"') {
+              s = s.substr(1, s.size() - 1);
+          }
+          state->ret_ = s;
           return;
         }
       }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -88,7 +88,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
           // Cookie values may be wrapped in double quotes.
           // https://tools.ietf.org/html/rfc6265#section-4.1.1
           if (v.size() >= 2 && v.back() == '"' && v[0] == '"') {
-            v = v.substr(1, v.size() - 1);
+            v = v.substr(1, v.size() - 2);
           }
           state->ret_ = v;
           return;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -129,8 +129,7 @@ TEST(HttpUtility, TestParseCookieWithQuotes) {
       {"someheader", "10.0.0.1"},
       {"cookie", "dquote=\"; quoteddquote=\"\"\""},
       {"cookie", "leadingdquote=\"foobar;"},
-      {"cookie", "abc=def; token=\"abc123\"; Expires=Wed, 09 Jun 2021 10:18:14 GMT"}
-  };
+      {"cookie", "abc=def; token=\"abc123\"; Expires=Wed, 09 Jun 2021 10:18:14 GMT"}};
 
   EXPECT_EQ(Utility::parseCookieValue(headers, "token"), "abc123");
   EXPECT_EQ(Utility::parseCookieValue(headers, "dquote"), "\"");

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -124,4 +124,18 @@ TEST(HttpUtility, TestParseCookie) {
   EXPECT_EQ(value, "abc123");
 }
 
+TEST(HttpUtility, TestParseCookieWithQuotes) {
+  TestHeaderMapImpl headers{
+      {"someheader", "10.0.0.1"},
+      {"cookie", "dquote=\"; quoteddquote=\"\"\""},
+      {"cookie", "leadingdquote=\"foobar;"},
+      {"cookie", "abc=def; token=\"abc123\"; Expires=Wed, 09 Jun 2021 10:18:14 GMT"}
+  };
+
+  EXPECT_EQ(Utility::parseCookieValue(headers, "token"), "abc123");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "dquote"), "\"");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "quoteddquote"), "\"");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "leadingdquote"), "\"foobar");
+}
+
 } // Http


### PR DESCRIPTION
Web servers (including [werkzeug](https://github.com/pallets/werkzeug/blob/423a356d4a49a50179a2be7ba131570dbc607a34/werkzeug/_internal.py#L29)) will double quote cookie values when they do not contain only whitelisted characters. For instance, a base64 encoded value with a `=` would be quoted.