### PR TITLE
Add SKIP_CHECK_FORMAT environment variable to skip check_format when …

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -42,3 +42,5 @@ Envoy source tree.
 
 * A `RUN_TEST_UNDER` environment variable is available to specify an executable to run the tests
   under. For example, to run a subset of tests under `gdb`: `run_envoy_docker 'RUN_TEST_UNDER="gdb --args" UNIT_TEST_ONLY=1 ./ci/do_ci.sh debug --gtest_filter="*Dns*"'`.
+
+* A `SKIP_CHECK_FORMAT` environment variable is available to skip `clang-format` checks while developing locally, e.g. `run_envoy_docker 'SKIP_CHECK_FORMAT=1 ./ci/do_ci.sh debug'`.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -38,5 +38,5 @@ fi
 shift
 export EXTRA_TEST_ARGS="$@"
 
-make check_format
+[[ "$SKIP_CHECK_FORMAT" == "1" ]] || make check_format
 make -j$NUM_CPUS $TEST_TARGET


### PR DESCRIPTION
…iterating locally.

It's somewhat distracting to be forced to fix_format while debugging.