### PR TITLE
Fix dynamic cluster immediate resolution initialization bugs.

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -182,6 +182,9 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
 
   // To avoid threading issues, for those clusters that start with hosts already in them (like
   // the static cluster), we need to post an update onto each thread to notify them of the update.
+  // We also require this for dynamic clusters where an immediate resolve
+  // occurred in the cluster constructor, prior to the member update callback
+  // being configured.
   for (auto& cluster : primary_clusters_) {
     postInitializeCluster(*cluster.second.cluster_);
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -180,11 +180,10 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
                     new ThreadLocalClusterManagerImpl(*this, dispatcher, local_cluster_name)};
               });
 
-  // To avoid threading issues, for those clusters that start with hosts already in them (like
-  // the static cluster), we need to post an update onto each thread to notify them of the update.
-  // We also require this for dynamic clusters where an immediate resolve
-  // occurred in the cluster constructor, prior to the member update callback
-  // being configured.
+  // To avoid threading issues, for those clusters that start with hosts already in them (like the
+  // static cluster), we need to post an update onto each thread to notify them of the update. We
+  // also require this for dynamic clusters where an immediate resolve occurred in the cluster
+  // constructor, prior to the member update callback being configured.
   for (auto& cluster : primary_clusters_) {
     postInitializeCluster(*cluster.second.cluster_);
   }

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -12,7 +12,7 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
     : ClusterImplBase(config, runtime, stats, ssl_context_manager), dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(config.getInteger("dns_refresh_rate_ms", 5000))),
-      tls_(tls), tls_slot_(tls.allocateSlot()),
+      tls_(tls), tls_slot_(tls.allocateSlot()), initialized_(false),
       resolve_timer_(dispatcher.createTimer([this]() -> void { startResolve(); })) {
 
   std::vector<Json::ObjectPtr> hosts_json = config.getObjectArray("hosts");
@@ -23,11 +23,14 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
   dns_url_ = hosts_json[0]->getString("url");
   Network::Utility::hostFromTcpUrl(dns_url_);
   Network::Utility::portFromTcpUrl(dns_url_);
-  startResolve();
 
+  // This must come before startResolve(), since the resolve callback relies on
+  // tls_slot_ being initialized.
   tls.set(tls_slot_, [](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectPtr {
     return ThreadLocal::ThreadLocalObjectPtr{new PerThreadCurrentHostData()};
   });
+
+  startResolve();
 }
 
 LogicalDnsCluster::~LogicalDnsCluster() {
@@ -80,6 +83,7 @@ void LogicalDnsCluster::startResolve() {
           initialize_callback_();
           initialize_callback_ = nullptr;
         }
+        initialized_ = true;
 
         resolve_timer_->enableTimer(dns_refresh_rate_ms_);
       });

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -33,7 +33,11 @@ public:
   void initialize() override {}
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
   void setInitializedCb(std::function<void()> callback) override {
-    initialize_callback_ = callback;
+    if (initialized_) {
+      callback();
+    } else {
+      initialize_callback_ = callback;
+    }
   }
 
 private:
@@ -80,6 +84,8 @@ private:
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;
   std::function<void()> initialize_callback_;
+  // Set once the first resolve completes.
+  bool initialized_;
   Event::TimerPtr resolve_timer_;
   std::string dns_url_;
   Network::Address::InstancePtr current_resolved_address_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -271,7 +271,11 @@ class BaseDynamicClusterImpl : public ClusterImplBase {
 public:
   // Upstream::Cluster
   void setInitializedCb(std::function<void()> callback) override {
-    initialize_callback_ = callback;
+    if (initialized_) {
+      callback();
+    } else {
+      initialize_callback_ = callback;
+    }
   }
 
 protected:
@@ -282,6 +286,8 @@ protected:
                              std::vector<HostPtr>& hosts_removed, bool depend_on_hc);
 
   std::function<void()> initialize_callback_;
+  // Set once the first resolve completes.
+  bool initialized_ = false;
 };
 
 /**

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -226,7 +226,7 @@
     {
       "name": "cluster_2",
       "connect_timeout_ms": 250,
-      "type": "strict_dns",
+      "type": "logical_dns",
       "lb_type": "round_robin",
       "hosts": [{"url": "tcp://localhost:11001"}]
     },


### PR DESCRIPTION
* Ensure that the cluster initialization callback is invoked immediately
  if initialization has already been complete when it is set.

* Don't invoke startResolve() for LogicalDnsCluster until we have the
  required TLS initialized.

* Initialize StrictDnsClusterImpl resolve_targets_ before starting DNS
  resolution, since the resolve callback iterates over this.

* Various unit tests and modified the H2 integration test to also cover logical_dns.