### PR TITLE
dynamic clusters misc fixes

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -49,7 +49,8 @@ public:
    * callers do not need to worry about per thread synchronization. The load balancing policy that
    * is used is the one defined on the cluster when it was created.
    *
-   * Can return nullptr if there is no host available in the cluster.
+   * Can return nullptr if there is no host available in the cluster or if the cluster does not
+   * exist.
    */
   virtual Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
                                                                  ResourcePriority priority) PURE;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -389,6 +389,11 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl
   }
 }
 
+ClusterManagerImpl::ThreadLocalClusterManagerImpl::~ThreadLocalClusterManagerImpl() {
+  ASSERT(thread_local_clusters_.empty());
+  ASSERT(host_http_conn_pool_map_.empty());
+}
+
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
     const std::vector<HostPtr>& hosts) {
   for (const HostPtr& host : hosts) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -51,7 +51,8 @@ void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
     cluster_list = &secondary_init_clusters_;
   }
 
-  ASSERT(std::find(cluster_list->begin(), cluster_list->end(), &cluster) != cluster_list->end());
+  // It is possible that the cluster we are removing has already been initialized, and is not
+  // present in the initializer list. If so, this is fine.
   cluster_list->remove(&cluster);
   maybeFinishInitialize();
 }
@@ -214,6 +215,10 @@ bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const Json::Object& new_confi
     return false;
   }
 
+  if (existing_cluster != primary_clusters_.end()) {
+    init_helper_.removeCluster(*existing_cluster->second.cluster_);
+  }
+
   loadCluster(new_config, true);
   ClusterInfoPtr new_cluster = primary_clusters_.at(cluster_name).cluster_->info();
   tls_.runOnAllThreads([this, new_cluster]() -> void {
@@ -302,7 +307,7 @@ ClusterManagerImpl::httpConnPoolForCluster(const std::string& cluster, ResourceP
   // Select a host and create a connection pool for it if it does not already exist.
   auto entry = cluster_manager.thread_local_clusters_.find(cluster);
   if (entry == cluster_manager.thread_local_clusters_.end()) {
-    throw EnvoyException(fmt::format("unknown cluster '{}'", cluster));
+    return nullptr;
   }
 
   return entry->second->connPool(priority);
@@ -379,6 +384,16 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl
 
     thread_local_clusters_[cluster.first].reset(
         new ClusterEntry(*this, cluster.second.cluster_->info()));
+  }
+}
+
+void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
+    const std::vector<HostPtr>& hosts) {
+  for (const HostPtr& host : hosts) {
+    auto container = host_http_conn_pool_map_.find(host);
+    if (container != host_http_conn_pool_map_.end()) {
+      drainConnPools(host, container->second);
+    }
   }
 }
 
@@ -461,13 +476,17 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
         // We need to go through and purge any connection pools for hosts that got deleted.
         // Even if two hosts actually point to the same address this will be safe, since if a
         // host is readded it will be a different physical HostPtr.
-        for (const HostPtr& old_host : hosts_removed) {
-          auto container = parent_.host_http_conn_pool_map_.find(old_host);
-          if (container != parent_.host_http_conn_pool_map_.end()) {
-            parent_.drainConnPools(old_host, container->second);
-          }
-        }
+        parent_.drainConnPools(hosts_removed);
       });
+}
+
+ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry() {
+  // We need to drain all connection pools for the cluster being removed. Then we can remove the
+  // cluster.
+  // TODO: Optimally, we would just fire member changed callbacks and remove all of the hosts
+  //       inside of the HostImpl destructor. That is a change with wide implications, so we are
+  //       going with a more targeted approach for now.
+  parent_.drainConnPools(host_set_.hosts());
 }
 
 Http::ConnectionPool::Instance*

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -148,6 +148,7 @@ private:
 
     struct ClusterEntry {
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoPtr cluster);
+      ~ClusterEntry();
 
       Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
 
@@ -162,6 +163,7 @@ private:
 
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
                                   const Optional<std::string>& local_cluster_name);
+    void drainConnPools(const std::vector<HostPtr>& hosts);
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,
                                         ConstHostVectorPtr healthy_hosts,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -163,6 +163,7 @@ private:
 
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
                                   const Optional<std::string>& local_cluster_name);
+    ~ThreadLocalClusterManagerImpl();
     void drainConnPools(const std::vector<HostPtr>& hosts);
     void drainConnPools(HostPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, ConstHostVectorPtr hosts,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -178,8 +178,10 @@ private:
 
     ClusterManagerImpl& parent_;
     Event::Dispatcher& thread_local_dispatcher_;
-    std::unordered_map<std::string, ClusterEntryPtr> thread_local_clusters_;
+    // Cluster entries reference the conn pool map during destruction, so the conn pool map needs
+    // to come first.
     std::unordered_map<ConstHostPtr, ConnPoolsContainer> host_http_conn_pool_map_;
+    std::unordered_map<std::string, ClusterEntryPtr> thread_local_clusters_;
     const HostSet* local_host_set_{};
   };
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -178,10 +178,8 @@ private:
 
     ClusterManagerImpl& parent_;
     Event::Dispatcher& thread_local_dispatcher_;
-    // Cluster entries reference the conn pool map during destruction, so the conn pool map needs
-    // to come first.
-    std::unordered_map<ConstHostPtr, ConnPoolsContainer> host_http_conn_pool_map_;
     std::unordered_map<std::string, ClusterEntryPtr> thread_local_clusters_;
+    std::unordered_map<ConstHostPtr, ConnPoolsContainer> host_http_conn_pool_map_;
     const HostSet* local_host_set_{};
   };
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -210,6 +210,8 @@ TEST_F(ClusterManagerImplTest, LocalClusterDefined) {
 
   EXPECT_EQ(3UL, factory_.stats_.counter("cluster_manager.cluster_added").value());
   EXPECT_EQ(3UL, factory_.stats_.gauge("cluster_manager.total_clusters").value());
+
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, DuplicateCluster) {
@@ -290,6 +292,7 @@ TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
   EXPECT_CALL(factory_.dispatcher_, createClientConnection_(PointeesEq(Network::Utility::resolveUrl(
                                         "tcp://127.0.0.1:11001")))).WillOnce(Return(connection));
   create(*loader);
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, UnknownCluster) {
@@ -312,6 +315,7 @@ TEST_F(ClusterManagerImplTest, UnknownCluster) {
   EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("hello", ResourcePriority::Default));
   EXPECT_THROW(cluster_manager_->tcpConnForCluster("hello"), EnvoyException);
   EXPECT_THROW(cluster_manager_->httpAsyncClientForCluster("hello"), EnvoyException);
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, ShutdownOrder) {
@@ -444,6 +448,8 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
 
   EXPECT_CALL(initialized, ready());
   cluster3->initialize_callback_();
+
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
@@ -529,7 +535,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   EXPECT_EQ(0UL, factory_.stats_.gauge("cluster_manager.total_clusters").value());
 }
 
-TEST_F(ClusterManagerImplTest, addOrUpdatePrimaryClusterStaticExists) {
+TEST_F(ClusterManagerImplTest, AddOrUpdatePrimaryClusterStaticExists) {
   std::string json = R"EOF(
   {
     "clusters": [
@@ -565,6 +571,8 @@ TEST_F(ClusterManagerImplTest, addOrUpdatePrimaryClusterStaticExists) {
 
   // Attempt to remove a static cluster.
   EXPECT_FALSE(cluster_manager_->removePrimaryCluster("fake_cluster"));
+
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
@@ -654,6 +662,8 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.3"}));
   dns_timer_->callback_();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2"}));
+
+  factory_.tls_.shutdownThread();
 }
 
 TEST(ClusterManagerInitHelper, ImmediateInitialize) {

--- a/test/example_configs_test.cc
+++ b/test/example_configs_test.cc
@@ -33,6 +33,8 @@ public:
     } catch (const EnvoyException& ex) {
       throw EnvoyException(fmt::format("'{}' config failed. Error: {}", file_path, ex.what()));
     }
+
+    server_.thread_local_.shutdownThread();
   }
 
   NiceMock<Server::MockInstance> server_;


### PR DESCRIPTION
1) httpConnPoolForCluster() can now be called when a cluster does not exist
   during normal operation (during router retry). Have it return nullptr in
   this case also. The router already handles the function returning nullptr
   so no other changes are needed.
2) When we remove a cluster, we need to drain the http connection pools for
   hosts in the cluster.
3) Correctly handle the cm initialize edge case where a cluster initialized,
   but then gets removed before overall initialization is complete.

fixes https://github.com/lyft/envoy/issues/460