### PR TITLE
Update LS library version to 0_33.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -113,13 +113,13 @@ tar xf tclap-1.2.1.tar.gz
 rm tclap-1.2.1.tar.gz
 
 # lightstep
-wget https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0_19/lightstep-tracer-cpp-0.19.tar.gz
-tar xf lightstep-tracer-cpp-0.19.tar.gz
-cd lightstep-tracer-cpp-0.19
+wget https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0_33/lightstep-tracer-cpp-0.33.tar.gz
+tar xf lightstep-tracer-cpp-0.33.tar.gz
+cd lightstep-tracer-cpp-0.33
 ./configure --disable-grpc --prefix=$THIRDPARTY_BUILD --enable-shared=no \
-	    protobuf_CFLAGS="-I$THIRDPARTY_BUILD/include" protobuf_LIBS="-L$THIRDPARTY_BUILD/lib -lprotobuf"
+	    protobuf_CFLAGS="-I$THIRDPARTY_BUILD/include" protobuf_LIBS="-L$THIRDPARTY_BUILD/lib -lprotobuf" PROTOC=$THIRDPARTY_BUILD/bin/protoc
 make install
-rm -rf lightstep-tracer-cpp-0.19
+rm -rf lightstep-tracer-cpp-0.33
 cd ..
 
 # rapidjson

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -19,7 +19,7 @@ Envoy has the following requirements:
 * `boringSSL <https://boringssl.googlesource.com/boringssl>`_ (last tested with sha b87c80300647c2c0311c1489a104470e099f1531).
   Envoy is built against BoringSSL but `openssl <https://www.openssl.org>`_ should still work.
 * `protobuf <https://github.com/google/protobuf>`_ (last tested with 3.0.0)
-* `lightstep-tracer-cpp <https://github.com/lightstep/lightstep-tracer-cpp/>`_ (last tested with 0.19)
+* `lightstep-tracer-cpp <https://github.com/lightstep/lightstep-tracer-cpp/>`_ (last tested with 0.33)
 * `rapidjson <https://github.com/miloyip/rapidjson/>`_ (last tested with 1.1.0)
 * `c-ares <https://github.com/c-ares/c-ares>`_ (last tested with 1.12.0)
 

--- a/thirdparty.cmake
+++ b/thirdparty.cmake
@@ -44,7 +44,7 @@ set(ENVOY_PROTOBUF_INCLUDE_DIR "" CACHE FILEPATH "location of protobuf includes"
 set(ENVOY_PROTOBUF_PROTOC "" CACHE FILEPATH "location of protoc")
 
 # http://lightstep.com/
-# Last tested with lightstep-tracer-cpp-0.19
+# Last tested with lightstep-tracer-cpp-0.33
 set(ENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR "" CACHE FILEPATH "location of lighstep tracer includes")
 
 # https://github.com/miloyip/rapidjson


### PR DESCRIPTION
This version should have proper fix for parent_guid to be set correctly so that Envoy inject/extract on spans will work correctly