### PR TITLE
orderly cm/cds/rds initialization

### DIFF
--- a/include/envoy/init/init.h
+++ b/include/envoy/init/init.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace Init {
+
+/**
+ * A single initialization target.
+ */
+class Target {
+public:
+  virtual ~Target() {}
+
+  /**
+   * Called when the target should begin its own initialization.
+   * @param callback supplies the callback to invoke when the target has completed its
+   *        initialization.
+   */
+  virtual void initialize(std::function<void()> callback) PURE;
+};
+
+/**
+ * A manager that initializes multiple targets.
+ */
+class Manager {
+public:
+  virtual ~Manager() {}
+
+  /**
+   * Register a target to be initialized in the future. The manager will call initialize() on
+   * each target at some point in the future.
+   */
+  virtual void registerTarget(Target& target) PURE;
+};
+
+} // Init

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -2,6 +2,7 @@
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/api/api.h"
+#include "envoy/init/init.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/runtime/runtime.h"
@@ -102,6 +103,16 @@ public:
    * @return the server's hot restarter.
    */
   virtual HotRestart& hotRestart() PURE;
+
+  /**
+   * @return the server's init manager. This can be used for extensions that need to initialize
+   *         after cluster manager init but before the server starts listening. All extensions
+   *         should register themselves during configuration load. initialize() will be called on
+   *         each registered target after cluster manager init but before the server starts
+   *         listening. Once all targets have initialized and invoked their callbacks, the server
+   *         will start listening.
+   */
+  virtual Init::Manager& initManager() PURE;
 
   /**
    * @return the server's CLI options.

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -74,7 +74,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
 
   route_config_provider_ = Router::RouteConfigProviderUtil::create(
       config, server.runtime(), server.clusterManager(), server.dispatcher(), server.random(),
-      server.localInfo(), server.stats(), stats_prefix_, server.threadLocal());
+      server.localInfo(), server.stats(), stats_prefix_, server.threadLocal(),
+      server.initManager());
 
   if (config.hasObject("use_remote_address")) {
     use_remote_address_ = config.getBoolean("use_remote_address");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(envoy-test
   mocks/filesystem/mocks.cc
   mocks/grpc/mocks.cc
   mocks/http/mocks.cc
+  mocks/init/mocks.cc
   mocks/local_info/mocks.cc
   mocks/network/mocks.cc
   mocks/ratelimit/mocks.cc
@@ -150,6 +151,7 @@ add_executable(envoy-test
   server/http/admin_test.cc
   server/http/health_check_test.cc
   server/options_impl_test.cc
+  server/server_test.cc
   test_common/printers.cc
   test_common/utility.cc)
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -2,6 +2,7 @@
 #include "common/json/json_loader.h"
 #include "common/router/rds_impl.h"
 
+#include "test/mocks/init/mocks.h"
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -34,9 +35,11 @@ public:
     Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
 
     interval_timer_ = new Event::MockTimer(&dispatcher_);
-    expectRequest();
+    EXPECT_CALL(init_manager_, registerTarget(_));
     rds_ = RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,
-                                           local_info_, store_, "foo.", tls_);
+                                           local_info_, store_, "foo.", tls_, init_manager_);
+    expectRequest();
+    init_manager_.initialize();
   }
 
   void expectRequest() {
@@ -62,6 +65,7 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Stats::IsolatedStoreImpl store_;
   NiceMock<ThreadLocal::MockInstance> tls_;
+  NiceMock<Init::MockManager> init_manager_;
   Http::MockAsyncClientRequest request_;
   RouteConfigProviderPtr rds_;
   Event::MockTimer* interval_timer_{};
@@ -78,7 +82,7 @@ TEST_F(RdsImplTest, RdsAndStatic) {
 
   Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
   EXPECT_THROW(RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,
-                                               local_info_, store_, "foo.", tls_),
+                                               local_info_, store_, "foo.", tls_, init_manager_),
                EnvoyException);
 }
 
@@ -97,7 +101,25 @@ TEST_F(RdsImplTest, LocalInfoNotDefined) {
   local_info_.node_name_ = "";
   interval_timer_ = new Event::MockTimer(&dispatcher_);
   EXPECT_THROW(RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,
-                                               local_info_, store_, "foo.", tls_),
+                                               local_info_, store_, "foo.", tls_, init_manager_),
+               EnvoyException);
+}
+
+TEST_F(RdsImplTest, UnknownCluster) {
+  std::string config_json = R"EOF(
+    {
+      "rds": {
+        "cluster": "foo_cluster",
+        "route_config_name": "foo_route_config"
+      }
+    }
+    )EOF";
+
+  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  ON_CALL(cm_, get("foo_cluster")).WillByDefault(Return(nullptr));
+  interval_timer_ = new Event::MockTimer(&dispatcher_);
+  EXPECT_THROW(RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,
+                                               local_info_, store_, "foo.", tls_, init_manager_),
                EnvoyException);
 }
 
@@ -120,6 +142,7 @@ TEST_F(RdsImplTest, Basic) {
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
 
+  EXPECT_CALL(init_manager_.initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
@@ -201,6 +224,7 @@ TEST_F(RdsImplTest, Failure) {
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
 
+  EXPECT_CALL(init_manager_.initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
 

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -223,6 +223,25 @@
         }
       }
     ]
+  },
+  {
+    "port": 10005,
+    "filters": [
+    {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+        "codec_type": "http1",
+        "stat_prefix": "rds_dummy",
+        "rds": {
+          "cluster": "rds",
+          "route_config_name": "foo"
+        },
+        "filters": [
+          { "type": "decoder", "name": "router", "config": {} }
+        ]
+      }
+    }]
   }],
 
   "admin": { "access_log_path": "/dev/null", "port": 10003 },
@@ -248,7 +267,23 @@
   },
 
   "cluster_manager": {
+    "cds": {
+      "cluster": {
+        "name": "cds",
+        "connect_timeout_ms": 250,
+        "type": "static",
+        "lb_type": "round_robin",
+        "hosts": [{"url": "tcp://127.0.0.1:12000"}]
+      }
+    },
     "clusters": [
+    {
+      "name": "rds",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://127.0.0.1:12000"}]
+    },
     {
       "name": "cluster_1",
       "connect_timeout_ms": 250,

--- a/test/mocks/init/mocks.cc
+++ b/test/mocks/init/mocks.cc
@@ -1,0 +1,25 @@
+#include "mocks.h"
+
+using testing::_;
+using testing::Invoke;
+
+namespace Init {
+
+MockTarget::MockTarget() {
+  ON_CALL(*this, initialize(_))
+      .WillByDefault(Invoke([this](std::function<void()> callback) -> void {
+        EXPECT_EQ(nullptr, callback_);
+        callback_ = callback;
+      }));
+}
+
+MockTarget::~MockTarget() {}
+
+MockManager::MockManager() {
+  ON_CALL(*this, registerTarget(_))
+      .WillByDefault(Invoke([this](Target& target) -> void { targets_.push_back(&target); }));
+}
+
+MockManager::~MockManager() {}
+
+} // Init

--- a/test/mocks/init/mocks.h
+++ b/test/mocks/init/mocks.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "envoy/init/init.h"
+
+#include "test/mocks/common.h"
+
+namespace Init {
+
+class MockTarget : public Target {
+public:
+  MockTarget();
+  ~MockTarget();
+
+  MOCK_METHOD1(initialize, void(std::function<void()> callback));
+
+  std::function<void()> callback_;
+};
+
+class MockManager : public Manager {
+public:
+  MockManager();
+  ~MockManager();
+
+  void initialize() {
+    for (auto target : targets_) {
+      target->initialize([this]() -> void { initialized_.ready(); });
+    }
+  }
+
+  // Init::Manager
+  MOCK_METHOD1(registerTarget, void(Target& target));
+
+  std::list<Target*> targets_;
+  ReadyWatcher initialized_;
+};
+
+} // Init

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -37,6 +37,7 @@ MockInstance::MockInstance() : ssl_context_manager_(runtime_loader_) {
   ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
+  ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
 }
 
 MockInstance::~MockInstance() {}

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -13,6 +13,7 @@
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/init/mocks.h"
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
@@ -101,6 +102,7 @@ public:
   MOCK_METHOD1(getParentStats, void(HotRestart::GetParentStatsInfo&));
   MOCK_METHOD0(healthCheckFailed, bool());
   MOCK_METHOD0(hotRestart, HotRestart&());
+  MOCK_METHOD0(initManager, Init::Manager&());
   MOCK_METHOD0(options, Options&());
   MOCK_METHOD0(random, Runtime::RandomGenerator&());
   MOCK_METHOD0(rateLimitClient_, RateLimit::Client*());
@@ -131,6 +133,7 @@ public:
   testing::NiceMock<MockOptions> options_;
   testing::NiceMock<Runtime::MockRandomGenerator> random_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  testing::NiceMock<Init::MockManager> init_manager_;
 };
 
 } // Server

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1,0 +1,32 @@
+#include "server/server.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/init/mocks.h"
+
+using testing::_;
+using testing::InSequence;
+
+namespace Server {
+
+TEST(InitManagerImplTest, NoTargets) {
+  InitManagerImpl manager;
+  ReadyWatcher initialized;
+
+  EXPECT_CALL(initialized, ready());
+  manager.initialize([&]() -> void { initialized.ready(); });
+}
+
+TEST(InitManagerImplTest, Targets) {
+  InSequence s;
+  InitManagerImpl manager;
+  Init::MockTarget target;
+  ReadyWatcher initialized;
+
+  manager.registerTarget(target);
+  EXPECT_CALL(target, initialize(_));
+  manager.initialize([&]() -> void { initialized.ready(); });
+  EXPECT_CALL(initialized, ready());
+  target.callback_();
+}
+
+} // Server


### PR DESCRIPTION
We have a fairly complicated init situation at this point in which we need to
do the following:
1) Initialize static cm clusters
2) Initialize cds cm clusters
3) Initialize rds
4) Start listening

This change sets up a generic init manager framework that allows extensions to
initialize after cm init but before we start listening.

This commit also adds "integration tests" for CDS/RDS in that we specify them
in one of the integration test configs. Nothing is currently implemented but it
at least checks that the server initialized correctly.

fixes https://github.com/lyft/envoy/issues/465