### PR TITLE
Update tag to d4610d5d7ac01b275612b14f0fbef72b1b374d87 for CI bulids

### DIFF
--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -6,7 +6,7 @@ set -e
 # Lint travis file.
 travis lint .travis.yml --skip-completion-check
 # Do a build matrix with different types of builds docs, coverage, normal, etc.
-docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:5ba9f93b749aaabdc4e6d16f941f9970a80fcf8e /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:d4610d5d7ac01b275612b14f0fbef72b1b374d87 /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
 
 # The following scripts are only relevant on a `normal` run.
 # This script build a lyft/envoy image an that image is pushed on merge to master.


### PR DESCRIPTION
New docker image contains 0_33 LightStep library with parent span guid fix.