### PR TITLE
json schema: always specify that the top level is an object

### DIFF
--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -32,6 +32,7 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
         "additionalProperties": false
       }
     },
+    "type" : "object",
     "properties": {
        "port": {"type": "number"},
        "filters" : {
@@ -51,6 +52,7 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
 const std::string Json::Schema::CLIENT_SSL_NETWORK_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties": {
       "auth_api_cluster" : {"type" : "string"},
       "stat_prefix" : {"type" : "string"},
@@ -77,6 +79,7 @@ const std::string Json::Schema::CLIENT_SSL_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::RDS_CONFIGURATION_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "cluster" : {"type": "string"},
       "route_config_name" : {"type": "string"},
@@ -217,6 +220,7 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "codec_type" : {
         "type" : "string",
@@ -273,6 +277,7 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::MONGO_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties":{
       "stat_prefix" : {"type" : "string"},
       "access_log" : {"type" : "string"}
@@ -285,6 +290,7 @@ const std::string Json::Schema::MONGO_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties":{
       "stat_prefix" : {"type" : "string"},
       "domain" : {"type" : "string"},
@@ -314,6 +320,7 @@ const std::string Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::REDIS_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties":{
       "cluster_name" : {"type" : "string"}
     },
@@ -325,6 +332,7 @@ const std::string Json::Schema::REDIS_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::TCP_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
   {
       "$schema": "http://json-schema.org/schema#",
+      "type" : "object",
       "properties": {
         "stat_prefix": {"type" : "string"},
         "route_config": {
@@ -374,6 +382,7 @@ const std::string Json::Schema::TCP_PROXY_NETWORK_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::ROUTE_CONFIGURATION_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties":{
       "virtual_hosts" : {"type" : "array"},
       "internal_only_headers" : {
@@ -407,6 +416,7 @@ const std::string Json::Schema::ROUTE_CONFIGURATION_SCHEMA(R"EOF(
 const std::string Json::Schema::VIRTUAL_HOST_CONFIGURATION_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "definitions" : {
       "virtual_clusters" : {
         "type" : "object" ,
@@ -467,6 +477,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "prefix" : {"type" : "string"},
       "path" : {"type" : "string"},
@@ -570,6 +581,7 @@ const std::string Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "stage" : {"type" : "integer"},
       "kill_switch_key" : {"type" : "string"},
@@ -594,6 +606,7 @@ const std::string Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA(R"EOF(
 const std::string Json::Schema::BUFFER_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "max_request_bytes" : {"type" : "integer"},
       "max_request_time_s" : {"type" : "integer"}
@@ -606,6 +619,7 @@ const std::string Json::Schema::BUFFER_HTTP_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::FAULT_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "abort": {
         "type" : "object",
@@ -668,6 +682,7 @@ const std::string Json::Schema::FAULT_HTTP_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::HEALTH_CHECK_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "pass_through_mode" : {"type" : "boolean"},
       "endpoint" : {"type" : "string"},
@@ -681,6 +696,7 @@ const std::string Json::Schema::HEALTH_CHECK_HTTP_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "domain" : {"type" : "string"},
       "stage" : {"type" : "integer"}
@@ -693,6 +709,7 @@ const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
 const std::string Json::Schema::ROUTER_HTTP_FILTER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "dynamic_stats" : {"type" : "boolean"}
     },
@@ -731,6 +748,7 @@ const std::string Json::Schema::CLUSTER_MANAGER_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "clusters" : {
         "type" : "array",
@@ -796,6 +814,7 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "listeners" : {
         "type" : "array",
@@ -926,6 +945,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
         "additionalProperties" : false
       }
     },
+    "type" : "object",
     "properties" : {
       "name" : {"type" : "string"},
       "type" : {
@@ -986,6 +1006,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
 const std::string Json::Schema::CDS_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
     "properties" : {
       "clusters" : {
         "type" : "array",
@@ -1022,6 +1043,7 @@ const std::string Json::Schema::SDS_SCHEMA(R"EOF(
         "required" : ["ip_address", "port"]
       }
     },
+    "type" : "object",
     "properties" : {
       "hosts" : {
         "type" : "array",

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -191,7 +191,7 @@ TEST_F(RdsImplTest, Failure) {
 
   setup();
 
-  std::string response1_json = R"EOF(
+  std::string response_json = R"EOF(
   {
     "blah": true
   }
@@ -199,7 +199,7 @@ TEST_F(RdsImplTest, Failure) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response_json)});
 
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
@@ -219,13 +219,13 @@ TEST_F(RdsImplTest, FailureArray) {
 
   setup();
 
-  std::string response1_json = R"EOF(
+  std::string response_json = R"EOF(
   []
   )EOF";
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response_json)});
 
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -214,4 +214,24 @@ TEST_F(RdsImplTest, Failure) {
   EXPECT_EQ(2UL, store_.counter("foo.rds.update_failure").value());
 }
 
+TEST_F(RdsImplTest, FailureArray) {
+  InSequence s;
+
+  setup();
+
+  std::string response1_json = R"EOF(
+  []
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ(1UL, store_.counter("foo.rds.update_attempt").value());
+  EXPECT_EQ(1UL, store_.counter("foo.rds.update_failure").value());
+}
+
 } // Upstream

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -163,7 +163,7 @@ TEST_F(CdsApiImplTest, Failure) {
 
   setup();
 
-  std::string response1_json = R"EOF(
+  std::string response_json = R"EOF(
   {
     "clusters" : {}
   }
@@ -171,7 +171,7 @@ TEST_F(CdsApiImplTest, Failure) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response_json)});
 
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -192,13 +192,13 @@ TEST_F(CdsApiImplTest, FailureArray) {
 
   setup();
 
-  std::string response1_json = R"EOF(
+  std::string response_json = R"EOF(
   []
   )EOF";
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response1_json)});
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response_json)});
 
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -324,4 +324,22 @@ TEST_F(SdsTest, Failure) {
   EXPECT_EQ(1UL, cluster_->info()->stats().update_failure_.value());
 }
 
+TEST_F(SdsTest, FailureArray) {
+  setupRequest();
+  cluster_->initialize();
+
+  std::string bad_response_json = R"EOF(
+  []
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(bad_response_json)});
+
+  EXPECT_CALL(*timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ(1UL, cluster_->info()->stats().update_failure_.value());
+}
+
 } // Upstream


### PR DESCRIPTION
Otherwise '[]' does not cause a schema error.