### PR TITLE
Rate Limit Action: Update descriptor keys

### DIFF
--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -57,7 +57,7 @@ Source Cluster
 
 The following descriptor entry is appended to the descriptor:
 
-  * ("from_cluster", "<local service cluster>")
+  * ("source_cluster", "<local service cluster>")
 
 <local service cluster> is derived from the :option:`--service-cluster` option.
 
@@ -72,7 +72,7 @@ Destination Cluster
 
 The following descriptor entry is appended to the descriptor:
 
-  * ("to_cluster", "<routed target cluster>")
+  * ("destination_cluster", "<routed target cluster>")
 
 Once a request matches against a route table rule, a routed cluster is determined by one of the
 following :ref:`route table configuration <config_http_conn_man_route_table_route_cluster>`

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -11,14 +11,14 @@ void SourceClusterAction::populateDescriptor(const Router::RouteEntry&,
                                              ::RateLimit::Descriptor& descriptor,
                                              const std::string& local_service_cluster,
                                              const Http::HeaderMap&, const std::string&) const {
-  descriptor.entries_.push_back({"from_cluster", local_service_cluster});
+  descriptor.entries_.push_back({"source_cluster", local_service_cluster});
 }
 
 void DestinationClusterAction::populateDescriptor(const Router::RouteEntry& route,
                                                   ::RateLimit::Descriptor& descriptor,
                                                   const std::string&, const Http::HeaderMap&,
                                                   const std::string&) const {
-  descriptor.entries_.push_back({"to_cluster", route.clusterName()});
+  descriptor.entries_.push_back({"destination_cluster", route.clusterName()});
 }
 
 void RequestHeadersAction::populateDescriptor(const Router::RouteEntry&,

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -220,7 +220,7 @@ TEST_F(RateLimitConfiguration, TestVirtualHost) {
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_, "");
   }
-  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"to_cluster", "www2test"}}}}),
+  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"destination_cluster", "www2test"}}}}),
               testing::ContainerEq(descriptors));
 }
 
@@ -282,8 +282,8 @@ TEST_F(RateLimitConfiguration, TestMultipleRateLimits) {
   }
   EXPECT_THAT(std::vector<::RateLimit::Descriptor>(
                   {{{{"remote_address", address}}},
-                   {{{"to_cluster", "www2test"}}},
-                   {{{"to_cluster", "www2test"}, {"from_cluster", "service_cluster"}}}}),
+                   {{{"destination_cluster", "www2test"}}},
+                   {{{"destination_cluster", "www2test"}, {"source_cluster", "service_cluster"}}}}),
               testing::ContainerEq(descriptors));
 }
 
@@ -370,7 +370,7 @@ TEST_F(RateLimitPolicyEntryTest, SourceService) {
   SetUpTest(json);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_, "");
-  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"from_cluster", "service_cluster"}}}}),
+  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"source_cluster", "service_cluster"}}}}),
               testing::ContainerEq(descriptors_));
 }
 
@@ -388,7 +388,7 @@ TEST_F(RateLimitPolicyEntryTest, DestinationService) {
   SetUpTest(json);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_, "");
-  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"to_cluster", "fake_cluster"}}}}),
+  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"}}}}),
               testing::ContainerEq(descriptors_));
 }
 
@@ -469,8 +469,8 @@ TEST_F(RateLimitPolicyEntryTest, CompoundActions) {
   SetUpTest(json);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_, "");
-  EXPECT_THAT(std::vector<::RateLimit::Descriptor>(
-                  {{{{"to_cluster", "fake_cluster"}, {"from_cluster", "service_cluster"}}}}),
+  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"},
+                                                      {"source_cluster", "service_cluster"}}}}),
               testing::ContainerEq(descriptors_));
 }
 


### PR DESCRIPTION
Change descriptor keys to match action names for source_cluster and destination_cluster.