### PR TITLE
Define findListenerByPort to fix use_original_dst flag

### DIFF
--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -49,12 +49,12 @@ public:
                               bool use_proxy_proto, bool use_orig_dst) PURE;
 
   /**
-   * Find a listener based on the provided socket name
-   * @param name supplies the name of the socket
+   * Find a listener based on the provided listener port value.
+   * @param port supplies the port value
    * @return a pointer to the listener or nullptr if not found.
    * Ownership of the listener is NOT transferred
    */
-  virtual Network::Listener* findListener(const std::string& socket_name) PURE;
+  virtual Network::Listener* findListenerByPort(uint32_t port) PURE;
 
   /**
    * Close and destroy all listeners.

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -23,9 +23,9 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
 
   Address::InstancePtr final_local_address = listener->socket_.localAddress();
   if (listener->use_original_dst_ && final_local_address->type() == Address::Type::Ip) {
-    Address::InstancePtr orginal_local_address = listener->getOriginalDst(fd);
-    if (orginal_local_address) {
-      final_local_address = orginal_local_address;
+    Address::InstancePtr original_local_address = listener->getOriginalDst(fd);
+    if (original_local_address) {
+      final_local_address = original_local_address;
     }
 
     // A listener that has the use_original_dst flag set to true can still receive connections
@@ -34,7 +34,7 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
     // In this case the listener handles the connection directly and does not hand it off.
     if (listener->socket_.localAddress()->ip()->port() != final_local_address->ip()->port()) {
       ListenerImpl* new_listener = dynamic_cast<ListenerImpl*>(
-          listener->connection_handler_.findListener(final_local_address->asString()));
+          listener->connection_handler_.findListenerByPort(final_local_address->ip()->port()));
 
       if (new_listener != nullptr) {
         listener = new_listener;

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -23,7 +23,7 @@ void ConnectionHandlerImpl::addListener(Network::FilterChainFactory& factory,
                                         bool use_proxy_proto, bool use_orig_dst) {
   ActiveListenerPtr l(
       new ActiveListener(*this, socket, factory, bind_to_port, use_proxy_proto, use_orig_dst));
-  listeners_.push_back(std::make_pair(socket.localAddress(), std::move(l)));
+  listeners_.emplace_back(socket.localAddress(), std::move(l));
 }
 
 void ConnectionHandlerImpl::addSslListener(Network::FilterChainFactory& factory,
@@ -32,7 +32,7 @@ void ConnectionHandlerImpl::addSslListener(Network::FilterChainFactory& factory,
                                            bool use_proxy_proto, bool use_orig_dst) {
   ActiveListenerPtr l(new SslActiveListener(*this, ssl_ctx, socket, factory, bind_to_port,
                                             use_proxy_proto, use_orig_dst));
-  listeners_.push_back(std::make_pair(socket.localAddress(), std::move(l)));
+  listeners_.emplace_back(socket.localAddress(), std::move(l));
 }
 
 void ConnectionHandlerImpl::closeConnections() {
@@ -86,6 +86,9 @@ ConnectionHandlerImpl::SslActiveListener::SslActiveListener(ConnectionHandlerImp
                      factory, socket.localAddress()->asString()) {}
 
 Network::Listener* ConnectionHandlerImpl::findListenerByPort(uint32_t port) {
+  // findListenerByPort is O(#listeners) operation, may need to add a map<port, listener>
+  // to improve performance to O(log #listeners); since the number of listeners is small
+  // linear performance might be adequate
   auto l = std::find_if(
       listeners_.begin(), listeners_.end(),
       [port](const std::pair<Network::Address::InstancePtr, ActiveListenerPtr>& p) {

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -63,7 +63,7 @@ public:
                       Network::ListenSocket& socket, bool bind_to_port, bool use_proxy_proto,
                       bool use_orig_dst) override;
 
-  Network::Listener* findListener(const std::string& socket_name) override;
+  Network::Listener* findListenerByPort(uint32_t port) override;
 
   void closeListeners() override;
 
@@ -138,7 +138,7 @@ private:
   spdlog::logger& logger_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
-  std::map<std::string, ActiveListenerPtr> listeners_;
+  std::list<std::pair<Network::Address::InstancePtr, ActiveListenerPtr>> listeners_;
   std::list<ActiveConnectionPtr> connections_;
   std::atomic<uint64_t> num_connections_{};
   Stats::Counter& watchdog_miss_counter_;

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -80,8 +80,7 @@ TEST(ListenerImplTest, UseOriginalDst) {
 
   Address::InstancePtr alt_address(new Address::Ipv4Instance("127.0.0.1", 10001));
   EXPECT_CALL(listener, getOriginalDst(_)).WillRepeatedly(Return(alt_address));
-  EXPECT_CALL(connection_handler, findListener("127.0.0.1:10001"))
-      .WillRepeatedly(Return(&listenerDst));
+  EXPECT_CALL(connection_handler, findListenerByPort(10001)).WillRepeatedly(Return(&listenerDst));
 
   EXPECT_CALL(listener, newConnection(_, _, _)).Times(0);
   EXPECT_CALL(listenerDst, newConnection(_, _, _));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -215,7 +215,7 @@ public:
   MOCK_METHOD6(addSslListener, void(Network::FilterChainFactory& factory,
                                     Ssl::ServerContext& ssl_ctx, Network::ListenSocket& socket,
                                     bool bind_to_port, bool use_proxy_proto, bool use_orig_dst));
-  MOCK_METHOD1(findListener, Network::Listener*(const std::string& socket_name));
+  MOCK_METHOD1(findListenerByPort, Network::Listener*(uint32_t port));
   MOCK_METHOD0(closeListeners, void());
 };
 


### PR DESCRIPTION
The listener socket address and getOriginalDst address do not match (0.0.0.0 vs link-local IP), causing an issue in finding a matching listener. The fix is to search by the port value alone for IP addresses. Since Envoy binds on all localhost addresses now, the function is well-defined for IP addresses.