### PR TITLE
HTTP consistent hash routing

### DIFF
--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -39,8 +39,8 @@ connect_timeout_ms
 
 lb_type
   *(required, string)* The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
-  when picking a host in the cluster. Possible options are *round_robin*, *least_request*, and
-  *random*.
+  when picking a host in the cluster. Possible options are *round_robin*, *least_request*,
+  *ring_hash*, and *random*.
 
 hosts
   *(sometimes required, array)* If the service discovery type is *static*, *strict_dns*, or

--- a/docs/configuration/cluster_manager/cluster_runtime.rst
+++ b/docs/configuration/cluster_manager/cluster_runtime.rst
@@ -65,6 +65,15 @@ upstream.weight_enabled
   Binary switch to turn on or off weighted load balancing. If set to non 0, weighted load balancing
   is enabled. Defaults to enabled.
 
+.. _config_cluster_manager_cluster_runtime_ring_hash:
+
+Ring hash load balancing
+------------------------
+
+upstream.ring_hash.min_ring_size
+  The minimum size of the hash ring for the :ref:`ring hash load balancer
+  <arch_overview_load_balancing_types>`. The default is 1024.
+
 .. _config_cluster_manager_cluster_runtime_zone_routing:
 
 Zone aware load balancing

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -321,4 +321,6 @@ Specifies the route's hashing policy if the upstream cluster uses a hashing :ref
    }
 
 header_name
-  *(required, string)* The name of the request header that will be used to obtain the hash key.
+  *(required, string)* The name of the request header that will be used to obtain the hash key. If
+  the request header is not present, the load balancer will use a random number as the hash,
+  effectively making the load balancing policy random.

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -25,7 +25,8 @@ next (e.g., redirect, forward, rewrite, etc.).
     "shadow": "{...}",
     "priority": "...",
     "headers": [],
-    "rate_limits": []
+    "rate_limits": [],
+    "hash_policy": "{...}"
   }
 
 prefix
@@ -133,6 +134,10 @@ priority
 :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>`
   *(optional, array)* Specifies a set of rate limit configurations that could be applied to the
   route.
+
+:ref:`hash_policy <config_http_conn_man_route_table_hash_policy>`
+  *(optional, array)* Specifies the route's hashing policy if the upstream cluster uses a hashing
+  :ref:`load balancer <arch_overview_load_balancing_types>`.
 
 .. _config_http_conn_man_route_table_route_runtime:
 
@@ -300,3 +305,20 @@ runtime_key_prefix
 
   **Note:** If the sum of runtime weights exceed 100, the traffic splitting behavior
   is undefined (although the request will be routed to one of the clusters).
+
+.. _config_http_conn_man_route_table_hash_policy:
+
+Hash policy
+-----------
+
+Specifies the route's hashing policy if the upstream cluster uses a hashing :ref:`load balancer
+<arch_overview_load_balancing_types>`.
+
+.. code-block:: json
+
+   {
+     "header_name": "..."
+   }
+
+header_name
+  *(required, string)* The name of the request header that will be used to obtain the hash key.

--- a/docs/intro/arch_overview/http_routing.rst
+++ b/docs/intro/arch_overview/http_routing.rst
@@ -40,6 +40,7 @@ request. The router filter supports the following features:
   used by Envoy to generate additional statistics on top of the standard cluster level ones. Virtual
   clusters can use regex matching.
 * :ref:`Priority <arch_overview_http_routing_priority>` based routing.
+* :ref:`Hash policy <config_http_conn_man_route_table_hash_policy>` based routing.
 
 Route table
 -----------

--- a/docs/intro/arch_overview/load_balancing.rst
+++ b/docs/intro/arch_overview/load_balancing.rst
@@ -43,7 +43,7 @@ when protocol routing is used that specifies a value to hash on. Currently the o
 mechanism is to hash via :ref:`HTTP header values <config_http_conn_man_route_table_hash_policy>` in
 the :ref:`HTTP router filter <arch_overview_http_routing>`. The default minimum ring size is
 specified in :ref:`runtime <config_cluster_manager_cluster_runtime_ring_hash>`. The minimum ring
-size is governs the replication factor for each host in the ring. For example, if the minimum ring
+size governs the replication factor for each host in the ring. For example, if the minimum ring
 size is 1024 and there are 16 hosts, each host will be replicated 64 times. The ring hash load
 balancer does not currently support weighting.
 

--- a/docs/intro/arch_overview/load_balancing.rst
+++ b/docs/intro/arch_overview/load_balancing.rst
@@ -36,12 +36,16 @@ Ring hash
 ^^^^^^^^^
 
 The ring/modulo hash load balancer implements consistent hashing to upstream hosts. The algorithm is
-based on mapping all hosts onto a circle such that any host set changes only affect 1/N requests.
-This technique is also commonly known as "ketama" hashing. The consistent hashing load balancer is
-only effective when protocol routing is used that specifies a value to hash on. Currently the only
-implemented mechanism is to hash via :ref:`HTTP header values
-<config_http_conn_man_route_table_hash_policy>` in the :ref:`HTTP router filter
-<arch_overview_http_routing>`.
+based on mapping all hosts onto a circle such that the addition or removal of a host from the host
+set changes only affect 1/N requests. This technique is also commonly known as `"ketama"
+<https://github.com/RJ/ketama>`_ hashing. The consistent hashing load balancer is only effective
+when protocol routing is used that specifies a value to hash on. Currently the only implemented
+mechanism is to hash via :ref:`HTTP header values <config_http_conn_man_route_table_hash_policy>` in
+the :ref:`HTTP router filter <arch_overview_http_routing>`. The default minimum ring size is
+specified in :ref:`runtime <config_cluster_manager_cluster_runtime_ring_hash>`. The minimum ring
+size is governs the replication factor for each host in the ring. For example, if the minimum ring
+size is 1024 and there are 16 hosts, each host will be replicated 64 times. The ring hash load
+balancer does not currently support weighting.
 
 Random
 ^^^^^^

--- a/docs/intro/arch_overview/load_balancing.rst
+++ b/docs/intro/arch_overview/load_balancing.rst
@@ -32,6 +32,17 @@ weighted least request behavior is desired (generally if request durations are v
 length). We may add a true full scan weighted least request variant in the future to cover this use
 case.
 
+Ring hash
+^^^^^^^^^
+
+The ring/modulo hash load balancer implements consistent hashing to upstream hosts. The algorithm is
+based on mapping all hosts onto a circle such that any host set changes only affect 1/N requests.
+This technique is also commonly known as "ketama" hashing. The consistent hashing load balancer is
+only effective when protocol routing is used that specifies a value to hash on. Currently the only
+implemented mechanism is to hash via :ref:`HTTP header values
+<config_http_conn_man_route_table_hash_policy>` in the :ref:`HTTP router filter
+<arch_overview_http_routing>`.
+
 Random
 ^^^^^^
 

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -141,6 +141,22 @@ public:
 };
 
 /**
+ * Route hash policy. I.e., if using a hashing load balancer, how the route should be hashed onto
+ * an upstream host.
+ */
+class HashPolicy {
+public:
+  virtual ~HashPolicy() {}
+
+  /**
+   * @return Optional<uint64_t> an optional hash value to route on given a set of HTTP headers.
+   *         A hash value might not be returned if for example the specified HTTP header does not
+   *         exist. In the future we might add addtional support for hashing on origin address, etc.
+   */
+  virtual Optional<uint64_t> generateHash(const Http::HeaderMap& headers) const PURE;
+};
+
+/**
  * An individual resolved route entry.
  */
 class RouteEntry {
@@ -159,6 +175,11 @@ public:
    * @param headers supplies the request headers, which may be modified during this call.
    */
   virtual void finalizeRequestHeaders(Http::HeaderMap& headers) const PURE;
+
+  /**
+   * @return const HashPolicy* the optional hash policy for the route.
+   */
+  virtual const HashPolicy* hashPolicy() const PURE;
 
   /**
    * @return the priority of the route.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -151,7 +151,8 @@ public:
   /**
    * @return Optional<uint64_t> an optional hash value to route on given a set of HTTP headers.
    *         A hash value might not be returned if for example the specified HTTP header does not
-   *         exist. In the future we might add addtional support for hashing on origin address, etc.
+   *         exist. In the future we might add additional support for hashing on origin address,
+   *         etc.
    */
   virtual Optional<uint64_t> generateHash(const Http::HeaderMap& headers) const PURE;
 };

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -3,6 +3,7 @@
 #include "envoy/http/async_client.h"
 #include "envoy/http/conn_pool.h"
 #include "envoy/json/json_object.h"
+#include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Upstream {
@@ -53,7 +54,8 @@ public:
    * exist.
    */
   virtual Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
-                                                                 ResourcePriority priority) PURE;
+                                                                 ResourcePriority priority,
+                                                                 LoadBalancerContext* context) PURE;
 
   /**
    * Allocate a load balanced TCP connection for a cluster. The created connection is already

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -6,6 +6,20 @@
 namespace Upstream {
 
 /**
+ * Context passed to a load balancer to use when choosing a host. Not all load balancers make use
+ * of all context information.
+ */
+class LoadBalancerContext {
+public:
+  virtual ~LoadBalancerContext() {}
+
+  /**
+   * @return const Optional<uint64_t>& the optional hash key to use during load balancing.
+   */
+  virtual const Optional<uint64_t>& hashKey() const PURE;
+};
+
+/**
  * Abstract load balancing interface.
  */
 class LoadBalancer {
@@ -14,8 +28,11 @@ public:
 
   /**
    * Ask the load balancer for the next host to use depending on the underlying LB algorithm.
+   * @param context supplies the load balancer context. Not all load balancers make use of all
+   *        context information. Load balancers should be written to assume that context information
+   *        is missing and use sensible defaults.
    */
-  virtual ConstHostPtr chooseHost() PURE;
+  virtual ConstHostPtr chooseHost(const LoadBalancerContext* context) PURE;
 };
 
 typedef std::unique_ptr<LoadBalancer> LoadBalancerPtr;

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -6,8 +6,8 @@
 namespace Upstream {
 
 /**
- * Context passed to a load balancer to use when choosing a host. Not all load balancers make use
- * of all context information.
+ * Context information passed to a load balancer to use when choosing a host. Not all load
+ * balancers make use of all context information.
  */
 class LoadBalancerContext {
 public:

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -5,6 +5,6 @@ namespace Upstream {
 /**
  * Type of load balancing to perform.
  */
-enum class LoadBalancerType { RoundRobin, LeastRequest, Random };
+enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash };
 
 } // Upstream

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(
   upstream/load_balancer_impl.cc
   upstream/logical_dns_cluster.cc
   upstream/outlier_detection_impl.cc
+  upstream/ring_hash_lb.cc
   upstream/sds.cc
   upstream/upstream_impl.cc
   ${gen_git_sha_target})

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -110,6 +110,7 @@ private:
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
     void finalizeRequestHeaders(Http::HeaderMap&) const override {}
+    const Router::HashPolicy* hashPolicy() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;
     }

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -535,7 +535,15 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
           "additionalProperties" : false
         }
       },
-      "rate_limits" : {"type" : "array"}
+      "rate_limits" : {"type" : "array"},
+      "hash_policy" : {
+        "type" : "object",
+        "properties" : {
+          "header_name" : {"type" : "string"}
+        },
+        "required" : ["header_name"],
+        "additionalProperties" : false
+      }
     },
     "additionalProperties" : false
   }
@@ -983,7 +991,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
       },
       "lb_type" : {
         "type" : "string",
-        "enum" : ["round_robin", "least_request", "random"]
+        "enum" : ["round_robin", "least_request", "random", "ring_hash"]
       },
       "hosts" : {
         "type" : "array",

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -7,8 +7,6 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "common/json/json_loader.h"
-
 namespace Router {
 
 /**
@@ -169,6 +167,21 @@ private:
 };
 
 /**
+ * Implementation of HashPolicy that reads from the JSON route config and only currently supports
+ * hashing on an HTTP header.
+ */
+class HashPolicyImpl : public HashPolicy {
+public:
+  HashPolicyImpl(const Json::Object& config);
+
+  // Router::HashPolicy
+  Optional<uint64_t> generateHash(const Http::HeaderMap& headers) const override;
+
+private:
+  const Http::LowerCaseString header_name_;
+};
+
+/**
  * Base implementation for all route entries.
  */
 class RouteEntryImplBase : public RouteEntry,
@@ -189,6 +202,7 @@ public:
   // Router::RouteEntry
   const std::string& clusterName() const override;
   void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
+  const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const RetryPolicy& retryPolicy() const override { return retry_policy_; }
@@ -232,6 +246,7 @@ private:
       return parent_->finalizeRequestHeaders(headers);
     }
 
+    const HashPolicy* hashPolicy() const override { return parent_->hashPolicy(); }
     Upstream::ResourcePriority priority() const override { return parent_->priority(); }
     const RateLimitPolicy& rateLimitPolicy() const override { return parent_->rateLimitPolicy(); }
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
@@ -299,6 +314,7 @@ private:
   const Upstream::ResourcePriority priority_;
   std::vector<ConfigUtility::HeaderData> config_headers_;
   std::vector<WeightedClusterEntryPtr> weighted_clusters_;
+  std::unique_ptr<const HashPolicyImpl> hash_policy_;
 };
 
 /**

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -168,6 +168,15 @@ private:
 
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;
 
+  struct LoadBalancerContextImpl : public Upstream::LoadBalancerContext {
+    LoadBalancerContextImpl(const Optional<uint64_t>& hash) : hash_(hash) {}
+
+    // Upstream::LoadBalancerContext
+    const Optional<uint64_t>& hashKey() const override { return hash_; }
+
+    Optional<uint64_t> hash_;
+  };
+
   enum class UpstreamResetType { Reset, GlobalTimeout, PerTryTimeout };
 
   Http::AccessLog::ResponseFlag
@@ -185,6 +194,7 @@ private:
                                          Event::Dispatcher& dispatcher,
                                          Upstream::ResourcePriority priority) PURE;
   Upstream::ResourcePriority finalPriority();
+  Http::ConnectionPool::Instance* getConnPool();
   void maybeDoShadowing();
   void onRequestComplete();
   void onResetStream();
@@ -214,6 +224,7 @@ private:
   Http::HeaderMap* downstream_headers_{};
   Http::HeaderMap* downstream_trailers_{};
   SystemTime downstream_request_complete_time_;
+  std::unique_ptr<LoadBalancerContextImpl> lb_context_;
 
   bool downstream_response_started_ : 1;
   bool downstream_end_stream_ : 1;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -174,7 +174,7 @@ private:
     // Upstream::LoadBalancerContext
     const Optional<uint64_t>& hashKey() const override { return hash_; }
 
-    Optional<uint64_t> hash_;
+    const Optional<uint64_t> hash_;
   };
 
   enum class UpstreamResetType { Reset, GlobalTimeout, PerTryTimeout };

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -123,7 +123,8 @@ public:
   }
   ClusterInfoPtr get(const std::string& cluster) override;
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
-                                                         ResourcePriority priority) override;
+                                                         ResourcePriority priority,
+                                                         LoadBalancerContext* context) override;
   Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) override;
   Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) override;
   bool removePrimaryCluster(const std::string& cluster) override;
@@ -150,7 +151,8 @@ private:
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoPtr cluster);
       ~ClusterEntry();
 
-      Http::ConnectionPool::Instance* connPool(ResourcePriority priority);
+      Http::ConnectionPool::Instance* connPool(ResourcePriority priority,
+                                               LoadBalancerContext* context);
 
       ThreadLocalClusterManagerImpl& parent_;
       HostSetImpl host_set_;

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -7,6 +7,19 @@
 namespace Upstream {
 
 /**
+ * Utilities common to all load balancers.
+ */
+class LoadBalancerUtility {
+public:
+  /**
+   * For the given host_set @return if we should be in a panic mode or not. For example, if the
+   * majority of hosts are unhealthy we'll be likely in a panic mode. In this case we'll route
+   * requests to hosts regardless of whether they are healthy or not.
+   */
+  static bool isGlobalPanic(const HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime);
+};
+
+/**
  * Base class for all LB implementations.
  */
 class LoadBalancerBase {
@@ -31,13 +44,6 @@ private:
    * This gets recalculated on update callback.
    */
   bool earlyExitNonZoneRouting();
-
-  /**
-   * For the given host_set it @return if we should be in a panic mode or not.
-   * For example, if majority of hosts are unhealthy we'll be likely in a panic mode.
-   * In this case we'll route requests to hosts no matter if they are healthy or not.
-   */
-  bool isGlobalPanic(const HostSet& host_set);
 
   /**
    * Try to select upstream hosts from the same zone.
@@ -76,7 +82,7 @@ public:
       : LoadBalancerBase(host_set, local_host_set_, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
-  ConstHostPtr chooseHost() override;
+  ConstHostPtr chooseHost(const LoadBalancerContext* context) override;
 
 private:
   size_t rr_index_{};
@@ -102,7 +108,7 @@ public:
                            Runtime::RandomGenerator& random);
 
   // Upstream::LoadBalancer
-  ConstHostPtr chooseHost() override;
+  ConstHostPtr chooseHost(const LoadBalancerContext* context) override;
 
 private:
   HostPtr last_host_;
@@ -119,7 +125,7 @@ public:
       : LoadBalancerBase(host_set, local_host_set, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
-  ConstHostPtr chooseHost() override;
+  ConstHostPtr chooseHost(const LoadBalancerContext* context) override;
 };
 
 } // Upstream

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -1,0 +1,124 @@
+#include "load_balancer_impl.h"
+#include "ring_hash_lb.h"
+
+#include "common/common/assert.h"
+
+namespace Upstream {
+
+RingHashLoadBalancer::RingHashLoadBalancer(HostSet& host_set, ClusterStats& stats,
+                                           Runtime::Loader& runtime,
+                                           Runtime::RandomGenerator& random)
+    : host_set_(host_set), stats_(stats), runtime_(runtime), random_(random) {
+  host_set_.addMemberUpdateCb([this](const std::vector<HostPtr>&, const std::vector<HostPtr>&)
+                                  -> void { refresh(); });
+
+  refresh();
+}
+
+ConstHostPtr RingHashLoadBalancer::chooseHost(const LoadBalancerContext* context) {
+  if (LoadBalancerUtility::isGlobalPanic(host_set_, stats_, runtime_)) {
+    return all_hosts_ring_.chooseHost(context, random_);
+  } else {
+    return healthy_hosts_ring_.chooseHost(context, random_);
+  }
+}
+
+ConstHostPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerContext* context,
+                                                    Runtime::RandomGenerator& random) {
+  if (ring_.empty()) {
+    return nullptr;
+  }
+
+  // If there is no hash in the context, just choose a random value (this effectively becomes
+  // the random LB but it won't crash if someone configures it this way).
+  uint64_t h;
+  if (!context || !context->hashKey().valid()) {
+    h = random.random();
+  } else {
+    h = context->hashKey().value();
+  }
+
+  // Ported from https://github.com/RJ/ketama/blob/master/libketama/ketama.c (ketama_get_server)
+  // I've generally kept the variable names to make the code easier to compare.
+  // NOTE: The algorithm depends on using signed integers for lowp, midp, and highp. Do not
+  //       change them!
+  int64_t lowp = 0;
+  int64_t highp = ring_.size();
+  while (true) {
+    int64_t midp = (lowp + highp) / 2;
+
+    if (midp == static_cast<int64_t>(ring_.size())) {
+      return ring_[0].host_;
+    }
+
+    uint64_t midval = ring_[midp].hash_;
+    uint64_t midval1 = midp == 0 ? 0 : ring_[midp - 1].hash_;
+
+    if (h <= midval && h > midval1) {
+      return ring_[midp].host_;
+    }
+
+    if (midval < h) {
+      lowp = midp + 1;
+    } else {
+      highp = midp - 1;
+    }
+
+    if (lowp > highp) {
+      return ring_[0].host_;
+    }
+  }
+}
+
+void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
+                                        const std::vector<HostPtr>& hosts) {
+  log_trace("ring hash: building ring");
+  if (hosts.empty()) {
+    ring_.clear();
+    return;
+  }
+
+  // Currently we specify the minimum size of the ring, and determine the replication factor
+  // based on the number of hosts. It's possible we might want to support more sophisticated
+  // configuration in the future.
+  // NOTE: Currently we keep a ring for healthy hosts and unhealthy hosts, and this is done per
+  //       thread. This is the simplest implementation, but it's expensive from a memory
+  //       standpoint and duplicates the regeneration computation. In the future we might want
+  //       to generate the rings centrally and then just RCU them out to each thread. This is
+  //       sufficient for getting started.
+  uint64_t min_ring_size = runtime.snapshot().getInteger("upstream.ring_hash.min_ring_size", 1024);
+
+  uint64_t hashes_per_host = 1;
+  if (hosts.size() < min_ring_size) {
+    hashes_per_host = min_ring_size / hosts.size();
+    if ((min_ring_size % hosts.size()) != 0) {
+      hashes_per_host++;
+    }
+  }
+
+  log_trace("ring hash: min_ring_size={} hashes_per_host={}", min_ring_size, hashes_per_host);
+  ring_.reserve(hosts.size() * hashes_per_host);
+  for (auto host : hosts) {
+    for (uint64_t i = 0; i < hashes_per_host; i++) {
+      std::string hash_key(host->address()->asString() + "_" + std::to_string(i));
+      uint64_t hash = std::hash<std::string>()(hash_key);
+      log_trace("ring hash: hash_key={} hash={}", hash_key, hash);
+      ring_.push_back({hash, host});
+    }
+  }
+
+  std::sort(ring_.begin(), ring_.end(), [](const RingEntry& lhs, const RingEntry& rhs)
+                                            -> bool { return lhs.hash_ < rhs.hash_; });
+#ifndef NDEBUG
+  for (auto entry : ring_) {
+    log_trace("ring hash: host={} hash={}", entry.host_->address()->asString(), entry.hash_);
+  }
+#endif
+}
+
+void RingHashLoadBalancer::refresh() {
+  all_hosts_ring_.create(runtime_, host_set_.hosts());
+  healthy_hosts_ring_.create(runtime_, host_set_.healthyHosts());
+}
+
+} // Upstream

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -73,8 +73,8 @@ ConstHostPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerContext* c
 void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
                                         const std::vector<HostPtr>& hosts) {
   log_trace("ring hash: building ring");
+  ring_.clear();
   if (hosts.empty()) {
-    ring_.clear();
     return;
   }
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "envoy/runtime/runtime.h"
+#include "envoy/upstream/load_balancer.h"
+
+#include "common/common/logger.h"
+
+namespace Upstream {
+
+/**
+ * A load balancer that implements consistent modulo hashing ("ketama"). Currently, zone aware
+ * routing is not supported. A ring is kept for all hosts as well as a ring for healthy hosts.
+ * Unless we are in panic mode, the healthy host ring is used.
+ * In the future it would be nice to support:
+ * 1) Weighting.
+ * 2) Per-zone rings and optional zone aware routing (not all applications will want this).
+ * 3) Max request fallback to support hot shards (not all applications will want this).
+ */
+class RingHashLoadBalancer : public LoadBalancer, Logger::Loggable<Logger::Id::upstream> {
+public:
+  RingHashLoadBalancer(HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
+                       Runtime::RandomGenerator& random);
+
+  // Upstream::LoadBalancer
+  ConstHostPtr chooseHost(const LoadBalancerContext* context) override;
+
+private:
+  struct RingEntry {
+    uint64_t hash_;
+    ConstHostPtr host_;
+  };
+
+  struct Ring {
+    ConstHostPtr chooseHost(const LoadBalancerContext* context, Runtime::RandomGenerator& random);
+    void create(Runtime::Loader& runtime, const std::vector<HostPtr>& hosts);
+
+    std::vector<RingEntry> ring_;
+  };
+
+  void refresh();
+
+  HostSet& host_set_;
+  ClusterStats& stats_;
+  Runtime::Loader& runtime_;
+  Runtime::RandomGenerator& random_;
+  Ring all_hosts_ring_;
+  Ring healthy_hosts_ring_;
+};
+
+} // Upstream

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -79,6 +79,8 @@ ClusterInfoImpl::ClusterInfoImpl(const Json::Object& config, Runtime::Loader& ru
     lb_type_ = LoadBalancerType::LeastRequest;
   } else if (string_lb_type == "random") {
     lb_type_ = LoadBalancerType::Random;
+  } else if (string_lb_type == "ring_hash") {
+    lb_type_ = LoadBalancerType::RingHash;
   } else {
     throw EnvoyException(fmt::format("cluster: unknown LB type '{}'", string_lb_type));
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,7 @@ add_executable(envoy-test
   common/upstream/logical_dns_cluster_test.cc
   common/upstream/outlier_detection_impl_test.cc
   common/upstream/resource_manager_impl_test.cc
+  common/upstream/ring_hash_lb_test.cc
   common/upstream/sds_test.cc
   common/upstream/upstream_impl_test.cc
   example_configs_test.cc

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -59,7 +59,7 @@ public:
   }
 
   NiceMock<Runtime::MockLoader> runtime_;
-  Upstream::MockClusterManager cm_;
+  NiceMock<Upstream::MockClusterManager> cm_;
   Event::MockDispatcher dispatcher_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
@@ -251,6 +251,7 @@ TEST_F(RdsImplTest, FailureArray) {
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
   message->body(Buffer::InstancePtr{new Buffer::OwnedImpl(response_json)});
 
+  EXPECT_CALL(init_manager_.initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -312,7 +312,8 @@ TEST_F(ClusterManagerImplTest, UnknownCluster) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   create(*loader);
   EXPECT_EQ(nullptr, cluster_manager_->get("hello"));
-  EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("hello", ResourcePriority::Default));
+  EXPECT_EQ(nullptr,
+            cluster_manager_->httpConnPoolForCluster("hello", ResourcePriority::Default, nullptr));
   EXPECT_THROW(cluster_manager_->tcpConnForCluster("hello"), EnvoyException);
   EXPECT_THROW(cluster_manager_->httpAsyncClientForCluster("hello"), EnvoyException);
   factory_.tls_.shutdownThread();
@@ -514,8 +515,8 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   EXPECT_EQ(1UL, cluster_manager_->clusters().size());
   Http::ConnectionPool::MockInstance* cp = new Http::ConnectionPool::MockInstance();
   EXPECT_CALL(factory_, allocateConnPool_(_)).WillOnce(Return(cp));
-  EXPECT_EQ(cp,
-            cluster_manager_->httpConnPoolForCluster("fake_cluster", ResourcePriority::Default));
+  EXPECT_EQ(cp, cluster_manager_->httpConnPoolForCluster("fake_cluster", ResourcePriority::Default,
+                                                         nullptr));
 
   // Now remove it. This should drain the connection pool.
   Http::ConnectionPool::Instance::DrainedCb drained_cb;
@@ -599,8 +600,8 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   create(*loader);
 
   // Test for no hosts returning the correct values before we have hosts.
-  EXPECT_EQ(nullptr,
-            cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default));
+  EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("cluster_1",
+                                                              ResourcePriority::Default, nullptr));
   EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1").connection_);
   EXPECT_EQ(2UL, factory_.stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
 
@@ -622,13 +623,13 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
 
   // This should provide us a CP for each of the above hosts.
   Http::ConnectionPool::MockInstance* cp1 = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default, nullptr));
   Http::ConnectionPool::MockInstance* cp2 = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default, nullptr));
   Http::ConnectionPool::MockInstance* cp1_high = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High, nullptr));
   Http::ConnectionPool::MockInstance* cp2_high = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High, nullptr));
 
   EXPECT_NE(cp1, cp2);
   EXPECT_NE(cp1_high, cp2_high);
@@ -650,9 +651,9 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
 
   // Make sure we get back the same connection pool for the 2nd host as we did before the change.
   Http::ConnectionPool::MockInstance* cp3 = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default, nullptr));
   Http::ConnectionPool::MockInstance* cp3_high = dynamic_cast<Http::ConnectionPool::MockInstance*>(
-      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High));
+      cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::High, nullptr));
   EXPECT_EQ(cp2, cp3);
   EXPECT_EQ(cp2_high, cp3_high);
 

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -84,7 +84,7 @@ public:
       local_host_set_->updateHosts(originating_hosts, originating_hosts, per_zone_local,
                                    per_zone_local, empty_vector_, empty_vector_);
 
-      ConstHostPtr selected = lb.chooseHost();
+      ConstHostPtr selected = lb.chooseHost(nullptr);
       hits[selected->address()->asString()]++;
     }
 

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -27,9 +27,11 @@ public:
 
 class RingHashLoadBalancerTest : public testing::Test {
 public:
+  RingHashLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
+
   NiceMock<MockCluster> cluster_;
   Stats::IsolatedStoreImpl stats_store_;
-  ClusterStats stats_{ClusterInfoImpl::generateStats(stats_store_)};
+  ClusterStats stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   RingHashLoadBalancer lb_{cluster_, stats_, runtime_, random_};

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -1,0 +1,115 @@
+#include "common/network/utility.h"
+#include "common/upstream/upstream_impl.h"
+#include "common/upstream/ring_hash_lb.h"
+
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+
+namespace Upstream {
+
+static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url) {
+  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, 1, "")};
+}
+
+class TestLoadBalancerContext : public LoadBalancerContext {
+public:
+  TestLoadBalancerContext(uint64_t hash_key) : hash_key_(hash_key) {}
+
+  // Upstream::LoadBalancerContext
+  const Optional<uint64_t>& hashKey() const override { return hash_key_; }
+
+  Optional<uint64_t> hash_key_;
+};
+
+class RingHashLoadBalancerTest : public testing::Test {
+public:
+  NiceMock<MockCluster> cluster_;
+  Stats::IsolatedStoreImpl stats_store_;
+  ClusterStats stats_{ClusterInfoImpl::generateStats(stats_store_)};
+  NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  RingHashLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+};
+
+TEST_F(RingHashLoadBalancerTest, NoHost) { EXPECT_EQ(nullptr, lb_.chooseHost(nullptr)); };
+
+TEST_F(RingHashLoadBalancerTest, Basic) {
+  cluster_.hosts_ = {newTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:82"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:83"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:84"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:85")};
+  cluster_.healthy_hosts_ = cluster_.hosts_;
+
+  ON_CALL(runtime_.snapshot_, getInteger("upstream.ring_hash.min_ring_size", _))
+      .WillByDefault(Return(12));
+  cluster_.runCallbacks({}, {});
+
+  // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
+  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // ring hash: host=127.0.0.1:85 hash=1358027074129602068
+  // ring hash: host=127.0.0.1:83 hash=4361834613929391114
+  // ring hash: host=127.0.0.1:84 hash=7224494972555149682
+  // ring hash: host=127.0.0.1:81 hash=7701421856454313576
+  // ring hash: host=127.0.0.1:82 hash=8649315368077433379
+  // ring hash: host=127.0.0.1:84 hash=8739448859063030639
+  // ring hash: host=127.0.0.1:81 hash=9887544217113020895
+  // ring hash: host=127.0.0.1:82 hash=10150910876324007731
+  // ring hash: host=127.0.0.1:83 hash=15168472011420622455
+  // ring hash: host=127.0.0.1:80 hash=15427156902705414897
+  // ring hash: host=127.0.0.1:85 hash=16375050414328759093
+  // ring hash: host=127.0.0.1:80 hash=17613279263364193813
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(std::numeric_limits<uint64_t>::max());
+    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(1358027074129602068);
+    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(1358027074129602069);
+    EXPECT_EQ(cluster_.hosts_[3], lb_.chooseHost(&context));
+  }
+  {
+    EXPECT_CALL(random_, random()).WillOnce(Return(10150910876324007730UL));
+    EXPECT_EQ(cluster_.hosts_[2], lb_.chooseHost(nullptr));
+  }
+
+  cluster_.healthy_hosts_.clear();
+  cluster_.runCallbacks({}, {});
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+  }
+}
+
+TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
+  cluster_.hosts_ = {newTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:81")};
+  ON_CALL(runtime_.snapshot_, getInteger("upstream.ring_hash.min_ring_size", _))
+      .WillByDefault(Return(3));
+  cluster_.runCallbacks({}, {});
+
+  // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
+  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // ring hash: host=127.0.0.1:81 hash=7701421856454313576
+  // ring hash: host=127.0.0.1:81 hash=9887544217113020895
+  // ring hash: host=127.0.0.1:80 hash=15427156902705414897
+  // ring hash: host=127.0.0.1:80 hash=17613279263364193813
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(cluster_.hosts_[1], lb_.chooseHost(&context));
+  }
+}
+
+} // Upstream

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -112,6 +112,21 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
     TestLoadBalancerContext context(0);
     EXPECT_EQ(cluster_.hosts_[1], lb_.chooseHost(&context));
   }
+
+  cluster_.hosts_ = {newTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
+                     newTestHost(cluster_.info_, "tcp://127.0.0.1:82")};
+  cluster_.runCallbacks({}, {});
+
+  // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
+  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // ring hash: host=127.0.0.1:81 hash=7701421856454313576
+  // ring hash: host=127.0.0.1:82 hash=8649315368077433379
+  // ring hash: host=127.0.0.1:81 hash=9887544217113020895
+  // ring hash: host=127.0.0.1:82 hash=10150910876324007731
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(cluster_.hosts_[0], lb_.chooseHost(&context));
+  }
 }
 
 } // Upstream

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -41,6 +41,9 @@ MockVirtualHost::MockVirtualHost() {
 
 MockVirtualHost::~MockVirtualHost() {}
 
+MockHashPolicy::MockHashPolicy() {}
+MockHashPolicy::~MockHashPolicy() {}
+
 MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
   ON_CALL(*this, rateLimitPolicy()).WillByDefault(ReturnRef(rate_limit_policy_));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -121,6 +121,15 @@ public:
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
 };
 
+class MockHashPolicy : public HashPolicy {
+public:
+  MockHashPolicy();
+  ~MockHashPolicy();
+
+  // Router::HashPolicy
+  MOCK_CONST_METHOD1(generateHash, Optional<uint64_t>(const Http::HeaderMap& headers));
+};
+
 class MockRouteEntry : public RouteEntry {
 public:
   MockRouteEntry();
@@ -129,6 +138,7 @@ public:
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
   MOCK_CONST_METHOD1(finalizeRequestHeaders, void(Http::HeaderMap& headers));
+  MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(retryPolicy, const RetryPolicy&());
@@ -144,6 +154,7 @@ public:
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
   TestShadowPolicy shadow_policy_;
   testing::NiceMock<MockVirtualHost> virtual_host_;
+  MockHashPolicy hash_policy_;
 };
 
 class MockRoute : public Route {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -79,7 +79,7 @@ MockCluster::MockCluster() {
 MockCluster::~MockCluster() {}
 
 MockClusterManager::MockClusterManager() {
-  ON_CALL(*this, httpConnPoolForCluster(_, _)).WillByDefault(Return(&conn_pool_));
+  ON_CALL(*this, httpConnPoolForCluster(_, _, _)).WillByDefault(Return(&conn_pool_));
   ON_CALL(*this, httpAsyncClientForCluster(_)).WillByDefault(ReturnRef(async_client_));
   ON_CALL(*this, httpAsyncClientForCluster(_)).WillByDefault((ReturnRef(async_client_)));
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -65,8 +65,10 @@ public:
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ClusterInfoPtr(const std::string& cluster));
-  MOCK_METHOD2(httpConnPoolForCluster, Http::ConnectionPool::Instance*(const std::string& cluster,
-                                                                       ResourcePriority priority));
+  MOCK_METHOD3(httpConnPoolForCluster,
+               Http::ConnectionPool::Instance*(const std::string& cluster,
+                                               ResourcePriority priority,
+                                               LoadBalancerContext* context));
   MOCK_METHOD1(tcpConnForCluster_, MockHost::MockCreateConnectionData(const std::string& cluster));
   MOCK_METHOD1(httpAsyncClientForCluster, Http::AsyncClient&(const std::string& cluster));
   MOCK_METHOD1(removePrimaryCluster, bool(const std::string& cluster));


### PR DESCRIPTION
Although the ring hashing load balancer ("ketama") was primarily implemented
for the upcoming redis support, as a bonus this commit adds  HTTP consistent
hash routing as well, since it's pretty simple and it's been requested several
times.

fixes https://github.com/lyft/envoy/issues/197