### PR TITLE
Tags Docker images with the Travis build commit

### DIFF
--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -19,6 +19,7 @@ then
   then
       docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       docker push lyft/envoy:latest
+      test -z "$TRAVIS_COMMIT" || docker push lyft/envoy:$TRAVIS_COMMIT
   else
       echo 'Ignoring PR branch for docker push.'
   fi


### PR DESCRIPTION
The current Travis build pushes a Docker image with the latest tag. But as latest is a sliding tag, it's hard to pick a particular image based on it. Adding a commit tag from Travis makes it possible to pick a docker image with a particular build of Envoy.