### PR TITLE
Auto host rewrite option for strict_dns and logical_dns clusters

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -18,6 +18,7 @@ next (e.g., redirect, forward, rewrite, etc.).
     "path_redirect": "...",
     "prefix_rewrite": "...",
     "host_rewrite": "...",
+    "auto_host_rewrite": "...",
     "case_sensitive": "...",
     "timeout_ms": "...",
     "runtime": "{...}",
@@ -97,6 +98,15 @@ prefix_rewrite
 host_rewrite
   *(optional, string)* Indicates that during forwarding, the host header will be swapped with this
   value.
+
+.. _config_http_conn_man_route_table_route_auto_host_rewrite:
+
+auto_host_rewrite
+  *(optional, boolean)* Indicates that during forwarding, the host header will be swapped with the
+  hostname of the upstream host chosen by the cluster manager. This option is applicable only when
+  the destination cluster for a route is of type *strict_dns* or *logical_dns*. Setting this to true
+  with other cluster types has no effect. *auto_host_rewrite* and *host_rewrite* are mutually exclusive 
+  options. Only one can be specified.
 
 .. _config_http_conn_man_route_table_route_case_sensitive:
 

--- a/docs/intro/arch_overview/http_routing.rst
+++ b/docs/intro/arch_overview/http_routing.rst
@@ -23,8 +23,8 @@ request. The router filter supports the following features:
 * :ref:`Path <config_http_conn_man_route_table_route_path_redirect>`/:ref:`host
   <config_http_conn_man_route_table_route_host_redirect>` redirection at the route level.
 * :ref:`Explicit host rewriting <config_http_conn_man_route_table_route_host_rewrite>`.
-* :ref:`Automatic host rewriting <config_http_conn_man_route_table_route_auto_host_rewrite>` based on DNS name of
-  the selected upstream host.
+* :ref:`Automatic host rewriting <config_http_conn_man_route_table_route_auto_host_rewrite>` based on
+  the DNS name of the selected upstream host.
 * :ref:`Prefix rewriting <config_http_conn_man_route_table_route_prefix_rewrite>`.
 * :ref:`Request retries <arch_overview_http_routing_retry>` specified either via HTTP header or via
   route configuration.

--- a/docs/intro/arch_overview/http_routing.rst
+++ b/docs/intro/arch_overview/http_routing.rst
@@ -22,7 +22,9 @@ request. The router filter supports the following features:
   level.
 * :ref:`Path <config_http_conn_man_route_table_route_path_redirect>`/:ref:`host
   <config_http_conn_man_route_table_route_host_redirect>` redirection at the route level.
-* :ref:`Host rewriting <config_http_conn_man_route_table_route_host_rewrite>`.
+* :ref:`Explicit host rewriting <config_http_conn_man_route_table_route_host_rewrite>`.
+* :ref:`Automatic host rewriting <config_http_conn_man_route_table_route_auto_host_rewrite>` based on DNS name of
+  the selected upstream host.
 * :ref:`Prefix rewriting <config_http_conn_man_route_table_route_prefix_rewrite>`.
 * :ref:`Request retries <arch_overview_http_routing_retry>` specified either via HTTP header or via
   route configuration.

--- a/examples/front-proxy/service-envoy.json
+++ b/examples/front-proxy/service-envoy.json
@@ -34,41 +34,6 @@
           }
         }
       ]
-    },
-    {
-      "port": 9090,
-      "filters": [
-        {
-          "type": "read",
-          "name": "http_connection_manager",
-          "config": {
-            "codec_type": "auto",
-            "stat_prefix": "ingress_http",
-            "route_config": {
-              "virtual_hosts": [
-                {
-                  "name": "service",
-                  "domains": ["*"],
-                  "routes": [
-                    {
-                      "timeout_ms": 0,
-                      "prefix": "/service",
-                      "cluster": "remote_local_service"
-                    }
-                  ]
-                }
-              ]
-            },
-            "filters": [
-              {
-                "type": "decoder",
-                "name": "router",
-                "config": {}
-              }
-            ]
-          }
-        }
-      ]
     }
   ],
   "admin": {
@@ -87,19 +52,8 @@
             "url": "tcp://127.0.0.1:8080"
           }
         ]
-      },
-      {
-        "name": "remote_local_service",
-        "connect_timeout_ms": 250,
-        "type": "strict_dns",
-        "lb_type": "round_robin",
-        "features" : "http2",
-        "hosts": [
-          {
-            "url": "tcp://127.0.0.1:80"
-          }
-        ]
       }
     ]
   }
 }
+

--- a/examples/front-proxy/service-envoy.json
+++ b/examples/front-proxy/service-envoy.json
@@ -34,6 +34,41 @@
           }
         }
       ]
+    },
+    {
+      "port": 9090,
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "service",
+                  "domains": ["*"],
+                  "routes": [
+                    {
+                      "timeout_ms": 0,
+                      "prefix": "/service",
+                      "cluster": "remote_local_service"
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
     }
   ],
   "admin": {
@@ -52,8 +87,19 @@
             "url": "tcp://127.0.0.1:8080"
           }
         ]
+      },
+      {
+        "name": "remote_local_service",
+        "connect_timeout_ms": 250,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "features" : "http2",
+        "hosts": [
+          {
+            "url": "tcp://127.0.0.1:80"
+          }
+        ]
       }
     ]
   }
 }
-

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -220,6 +220,11 @@ public:
    * @return const VirtualHost& the virtual host that owns the route.
    */
   virtual const VirtualHost& virtualHost() const PURE;
+
+  /**
+   * @return bool true if the Host header should be overwritten with the Upstream hostname.
+   */
+  virtual bool autoHostRewrite() const PURE;
 };
 
 /**

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -222,7 +222,7 @@ public:
   virtual const VirtualHost& virtualHost() const PURE;
 
   /**
-   * @return bool true if the Host header should be overwritten with the Upstream hostname.
+   * @return bool true if the :authority header should be overwritten with the upstream hostname.
    */
   virtual bool autoHostRewrite() const PURE;
 };

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -51,6 +51,12 @@ public:
   virtual Outlier::DetectorHostSink& outlierDetector() const PURE;
 
   /**
+   * @return the hostname associated with the host if any.
+   * Empty string "" indicates that hostname is not a DNS name.
+   */
+  virtual const std::string& hostName() const PURE;
+
+  /**
    * @return the address used to connect to the host.
    */
   virtual Network::Address::InstancePtr address() const PURE;

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -54,7 +54,7 @@ public:
    * @return the hostname associated with the host if any.
    * Empty string "" indicates that hostname is not a DNS name.
    */
-  virtual const std::string& hostName() const PURE;
+  virtual const std::string& hostname() const PURE;
 
   /**
    * @return the address used to connect to the host.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -129,6 +129,7 @@ private:
       return nullptr;
     }
     const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
+    bool autoHostRewrite() const override { return false; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -488,6 +488,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "path_redirect" : {"type" : "string"},
       "prefix_rewrite" : {"type" : "string"},
       "host_rewrite" : {"type" : "string"},
+      "auto_host_rewrite" : {"type" : "boolean"},
       "case_sensitive" : {"type" : "boolean"},
       "timeout_ms" : {"type" : "integer"},
       "runtime" : {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -121,14 +121,6 @@ uint32_t Utility::portFromTcpUrl(const std::string& url) {
   }
 }
 
-std::string Utility::hostAndPortFromTcpUrl(const std::string& url) {
-  if (url.find(TCP_SCHEME) != 0) {
-    throw EnvoyException(fmt::format("unknown protocol scheme: {}", url));
-  }
-
-  return url.substr(TCP_SCHEME.size());
-}
-
 Address::InstancePtr Utility::getLocalAddress() {
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -129,7 +129,6 @@ std::string Utility::hostAndPortFromTcpUrl(const std::string& url) {
   return url.substr(TCP_SCHEME.size());
 }
 
-
 Address::InstancePtr Utility::getLocalAddress() {
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -121,6 +121,15 @@ uint32_t Utility::portFromTcpUrl(const std::string& url) {
   }
 }
 
+std::string Utility::hostAndPortFromTcpUrl(const std::string& url) {
+  if (url.find(TCP_SCHEME) != 0) {
+    throw EnvoyException(fmt::format("unknown protocol scheme: {}", url));
+  }
+
+  return url.substr(TCP_SCHEME.size());
+}
+
+
 Address::InstancePtr Utility::getLocalAddress() {
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -74,13 +74,6 @@ public:
   static uint32_t portFromTcpUrl(const std::string& url);
 
   /**
-   * Parses the host:port from a TCP URL
-   * @param the URL to parse port from
-   * @return std::string of form host:port
-   */
-  static std::string hostAndPortFromTcpUrl(const std::string& url);
-
-  /**
    * @return the local IP address of the server
    */
   static Address::InstancePtr getLocalAddress();

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -74,6 +74,13 @@ public:
   static uint32_t portFromTcpUrl(const std::string& url);
 
   /**
+   * Parses the host:port from a TCP URL
+   * @param the URL to parse port from
+   * @return std::string of form host:port
+   */
+  static std::string hostAndPortFromTcpUrl(const std::string& url);
+
+  /**
    * @return the local IP address of the server
    */
   static Address::InstancePtr getLocalAddress();

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -106,7 +106,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
 
   route.validateSchema(Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA);
 
-  // Route can either have a host_rewrite with fixed host header or automatic host rewrite 
+  // Route can either have a host_rewrite with fixed host header or automatic host rewrite
   // based on the DNS name of the instance in the backing cluster.
   if (auto_host_rewrite_ && !host_rewrite_.empty()) {
     throw EnvoyException("routes cannot have both auto_host_rewrite and host_rewrite options set");

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -92,9 +92,9 @@ const uint64_t RouteEntryImplBase::WeightedClusterEntry::MAX_CLUSTER_WEIGHT = 10
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json::Object& route,
                                        Runtime::Loader& loader)
     : case_sensitive_(route.getBoolean("case_sensitive", true)),
-      auto_host_rewrite_(route.getBoolean("auto_host_rewrite", true)),
       prefix_rewrite_(route.getString("prefix_rewrite", "")),
       host_rewrite_(route.getString("host_rewrite", "")), vhost_(vhost),
+      auto_host_rewrite_(route.getBoolean("auto_host_rewrite", false)),
       cluster_name_(route.getString("cluster", "")),
       cluster_header_name_(route.getString("cluster_header", "")),
       timeout_(route.getInteger("timeout_ms", DEFAULT_ROUTE_TIMEOUT_MS)),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -223,7 +223,6 @@ public:
 
 protected:
   const bool case_sensitive_;
-  const bool auto_host_rewrite_;
   const std::string prefix_rewrite_;
   const std::string host_rewrite_;
 
@@ -304,6 +303,7 @@ private:
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;
 
   const VirtualHostImpl& vhost_;
+  const bool auto_host_rewrite_;
   const std::string cluster_name_;
   const Http::LowerCaseString cluster_header_name_;
   const std::chrono::milliseconds timeout_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -222,6 +222,7 @@ public:
 
 protected:
   const bool case_sensitive_;
+  const bool auto_host_rewrite_;
   const std::string prefix_rewrite_;
   const std::string host_rewrite_;
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -212,6 +212,7 @@ public:
   }
   std::chrono::milliseconds timeout() const override { return timeout_; }
   const VirtualHost& virtualHost() const override { return vhost_; }
+  bool autoHostRewrite() const override { return auto_host_rewrite_; }
 
   // Router::RedirectEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -259,6 +260,7 @@ private:
     }
 
     const VirtualHost& virtualHost() const override { return parent_->virtualHost(); }
+    bool autoHostRewrite() const override { return parent_->autoHostRewrite(); }
 
     // Router::Route
     const RedirectEntry* redirectEntry() const override { return nullptr; }

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -704,8 +704,8 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
   conn_pool_stream_handle_ = nullptr;
   request_encoder_ = &request_encoder;
   calling_encode_headers_ = true;
-  if (route_entry_->autoHostRewrite()) {
-    *parent_.downstream_headers_->Host()->value(host->hostname());
+  if (parent_.route_entry_->autoHostRewrite()) {
+    parent_.downstream_headers_->Host()->value(host->hostname());
   }
 
   request_encoder.encodeHeaders(*parent_.downstream_headers_,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -704,6 +704,10 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
   conn_pool_stream_handle_ = nullptr;
   request_encoder_ = &request_encoder;
   calling_encode_headers_ = true;
+  if (route_entry_->autoHostRewrite()) {
+    *parent_.downstream_headers_->Host()->value(host->hostname());
+  }
+
   request_encoder.encodeHeaders(*parent_.downstream_headers_,
                                 !buffered_request_body_ && encode_complete_ && !encode_trailers_);
   calling_encode_headers_ = false;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -704,7 +704,7 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
   conn_pool_stream_handle_ = nullptr;
   request_encoder_ = &request_encoder;
   calling_encode_headers_ = true;
-  if (parent_.route_entry_->autoHostRewrite()) {
+  if (parent_.route_entry_->autoHostRewrite() && !host->hostname().empty()) {
     parent_.downstream_headers_->Host()->value(host->hostname());
   }
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -21,9 +21,8 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
   }
 
   dns_url_ = hosts_json[0]->getString("url");
-  Network::Utility::hostFromTcpUrl(dns_url_);
-  Network::Utility::portFromTcpUrl(dns_url_);
-
+  hostname_ = Network::Utility::hostAndPortFromTcpUrl(dns_url_);
+    
   // This must come before startResolve(), since the resolve callback relies on
   // tls_slot_ being initialized.
   tls.set(tls_slot_, [](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectPtr {
@@ -71,7 +70,7 @@ void LogicalDnsCluster::startResolve() {
             //       express a DNS name inside of an Address::Instance. For now this is OK but
             //       we might want to do better again later.
             logical_host_.reset(
-                new LogicalHost(info_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
+                                new LogicalHost(info_, "", Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());
             new_hosts->emplace_back(logical_host_);
             updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -22,7 +22,7 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
 
   dns_url_ = hosts_json[0]->getString("url");
   hostname_ = Network::Utility::hostAndPortFromTcpUrl(dns_url_);
-    
+
   // This must come before startResolve(), since the resolve callback relies on
   // tls_slot_ being initialized.
   tls.set(tls_slot_, [](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectPtr {
@@ -70,7 +70,7 @@ void LogicalDnsCluster::startResolve() {
             //       express a DNS name inside of an Address::Instance. For now this is OK but
             //       we might want to do better again later.
             logical_host_.reset(
-                                new LogicalHost(info_, "", Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
+                new LogicalHost(info_, "", Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());
             new_hosts->emplace_back(logical_host_);
             updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -69,8 +69,8 @@ void LogicalDnsCluster::startResolve() {
             //       the friendly DNS name in that output, but currently there is no way to
             //       express a DNS name inside of an Address::Instance. For now this is OK but
             //       we might want to do better again later.
-            logical_host_.reset(
-                new LogicalHost(info_, "", Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
+            logical_host_.reset(new LogicalHost(
+                info_, hostname_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());
             new_hosts->emplace_back(logical_host_);
             updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -21,7 +21,8 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
   }
 
   dns_url_ = hosts_json[0]->getString("url");
-  hostname_ = Network::Utility::hostAndPortFromTcpUrl(dns_url_);
+  hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
+  Network::Utility::portFromTcpUrl(dns_url_);
 
   // This must come before startResolve(), since the resolve callback relies on
   // tls_slot_ being initialized.

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -63,7 +63,7 @@ private:
       return logical_host_->outlierDetector();
     }
     const HostStats& stats() const override { return logical_host_->stats(); }
-    const std::string& hostName() const override { return logical_host->hostName(); }
+    const std::string& hostname() const override { return logical_host_->hostname(); }
     Network::Address::InstancePtr address() const override { return address_; }
     const std::string& zone() const override { return EMPTY_STRING; }
 

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -42,9 +42,9 @@ public:
 
 private:
   struct LogicalHost : public HostImpl {
-  LogicalHost(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address,
-                LogicalDnsCluster& parent)
-      : HostImpl(cluster, hostname, address, false, 1, ""), parent_(parent) {}
+    LogicalHost(ClusterInfoPtr cluster, const std::string& hostname,
+                Network::Address::InstancePtr address, LogicalDnsCluster& parent)
+        : HostImpl(cluster, hostname, address, false, 1, ""), parent_(parent) {}
 
     // Upstream::Host
     CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const override;

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -42,9 +42,9 @@ public:
 
 private:
   struct LogicalHost : public HostImpl {
-    LogicalHost(ClusterInfoPtr cluster, Network::Address::InstancePtr address,
+  LogicalHost(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address,
                 LogicalDnsCluster& parent)
-        : HostImpl(cluster, address, false, 1, ""), parent_(parent) {}
+      : HostImpl(cluster, hostname, address, false, 1, ""), parent_(parent) {}
 
     // Upstream::Host
     CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const override;
@@ -63,6 +63,7 @@ private:
       return logical_host_->outlierDetector();
     }
     const HostStats& stats() const override { return logical_host_->stats(); }
+    const std::string& hostName() const override { return logical_host->hostName(); }
     Network::Address::InstancePtr address() const override { return address_; }
     const std::string& zone() const override { return EMPTY_STRING; }
 
@@ -88,6 +89,7 @@ private:
   bool initialized_;
   Event::TimerPtr resolve_timer_;
   std::string dns_url_;
+  std::string hostname_;
   Network::Address::InstancePtr current_resolved_address_;
   HostPtr logical_host_;
   Network::ActiveDnsQuery* active_dns_query_{};

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -35,8 +35,8 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
     // In CF, discovery will only return hostnames for a service
     // while SDS expects only IPs. Possibly extend this with additional field called hostname?
     new_hosts.emplace_back(
-                           new HostImpl(info_, "", Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
-                                host->getString("ip_address"), host->getInteger("port"))},
+        new HostImpl(info_, "", Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+                                    host->getString("ip_address"), host->getInteger("port"))},
                      canary, weight, zone));
   }
 

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -31,8 +31,11 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
       zone = host->getObject("tags")->getString("az", zone);
     }
 
+    // TODO: This will be a problem for CloudFoundry + service discovery
+    // In CF, discovery will only return hostnames for a service
+    // while SDS expects only IPs. Possibly extend this with additional field called hostname?
     new_hosts.emplace_back(
-        new HostImpl(info_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+                           new HostImpl(info_, "", Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
                                 host->getString("ip_address"), host->getInteger("port"))},
                      canary, weight, zone));
   }

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -31,9 +31,6 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
       zone = host->getObject("tags")->getString("az", zone);
     }
 
-    // TODO: This will be a problem for CloudFoundry + service discovery
-    // In CF, discovery will only return hostnames for a service
-    // while SDS expects only IPs. Possibly extend this with additional field called hostname?
     new_hosts.emplace_back(
         new HostImpl(info_, "", Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
                                     host->getString("ip_address"), host->getInteger("port"))},

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -396,7 +396,6 @@ StrictDnsClusterImpl::ResolveTarget::ResolveTarget(StrictDnsClusterImpl& parent,
                                                    const std::string& url)
     : parent_(parent), dns_address_(Network::Utility::hostFromTcpUrl(url)),
       port_(Network::Utility::portFromTcpUrl(url)),
-      hostname_(Network::Utility::hostAndPortFromTcpUrl(url)),
       resolve_timer_(dispatcher.createTimer([this]() -> void { startResolve(); })) {}
 
 StrictDnsClusterImpl::ResolveTarget::~ResolveTarget() {
@@ -422,7 +421,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           //       move port handling into the DNS interface itself, which would work better for
           //       SRV.
           new_hosts.emplace_back(
-              new HostImpl(parent_.info_, hostname_,
+              new HostImpl(parent_.info_, dns_address_,
                            Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
                                address->ip()->addressAsString(), port_)},
                            false, 1, ""));

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -267,8 +267,8 @@ StaticClusterImpl::StaticClusterImpl(const Json::Object& config, Runtime::Loader
   std::vector<Json::ObjectPtr> hosts_json = config.getObjectArray("hosts");
   HostVectorPtr new_hosts(new std::vector<HostPtr>());
   for (Json::ObjectPtr& host : hosts_json) {
-    new_hosts->emplace_back(HostPtr{
-        new HostImpl(info_, "", Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
+    new_hosts->emplace_back(HostPtr{new HostImpl(
+        info_, "", Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
   }
 
   updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
@@ -421,9 +421,11 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           //       address that has port in it. We need to both support IPv6 as well as potentially
           //       move port handling into the DNS interface itself, which would work better for
           //       SRV.
-          new_hosts.emplace_back(new HostImpl(parent_.info_, hostname_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
-                                 address->ip()->addressAsString(), port_)},
-              false, 1, ""));
+          new_hosts.emplace_back(
+              new HostImpl(parent_.info_, hostname_,
+                           Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+                               address->ip()->addressAsString(), port_)},
+                           false, 1, ""));
         }
 
         std::vector<HostPtr> hosts_added;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -268,7 +268,7 @@ StaticClusterImpl::StaticClusterImpl(const Json::Object& config, Runtime::Loader
   HostVectorPtr new_hosts(new std::vector<HostPtr>());
   for (Json::ObjectPtr& host : hosts_json) {
     new_hosts->emplace_back(HostPtr{
-        new HostImpl(info_, Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
+        new HostImpl(info_, "", Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
   }
 
   updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
@@ -396,6 +396,7 @@ StrictDnsClusterImpl::ResolveTarget::ResolveTarget(StrictDnsClusterImpl& parent,
                                                    const std::string& url)
     : parent_(parent), dns_address_(Network::Utility::hostFromTcpUrl(url)),
       port_(Network::Utility::portFromTcpUrl(url)),
+      hostname_(Network::Utility::hostAndPortFromTcpUrl(url)),
       resolve_timer_(dispatcher.createTimer([this]() -> void { startResolve(); })) {}
 
 StrictDnsClusterImpl::ResolveTarget::~ResolveTarget() {
@@ -420,8 +421,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           //       address that has port in it. We need to both support IPv6 as well as potentially
           //       move port handling into the DNS interface itself, which would work better for
           //       SRV.
-          new_hosts.emplace_back(new HostImpl(
-              parent_.info_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
+          new_hosts.emplace_back(new HostImpl(parent_.info_, hostname_, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(
                                  address->ip()->addressAsString(), port_)},
               false, 1, ""));
         }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -41,7 +41,7 @@ public:
     }
   }
   const HostStats& stats() const override { return stats_; }
-  const std::string& hostName() const override { return hostname_; }
+  const std::string& hostname() const override { return hostname_; }
   Network::Address::InstancePtr address() const override { return address_; }
   const std::string& zone() const override { return zone_; }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -25,9 +25,9 @@ namespace Upstream {
  */
 class HostDescriptionImpl : virtual public HostDescription {
 public:
-  HostDescriptionImpl(ClusterInfoPtr cluster, Network::Address::InstancePtr address, bool canary,
+ HostDescriptionImpl(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address, bool canary,
                       const std::string& zone)
-      : cluster_(cluster), address_(address), canary_(canary), zone_(zone),
+      : cluster_(cluster), hostname_(hostname), address_(address), canary_(canary), zone_(zone),
         stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))} {}
 
   // Upstream::HostDescription
@@ -41,11 +41,13 @@ public:
     }
   }
   const HostStats& stats() const override { return stats_; }
+  const std::string& hostName() const override {return hostname_; }
   Network::Address::InstancePtr address() const override { return address_; }
   const std::string& zone() const override { return zone_; }
 
 protected:
   ClusterInfoPtr cluster_;
+  const std::string hostname_;
   Network::Address::InstancePtr address_;
   const bool canary_;
   const std::string zone_;
@@ -64,9 +66,9 @@ class HostImpl : public HostDescriptionImpl,
                  public Host,
                  public std::enable_shared_from_this<HostImpl> {
 public:
-  HostImpl(ClusterInfoPtr cluster, Network::Address::InstancePtr address, bool canary,
+ HostImpl(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address, bool canary,
            uint32_t initial_weight, const std::string& zone)
-      : HostDescriptionImpl(cluster, address, canary, zone) {
+     : HostDescriptionImpl(cluster, hostname, address, canary, zone) {
     weight(initial_weight);
   }
 
@@ -315,6 +317,7 @@ private:
     Network::ActiveDnsQuery* active_query_{};
     std::string dns_address_;
     uint32_t port_;
+    std::string hostname_;
     Event::TimerPtr resolve_timer_;
     std::vector<HostPtr> hosts_;
   };

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -25,8 +25,8 @@ namespace Upstream {
  */
 class HostDescriptionImpl : virtual public HostDescription {
 public:
- HostDescriptionImpl(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address, bool canary,
-                      const std::string& zone)
+  HostDescriptionImpl(ClusterInfoPtr cluster, const std::string& hostname,
+                      Network::Address::InstancePtr address, bool canary, const std::string& zone)
       : cluster_(cluster), hostname_(hostname), address_(address), canary_(canary), zone_(zone),
         stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))} {}
 
@@ -41,7 +41,7 @@ public:
     }
   }
   const HostStats& stats() const override { return stats_; }
-  const std::string& hostName() const override {return hostname_; }
+  const std::string& hostName() const override { return hostname_; }
   Network::Address::InstancePtr address() const override { return address_; }
   const std::string& zone() const override { return zone_; }
 
@@ -66,9 +66,10 @@ class HostImpl : public HostDescriptionImpl,
                  public Host,
                  public std::enable_shared_from_this<HostImpl> {
 public:
- HostImpl(ClusterInfoPtr cluster, const std::string& hostname, Network::Address::InstancePtr address, bool canary,
-           uint32_t initial_weight, const std::string& zone)
-     : HostDescriptionImpl(cluster, hostname, address, canary, zone) {
+  HostImpl(ClusterInfoPtr cluster, const std::string& hostname,
+           Network::Address::InstancePtr address, bool canary, uint32_t initial_weight,
+           const std::string& zone)
+      : HostDescriptionImpl(cluster, hostname, address, canary, zone) {
     weight(initial_weight);
   }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -318,7 +318,6 @@ private:
     Network::ActiveDnsQuery* active_query_{};
     std::string dns_address_;
     uint32_t port_;
-    std::string hostname_;
     Event::TimerPtr resolve_timer_;
     std::vector<HostPtr> hosts_;
   };

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -312,7 +312,7 @@ public:
       Upstream::MockHost::MockCreateConnectionData conn_info;
       conn_info.connection_ = upstream_connection_;
       conn_info.host_.reset(
-          new Upstream::HostImpl(cluster_manager_.cluster_.info_,
+          new Upstream::HostImpl(cluster_manager_.cluster_.info_, "",
                                  Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
       EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
       EXPECT_CALL(*upstream_connection_, addReadFilter(_))

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -140,7 +140,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
 TEST_F(AccessLogImplTest, UpstreamHost) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new Upstream::MockClusterInfo()};
   request_info_.upstream_host_ = std::make_shared<Upstream::HostDescriptionImpl>(
-                                                                                 cluster, "", Network::Utility::resolveUrl("tcp://10.0.0.5:1234"), false, "");
+      cluster, "", Network::Utility::resolveUrl("tcp://10.0.0.5:1234"), false, "");
 
   std::string json = R"EOF(
       {

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -140,7 +140,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
 TEST_F(AccessLogImplTest, UpstreamHost) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new Upstream::MockClusterInfo()};
   request_info_.upstream_host_ = std::make_shared<Upstream::HostDescriptionImpl>(
-      cluster, Network::Utility::resolveUrl("tcp://10.0.0.5:1234"), false, "");
+                                                                                 cluster, "", Network::Utility::resolveUrl("tcp://10.0.0.5:1234"), false, "");
 
   std::string json = R"EOF(
       {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -49,7 +49,7 @@ public:
   Network::ReadFilterPtr filter_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_{new Upstream::HostDescriptionImpl(
-      cluster_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+                                                                       cluster_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
 };
 
 TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -49,7 +49,7 @@ public:
   Network::ReadFilterPtr filter_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_{new Upstream::HostDescriptionImpl(
-                                                                       cluster_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+      cluster_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
 };
 
 TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -30,10 +30,11 @@ namespace Http1 {
 class ConnPoolImplForTest : public ConnPoolImpl {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::ClusterInfoPtr cluster)
-      : ConnPoolImpl(dispatcher, Upstream::HostPtr{new Upstream::HostImpl(
-                                     cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:9000"),
-                                     false, 1, "")},
-                     Upstream::ResourcePriority::Default),
+      : ConnPoolImpl(
+            dispatcher,
+            Upstream::HostPtr{new Upstream::HostImpl(
+                cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:9000"), false, 1, "")},
+            Upstream::ResourcePriority::Default),
         mock_dispatcher_(dispatcher) {}
 
   ~ConnPoolImplForTest() {

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -88,7 +88,7 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostPtr host_{new Upstream::HostImpl(
-      cluster_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")};
+      cluster_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")};
   TestConnPoolImpl pool_;
   std::vector<TestCodecClient> test_clients_;
   NiceMock<Runtime::MockLoader> runtime_;

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -149,7 +149,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = upstream_connection;
   conn_info.host_.reset(new Upstream::HostImpl(
-      cm.cluster_.info_, Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
+      cm.cluster_.info_, "", Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
   EXPECT_CALL(cm, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -30,7 +30,7 @@ public:
     Upstream::MockHost::MockCreateConnectionData conn_info;
     conn_info.connection_ = upstream_connection_;
     conn_info.host_.reset(new Upstream::HostImpl(
-        cm_.cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
+        cm_.cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
     EXPECT_CALL(cm_, tcpConnForCluster_("foo")).WillOnce(Return(conn_info));
     EXPECT_CALL(*upstream_connection_, addReadFilter(_))
         .WillOnce(SaveArg<0>(&upstream_read_filter_));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -412,6 +412,32 @@ TEST(RouteMatcherTest, Priority) {
   }
 }
 
+TEST(RouteMatcherTest, NoHostRewriteAndAutoRewrite) {
+  std::string json = R"EOF(
+{
+  "virtual_hosts": [
+    {
+      "name": "local_service",
+      "domains": ["*"],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "local_service",
+          "host_rewrite": "foo",
+          "auto_host_rewrite" : true
+        }
+      ]
+    }
+  ]
+}
+  )EOF";
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
+}
+
 TEST(RouteMatcherTest, HeaderMatchedRouting) {
   std::string json = R"EOF(
 {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -953,18 +953,16 @@ TEST_F(RouterTest, CanaryStatusFalse) {
 
 TEST_F(RouterTest, AutoHostRewriteEnabled) {
   NiceMock<Http::MockStreamEncoder> encoder;
-  std::string dns_host{"scooby.doo"};
   std::string req_host{"foo.bar.com"};
 
   Http::TestHeaderMapImpl incoming_headers;
   HttpTestUtility::addDefaultHeaders(incoming_headers);
   incoming_headers.Host()->value(req_host);
 
+  cm_.conn_pool_.host_->hostname_ = "scooby.doo";
   Http::TestHeaderMapImpl outgoing_headers;
   HttpTestUtility::addDefaultHeaders(outgoing_headers);
-  outgoing_headers.Host()->value(dns_host);
-
-  ON_CALL(*cm_.conn_pool_.host_, hostname()).WillByDefault(ReturnRef(dns_host));
+  outgoing_headers.Host()->value(cm_.conn_pool_.host_->hostname_);
 
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));
@@ -992,14 +990,13 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
 
 TEST_F(RouterTest, AutoHostRewriteDisabled) {
   NiceMock<Http::MockStreamEncoder> encoder;
-  std::string dns_host{"scooby.doo"};
   std::string req_host{"foo.bar.com"};
 
   Http::TestHeaderMapImpl incoming_headers;
   HttpTestUtility::addDefaultHeaders(incoming_headers);
   incoming_headers.Host()->value(req_host);
 
-  ON_CALL(*cm_.conn_pool_.host_, hostname()).WillByDefault(ReturnRef(dns_host));
+  cm_.conn_pool_.host_->hostname_ = "scooby.doo";
 
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -33,7 +33,7 @@ TEST_F(TcpStatsdSinkTest, All) {
   Upstream::MockHost::MockCreateConnectionData conn_info;
   conn_info.connection_ = connection;
   conn_info.host_.reset(
-      new Upstream::HostImpl(Upstream::ClusterInfoPtr{new Upstream::MockClusterInfo},
+      new Upstream::HostImpl(Upstream::ClusterInfoPtr{new Upstream::MockClusterInfo}, "",
                              Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
 
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("statsd")).WillOnce(Return(conn_info));

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -505,7 +505,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   loader_api = Json::Factory::LoadFromString(json_api_3);
   MockCluster* cluster2 = new NiceMock<MockCluster>();
   cluster2->hosts_ = {HostPtr{new HostImpl(
-      cluster2->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster2->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster2));
   EXPECT_CALL(*cluster2, initializePhase()).Times(0);
   EXPECT_CALL(*cluster2, initialize());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -162,7 +162,7 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -184,7 +184,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -207,7 +207,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -231,7 +231,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
   EXPECT_CALL(*this, onHostStatus(_, true)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -254,7 +254,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->info_->stats().upstream_cx_total_.inc();
   expectSessionCreate();
   expectStreamCreate(0);
@@ -274,7 +274,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillRepeatedly(Return(true));
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -306,7 +306,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -319,7 +319,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   setupNoServiceValidationHC();
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -337,7 +337,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   setupNoServiceValidationHC();
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->hosts_[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   expectSessionCreate();
   expectStreamCreate(0);
@@ -366,7 +366,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   setupNoServiceValidationHC();
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -395,7 +395,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(1);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -416,7 +416,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
   setupNoServiceValidationHC();
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -443,7 +443,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
   expectSessionCreate();
   expectStreamCreate(0);
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   std::vector<HostPtr> removed{cluster_->hosts_.back()};
@@ -457,7 +457,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   EXPECT_CALL(*this, onHostStatus(_, false));
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -476,7 +476,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   EXPECT_CALL(*this, onHostStatus(_, false)).Times(2);
 
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectStreamCreate(0);
   health_checker_->start();
@@ -628,7 +628,7 @@ public:
 
 TEST_F(TcpHealthCheckerImplTest, Success) {
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   expectSessionCreate();
   expectClientCreate();
   health_checker_->start();
@@ -646,7 +646,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   expectSessionCreate();
   expectClientCreate();
   cluster_->hosts_ = {HostPtr{new HostImpl(
-      cluster_->info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   cluster_->runCallbacks({cluster_->hosts_.back()}, {});
 
   Buffer::OwnedImpl response;

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -8,7 +8,7 @@ namespace Upstream {
 
 TEST(HostUtilityTest, All) {
   ClusterInfoPtr cluster{new MockClusterInfo()};
-  HostImpl host(cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "");
+  HostImpl host(cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "");
   EXPECT_EQ("healthy", HostUtility::healthFlagsToString(host));
 
   host.healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -12,7 +12,7 @@ namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
                            uint32_t weight = 1) {
-  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, weight, "")};
+  return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, weight, "")};
 }
 
 class RoundRobinLoadBalancerTest : public testing::Test {

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -13,7 +13,7 @@ namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
                            uint32_t weight = 1, const std::string& zone = "") {
-  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, weight, zone)};
+  return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, weight, zone)};
 }
 
 /**

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -88,7 +88,7 @@ TEST_F(LogicalDnsClusterTest, ImmediateResolve) {
   setup(json);
   EXPECT_EQ(1UL, cluster_->hosts().size());
   EXPECT_EQ(1UL, cluster_->healthyHosts().size());
-  EXPECT_EQ("foo.bar.com:443", cluster_->hosts()[0]->hostname());
+  EXPECT_EQ("foo.bar.com", cluster_->hosts()[0]->hostname());
   tls_.shutdownThread();
 }
 

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -88,6 +88,7 @@ TEST_F(LogicalDnsClusterTest, ImmediateResolve) {
   setup(json);
   EXPECT_EQ(1UL, cluster_->hosts().size());
   EXPECT_EQ(1UL, cluster_->healthyHosts().size());
+  EXPECT_EQ("foo.bar.com:443", cluster_->hosts()[0]->hostname());
   tls_.shutdownThread();
 }
 

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -67,7 +67,7 @@ public:
 TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -97,7 +97,7 @@ TEST_F(OutlierDetectorImplTest, DestroyWithActive) {
 TEST_F(OutlierDetectorImplTest, DestroyHostInUse) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -115,14 +115,14 @@ TEST_F(OutlierDetectorImplTest, DestroyHostInUse) {
 TEST_F(OutlierDetectorImplTest, BasicFlow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
   detector->addChangedStateCb([&](HostPtr host) -> void { checker_.check(host); });
 
   cluster_.hosts_.push_back(HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:81"), false, 1, "")});
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:81"), false, 1, "")});
   cluster_.runCallbacks({cluster_.hosts_[1]}, {});
 
   // Cause a consecutive 5xx error.
@@ -172,7 +172,7 @@ TEST_F(OutlierDetectorImplTest, BasicFlow) {
 TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -208,9 +208,9 @@ TEST_F(OutlierDetectorImplTest, RemoveWhileEjected) {
 TEST_F(OutlierDetectorImplTest, Overflow) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {
-      HostPtr{new HostImpl(cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
+      HostPtr{new HostImpl(cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
                            false, 1, "")},
-      HostPtr{new HostImpl(cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:81"),
+      HostPtr{new HostImpl(cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:81"),
                            false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
@@ -249,7 +249,7 @@ TEST_F(OutlierDetectorImplTest, Overflow) {
 TEST_F(OutlierDetectorImplTest, NotEnforcing) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -274,7 +274,7 @@ TEST_F(OutlierDetectorImplTest, NotEnforcing) {
 TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -300,7 +300,7 @@ TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
 TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -327,7 +327,7 @@ TEST_F(OutlierDetectorImplTest, CrossThreadDestroyRace) {
 TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));
@@ -360,7 +360,7 @@ TEST_F(OutlierDetectorImplTest, CrossThreadFailRace) {
 TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
   EXPECT_CALL(cluster_, addMemberUpdateCb(_));
   cluster_.hosts_ = {HostPtr{new HostImpl(
-      cluster_.info_, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
+      cluster_.info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000)));
   std::shared_ptr<DetectorImpl> detector(
       DetectorImpl::create(cluster_, dispatcher_, runtime_, time_source_, event_logger_));

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -12,7 +12,7 @@ using testing::Return;
 namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url) {
-  return HostPtr{new HostImpl(cluster, Network::Utility::resolveUrl(url), false, 1, "")};
+  return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, 1, "")};
 }
 
 class TestLoadBalancerContext : public LoadBalancerContext {

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -134,6 +134,9 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ(5UL, cluster_->healthyHostsPerZone()[1].size());
   EXPECT_EQ(4UL, cluster_->healthyHostsPerZone()[2].size());
 
+  // Hosts in SDS and static clusters should have empty hostname
+  EXPECT_EQ("", cluster_->hosts()[0]->hostname());
+
   HostPtr canary_host = findHost("10.0.16.43");
   EXPECT_TRUE(canary_host->canary());
   EXPECT_EQ("us-east-1d", canary_host->zone());

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -200,6 +200,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
 }
 
+#if 0
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
   HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1,
@@ -247,6 +248,7 @@ TEST(HostImplTest, HostameCanaryAndZone) {
   EXPECT_TRUE(host.canary());
   EXPECT_EQ("hello", host.zone());
 }
+#endif
 
 TEST(StaticClusterImplTest, OutlierDetector) {
   Stats::IsolatedStoreImpl stats;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -202,7 +202,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
 }
 
-#if 0
+#if 0 // FIXME: error: invalid use of non-static member function???
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
   HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1,

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -250,6 +250,26 @@ TEST(HostImplTest, HostameCanaryAndZone) {
   EXPECT_EQ("hello", host.zone());
 }
 
+TEST(StaticClusterImplTest, EmptyHostname) {
+  Stats::IsolatedStoreImpl stats;
+  Ssl::MockContextManager ssl_context_manager;
+  NiceMock<Runtime::MockLoader> runtime;
+  std::string json = R"EOF(
+  {
+    "name": "staticcluster",
+    "connect_timeout_ms": 250,
+    "type": "static",
+    "lb_type": "random",
+    "hosts": [{"url": "tcp://10.0.0.1:11001"}]
+  }
+  )EOF";
+
+  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
+  EXPECT_EQ(1UL, cluster.healthyHosts().size());
+  EXPECT_EQ("", cluster.hosts()[0]->hostname());
+}
+
 TEST(StaticClusterImplTest, OutlierDetector) {
   Stats::IsolatedStoreImpl stats;
   Ssl::MockContextManager ssl_context_manager;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -153,8 +153,8 @@ TEST(StrictDnsClusterImplTest, Basic) {
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
   EXPECT_THAT(std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
               ContainerEq(hostListToAddresses(cluster.hosts())));
-  EXPECT_EQ("localhost1:11001", cluster.hosts()[0]->hostname());
-  EXPECT_EQ("localhost1:11001", cluster.hosts()[1]->hostname());
+  EXPECT_EQ("localhost1", cluster.hosts()[0]->hostname());
+  EXPECT_EQ("localhost1", cluster.hosts()[1]->hostname());
 
   resolver1.expectResolve(dns_resolver);
   resolver1.timer_->callback_();

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -117,7 +117,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
     },
     "max_requests_per_connection": 3,
     "http_codec_options": "no_compression",
-    "hosts": [{"url": "tcp://localhost:11001"},
+    "hosts": [{"url": "tcp://localhost1:11001"},
               {"url": "tcp://localhost2:11002"}]
   }
   )EOF";
@@ -153,6 +153,8 @@ TEST(StrictDnsClusterImplTest, Basic) {
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
   EXPECT_THAT(std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
               ContainerEq(hostListToAddresses(cluster.hosts())));
+  EXPECT_EQ("localhost1:11001", cluster.hosts()[0]->hostname());
+  EXPECT_EQ("localhost1:11001", cluster.hosts()[1]->hostname());
 
   resolver1.expectResolve(dns_resolver);
   resolver1.timer_->callback_();

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -202,10 +202,9 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
 }
 
-#if 0 // FIXME: error: invalid use of non-static member function???
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
-  HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1,
+  HostImpl host(cluster.info_, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1,
                 "");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_EQ("", host.hostname());
@@ -217,19 +216,19 @@ TEST(HostImplTest, Weight) {
   MockCluster cluster;
 
   {
-    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 0,
+    HostImpl host(cluster.info_, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 0,
                   "");
     EXPECT_EQ(1U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 101,
-                  "");
+    HostImpl host(cluster.info_, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false,
+                  101, "");
     EXPECT_EQ(100U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 50,
+    HostImpl host(cluster.info_, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 50,
                   "");
     EXPECT_EQ(50U, host.weight());
     host.weight(51);
@@ -243,14 +242,13 @@ TEST(HostImplTest, Weight) {
 
 TEST(HostImplTest, HostameCanaryAndZone) {
   MockCluster cluster;
-  HostImpl host(cluster.info, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), true,
-                1, "hello");
+  HostImpl host(cluster.info_, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
+                true, 1, "hello");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_EQ("lyft.com", host.hostname());
   EXPECT_TRUE(host.canary());
   EXPECT_EQ("hello", host.zone());
 }
-#endif
 
 TEST(StaticClusterImplTest, OutlierDetector) {
   Stats::IsolatedStoreImpl stats;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -202,8 +202,10 @@ TEST(StrictDnsClusterImplTest, Basic) {
 
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
-  HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1, "");
+  HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 1,
+                "");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
+  EXPECT_EQ("", host.hostname());
   EXPECT_FALSE(host.canary());
   EXPECT_EQ("", host.zone());
 }
@@ -212,18 +214,19 @@ TEST(HostImplTest, Weight) {
   MockCluster cluster;
 
   {
-    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 0, "");
+    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 0,
+                  "");
     EXPECT_EQ(1U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 101,
+    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 101,
                   "");
     EXPECT_EQ(100U, host.weight());
   }
 
   {
-    HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 50,
+    HostImpl host(cluster.info, "", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), false, 50,
                   "");
     EXPECT_EQ(50U, host.weight());
     host.weight(51);
@@ -235,11 +238,12 @@ TEST(HostImplTest, Weight) {
   }
 }
 
-TEST(HostImplTest, CanaryAndZone) {
+TEST(HostImplTest, HostameCanaryAndZone) {
   MockCluster cluster;
-  HostImpl host(cluster.info_, Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), true, 1,
-                "hello");
+  HostImpl host(cluster.info, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), true,
+                1, "hello");
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
+  EXPECT_EQ("lyft.com", host.hostname());
   EXPECT_TRUE(host.canary());
   EXPECT_EQ("hello", host.zone());
 }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -238,7 +238,7 @@ BaseIntegrationTest::makeHttpConnection(Network::ClientConnectionPtr&& conn,
                                         Http::CodecClient::Type type) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_description{new Upstream::HostDescriptionImpl(
-      cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+                                                                                  cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
   return IntegrationCodecClientPtr{
       new IntegrationCodecClient(*dispatcher_, std::move(conn), host_description, type)};
 }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -238,7 +238,7 @@ BaseIntegrationTest::makeHttpConnection(Network::ClientConnectionPtr&& conn,
                                         Http::CodecClient::Type type) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_description{new Upstream::HostDescriptionImpl(
-                                                                                  cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+      cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
   return IntegrationCodecClientPtr{
       new IntegrationCodecClient(*dispatcher_, std::move(conn), host_description, type)};
 }

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -49,7 +49,7 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
   Event::DispatcherPtr dispatcher(api.allocateDispatcher());
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_description{new Upstream::HostDescriptionImpl(
-                                                                                  cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+      cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
   Http::CodecClientProd client(type,
                                dispatcher->createClientConnection(Network::Utility::resolveUrl(
                                    fmt::format("tcp://127.0.0.1:{}", port))),

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -49,7 +49,7 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
   Event::DispatcherPtr dispatcher(api.allocateDispatcher());
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionPtr host_description{new Upstream::HostDescriptionImpl(
-      cluster, Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
+                                                                                  cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, "")};
   Http::CodecClientProd client(type,
                                dispatcher->createClientConnection(Network::Utility::resolveUrl(
                                    fmt::format("tcp://127.0.0.1:{}", port))),

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -147,6 +147,7 @@ public:
   MOCK_CONST_METHOD1(virtualCluster, const VirtualCluster*(const Http::HeaderMap& headers));
   MOCK_CONST_METHOD0(virtualHostName, const std::string&());
   MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
+  MOCK_CONST_METHOD0(autoHostRewrite, bool());
 
   std::string cluster_name_{"fake_cluster"};
   TestVirtualCluster virtual_cluster_;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -61,7 +61,7 @@ public:
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());
 
-  std::string hostname_{};
+  std::string hostname_;
   Network::Address::InstancePtr address_;
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
   testing::NiceMock<MockClusterInfo> cluster_;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -61,6 +61,7 @@ public:
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());
 
+  std::string hostname_{};
   Network::Address::InstancePtr address_;
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
   testing::NiceMock<MockClusterInfo> cluster_;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -56,6 +56,7 @@ public:
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
+  MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(address, Network::Address::InstancePtr());
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -32,6 +32,7 @@ MockDetector::~MockDetector() {}
 
 MockHostDescription::MockHostDescription()
     : address_(Network::Utility::resolveUrl("tcp://10.0.0.1:443")) {
+  ON_CALL(*this, hostname()).WillByDefault(ReturnRef(hostname_));
   ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));


### PR DESCRIPTION
Enables envoy to rewrite Host headers for upstream requests, based on the hostname of the upstream instance (only for strict_dns and logical_dns clusters). 

This is specifically useful when proxying to multiple cloud foundry instances (each of which has its own hostname, where the GoRouter routes requests to instances based on the hostname).

fixes #204 

cc @mattklein123 

While the changes are spread over a lot of files, they are pretty minor in 90% of the cases. The key changes are in the strict/logical dns implementations and hostdescription implementation.