### PR TITLE
http/2: do not keep closed streams for priority calculations

### DIFF
--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=d4610d5d7ac01b275612b14f0fbef72b1b374d87
+ENVOY_BUILD_SHA=c980e0936bc12092930ef1f9a3cb471f5e40af49
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -540,8 +540,8 @@ ConnectionImpl::Http2Options::Http2Options() {
   nghttp2_option_new(&options_);
   // Currently we do not do anything with stream priority. Setting the following option prevents
   // nghttp2 from keeping around closed streams for use during stream priority dependency graph
-  // calculations. This saves a tremendous amount of memory in cases where there a large number of
-  // kept alive http/2 connections.
+  // calculations. This saves a tremendous amount of memory in cases where there are a large number
+  // of kept alive http/2 connections.
   nghttp2_option_set_no_closed_streams(options_, 1);
 }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -86,10 +86,24 @@ protected:
     Http2Callbacks();
     ~Http2Callbacks();
 
-    nghttp2_session_callbacks* callbacks() { return callbacks_; }
+    const nghttp2_session_callbacks* callbacks() { return callbacks_; }
 
   private:
     nghttp2_session_callbacks* callbacks_;
+  };
+
+  /**
+   * Wrapper for static nghttp2 session options.
+   */
+  class Http2Options {
+  public:
+    Http2Options();
+    ~Http2Options();
+
+    const nghttp2_option* options() { return options_; }
+
+  private:
+    nghttp2_option* options_;
   };
 
   /**
@@ -176,6 +190,7 @@ protected:
   void sendSettings(uint64_t codec_options);
 
   static Http2Callbacks http2_callbacks_;
+  static Http2Options http2_options_;
 
   std::list<StreamImplPtr> active_streams_;
   nghttp2_session* session_{};


### PR DESCRIPTION
Saves a ton of memory. Requires nghttp2 1.20.0.

fixes https://github.com/lyft/envoy/issues/471