### PR TITLE
docs: Add "docker pull" to build steps

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ an Envoy binary built from the latest tip of master that passed tests.
 An example basic invocation to build a debug image and run all tests is:
 
 ```bash
-docker run -t -i -u $(id -u):$(id -g) -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
+docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
 ```
 
 On OSX using the command below may work better. Unlike on Linux, users are not
@@ -20,7 +20,7 @@ create artifacts with the same ownership as in the container ([read more about
 osxfs][osxfs]).
 
 ```bash
-docker run -t -i -u root:root -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
+docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
 ```
 
 This bind mounts `<SOURCE_DIR>`, which allows for changes on the local
@@ -40,13 +40,13 @@ The `do_ci.sh` targets are:
 A convenient shell function to define is:
 
 ```bash
-run_envoy_docker() { docker run -t -i -u $(id -u):$(id -g) -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
+run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
 ```
 
 Or on OSX.
 
 ```bash
-run_envoy_docker() { docker run -t -i -u root:root -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
+run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
 ```
 
 This then allows for a simple invocation of `run_envoy_docker './ci/do_ci.sh debug'` from the


### PR DESCRIPTION
Just running "docker run" doesn't update image tags that are already
present in an older version. If the "latest" tag has advanced, we need
to update it before trying to run do_ci.sh.