### PR TITLE
Update all unattributed TODOs to TODO(mattklein123)

### DIFF
--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -198,10 +198,10 @@ void TcpProxy::onDownstreamEvent(uint32_t event) {
   if ((event & Network::ConnectionEvent::RemoteClose ||
        event & Network::ConnectionEvent::LocalClose) &&
       upstream_connection_) {
-    // TODO: If we close without flushing here we may drop some data. The downstream connection
-    //       is about to go away. So to support this we need to either have a way for the downstream
-    //       connection to stick around, or, we need to be able to pass this connection to a flush
-    //       worker which will attempt to flush the remaining data with a timeout.
+    // TODO(mklein23): If we close without flushing here we may drop some data. The downstream
+    // connection  is about to go away. So to support this we need to either have a way for the
+    // downstream  connection to stick around, or, we need to be able to pass this connection to a
+    // flush  worker which will attempt to flush the remaining data with a timeout.
     upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
   }
 }

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -198,10 +198,10 @@ void TcpProxy::onDownstreamEvent(uint32_t event) {
   if ((event & Network::ConnectionEvent::RemoteClose ||
        event & Network::ConnectionEvent::LocalClose) &&
       upstream_connection_) {
-    // TODO(mklein23): If we close without flushing here we may drop some data. The downstream
-    // connection  is about to go away. So to support this we need to either have a way for the
-    // downstream  connection to stick around, or, we need to be able to pass this connection to a
-    // flush  worker which will attempt to flush the remaining data with a timeout.
+    // TODO(mattklein23): If we close without flushing here we may drop some data. The downstream
+    // connection is about to go away. So to support this we need to either have a way for the
+    // downstream connection to stick around, or, we need to be able to pass this connection to a
+    // flush worker which will attempt to flush the remaining data with a timeout.
     upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
   }
 }

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -198,7 +198,7 @@ void TcpProxy::onDownstreamEvent(uint32_t event) {
   if ((event & Network::ConnectionEvent::RemoteClose ||
        event & Network::ConnectionEvent::LocalClose) &&
       upstream_connection_) {
-    // TODO(mattklein23): If we close without flushing here we may drop some data. The downstream
+    // TODO(mattklein123): If we close without flushing here we may drop some data. The downstream
     // connection is about to go away. So to support this we need to either have a way for the
     // downstream connection to stick around, or, we need to be able to pass this connection to a
     // flush worker which will attempt to flush the remaining data with a timeout.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -58,7 +58,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       route_(std::make_shared<RouteImpl>(parent_.cluster_.name(), timeout)) {
 
   router_.setDecoderFilterCallbacks(*this);
-  // TODO(mklein123): Correctly set protocol in request info when we support access logging.
+  // TODO(mattklein123): Correctly set protocol in request info when we support access logging.
 }
 
 AsyncStreamImpl::~AsyncStreamImpl() { ASSERT(!reset_callback_); }
@@ -156,7 +156,7 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
   if (!remoteClosed() && request_->body()) {
     sendData(*request_->body(), true);
   }
-  // TODO(mklein123): Support request trailers.
+  // TODO(mattklein123): Support request trailers.
 }
 
 void AsyncRequestImpl::onComplete() { callbacks_.onSuccess(std::move(response_)); }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -58,7 +58,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       route_(std::make_shared<RouteImpl>(parent_.cluster_.name(), timeout)) {
 
   router_.setDecoderFilterCallbacks(*this);
-  // TODO: Correctly set protocol in request info when we support access logging.
+  // TODO(mklein123): Correctly set protocol in request info when we support access logging.
 }
 
 AsyncStreamImpl::~AsyncStreamImpl() { ASSERT(!reset_callback_); }
@@ -156,7 +156,7 @@ AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent
   if (!remoteClosed() && request_->body()) {
     sendData(*request_->body(), true);
   }
-  // TODO: Support request trailers.
+  // TODO(mklein123): Support request trailers.
 }
 
 void AsyncRequestImpl::onComplete() { callbacks_.onSuccess(std::move(response_)); }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -729,7 +729,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
   }
 
   // TODO(mattklein123): If a filter returns StopIterationNoBuffer and then does a continue, we
-  // won't be able to  end the stream if there is no buffered data. Need to handle this.
+  // won't be able to end the stream if there is no buffered data. Need to handle this.
   if (bufferedData()) {
     doData(complete() && !trailers());
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -728,8 +728,8 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
     doHeaders(complete() && !bufferedData() && !trailers());
   }
 
-  // TODO(mklein123): If a filter returns StopIterationNoBuffer and then does a continue, we won't
-  // be able to  end the stream if there is no buffered data. Need to handle this.
+  // TODO(mattklein123): If a filter returns StopIterationNoBuffer and then does a continue, we
+  // won't be able to  end the stream if there is no buffered data. Need to handle this.
   if (bufferedData()) {
     doData(complete() && !trailers());
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -728,8 +728,8 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
     doHeaders(complete() && !bufferedData() && !trailers());
   }
 
-  // TODO: If a filter returns StopIterationNoBuffer and then does a continue, we won't be able to
-  //       end the stream if there is no buffered data. Need to handle this.
+  // TODO(mklein123): If a filter returns StopIterationNoBuffer and then does a continue, we won't
+  // be able to  end the stream if there is no buffered data. Need to handle this.
   if (bufferedData()) {
     doData(complete() && !trailers());
   }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -406,10 +406,10 @@ private:
     const uint64_t stream_id_;
     StreamEncoder* response_encoder_{};
     HeaderMapPtr response_headers_;
-    Buffer::InstancePtr buffered_response_data_; // TODO: buffer data stat
+    Buffer::InstancePtr buffered_response_data_; // TODO(mklein123): buffer data stat
     HeaderMapPtr response_trailers_{};
     HeaderMapPtr request_headers_;
-    Buffer::InstancePtr buffered_request_data_; // TODO: buffer data stat
+    Buffer::InstancePtr buffered_request_data_; // TODO(mklein123): buffer data stat
     HeaderMapPtr request_trailers_;
     std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
     std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -406,10 +406,10 @@ private:
     const uint64_t stream_id_;
     StreamEncoder* response_encoder_{};
     HeaderMapPtr response_headers_;
-    Buffer::InstancePtr buffered_response_data_; // TODO(mklein123): buffer data stat
+    Buffer::InstancePtr buffered_response_data_; // TODO(mattklein123): buffer data stat
     HeaderMapPtr response_trailers_{};
     HeaderMapPtr request_headers_;
-    Buffer::InstancePtr buffered_request_data_; // TODO(mklein123): buffer data stat
+    Buffer::InstancePtr buffered_request_data_; // TODO(mattklein123): buffer data stat
     HeaderMapPtr request_trailers_;
     std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
     std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -37,7 +37,7 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
       }
     }
 
-    // TODO: Throw error if invalid return code is provided
+    // TODO(mklein123): Throw error if invalid return code is provided
     if (abort->hasObject("http_status")) {
       http_status_ = static_cast<uint64_t>(abort->getInteger("http_status"));
     } else {
@@ -148,7 +148,7 @@ void FaultFilter::postDelayInjection() {
 }
 
 void FaultFilter::abortWithHTTPStatus() {
-  // TODO: check http status codes obtained from runtime
+  // TODO(mklein123): check http status codes obtained from runtime
   Http::HeaderMapPtr response_headers{new HeaderMapImpl{
       {Headers::get().Status, std::to_string(config_->runtime().snapshot().getInteger(
                                   "fault.http.abort.http_status", config_->abortCode()))}}};

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -37,7 +37,7 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
       }
     }
 
-    // TODO(mklein123): Throw error if invalid return code is provided
+    // TODO(mattklein123): Throw error if invalid return code is provided
     if (abort->hasObject("http_status")) {
       http_status_ = static_cast<uint64_t>(abort->getInteger("http_status"));
     } else {
@@ -148,7 +148,7 @@ void FaultFilter::postDelayInjection() {
 }
 
 void FaultFilter::abortWithHTTPStatus() {
-  // TODO(mklein123): check http status codes obtained from runtime
+  // TODO(mattklein123): check http status codes obtained from runtime
   Http::HeaderMapPtr response_headers{new HeaderMapImpl{
       {Headers::get().Status, std::to_string(config_->runtime().snapshot().getInteger(
                                   "fault.http.abort.http_status", config_->abortCode()))}}};

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -237,7 +237,7 @@ HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_heade
 
 HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
   rhs.iterate([](const HeaderEntry& header, void* context) -> void {
-    // TODO PERF: Avoid copying here is not necessary.
+    // TODO(mklein123) PERF: Avoid copying here is not necessary.
     HeaderString key_string;
     key_string.setCopy(header.key().c_str(), header.key().size());
     HeaderString value_string;
@@ -277,11 +277,11 @@ bool HeaderMapImpl::operator==(const HeaderMapImpl& rhs) const {
 void HeaderMapImpl::insertByKey(HeaderString&& key, HeaderString&& value) {
   StaticLookupEntry::EntryCb cb = static_lookup_table_.find(key.c_str());
   if (cb) {
-    // TODO: Currently, for all of the inline headers, we don't support appending. The only inline
-    //       header where we should be converting multiple headers into a comma delimited list is
-    //       XFF. This is not a crisis for now but we should allow an inline header to indicate that
-    //       it should be appended to. In that case, we would do an append here. We can do this in
-    //       a follow up.
+    // TODO(mklein123): Currently, for all of the inline headers, we don't support appending. The
+    // only inline  header where we should be converting multiple headers into a comma delimited
+    // list is  XFF. This is not a crisis for now but we should allow an inline header to indicate
+    // that  it should be appended to. In that case, we would do an append here. We can do this in
+    // a follow up.
     key.clear();
     StaticLookupResponse static_lookup_response = cb(*this);
     maybeCreateInline(static_lookup_response.entry_, *static_lookup_response.key_,

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -189,7 +189,7 @@ void HeaderMapImpl::HeaderEntryImpl::value(const HeaderEntry& header) {
 }
 
 #define INLINE_HEADER_STATIC_MAP_ENTRY(name)                                                       \
-  add(Headers::get().name.get().c_str(), [](HeaderMapImpl & h) -> StaticLookupResponse {           \
+  add(Headers::get().name.get().c_str(), [](HeaderMapImpl& h) -> StaticLookupResponse {            \
     return {&h.inline_headers_.name##_, &Headers::get().name};                                     \
   });
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -236,16 +236,18 @@ HeaderMapImpl::StaticLookupTable::find(const char* key) const {
 HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_headers_)); }
 
 HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
-  rhs.iterate([](const HeaderEntry& header, void* context) -> void {
-    // TODO(mklein123) PERF: Avoid copying here is not necessary.
-    HeaderString key_string;
-    key_string.setCopy(header.key().c_str(), header.key().size());
-    HeaderString value_string;
-    value_string.setCopy(header.value().c_str(), header.value().size());
+  rhs.iterate(
+      [](const HeaderEntry& header, void* context) -> void {
+        // TODO(mattklein123) PERF: Avoid copying here is not necessary.
+        HeaderString key_string;
+        key_string.setCopy(header.key().c_str(), header.key().size());
+        HeaderString value_string;
+        value_string.setCopy(header.value().c_str(), header.value().size());
 
-    static_cast<HeaderMapImpl*>(context)
-        ->addViaMove(std::move(key_string), std::move(value_string));
-  }, this);
+        static_cast<HeaderMapImpl*>(context)->addViaMove(std::move(key_string),
+                                                         std::move(value_string));
+      },
+      this);
 }
 
 HeaderMapImpl::HeaderMapImpl(
@@ -277,7 +279,7 @@ bool HeaderMapImpl::operator==(const HeaderMapImpl& rhs) const {
 void HeaderMapImpl::insertByKey(HeaderString&& key, HeaderString&& value) {
   StaticLookupEntry::EntryCb cb = static_lookup_table_.find(key.c_str());
   if (cb) {
-    // TODO(mklein123): Currently, for all of the inline headers, we don't support appending. The
+    // TODO(mattklein123): Currently, for all of the inline headers, we don't support appending. The
     // only inline  header where we should be converting multiple headers into a comma delimited
     // list is  XFF. This is not a crisis for now but we should allow an inline header to indicate
     // that  it should be appended to. In that case, we would do an append here. We can do this in

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -189,7 +189,7 @@ void HeaderMapImpl::HeaderEntryImpl::value(const HeaderEntry& header) {
 }
 
 #define INLINE_HEADER_STATIC_MAP_ENTRY(name)                                                       \
-  add(Headers::get().name.get().c_str(), [](HeaderMapImpl& h) -> StaticLookupResponse {            \
+  add(Headers::get().name.get().c_str(), [](HeaderMapImpl & h) -> StaticLookupResponse {           \
     return {&h.inline_headers_.name##_, &Headers::get().name};                                     \
   });
 
@@ -236,18 +236,16 @@ HeaderMapImpl::StaticLookupTable::find(const char* key) const {
 HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_headers_)); }
 
 HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
-  rhs.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
-        // TODO(mattklein123) PERF: Avoid copying here is not necessary.
-        HeaderString key_string;
-        key_string.setCopy(header.key().c_str(), header.key().size());
-        HeaderString value_string;
-        value_string.setCopy(header.value().c_str(), header.value().size());
+  rhs.iterate([](const HeaderEntry& header, void* context) -> void {
+    // TODO(mattklein123) PERF: Avoid copying here is not necessary.
+    HeaderString key_string;
+    key_string.setCopy(header.key().c_str(), header.key().size());
+    HeaderString value_string;
+    value_string.setCopy(header.value().c_str(), header.value().size());
 
-        static_cast<HeaderMapImpl*>(context)->addViaMove(std::move(key_string),
-                                                         std::move(value_string));
-      },
-      this);
+    static_cast<HeaderMapImpl*>(context)
+        ->addViaMove(std::move(key_string), std::move(value_string));
+  }, this);
 }
 
 HeaderMapImpl::HeaderMapImpl(

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -280,9 +280,9 @@ void HeaderMapImpl::insertByKey(HeaderString&& key, HeaderString&& value) {
   StaticLookupEntry::EntryCb cb = static_lookup_table_.find(key.c_str());
   if (cb) {
     // TODO(mattklein123): Currently, for all of the inline headers, we don't support appending. The
-    // only inline  header where we should be converting multiple headers into a comma delimited
-    // list is  XFF. This is not a crisis for now but we should allow an inline header to indicate
-    // that  it should be appended to. In that case, we would do an append here. We can do this in
+    // only inline header where we should be converting multiple headers into a comma delimited
+    // list is XFF. This is not a crisis for now but we should allow an inline header to indicate
+    // that it should be appended to. In that case, we would do an append here. We can do this in
     // a follow up.
     key.clear();
     StaticLookupResponse static_lookup_response = cb(*this);

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -142,7 +142,7 @@ int ConnectionImpl::StreamImpl::onDataSourceSend(const uint8_t* framehd, size_t 
   // https://nghttp2.org/documentation/types.html#c.nghttp2_send_data_callback
   static const uint64_t FRAME_HEADER_SIZE = 9;
 
-  // TODO(mklein123): Back pressure.
+  // TODO(mattklein123): Back pressure.
   Buffer::OwnedImpl output(framehd, FRAME_HEADER_SIZE);
   output.move(pending_send_data_, length);
   parent_.connection_.write(output);
@@ -361,7 +361,7 @@ int ConnectionImpl::onInvalidFrame(int error_code) {
 }
 
 ssize_t ConnectionImpl::onSend(const uint8_t* data, size_t length) {
-  // TODO(mklein123): Back pressure.
+  // TODO(mattklein123): Back pressure.
   conn_log_trace("send data: bytes={}", connection_, length);
   Buffer::OwnedImpl buffer(data, length);
   connection_.write(buffer);
@@ -396,7 +396,7 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
     // code it looks possible that inflate_header_block() can safely inflate headers for an already
     // closed stream, but will still call the headers callback. Since that seems possible, we should
     // ignore this case here.
-    // TODO(mklein123): Figure out a test case that can hit this.
+    // TODO(mattklein123): Figure out a test case that can hit this.
     stats_.headers_cb_no_stream_.inc();
     return 0;
   }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -142,7 +142,7 @@ int ConnectionImpl::StreamImpl::onDataSourceSend(const uint8_t* framehd, size_t 
   // https://nghttp2.org/documentation/types.html#c.nghttp2_send_data_callback
   static const uint64_t FRAME_HEADER_SIZE = 9;
 
-  // TODO: Back pressure.
+  // TODO(mklein123): Back pressure.
   Buffer::OwnedImpl output(framehd, FRAME_HEADER_SIZE);
   output.move(pending_send_data_, length);
   parent_.connection_.write(output);
@@ -361,7 +361,7 @@ int ConnectionImpl::onInvalidFrame(int error_code) {
 }
 
 ssize_t ConnectionImpl::onSend(const uint8_t* data, size_t length) {
-  // TODO: Back pressure.
+  // TODO(mklein123): Back pressure.
   conn_log_trace("send data: bytes={}", connection_, length);
   Buffer::OwnedImpl buffer(data, length);
   connection_.write(buffer);
@@ -396,7 +396,7 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
     // code it looks possible that inflate_header_block() can safely inflate headers for an already
     // closed stream, but will still call the headers callback. Since that seems possible, we should
     // ignore this case here.
-    // TODO: Figure out a test case that can hit this.
+    // TODO(mklein123): Figure out a test case that can hit this.
     stats_.headers_cb_no_stream_.inc();
     return 0;
   }

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -167,7 +167,7 @@ public:
     rapidjson::SchemaValidator schema_validator(schema_document);
 
     if (!value_.Accept(schema_validator)) {
-      // TODO(mklein123): Improve errors by switching to SAX API.
+      // TODO(mattklein123): Improve errors by switching to SAX API.
       rapidjson::StringBuffer schema_string_buffer;
       rapidjson::StringBuffer document_string_buffer;
 

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -167,7 +167,7 @@ public:
     rapidjson::SchemaValidator schema_validator(schema_document);
 
     if (!value_.Accept(schema_validator)) {
-      // TODO: Improve errors by switching to SAX API.
+      // TODO(mklein123): Improve errors by switching to SAX API.
       rapidjson::StringBuffer schema_string_buffer;
       rapidjson::StringBuffer document_string_buffer;
 

--- a/source/common/mongo/bson_impl.h
+++ b/source/common/mongo/bson_impl.h
@@ -145,7 +145,7 @@ private:
 
   /**
    * All of the possible variadic values that a field can be.
-   * TODO: Make this a C++11 union to save a little space and time.
+   * TODO(mklein123): Make this a C++11 union to save a little space and time.
    */
   struct Value {
     double double_value_;

--- a/source/common/mongo/bson_impl.h
+++ b/source/common/mongo/bson_impl.h
@@ -145,7 +145,7 @@ private:
 
   /**
    * All of the possible variadic values that a field can be.
-   * TODO(mklein123): Make this a C++11 union to save a little space and time.
+   * TODO(mattklein123): Make this a C++11 union to save a little space and time.
    */
   struct Value {
     double double_value_;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -34,8 +34,8 @@ void ConnectionImplUtility::updateBufferStats(uint64_t delta, uint64_t new_total
 
 std::atomic<uint64_t> ConnectionImpl::next_global_id_;
 
-// TODO: Currently we don't populate local address for client connections. Nothing looks at this
-//       currently, but we may want to populate this later for logging purposes.
+// TODO(mklein123): Currently we don't populate local address for client connections. Nothing looks
+// at this currently, but we may want to populate this later for logging purposes.
 const Address::InstancePtr
     ConnectionImpl::null_local_address_(new Address::Ipv4Instance("0.0.0.0"));
 
@@ -178,8 +178,9 @@ void ConnectionImpl::readDisable(bool disable) {
   // This allows us to still detect remote close in a timely manner. In practice there is a chance
   // that a bad client could send us a large amount of data on a HTTP/1.1 connection while we are
   // processing the current request.
-  // TODO: Add buffered data stats and potentially fail safe processing that disconnects or
-  //       applies back pressure to bad HTTP/1.1 clients.
+  //
+  // TODO(mklein123): Add buffered data stats and potentially fail safe processing that disconnects
+  // or applies back pressure to bad HTTP/1.1 clients.
   if (disable) {
     ASSERT(read_enabled);
     state_ &= ~InternalState::ReadEnabled;
@@ -194,8 +195,8 @@ void ConnectionImpl::readDisable(bool disable) {
 
 void ConnectionImpl::raiseEvents(uint32_t events) {
   for (ConnectionCallbacks* callback : callbacks_) {
-    // TODO: If we close while raising a connected event we should not raise further connected
-    //       events.
+    // TODO(mklein123): If we close while raising a connected event we should not raise further
+    // connected events.
     callback->onEvent(events);
   }
 }
@@ -252,8 +253,9 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
   do {
     // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
     // use an ioctl() before every read to figure out how much data there is to read.
-    // TODO PERF: Tune the read size and figure out a way of getting rid of the ioctl(). The extra
-    //            syscall is not worth it.
+    //
+    // TODO(mklein) PERF: Tune the read size and figure out a way of getting rid of the ioctl(). The
+    // extra syscall is not worth it.
     int rc = read_buffer_.read(fd_, 16384);
     conn_log_trace("read returns: {}", *this, rc);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1,8 +1,8 @@
 #include "connection_impl.h"
 #include "utility.h"
 
-#include "envoy/event/timer.h"
 #include "envoy/common/exception.h"
+#include "envoy/event/timer.h"
 #include "envoy/network/filter.h"
 
 #include "common/common/assert.h"
@@ -254,8 +254,8 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
     // use an ioctl() before every read to figure out how much data there is to read.
     //
-    // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the ioctl(). The
-    // extra syscall is not worth it.
+    // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the
+    // ioctl(). The extra syscall is not worth it.
     int rc = read_buffer_.read(fd_, 16384);
     conn_log_trace("read returns: {}", *this, rc);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -34,8 +34,8 @@ void ConnectionImplUtility::updateBufferStats(uint64_t delta, uint64_t new_total
 
 std::atomic<uint64_t> ConnectionImpl::next_global_id_;
 
-// TODO(mklein123): Currently we don't populate local address for client connections. Nothing looks
-// at this currently, but we may want to populate this later for logging purposes.
+// TODO(mattklein123): Currently we don't populate local address for client connections. Nothing
+// looks at this currently, but we may want to populate this later for logging purposes.
 const Address::InstancePtr
     ConnectionImpl::null_local_address_(new Address::Ipv4Instance("0.0.0.0"));
 
@@ -179,8 +179,8 @@ void ConnectionImpl::readDisable(bool disable) {
   // that a bad client could send us a large amount of data on a HTTP/1.1 connection while we are
   // processing the current request.
   //
-  // TODO(mklein123): Add buffered data stats and potentially fail safe processing that disconnects
-  // or applies back pressure to bad HTTP/1.1 clients.
+  // TODO(mattklein123): Add buffered data stats and potentially fail safe processing that
+  // disconnects or applies back pressure to bad HTTP/1.1 clients.
   if (disable) {
     ASSERT(read_enabled);
     state_ &= ~InternalState::ReadEnabled;
@@ -195,7 +195,7 @@ void ConnectionImpl::readDisable(bool disable) {
 
 void ConnectionImpl::raiseEvents(uint32_t events) {
   for (ConnectionCallbacks* callback : callbacks_) {
-    // TODO(mklein123): If we close while raising a connected event we should not raise further
+    // TODO(mattklein123): If we close while raising a connected event we should not raise further
     // connected events.
     callback->onEvent(events);
   }
@@ -254,7 +254,7 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
     // use an ioctl() before every read to figure out how much data there is to read.
     //
-    // TODO(mklein) PERF: Tune the read size and figure out a way of getting rid of the ioctl(). The
+    // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the ioctl(). The
     // extra syscall is not worth it.
     int rc = read_buffer_.read(fd_, 16384);
     conn_log_trace("read returns: {}", *this, rc);

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -49,7 +49,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
       ASSERT(hostent->h_length == sizeof(in_addr));
       sockaddr_in address;
       memset(&address, 0, sizeof(address));
-      // TODO: IPv6 support.
+      // TODO(mklein123): IPv6 support.
       address.sin_family = AF_INET;
       address.sin_port = 0;
       address.sin_addr = *reinterpret_cast<in_addr*>(hostent->h_addr_list[i]);

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -49,7 +49,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
       ASSERT(hostent->h_length == sizeof(in_addr));
       sockaddr_in address;
       memset(&address, 0, sizeof(address));
-      // TODO(mklein123): IPv6 support.
+      // TODO(mattklein123): IPv6 support.
       address.sin_family = AF_INET;
       address.sin_port = 0;
       address.sin_addr = *reinterpret_cast<in_addr*>(hostent->h_addr_list[i]);

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -18,7 +18,7 @@ void ListenSocketImpl::doBind() {
 }
 
 TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) {
-  // TODO: IPv6 support.
+  // TODO(mklein123): IPv6 support.
   local_address_.reset(new Address::Ipv4Instance(port));
   fd_ = local_address_->socket(Address::SocketType::Stream);
   RELEASE_ASSERT(fd_ != -1);

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -18,7 +18,7 @@ void ListenSocketImpl::doBind() {
 }
 
 TcpListenSocket::TcpListenSocket(uint32_t port, bool bind_to_port) {
-  // TODO(mklein123): IPv6 support.
+  // TODO(mattklein123): IPv6 support.
   local_address_.reset(new Address::Ipv4Instance(port));
   fd_ = local_address_->socket(Address::SocketType::Stream);
   RELEASE_ASSERT(fd_ != -1);

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -50,7 +50,7 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
       final_remote_address.reset(
           new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(remote_addr)));
     } else {
-      // TODO: IPv6 support.
+      // TODO(mklein123): IPv6 support.
       ASSERT(remote_addr->sa_family == AF_UNIX);
       final_remote_address.reset(
           new Address::PipeInstance(reinterpret_cast<sockaddr_un*>(remote_addr)));

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -50,7 +50,7 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
       final_remote_address.reset(
           new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(remote_addr)));
     } else {
-      // TODO(mklein123): IPv6 support.
+      // TODO(mattklein123): IPv6 support.
       ASSERT(remote_addr->sa_family == AF_UNIX);
       final_remote_address.reset(
           new Address::PipeInstance(reinterpret_cast<sockaddr_un*>(remote_addr)));

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -72,8 +72,8 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   removeFromList(parent_.connections_);
 
-  // TODO: Parse the remote port instead of passing zero.
-  // TODO: IPv6 support.
+  // TODO(mklein123): Parse the remote port instead of passing zero.
+  // TODO(mklein123): IPv6 support.
   listener.newConnection(
       fd, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(remote_address, 0)},
       listener.socket().localAddress());

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -72,8 +72,8 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   removeFromList(parent_.connections_);
 
-  // TODO(mklein123): Parse the remote port instead of passing zero.
-  // TODO(mklein123): IPv6 support.
+  // TODO(mattklein123): Parse the remote port instead of passing zero.
+  // TODO(mattklein123): IPv6 support.
   listener.newConnection(
       fd, Network::Address::InstancePtr{new Network::Address::Ipv4Instance(remote_address, 0)},
       listener.socket().localAddress());

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -77,8 +77,8 @@ const std::string Utility::UNIX_SCHEME = "unix://";
 
 Address::InstancePtr Utility::resolveUrl(const std::string& url) {
   // TODO(mattklein123): IPv6 support.
-  // TODO(mattklein123): We still support the legacy tcp:// and unix:// names. We should support/parse
-  // ip:// and pipe:// as better names.
+  // TODO(mattklein123): We still support the legacy tcp:// and unix:// names. We should
+  // support/parse ip:// and pipe:// as better names.
   if (url.find(TCP_SCHEME) == 0) {
     return Address::InstancePtr{
         new Address::Ipv4Instance(hostFromTcpUrl(url), portFromTcpUrl(url))};

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -59,7 +59,7 @@ bool IpList::contains(const Address::Instance& address) const {
   }
 
   for (const Ipv4Entry& entry : ipv4_list_) {
-    // TODO: IPv6 support
+    // TODO(mklein123): IPv6 support
     if ((ntohl(address.ip()->ipv4()->address()) & entry.ipv4_mask_) == entry.ipv4_address_) {
       return true;
     }
@@ -76,9 +76,9 @@ const std::string Utility::TCP_SCHEME = "tcp://";
 const std::string Utility::UNIX_SCHEME = "unix://";
 
 Address::InstancePtr Utility::resolveUrl(const std::string& url) {
-  // TODO: IPv6 support.
-  // TODO: We still support the legacy tcp:// and unix:// names. We should support/parse ip:// and
-  //       pipe:// as better names.
+  // TODO(mklein123): IPv6 support.
+  // TODO(mklein123): We still support the legacy tcp:// and unix:// names. We should support/parse
+  // ip:// and pipe:// as better names.
   if (url.find(TCP_SCHEME) == 0) {
     return Address::InstancePtr{
         new Address::Ipv4Instance(hostFromTcpUrl(url), portFromTcpUrl(url))};
@@ -184,7 +184,7 @@ Address::InstancePtr Utility::getOriginalDst(int fd) {
   int status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
 
   if (status == 0) {
-    // TODO: IPv6 support
+    // TODO(mklein123): IPv6 support
     ASSERT(orig_addr.ss_family == AF_INET);
     return Address::InstancePtr{
         new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -59,7 +59,7 @@ bool IpList::contains(const Address::Instance& address) const {
   }
 
   for (const Ipv4Entry& entry : ipv4_list_) {
-    // TODO(mklein123): IPv6 support
+    // TODO(mattklein123): IPv6 support
     if ((ntohl(address.ip()->ipv4()->address()) & entry.ipv4_mask_) == entry.ipv4_address_) {
       return true;
     }
@@ -76,8 +76,8 @@ const std::string Utility::TCP_SCHEME = "tcp://";
 const std::string Utility::UNIX_SCHEME = "unix://";
 
 Address::InstancePtr Utility::resolveUrl(const std::string& url) {
-  // TODO(mklein123): IPv6 support.
-  // TODO(mklein123): We still support the legacy tcp:// and unix:// names. We should support/parse
+  // TODO(mattklein123): IPv6 support.
+  // TODO(mattklein123): We still support the legacy tcp:// and unix:// names. We should support/parse
   // ip:// and pipe:// as better names.
   if (url.find(TCP_SCHEME) == 0) {
     return Address::InstancePtr{
@@ -184,7 +184,7 @@ Address::InstancePtr Utility::getOriginalDst(int fd) {
   int status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
 
   if (status == 0) {
-    // TODO(mklein123): IPv6 support
+    // TODO(mattklein123): IPv6 support
     ASSERT(orig_addr.ss_family == AF_INET);
     return Address::InstancePtr{
         new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -206,7 +206,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
       } else {
         ASSERT(current_value.value_->type() == RespType::BulkString);
         if (pending_integer_.integer_ >= 0) {
-          // TODO(mklein123): reserve and define max length since we don't stream currently.
+          // TODO(mattklein123): reserve and define max length since we don't stream currently.
           state_ = State::BulkStringBody;
         } else {
           // Null bulk string. Switch type to null and move to value complete.

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -206,7 +206,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
       } else {
         ASSERT(current_value.value_->type() == RespType::BulkString);
         if (pending_integer_.integer_ >= 0) {
-          // TODO: reserve and define max length since we don't stream currently.
+          // TODO(mklein123): reserve and define max length since we don't stream currently.
           state_ = State::BulkStringBody;
         } else {
           // Null bulk string. Switch type to null and move to value complete.

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -11,10 +11,10 @@
 namespace Redis {
 namespace ConnPool {
 
-// TODO: Stats
-// TODO: Connect timeout
-// TODO: Op timeout
-// TODO: Circuit breaking
+// TODO(mklein123): Stats
+// TODO(mklein123): Connect timeout
+// TODO(mklein123): Op timeout
+// TODO(mklein123): Circuit breaking
 
 class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
 public:

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -11,10 +11,10 @@
 namespace Redis {
 namespace ConnPool {
 
-// TODO(mklein123): Stats
-// TODO(mklein123): Connect timeout
-// TODO(mklein123): Op timeout
-// TODO(mklein123): Circuit breaking
+// TODO(mattklein123): Stats
+// TODO(mattklein123): Connect timeout
+// TODO(mattklein123): Op timeout
+// TODO(mattklein123): Circuit breaking
 
 class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
 public:

--- a/source/common/redis/proxy_filter.h
+++ b/source/common/redis/proxy_filter.h
@@ -9,8 +9,8 @@
 
 namespace Redis {
 
-// TODO(mklein123): Stats
-// TODO(mklein123): Actual multiplexing, command verification, and splitting
+// TODO(mattklein123): Stats
+// TODO(mattklein123): Actual multiplexing, command verification, and splitting
 
 /**
  * Configuration for the redis proxy filter.

--- a/source/common/redis/proxy_filter.h
+++ b/source/common/redis/proxy_filter.h
@@ -9,8 +9,8 @@
 
 namespace Redis {
 
-// TODO: Stats
-// TODO: Actual multiplexing, command verification, and splitting
+// TODO(mklein123): Stats
+// TODO(mklein123): Actual multiplexing, command verification, and splitting
 
 /**
  * Configuration for the redis proxy filter.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -80,7 +80,7 @@ Optional<uint64_t> HashPolicyImpl::generateHash(const Http::HeaderMap& headers) 
   Optional<uint64_t> hash;
   const Http::HeaderEntry* header = headers.get(header_name_);
   if (header) {
-    // TODO(mklein123): Compile in murmur3/city/etc. and potentially allow the user to choose so we
+    // TODO(mattklein123): Compile in murmur3/city/etc. and potentially allow the user to choose so we
     // know exactly what we are going to get.
     hash.value(std::hash<std::string>()(header->value().c_str()));
   }
@@ -384,7 +384,7 @@ void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const 
 
 RoutePtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers, uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, random_value)) {
-    // TODO PERF: Avoid copy.
+    // TODO(mattklein123) PERF: Avoid copy.
     std::string path = headers.Path()->value().c_str();
     size_t query_string_start = path.find("?");
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -80,8 +80,8 @@ Optional<uint64_t> HashPolicyImpl::generateHash(const Http::HeaderMap& headers) 
   Optional<uint64_t> hash;
   const Http::HeaderEntry* header = headers.get(header_name_);
   if (header) {
-    // TODO: Compile in murmur3/city/etc. and potentially allow the user to choose so we know
-    //       exactly what we are going to get.
+    // TODO(mklein123): Compile in murmur3/city/etc. and potentially allow the user to choose so we
+    // know exactly what we are going to get.
     hash.value(std::hash<std::string>()(header->value().c_str()));
   }
   return hash;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -80,8 +80,8 @@ Optional<uint64_t> HashPolicyImpl::generateHash(const Http::HeaderMap& headers) 
   Optional<uint64_t> hash;
   const Http::HeaderEntry* header = headers.get(header_name_);
   if (header) {
-    // TODO(mattklein123): Compile in murmur3/city/etc. and potentially allow the user to choose so we
-    // know exactly what we are going to get.
+    // TODO(mattklein123): Compile in murmur3/city/etc. and potentially allow the user to choose so
+    // we know exactly what we are going to get.
     hash.value(std::hash<std::string>()(header->value().c_str()));
   }
   return hash;

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -105,7 +105,8 @@ RateLimitPolicyImpl::RateLimitPolicyImpl(const Json::Object& config) {
 const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&
     RateLimitPolicyImpl::getApplicableRateLimit(int64_t) const {
   // Currently return all rate limit policy entries.
-  // TODO: Implement returning only rate limit policy entries that match the stage setting.
+  // TODO(mklein123): Implement returning only rate limit policy entries that match the stage
+  // setting.
   if (rate_limit_entries_.empty()) {
     return empty_rate_limit_;
   } else {

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -105,7 +105,7 @@ RateLimitPolicyImpl::RateLimitPolicyImpl(const Json::Object& config) {
 const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&
     RateLimitPolicyImpl::getApplicableRateLimit(int64_t) const {
   // Currently return all rate limit policy entries.
-  // TODO(mklein123): Implement returning only rate limit policy entries that match the stage
+  // TODO(mattklein123): Implement returning only rate limit policy entries that match the stage
   // setting.
   if (rate_limit_entries_.empty()) {
     return empty_rate_limit_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -498,8 +498,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry()
   // We need to drain all connection pools for the cluster being removed. Then we can remove the
   // cluster.
   //
-  // TODO(mklein123): Optimally, we would just fire member changed callbacks and remove all of the
-  // hosts inside of the HostImpl destructor. That is a change with wide implications, so we are
+  // TODO(mattklein123): Optimally, we would just fire member changed callbacks and remove all of
+  // the hosts inside of the HostImpl destructor. That is a change with wide implications, so we are
   // going with a more targeted approach for now.
   parent_.drainConnPools(host_set_.hosts());
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -497,9 +497,10 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry() {
   // We need to drain all connection pools for the cluster being removed. Then we can remove the
   // cluster.
-  // TODO: Optimally, we would just fire member changed callbacks and remove all of the hosts
-  //       inside of the HostImpl destructor. That is a change with wide implications, so we are
-  //       going with a more targeted approach for now.
+  //
+  // TODO(mklein123): Optimally, we would just fire member changed callbacks and remove all of the
+  // hosts inside of the HostImpl destructor. That is a change with wide implications, so we are
+  // going with a more targeted approach for now.
   parent_.drainConnPools(host_set_.hosts());
 }
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -52,7 +52,7 @@ void LogicalDnsCluster::startResolve() {
         info_->stats().update_success_.inc();
 
         if (!address_list.empty()) {
-          // TODO: IPv6 support as well as moving port handling into the DNS interface.
+          // TODO(mklein123): IPv6 support as well as moving port handling into the DNS interface.
           Network::Address::InstancePtr new_address(
               new Network::Address::Ipv4Instance(address_list.front()->ip()->addressAsString(),
                                                  Network::Utility::portFromTcpUrl(dns_url_)));
@@ -66,10 +66,10 @@ void LogicalDnsCluster::startResolve() {
           }
 
           if (!logical_host_) {
-            // TODO: The logical host is only used in /clusters admin output. We used to show
-            //       the friendly DNS name in that output, but currently there is no way to
-            //       express a DNS name inside of an Address::Instance. For now this is OK but
-            //       we might want to do better again later.
+            // TODO(mklein123): The logical host is only used in /clusters admin output. We used to
+            // show the friendly DNS name in that output, but currently there is no way to express a
+            // DNS name inside of an Address::Instance. For now this is OK but we might want to do
+            // better again later.
             logical_host_.reset(new LogicalHost(
                 info_, hostname_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -52,7 +52,8 @@ void LogicalDnsCluster::startResolve() {
         info_->stats().update_success_.inc();
 
         if (!address_list.empty()) {
-          // TODO(mklein123): IPv6 support as well as moving port handling into the DNS interface.
+          // TODO(mattklein123): IPv6 support as well as moving port handling into the DNS
+          // interface.
           Network::Address::InstancePtr new_address(
               new Network::Address::Ipv4Instance(address_list.front()->ip()->addressAsString(),
                                                  Network::Utility::portFromTcpUrl(dns_url_)));
@@ -66,10 +67,10 @@ void LogicalDnsCluster::startResolve() {
           }
 
           if (!logical_host_) {
-            // TODO(mklein123): The logical host is only used in /clusters admin output. We used to
-            // show the friendly DNS name in that output, but currently there is no way to express a
-            // DNS name inside of an Address::Instance. For now this is OK but we might want to do
-            // better again later.
+            // TODO(mattklein123): The logical host is only used in /clusters admin output. We used
+            // to show the friendly DNS name in that output, but currently there is no way to
+            // express a DNS name inside of an Address::Instance. For now this is OK but we might
+            // want to do better again later.
             logical_host_.reset(new LogicalHost(
                 info_, hostname_, Network::Utility::resolveUrl("tcp://0.0.0.0:0"), *this));
             HostVectorPtr new_hosts(new std::vector<HostPtr>());

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -214,7 +214,7 @@ void DetectorImpl::runCallbacks(HostPtr host) {
 }
 
 void EventLoggerImpl::logEject(HostDescriptionPtr host, EjectionType type) {
-  // TODO: Log friendly host name (e.g., instance ID or DNS name).
+  // TODO(mklein123): Log friendly host name (e.g., instance ID or DNS name).
   // clang-format off
   static const std::string json =
     std::string("{{") +
@@ -235,7 +235,7 @@ void EventLoggerImpl::logEject(HostDescriptionPtr host, EjectionType type) {
 }
 
 void EventLoggerImpl::logUneject(HostDescriptionPtr host) {
-  // TODO: Log friendly host name (e.g., instance ID or DNS name).
+  // TODO(mklein123): Log friendly host name (e.g., instance ID or DNS name).
   // clang-format off
   static const std::string json =
     std::string("{{") +

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -214,7 +214,7 @@ void DetectorImpl::runCallbacks(HostPtr host) {
 }
 
 void EventLoggerImpl::logEject(HostDescriptionPtr host, EjectionType type) {
-  // TODO(mklein123): Log friendly host name (e.g., instance ID or DNS name).
+  // TODO(mattklein123): Log friendly host name (e.g., instance ID or DNS name).
   // clang-format off
   static const std::string json =
     std::string("{{") +
@@ -235,7 +235,7 @@ void EventLoggerImpl::logEject(HostDescriptionPtr host, EjectionType type) {
 }
 
 void EventLoggerImpl::logUneject(HostDescriptionPtr host) {
-  // TODO(mklein123): Log friendly host name (e.g., instance ID or DNS name).
+  // TODO(mattklein123): Log friendly host name (e.g., instance ID or DNS name).
   // clang-format off
   static const std::string json =
     std::string("{{") +

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -416,8 +416,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
 
         std::vector<HostPtr> new_hosts;
         for (Network::Address::InstancePtr address : address_list) {
-          // TODO(mklein123): Currently the DNS interface does not consider port. We need to make a
-          // new address that has port in it. We need to both support IPv6 as well as potentially
+          // TODO(mattklein123): Currently the DNS interface does not consider port. We need to make
+          // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.
           new_hosts.emplace_back(
               new HostImpl(parent_.info_, dns_address_,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -416,10 +416,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
 
         std::vector<HostPtr> new_hosts;
         for (Network::Address::InstancePtr address : address_list) {
-          // TODO: Currently the DNS interface does not consider port. We need to make a new
-          //       address that has port in it. We need to both support IPv6 as well as potentially
-          //       move port handling into the DNS interface itself, which would work better for
-          //       SRV.
+          // TODO(mklein123): Currently the DNS interface does not consider port. We need to make a
+          // new address that has port in it. We need to both support IPv6 as well as potentially
+          // move port handling into the DNS interface itself, which would work better for SRV.
           new_hosts.emplace_back(
               new HostImpl(parent_.info_, dns_address_,
                            Network::Address::InstancePtr{new Network::Address::Ipv4Instance(

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -135,7 +135,7 @@ void InstanceImpl::flushStats() {
 
 int InstanceImpl::getListenSocketFd(uint32_t port) {
   for (const auto& entry : socket_map_) {
-    // TODO(mklein123): UDS listeners.
+    // TODO(mattklein123): UDS listeners.
     if (entry.second->localAddress()->ip()->port() == port) {
       return entry.second->fd();
     }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -135,7 +135,7 @@ void InstanceImpl::flushStats() {
 
 int InstanceImpl::getListenSocketFd(uint32_t port) {
   for (const auto& entry : socket_map_) {
-    // TODO: UDS listeners.
+    // TODO(mklein123): UDS listeners.
     if (entry.second->localAddress()->ip()->port() == port) {
       return entry.second->fd();
     }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -41,7 +41,7 @@ public:
   void run(std::vector<uint32_t> originating_cluster, std::vector<uint32_t> all_destination_cluster,
            std::vector<uint32_t> healthy_destination_cluster) {
     local_host_set_ = new HostSetImpl();
-    // TODO(mklein123): make load balancer per originating cluster host.
+    // TODO(mattklein123): make load balancer per originating cluster host.
     RandomLoadBalancer lb(cluster_, local_host_set_, stats_, runtime_, random_);
 
     HostListsPtr upstream_per_zone_hosts = generateHostsPerZone(healthy_destination_cluster);

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -41,7 +41,7 @@ public:
   void run(std::vector<uint32_t> originating_cluster, std::vector<uint32_t> all_destination_cluster,
            std::vector<uint32_t> healthy_destination_cluster) {
     local_host_set_ = new HostSetImpl();
-    // TODO: make load balancer per originating cluster host.
+    // TODO(mklein123): make load balancer per originating cluster host.
     RandomLoadBalancer lb(cluster_, local_host_set_, stats_, runtime_, random_);
 
     HostListsPtr upstream_per_zone_hosts = generateHostsPerZone(healthy_destination_cluster);

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -53,7 +53,7 @@ TEST_F(RingHashLoadBalancerTest, Basic) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
   // what we are going to get.
   // ring hash: host=127.0.0.1:85 hash=1358027074129602068
   // ring hash: host=127.0.0.1:83 hash=4361834613929391114
@@ -104,7 +104,7 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
   // what we are going to get.
   // ring hash: host=127.0.0.1:81 hash=7701421856454313576
   // ring hash: host=127.0.0.1:81 hash=9887544217113020895
@@ -120,7 +120,7 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
   // what we are going to get.
   // ring hash: host=127.0.0.1:81 hash=7701421856454313576
   // ring hash: host=127.0.0.1:82 hash=8649315368077433379

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -53,7 +53,8 @@ TEST_F(RingHashLoadBalancerTest, Basic) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // what we are going to get.
   // ring hash: host=127.0.0.1:85 hash=1358027074129602068
   // ring hash: host=127.0.0.1:83 hash=4361834613929391114
   // ring hash: host=127.0.0.1:84 hash=7224494972555149682
@@ -103,7 +104,8 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // what we are going to get.
   // ring hash: host=127.0.0.1:81 hash=7701421856454313576
   // ring hash: host=127.0.0.1:81 hash=9887544217113020895
   // ring hash: host=127.0.0.1:80 hash=15427156902705414897
@@ -118,7 +120,8 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   cluster_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
-  // TODO: Compile in and use murmur3 or city so we know exactly what we are going to get.
+  // TODO(mklein123): Compile in and use murmur3 or city so we know exactly
+  // what we are going to get.
   // ring hash: host=127.0.0.1:81 hash=7701421856454313576
   // ring hash: host=127.0.0.1:82 hash=8649315368077433379
   // ring hash: host=127.0.0.1:81 hash=9887544217113020895

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -656,7 +656,7 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
                   [&]() -> void {
                     fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
                   },
-                  // TODO: Waiting for exact amount of data is a hack. This needs to be fixed.
+                  // TODO(mklein123): Waiting for exact amount of data is a hack. This needs to be fixed.
                   [&]() -> void { fake_upstream_connection->waitForData(187); },
                   [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
                   [&]() -> void { fake_upstream_connection->waitForDisconnect(); },

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -645,8 +645,9 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
   FakeRawConnectionPtr fake_upstream_connection;
   executeActions({[&]() -> void {
-    codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, Http::CodecClient::Type::HTTP1);
-  },
+                    codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT,
+                                                      Http::CodecClient::Type::HTTP1);
+                  },
                   [&]() -> void {
                     codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                                        {":path", "/test/long/url"},
@@ -656,7 +657,8 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
                   [&]() -> void {
                     fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
                   },
-                  // TODO(mklein123): Waiting for exact amount of data is a hack. This needs to be fixed.
+                  // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
+                  // be fixed.
                   [&]() -> void { fake_upstream_connection->waitForData(187); },
                   [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
                   [&]() -> void { fake_upstream_connection->waitForDisconnect(); },

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1,108 +1,699 @@
-== network/connection_impl.cc ==
-Vim: Warning: Output is not to a terminal
-[?1002h[?1049h[?1h=[1;42r[34l[34h[?25h[23m[24m[0m[93m[44m[?25l[42;1H[97m[41mE325: ATTENTION[0m[93m[44m                                                                                                                     [42;1H
-                                                                                                                                    [42;1HFound a swap file by the name "~/.vim/cache//%usr%local%google%home%trevors%github%envoy%source%common%network%connection_impl.cc.s
-                                                                                                                                    [41;132Hw[42;1Hp"
-                                                                                                                                    [42;11Howned by: trevors   dated: Fri Mar  3 14:19:08 2017
-                                                                                                                                    [42;10Hfile name: ~trevors/github/envoy/source/common/network/connection_impl.cc
-                                                                                                                                    [42;11Hmodified: YES
-                                                                                                                                    [42;10Huser name: trevors   host name: abnormal.cam.corp.google.com
-                                                                                                                                    [42;9Hprocess ID: 141839
-                                                                                                                                    [42;1HWhile opening file "network/connection_impl.cc"
-                                                                                                                                    [42;14Hdated: Fri Mar  3 12:18:08 2017
-                                                                                                                                    [42;1H
-                                                                                                                                    [42;1H(1) Another program may be editing the same file.  If this is the case,
-                                                                                                                                    [42;5Hbe careful not to end up with two different instances of the same
-                                                                                                                                    [42;5Hfile when making changes.  Quit, or continue with caution.
-                                                                                                                                    [42;1H(2) An edit session for this file crashed.
-                                                                                                                                    [42;5HIf this is the case, use ":recover" or "vim -r network/connection_impl.cc"
-                                                                                                                                    [42;5Hto recover the changes (see ":help recovery").
-                                                                                                                                    [42;5HIf you did this already, delete the swap file "/usr/local/google/home/trevors/.vim/cache//%usr%local%google%home%trevors%github
-                                                                                                                                    [41;132H%[42;1Henvoy%source%common%network%connection_impl.cc.swp"
-                                                                                                                                    [42;5Hto avoid this message.
-                                                                                                                                    [?1002l[42;1H
-                                                                                                                                    [42;1H[92mSwap file "~/.vim/cache//%usr%local%google%home%trevors%github%envoy%source%common%network%connection_impl.cc.swp" already exists![0m[93m[44m
-                                                                                                                                    [42;1H[92m[O]pen Read-Only, (E)dit anyway, (R)ecover, (D)elete it, (Q)uit, (A)bort: [34h[?25h[?1002h[0m[93m[44m                                                                          
-                                                                                                                                    [?1002l[42;1HInterrupt: [92mPress ENTER or type command to continue[?1002h[0m[93m[44m[1;1H[L[?25l[1;1H[30m[47m  [0m[93m[44m                                                                [7m[94m[104m|[2;67H|[3;67H|[4;67H|[5;67H|[6;67H|[7;67H|[8;67H|[9;67H|[10;67H|[11;67H|[12;67H|[13;67H|[14;67H|[15;67H|[16;67H|[17;67H|[18;67H|[19;67H|[20;67H|[21;67H|[22;67H|[23;67H|[24;67H|[25;67H|[26;67H|[27;67H|[28;67H|[29;67H|[30;67H|[31;67H|[32;67H|[33;67H|[34;67H|[35;67H|[36;67H|[37;67H|[38;67H|[39;67H|[40;67H|[0m[93m[44m[2;1H[30m[47m  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  [0m[93m[44m[2;3H[95m~                                                               [3;3H~                                                               [4;3H~                                                               [5;3H~                                                               [6;3H~                                                               [7;3H~                                                               [8;3H~                                                               [9;3H~                                                               [10;3H~                                                               [11;3H~                                                               [12;3H~                                                               [13;3H~                                                               [14;3H~                                                               [15;3H~                                                               [16;3H~                                                               [17;3H~                                                               [18;3H~                                                               [19;3H~                                                               [20;3H~                                                               [21;3H~                                                               [22;3H~                                                               [23;3H~                                                               [24;3H~                                                               [25;3H~                                                               [26;3H~                                                               [27;3H~                                                               [28;3H~                                                               [29;3H~                                                               [30;3H~                                                               [31;3H~                                                               [32;3H~                                                               [33;3H~                                                               [34;3H~                                                               [35;3H~                                                               [36;3H~                                                               [37;3H~                                                               [38;3H~                                                               [39;3H~                                                               [40;3H~                                                               [0m[93m[44m
-[1m[7m[96m[104mnetwork/connection_impl.cc [RO]                 0,0-1          All [0m[93m[44m[1;68H[30m[47m  [0m[93m[44m                                                               [2;68H[30m[47m  [3;68H  [4;68H  [5;68H  [6;68H  [7;68H  [8;68H  [9;68H  [10;68H  [11;68H  [12;68H  [13;68H  [14;68H  [15;68H  [16;68H  [17;68H  [18;68H  [19;68H  [20;68H  [21;68H  [22;68H  [23;68H  [24;68H  [25;68H  [26;68H  [27;68H  [28;68H  [29;68H  [30;68H  [31;68H  [32;68H  [33;68H  [34;68H  [35;68H  [36;68H  [37;68H  [38;68H  [39;68H  [40;68H  [0m[93m[44m[2;70H[95m~                                                              [3;70H~                                                              [4;70H~                                                              [5;70H~                                                              [6;70H~                                                              [7;70H~                                                              [8;70H~                                                              [9;70H~                                                              [10;70H~                                                              [11;70H~                                                              [12;70H~                                                              [13;70H~                                                              [14;70H~                                                              [15;70H~                                                              [16;70H~                                                              [17;70H~                                                              [18;70H~                                                              [19;70H~                                                              [20;70H~                                                              [21;70H~                                                              [22;70H~                                                              [23;70H~                                                              [24;70H~                                                              [25;70H~                                                              [26;70H~                                                              [27;70H~                                                              [28;70H~                                                              [29;70H~                                                              [30;70H~                                                              [31;70H~                                                              [32;70H~                                                              [33;70H~                                                              [34;70H~                                                              [35;70H~                                                              [36;70H~                                                              [37;70H~                                                              [38;70H~                                                              [39;70H~                                                              [40;70H~                                                              [0m[93m[44m[41;68H[7m[30m[104mnetwork/connection_impl.cc [RO]                0,0-1          All[1;3H[34h[?25h[?25l[34h[?25h[42;1H
-[0m[93m[44m[39;49m[?1l>[?1049l[?1002l[?1002h[?1049h[?1h=[34l[34h[?25h[23m[24m[0m[93m[44m[?25l[1;1H[30m[47m  [0m[93m[44m                                                                [7m[94m[104m|[2;67H|[3;67H|[4;67H|[5;67H|[6;67H|[7;67H|[8;67H|[9;67H|[10;67H|[11;67H|[12;67H|[13;67H|[14;67H|[15;67H|[16;67H|[17;67H|[18;67H|[19;67H|[20;67H|[21;67H|[22;67H|[23;67H|[24;67H|[25;67H|[26;67H|[27;67H|[28;67H|[29;67H|[30;67H|[31;67H|[32;67H|[33;67H|[34;67H|[35;67H|[36;67H|[37;67H|[38;67H|[39;67H|[40;67H|[0m[93m[44m[2;1H[30m[47m  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  [0m[93m[44m[2;3H[95m~                                                               [3;3H~                                                               [4;3H~                                                               [5;3H~                                                               [6;3H~                                                               [7;3H~                                                               [8;3H~                                                               [9;3H~                                                               [10;3H~                                                               [11;3H~                                                               [12;3H~                                                               [13;3H~                                                               [14;3H~                                                               [15;3H~                                                               [16;3H~                                                               [17;3H~                                                               [18;3H~                                                               [19;3H~                                                               [20;3H~                                                               [21;3H~                                                               [22;3H~                                                               [23;3H~                                                               [24;3H~                                                               [25;3H~                                                               [26;3H~                                                               [27;3H~                                                               [28;3H~                                                               [29;3H~                                                               [30;3H~                                                               [31;3H~                                                               [32;3H~                                                               [33;3H~                                                               [34;3H~                                                               [35;3H~                                                               [36;3H~                                                               [37;3H~                                                               [38;3H~                                                               [39;3H~                                                               [40;3H~                                                               [0m[93m[44m
-[1m[7m[96m[104mnetwork/connection_impl.cc [RO]                 0,0-1          All [0m[93m[44m[1;68H[30m[47m  [0m[93m[44m                                                               [2;68H[30m[47m  [3;68H  [4;68H  [5;68H  [6;68H  [7;68H  [8;68H  [9;68H  [10;68H  [11;68H  [12;68H  [13;68H  [14;68H  [15;68H  [16;68H  [17;68H  [18;68H  [19;68H  [20;68H  [21;68H  [22;68H  [23;68H  [24;68H  [25;68H  [26;68H  [27;68H  [28;68H  [29;68H  [30;68H  [31;68H  [32;68H  [33;68H  [34;68H  [35;68H  [36;68H  [37;68H  [38;68H  [39;68H  [40;68H  [0m[93m[44m[2;70H[95m~                                                              [3;70H~                                                              [4;70H~                                                              [5;70H~                                                              [6;70H~                                                              [7;70H~                                                              [8;70H~                                                              [9;70H~                                                              [10;70H~                                                              [11;70H~                                                              [12;70H~                                                              [13;70H~                                                              [14;70H~                                                              [15;70H~                                                              [16;70H~                                                              [17;70H~                                                              [18;70H~                                                              [19;70H~                                                              [20;70H~                                                              [21;70H~                                                              [22;70H~                                                              [23;70H~                                                              [24;70H~                                                              [25;70H~                                                              [26;70H~                                                              [27;70H~                                                              [28;70H~                                                              [29;70H~                                                              [30;70H~                                                              [31;70H~                                                              [32;70H~                                                              [33;70H~                                                              [34;70H~                                                              [35;70H~                                                              [36;70H~                                                              [37;70H~                                                              [38;70H~                                                              [39;70H~                                                              [40;70H~                                                              [0m[93m[44m[41;68H[7m[30m[104mnetwork/connection_impl.cc [RO]                0,0-1          All[0m[93m[44m[42;1H                                                                                                                                    [1;3H[34h[?25h[?25l[34h[?25h[42;1H[39;49m[?1l>[?1049lVim: Caught deadly signal HUP
-2 files to edit
-Vim: Finished.
-[42;1H[23m[24m[0m[93m[44m[39;49m
+#include "integration.h"
+#include "utility.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/http/header_map_impl.h"
+
+#include "test/test_common/utility.h"
+
+TEST_F(IntegrationTest, Echo) {
+  Buffer::OwnedImpl buffer("hello");
+  std::string response;
+  RawConnectionDriver connection(
+      ECHO_PORT, buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        connection.close();
+      });
+
+  connection.run();
+  EXPECT_EQ("hello", response);
+}
+
+TEST_F(IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP1); }
+
+void BaseIntegrationTest::testRouterNotFound(Http::CodecClient::Type type) {
+  BufferingStreamDecoderPtr response =
+      IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/notfound", "", type);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
+}
+
+TEST_F(IntegrationTest, RouterNotFoundBodyNoBuffer) {
+  testRouterNotFoundWithBody(HTTP_PORT, Http::CodecClient::Type::HTTP1);
+}
+
+TEST_F(IntegrationTest, RouterNotFoundBodyBuffer) {
+  testRouterNotFoundWithBody(HTTP_BUFFER_PORT, Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type) {
+  BufferingStreamDecoderPtr response =
+      IntegrationUtil::makeSingleRequest(port, "POST", "/notfound", "foo", type);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
+}
+
+TEST_F(IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP1); }
+
+void BaseIntegrationTest::testRouterRedirect(Http::CodecClient::Type type) {
+  BufferingStreamDecoderPtr response =
+      IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/foo", "", type, "www.redirect.com");
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("301", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("https://www.redirect.com/foo",
+               response->headers().get(Http::Headers::get().Location)->value().c_str());
+}
+
+TEST_F(IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP1); }
+
+void BaseIntegrationTest::testDrainClose(Http::CodecClient::Type type) {
+  test_server_->drainManager().draining_ = true;
+
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  executeActions({[&]() -> void { codec_client = makeHttpConnection(HTTP_PORT, type); },
+                  [&]() -> void {
+                    codec_client->makeHeaderOnlyRequest(
+                        Http::TestHeaderMapImpl{{":method", "GET"},
+                                                {":path", "/healthcheck"},
+                                                {":scheme", "http"},
+                                                {":authority", "host"}},
+                        *response);
+                  },
+                  [&]() -> void { response->waitForEndStream(); },
+                  [&]() -> void { codec_client->waitForDisconnect(); }});
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  if (type == Http::CodecClient::Type::HTTP2) {
+    EXPECT_TRUE(codec_client->sawGoAway());
+  }
+
+  test_server_->drainManager().draining_ = false;
+}
+
+TEST_F(IntegrationTest, ConnectionClose) {
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  executeActions({[&]() -> void {
+    codec_client = makeHttpConnection(HTTP_PORT, Http::CodecClient::Type::HTTP1);
+  },
+                  [&]() -> void {
+                    codec_client->makeHeaderOnlyRequest(
+                        Http::TestHeaderMapImpl{{":method", "GET"},
+                                                {":path", "/healthcheck"},
+                                                {":authority", "host"},
+                                                {"connection", "close"}},
+                        *response);
+                  },
+                  [&]() -> void { response->waitForEndStream(); },
+                  [&]() -> void { codec_client->waitForDisconnect(); }});
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+}
+
+void BaseIntegrationTest::testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
+                                                               Http::CodecClient::Type type,
+                                                               uint64_t request_size,
+                                                               uint64_t response_size,
+                                                               bool big_header) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  executeActions({[&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+                  [&]() -> void {
+                    Http::TestHeaderMapImpl headers{{":method", "POST"},
+                                                    {":path", "/test/long/url"},
+                                                    {":scheme", "http"},
+                                                    {":authority", "host"},
+                                                    {"x-lyft-user-id", "123"},
+                                                    {"x-forwarded-for", "10.0.0.1"}};
+                    if (big_header) {
+                      headers.addViaCopy("big", std::string(4096, 'a'));
+                    }
+
+                    codec_client->makeRequestWithBody(headers, request_size, *response);
+                  },
+                  [&]() -> void {
+                    fake_upstream_connection =
+                        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+                  },
+                  [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+                  [&]() -> void { request->waitForEndStream(*dispatcher_); },
+                  [&]() -> void {
+                    request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+                    request->encodeData(response_size, true);
+                  },
+                  [&]() -> void { response->waitForEndStream(); },
+                  // Cleanup both downstream and upstream
+                  [&]() -> void { codec_client->close(); },
+                  [&]() -> void { fake_upstream_connection->close(); },
+                  [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
+
+  EXPECT_TRUE(request->complete());
+  EXPECT_EQ(request_size, request->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(response_size, response->body().size());
+}
+
+TEST_F(IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_PORT),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
+}
+
+TEST_F(IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
+}
+
+TEST_F(IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
+                                       Http::CodecClient::Type::HTTP1, 4 * 1024 * 1024,
+                                       4 * 1024 * 1024, false);
+}
+
+TEST_F(IntegrationTest, RouterRequestAndResponseLargeHeaderNoBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_PORT),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, true);
+}
+
+void BaseIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  executeActions(
+      {[&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+       [&]() -> void {
+         codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                     {":path", "/test/long/url"},
+                                                                     {":scheme", "http"},
+                                                                     {":authority", "host"},
+                                                                     {"x-lyft-user-id", "123"}},
+                                             *response);
+       },
+       [&]() -> void {
+         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+       },
+       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+       [&]() -> void { request->waitForEndStream(*dispatcher_); },
+       [&]() -> void {
+         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+       },
+       [&]() -> void { response->waitForEndStream(); },
+       // Cleanup both downstream and upstream
+       [&]() -> void { codec_client->close(); },
+       [&]() -> void { fake_upstream_connection->close(); },
+       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
+
+  EXPECT_TRUE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(0U, response->body().size());
+}
+
+TEST_F(IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
+  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(IntegrationTest::HTTP_PORT),
+                                         Http::CodecClient::Type::HTTP1);
+}
+
+TEST_F(IntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
+  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
+                                         Http::CodecClient::Type::HTTP1);
+}
+
+TEST_F(IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
+  testRouterUpstreamDisconnectBeforeRequestComplete(
+      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  std::list<std::function<void()>> actions = {
+      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+      [&]() -> void {
+        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                           {":path", "/test/long/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"}},
+                                   *response);
+      },
+      [&]() -> void {
+        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+      },
+      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+      [&]() -> void { request->waitForHeadersComplete(); },
+      [&]() -> void { fake_upstream_connection->close(); },
+      [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
+      [&]() -> void { response->waitForEndStream(); }};
+
+  if (type == Http::CodecClient::Type::HTTP1) {
+    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { codec_client->close(); });
+  }
+
+  executeActions(actions);
+
+  EXPECT_FALSE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
+  EXPECT_EQ("upstream connect error or disconnect/reset before headers", response->body());
+}
+
+TEST_F(IntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
+  testRouterUpstreamDisconnectBeforeResponseComplete(
+      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  std::list<std::function<void()>> actions = {
+      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+      [&]() -> void {
+        codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                    {":path", "/test/long/url"},
+                                                                    {":scheme", "http"},
+                                                                    {":authority", "host"}},
+                                            *response);
+      },
+      [&]() -> void {
+        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+      },
+      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+      [&]() -> void { request->waitForEndStream(*dispatcher_); },
+      [&]() -> void {
+        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+      },
+      [&]() -> void { fake_upstream_connection->close(); },
+      [&]() -> void { fake_upstream_connection->waitForDisconnect(); }};
+
+  if (type == Http::CodecClient::Type::HTTP1) {
+    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { response->waitForReset(); });
+    actions.push_back([&]() -> void { codec_client->close(); });
+  }
+
+  executeActions(actions);
+
+  EXPECT_TRUE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_FALSE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(0U, response->body().size());
+}
+
+TEST_F(IntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
+  testRouterDownstreamDisconnectBeforeRequestComplete(
+      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterDownstreamDisconnectBeforeRequestComplete(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  std::list<std::function<void()>> actions = {
+      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+      [&]() -> void {
+        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                           {":path", "/test/long/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"}},
+                                   *response);
+      },
+      [&]() -> void {
+        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+      },
+      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+      [&]() -> void { request->waitForHeadersComplete(); },
+      [&]() -> void { codec_client->close(); }};
+
+  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { request->waitForReset(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  }
+
+  executeActions(actions);
+
+  EXPECT_FALSE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_FALSE(response->complete());
+}
+
+TEST_F(IntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
+  testRouterDownstreamDisconnectBeforeResponseComplete(
+      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterDownstreamDisconnectBeforeResponseComplete(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  std::list<std::function<void()>> actions = {
+      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+      [&]() -> void {
+        codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                    {":path", "/test/long/url"},
+                                                                    {":scheme", "http"},
+                                                                    {":authority", "host"}},
+                                            *response);
+      },
+      [&]() -> void {
+        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+      },
+      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+      [&]() -> void { request->waitForEndStream(*dispatcher_); },
+      [&]() -> void {
+        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+        request->encodeData(512, false);
+      },
+      [&]() -> void { response->waitForBodyData(512); }, [&]() -> void { codec_client->close(); }};
+
+  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { request->waitForReset(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  }
+
+  executeActions(actions);
+
+  EXPECT_TRUE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_FALSE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(512U, response->body().size());
+}
+
+TEST_F(IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
+  testRouterUpstreamResponseBeforeRequestComplete(makeClientConnection(IntegrationTest::HTTP_PORT),
+                                                  Http::CodecClient::Type::HTTP1);
+}
+
+void BaseIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete(
+    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  std::list<std::function<void()>> actions = {
+      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
+      [&]() -> void {
+        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                           {":path", "/test/long/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"}},
+                                   *response);
+      },
+      [&]() -> void {
+        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+      },
+      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+      [&]() -> void { request->waitForHeadersComplete(); },
+      [&]() -> void {
+        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+        request->encodeData(512, true);
+      },
+      [&]() -> void { response->waitForEndStream(); }};
+
+  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { request->waitForReset(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
+    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
+  }
+
+  if (type == Http::CodecClient::Type::HTTP1) {
+    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
+  } else {
+    actions.push_back([&]() -> void { codec_client->close(); });
+  }
+
+  executeActions(actions);
+
+  EXPECT_FALSE(request->complete());
+  EXPECT_EQ(0U, request->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(512U, response->body().size());
+}
+
+TEST_F(IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP1); }
+
+void BaseIntegrationTest::testRetry(Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  executeActions(
+      {[&]() -> void { codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, type); },
+       [&]() -> void {
+         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                   {":path", "/test/long/url"},
+                                                                   {":scheme", "http"},
+                                                                   {":authority", "host"},
+                                                                   {"x-forwarded-for", "10.0.0.1"},
+                                                                   {"x-envoy-retry-on", "5xx"}},
+                                           1024, *response);
+       },
+       [&]() -> void {
+         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+       },
+       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+       [&]() -> void { request->waitForEndStream(*dispatcher_); },
+       [&]() -> void {
+         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+       },
+       [&]() -> void {
+         if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+           fake_upstream_connection->waitForDisconnect();
+           fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+         } else {
+           request->waitForReset();
+         }
+       },
+       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+       [&]() -> void { request->waitForEndStream(*dispatcher_); },
+       [&]() -> void {
+         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+         request->encodeData(512, true);
+       },
+       [&]() -> void {
+         response->waitForEndStream();
+         EXPECT_TRUE(request->complete());
+         EXPECT_EQ(1024U, request->bodyLength());
+
+         EXPECT_TRUE(response->complete());
+         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+         EXPECT_EQ(512U, response->body().size());
+       },
+       // Cleanup both downstream and upstream
+       [&]() -> void { codec_client->close(); },
+       [&]() -> void { fake_upstream_connection->close(); },
+       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
+}
+
+TEST_F(IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP1); }
+
+void BaseIntegrationTest::testTwoRequests(Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request;
+  executeActions(
+      {[&]() -> void { codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, type); },
+       // Request 1.
+       [&]() -> void {
+         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                   {":path", "/test/long/url"},
+                                                                   {":scheme", "http"},
+                                                                   {":authority", "host"}},
+                                           1024, *response);
+       },
+       [&]() -> void {
+         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+       },
+       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+       [&]() -> void { request->waitForEndStream(*dispatcher_); },
+       [&]() -> void {
+         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+         request->encodeData(512, true);
+       },
+       [&]() -> void {
+         response->waitForEndStream();
+         EXPECT_TRUE(request->complete());
+         EXPECT_EQ(1024U, request->bodyLength());
+
+         EXPECT_TRUE(response->complete());
+         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+         EXPECT_EQ(512U, response->body().size());
+       },
+       // Request 2.
+       [&]() -> void {
+         response.reset(new IntegrationStreamDecoder(*dispatcher_));
+         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                   {":path", "/test/long/url"},
+                                                                   {":scheme", "http"},
+                                                                   {":authority", "host"}},
+                                           512, *response);
+       },
+       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
+       [&]() -> void { request->waitForEndStream(*dispatcher_); },
+       [&]() -> void {
+         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+         request->encodeData(1024, true);
+       },
+       [&]() -> void {
+         response->waitForEndStream();
+         EXPECT_TRUE(request->complete());
+         EXPECT_EQ(512U, request->bodyLength());
+
+         EXPECT_TRUE(response->complete());
+         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+         EXPECT_EQ(1024U, response->body().size());
+       },
+       // Cleanup both downstream and upstream
+       [&]() -> void { codec_client->close(); },
+       [&]() -> void { fake_upstream_connection->close(); },
+       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
+}
+
+TEST_F(IntegrationTest, BadHttpRequest) { testBadHttpRequest(); }
+
+void BaseIntegrationTest::testBadHttpRequest() {
+  Buffer::OwnedImpl buffer("hello");
+  std::string response;
+  RawConnectionDriver connection(
+      HTTP_PORT, buffer, [&](Network::ClientConnection&, const Buffer::Instance& data)
+                             -> void { response.append(TestUtility::bufferToString(data)); });
+
+  connection.run();
+  EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
+}
+
+TEST_F(IntegrationTest, Http10Request) { testHttp10Request(); }
+
+void BaseIntegrationTest::testHttp10Request() {
+  Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
+  std::string response;
+  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
+                                                        const Buffer::Instance& data) -> void {
+    response.append(TestUtility::bufferToString(data));
+    client.close(Network::ConnectionCloseType::NoFlush);
+  });
+
+  connection.run();
+  EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
+}
+
+TEST_F(IntegrationTest, NoHost) { testNoHost(); }
+
+void BaseIntegrationTest::testNoHost() {
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
+  std::string response;
+  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
+                                                        const Buffer::Instance& data) -> void {
+    response.append(TestUtility::bufferToString(data));
+    client.close(Network::ConnectionCloseType::NoFlush);
+  });
+
+  connection.run();
+  EXPECT_TRUE(response.find("HTTP/1.1 400 Bad Request\r\n") == 0);
+}
+
+TEST_F(IntegrationTest, BadPath) { testBadPath(); }
+
+void BaseIntegrationTest::testBadPath() {
+  Buffer::OwnedImpl buffer("GET http://api.lyft.com HTTP/1.1\r\nHost: host\r\n\r\n");
+  std::string response;
+  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
+                                                        const Buffer::Instance& data) -> void {
+    response.append(TestUtility::bufferToString(data));
+    client.close(Network::ConnectionCloseType::NoFlush);
+  });
+
+  connection.run();
+  EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
+}
+
+TEST_F(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
+
+void BaseIntegrationTest::testUpstreamProtocolError() {
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  FakeRawConnectionPtr fake_upstream_connection;
+  executeActions({[&]() -> void {
+    codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, Http::CodecClient::Type::HTTP1);
+  },
+                  [&]() -> void {
+                    codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                       {":path", "/test/long/url"},
+                                                                       {":authority", "host"}},
+                                               *response);
+                  },
+                  [&]() -> void {
+                    fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
+                  },
+                  // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
+                  // be fixed.
+                  [&]() -> void { fake_upstream_connection->waitForData(187); },
+                  [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
+                  [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
+                  [&]() -> void { codec_client->waitForDisconnect(); }});
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
+}
+
+TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
+  IntegrationTcpClientPtr tcp_client;
+  FakeRawConnectionPtr fake_upstream_connection;
+  executeActions(
+      {[&]() -> void { tcp_client = makeTcpConnection(IntegrationTest::TCP_PROXY_PORT); },
+       [&]() -> void { tcp_client->write("hello"); },
+       [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
+       [&]() -> void { fake_upstream_connection->waitForData(5); },
+       [&]() -> void { fake_upstream_connection->write("world"); },
+       [&]() -> void { fake_upstream_connection->close(); },
+       [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
+       [&]() -> void { tcp_client->waitForDisconnect(); }});
+
+  EXPECT_EQ("world", tcp_client->data());
+}
+
+TEST_F(IntegrationTest, TcpProxyDownstreamDisconnect) {
+  IntegrationTcpClientPtr tcp_client;
+  FakeRawConnectionPtr fake_upstream_connection;
+  executeActions(
+      {[&]() -> void { tcp_client = makeTcpConnection(IntegrationTest::TCP_PROXY_PORT); },
+       [&]() -> void { tcp_client->write("hello"); },
+       [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
+       [&]() -> void { fake_upstream_connection->waitForData(5); },
+       [&]() -> void { fake_upstream_connection->write("world"); },
+       [&]() -> void { tcp_client->waitForData("world"); },
+       [&]() -> void { tcp_client->write("hello"); }, [&]() -> void { tcp_client->close(); },
+       [&]() -> void { fake_upstream_connection->waitForData(10); },
+       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
+}

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1,700 +1,108 @@
-#include "integration.h"
-#include "utility.h"
-
-#include "common/buffer/buffer_impl.h"
-#include "common/http/header_map_impl.h"
-
-#include "test/test_common/utility.h"
-
-TEST_F(IntegrationTest, Echo) {
-  Buffer::OwnedImpl buffer("hello");
-  std::string response;
-  RawConnectionDriver connection(
-      ECHO_PORT, buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        connection.close();
-      });
-
-  connection.run();
-  EXPECT_EQ("hello", response);
-}
-
-TEST_F(IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP1); }
-
-void BaseIntegrationTest::testRouterNotFound(Http::CodecClient::Type type) {
-  BufferingStreamDecoderPtr response =
-      IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/notfound", "", type);
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
-}
-
-TEST_F(IntegrationTest, RouterNotFoundBodyNoBuffer) {
-  testRouterNotFoundWithBody(HTTP_PORT, Http::CodecClient::Type::HTTP1);
-}
-
-TEST_F(IntegrationTest, RouterNotFoundBodyBuffer) {
-  testRouterNotFoundWithBody(HTTP_BUFFER_PORT, Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type) {
-  BufferingStreamDecoderPtr response =
-      IntegrationUtil::makeSingleRequest(port, "POST", "/notfound", "foo", type);
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("404", response->headers().Status()->value().c_str());
-}
-
-TEST_F(IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP1); }
-
-void BaseIntegrationTest::testRouterRedirect(Http::CodecClient::Type type) {
-  BufferingStreamDecoderPtr response =
-      IntegrationUtil::makeSingleRequest(HTTP_PORT, "GET", "/foo", "", type, "www.redirect.com");
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("301", response->headers().Status()->value().c_str());
-  EXPECT_STREQ("https://www.redirect.com/foo",
-               response->headers().get(Http::Headers::get().Location)->value().c_str());
-}
-
-TEST_F(IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP1); }
-
-void BaseIntegrationTest::testDrainClose(Http::CodecClient::Type type) {
-  test_server_->drainManager().draining_ = true;
-
-  IntegrationCodecClientPtr codec_client;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  executeActions({[&]() -> void { codec_client = makeHttpConnection(HTTP_PORT, type); },
-                  [&]() -> void {
-                    codec_client->makeHeaderOnlyRequest(
-                        Http::TestHeaderMapImpl{{":method", "GET"},
-                                                {":path", "/healthcheck"},
-                                                {":scheme", "http"},
-                                                {":authority", "host"}},
-                        *response);
-                  },
-                  [&]() -> void { response->waitForEndStream(); },
-                  [&]() -> void { codec_client->waitForDisconnect(); }});
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  if (type == Http::CodecClient::Type::HTTP2) {
-    EXPECT_TRUE(codec_client->sawGoAway());
-  }
-
-  test_server_->drainManager().draining_ = false;
-}
-
-TEST_F(IntegrationTest, ConnectionClose) {
-  IntegrationCodecClientPtr codec_client;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  executeActions({[&]() -> void {
-    codec_client = makeHttpConnection(HTTP_PORT, Http::CodecClient::Type::HTTP1);
-  },
-                  [&]() -> void {
-                    codec_client->makeHeaderOnlyRequest(
-                        Http::TestHeaderMapImpl{{":method", "GET"},
-                                                {":path", "/healthcheck"},
-                                                {":authority", "host"},
-                                                {"connection", "close"}},
-                        *response);
-                  },
-                  [&]() -> void { response->waitForEndStream(); },
-                  [&]() -> void { codec_client->waitForDisconnect(); }});
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-}
-
-void BaseIntegrationTest::testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
-                                                               Http::CodecClient::Type type,
-                                                               uint64_t request_size,
-                                                               uint64_t response_size,
-                                                               bool big_header) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  executeActions({[&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-                  [&]() -> void {
-                    Http::TestHeaderMapImpl headers{{":method", "POST"},
-                                                    {":path", "/test/long/url"},
-                                                    {":scheme", "http"},
-                                                    {":authority", "host"},
-                                                    {"x-lyft-user-id", "123"},
-                                                    {"x-forwarded-for", "10.0.0.1"}};
-                    if (big_header) {
-                      headers.addViaCopy("big", std::string(4096, 'a'));
-                    }
-
-                    codec_client->makeRequestWithBody(headers, request_size, *response);
-                  },
-                  [&]() -> void {
-                    fake_upstream_connection =
-                        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-                  },
-                  [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-                  [&]() -> void { request->waitForEndStream(*dispatcher_); },
-                  [&]() -> void {
-                    request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-                    request->encodeData(response_size, true);
-                  },
-                  [&]() -> void { response->waitForEndStream(); },
-                  // Cleanup both downstream and upstream
-                  [&]() -> void { codec_client->close(); },
-                  [&]() -> void { fake_upstream_connection->close(); },
-                  [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
-
-  EXPECT_TRUE(request->complete());
-  EXPECT_EQ(request_size, request->bodyLength());
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_EQ(response_size, response->body().size());
-}
-
-TEST_F(IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_PORT),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
-}
-
-TEST_F(IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
-}
-
-TEST_F(IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
-                                       Http::CodecClient::Type::HTTP1, 4 * 1024 * 1024,
-                                       4 * 1024 * 1024, false);
-}
-
-TEST_F(IntegrationTest, RouterRequestAndResponseLargeHeaderNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(IntegrationTest::HTTP_PORT),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, true);
-}
-
-void BaseIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  executeActions(
-      {[&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-       [&]() -> void {
-         codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                     {":path", "/test/long/url"},
-                                                                     {":scheme", "http"},
-                                                                     {":authority", "host"},
-                                                                     {"x-lyft-user-id", "123"}},
-                                             *response);
-       },
-       [&]() -> void {
-         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-       },
-       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-       [&]() -> void { request->waitForEndStream(*dispatcher_); },
-       [&]() -> void {
-         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
-       },
-       [&]() -> void { response->waitForEndStream(); },
-       // Cleanup both downstream and upstream
-       [&]() -> void { codec_client->close(); },
-       [&]() -> void { fake_upstream_connection->close(); },
-       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
-
-  EXPECT_TRUE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_EQ(0U, response->body().size());
-}
-
-TEST_F(IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
-  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(IntegrationTest::HTTP_PORT),
-                                         Http::CodecClient::Type::HTTP1);
-}
-
-TEST_F(IntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
-  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(IntegrationTest::HTTP_BUFFER_PORT),
-                                         Http::CodecClient::Type::HTTP1);
-}
-
-TEST_F(IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
-  testRouterUpstreamDisconnectBeforeRequestComplete(
-      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-      [&]() -> void {
-        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response);
-      },
-      [&]() -> void {
-        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      },
-      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-      [&]() -> void { request->waitForHeadersComplete(); },
-      [&]() -> void { fake_upstream_connection->close(); },
-      [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
-      [&]() -> void { response->waitForEndStream(); }};
-
-  if (type == Http::CodecClient::Type::HTTP1) {
-    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { codec_client->close(); });
-  }
-
-  executeActions(actions);
-
-  EXPECT_FALSE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
-  EXPECT_EQ("upstream connect error or disconnect/reset before headers", response->body());
-}
-
-TEST_F(IntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
-  testRouterUpstreamDisconnectBeforeResponseComplete(
-      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-      [&]() -> void {
-        codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                    {":path", "/test/long/url"},
-                                                                    {":scheme", "http"},
-                                                                    {":authority", "host"}},
-                                            *response);
-      },
-      [&]() -> void {
-        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      },
-      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-      [&]() -> void { request->waitForEndStream(*dispatcher_); },
-      [&]() -> void {
-        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-      },
-      [&]() -> void { fake_upstream_connection->close(); },
-      [&]() -> void { fake_upstream_connection->waitForDisconnect(); }};
-
-  if (type == Http::CodecClient::Type::HTTP1) {
-    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { response->waitForReset(); });
-    actions.push_back([&]() -> void { codec_client->close(); });
-  }
-
-  executeActions(actions);
-
-  EXPECT_TRUE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_FALSE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_EQ(0U, response->body().size());
-}
-
-TEST_F(IntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
-  testRouterDownstreamDisconnectBeforeRequestComplete(
-      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterDownstreamDisconnectBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-      [&]() -> void {
-        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response);
-      },
-      [&]() -> void {
-        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      },
-      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-      [&]() -> void { request->waitForHeadersComplete(); },
-      [&]() -> void { codec_client->close(); }};
-
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { request->waitForReset(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  }
-
-  executeActions(actions);
-
-  EXPECT_FALSE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_FALSE(response->complete());
-}
-
-TEST_F(IntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
-  testRouterDownstreamDisconnectBeforeResponseComplete(
-      makeClientConnection(IntegrationTest::HTTP_PORT), Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterDownstreamDisconnectBeforeResponseComplete(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-      [&]() -> void {
-        codec_client->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                    {":path", "/test/long/url"},
-                                                                    {":scheme", "http"},
-                                                                    {":authority", "host"}},
-                                            *response);
-      },
-      [&]() -> void {
-        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      },
-      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-      [&]() -> void { request->waitForEndStream(*dispatcher_); },
-      [&]() -> void {
-        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-        request->encodeData(512, false);
-      },
-      [&]() -> void { response->waitForBodyData(512); }, [&]() -> void { codec_client->close(); }};
-
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { request->waitForReset(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  }
-
-  executeActions(actions);
-
-  EXPECT_TRUE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_FALSE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_EQ(512U, response->body().size());
-}
-
-TEST_F(IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
-  testRouterUpstreamResponseBeforeRequestComplete(makeClientConnection(IntegrationTest::HTTP_PORT),
-                                                  Http::CodecClient::Type::HTTP1);
-}
-
-void BaseIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client = makeHttpConnection(std::move(conn), type); },
-      [&]() -> void {
-        codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response);
-      },
-      [&]() -> void {
-        fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      },
-      [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-      [&]() -> void { request->waitForHeadersComplete(); },
-      [&]() -> void {
-        request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-        request->encodeData(512, true);
-      },
-      [&]() -> void { response->waitForEndStream(); }};
-
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { request->waitForReset(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->close(); });
-    actions.push_back([&]() -> void { fake_upstream_connection->waitForDisconnect(); });
-  }
-
-  if (type == Http::CodecClient::Type::HTTP1) {
-    actions.push_back([&]() -> void { codec_client->waitForDisconnect(); });
-  } else {
-    actions.push_back([&]() -> void { codec_client->close(); });
-  }
-
-  executeActions(actions);
-
-  EXPECT_FALSE(request->complete());
-  EXPECT_EQ(0U, request->bodyLength());
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_EQ(512U, response->body().size());
-}
-
-TEST_F(IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP1); }
-
-void BaseIntegrationTest::testRetry(Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  executeActions(
-      {[&]() -> void { codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, type); },
-       [&]() -> void {
-         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                   {":path", "/test/long/url"},
-                                                                   {":scheme", "http"},
-                                                                   {":authority", "host"},
-                                                                   {"x-forwarded-for", "10.0.0.1"},
-                                                                   {"x-envoy-retry-on", "5xx"}},
-                                           1024, *response);
-       },
-       [&]() -> void {
-         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-       },
-       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-       [&]() -> void { request->waitForEndStream(*dispatcher_); },
-       [&]() -> void {
-         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
-       },
-       [&]() -> void {
-         if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
-           fake_upstream_connection->waitForDisconnect();
-           fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-         } else {
-           request->waitForReset();
-         }
-       },
-       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-       [&]() -> void { request->waitForEndStream(*dispatcher_); },
-       [&]() -> void {
-         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-         request->encodeData(512, true);
-       },
-       [&]() -> void {
-         response->waitForEndStream();
-         EXPECT_TRUE(request->complete());
-         EXPECT_EQ(1024U, request->bodyLength());
-
-         EXPECT_TRUE(response->complete());
-         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-         EXPECT_EQ(512U, response->body().size());
-       },
-       // Cleanup both downstream and upstream
-       [&]() -> void { codec_client->close(); },
-       [&]() -> void { fake_upstream_connection->close(); },
-       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
-}
-
-TEST_F(IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP1); }
-
-void BaseIntegrationTest::testTwoRequests(Http::CodecClient::Type type) {
-  IntegrationCodecClientPtr codec_client;
-  FakeHttpConnectionPtr fake_upstream_connection;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeStreamPtr request;
-  executeActions(
-      {[&]() -> void { codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT, type); },
-       // Request 1.
-       [&]() -> void {
-         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                   {":path", "/test/long/url"},
-                                                                   {":scheme", "http"},
-                                                                   {":authority", "host"}},
-                                           1024, *response);
-       },
-       [&]() -> void {
-         fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-       },
-       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-       [&]() -> void { request->waitForEndStream(*dispatcher_); },
-       [&]() -> void {
-         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-         request->encodeData(512, true);
-       },
-       [&]() -> void {
-         response->waitForEndStream();
-         EXPECT_TRUE(request->complete());
-         EXPECT_EQ(1024U, request->bodyLength());
-
-         EXPECT_TRUE(response->complete());
-         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-         EXPECT_EQ(512U, response->body().size());
-       },
-       // Request 2.
-       [&]() -> void {
-         response.reset(new IntegrationStreamDecoder(*dispatcher_));
-         codec_client->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                   {":path", "/test/long/url"},
-                                                                   {":scheme", "http"},
-                                                                   {":authority", "host"}},
-                                           512, *response);
-       },
-       [&]() -> void { request = fake_upstream_connection->waitForNewStream(); },
-       [&]() -> void { request->waitForEndStream(*dispatcher_); },
-       [&]() -> void {
-         request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-         request->encodeData(1024, true);
-       },
-       [&]() -> void {
-         response->waitForEndStream();
-         EXPECT_TRUE(request->complete());
-         EXPECT_EQ(512U, request->bodyLength());
-
-         EXPECT_TRUE(response->complete());
-         EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-         EXPECT_EQ(1024U, response->body().size());
-       },
-       // Cleanup both downstream and upstream
-       [&]() -> void { codec_client->close(); },
-       [&]() -> void { fake_upstream_connection->close(); },
-       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
-}
-
-TEST_F(IntegrationTest, BadHttpRequest) { testBadHttpRequest(); }
-
-void BaseIntegrationTest::testBadHttpRequest() {
-  Buffer::OwnedImpl buffer("hello");
-  std::string response;
-  RawConnectionDriver connection(
-      HTTP_PORT, buffer, [&](Network::ClientConnection&, const Buffer::Instance& data)
-                             -> void { response.append(TestUtility::bufferToString(data)); });
-
-  connection.run();
-  EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
-}
-
-TEST_F(IntegrationTest, Http10Request) { testHttp10Request(); }
-
-void BaseIntegrationTest::testHttp10Request() {
-  Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
-  std::string response;
-  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
-                                                        const Buffer::Instance& data) -> void {
-    response.append(TestUtility::bufferToString(data));
-    client.close(Network::ConnectionCloseType::NoFlush);
-  });
-
-  connection.run();
-  EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
-}
-
-TEST_F(IntegrationTest, NoHost) { testNoHost(); }
-
-void BaseIntegrationTest::testNoHost() {
-  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
-  std::string response;
-  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
-                                                        const Buffer::Instance& data) -> void {
-    response.append(TestUtility::bufferToString(data));
-    client.close(Network::ConnectionCloseType::NoFlush);
-  });
-
-  connection.run();
-  EXPECT_TRUE(response.find("HTTP/1.1 400 Bad Request\r\n") == 0);
-}
-
-TEST_F(IntegrationTest, BadPath) { testBadPath(); }
-
-void BaseIntegrationTest::testBadPath() {
-  Buffer::OwnedImpl buffer("GET http://api.lyft.com HTTP/1.1\r\nHost: host\r\n\r\n");
-  std::string response;
-  RawConnectionDriver connection(HTTP_PORT, buffer, [&](Network::ClientConnection& client,
-                                                        const Buffer::Instance& data) -> void {
-    response.append(TestUtility::bufferToString(data));
-    client.close(Network::ConnectionCloseType::NoFlush);
-  });
-
-  connection.run();
-  EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
-}
-
-TEST_F(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
-
-void BaseIntegrationTest::testUpstreamProtocolError() {
-  IntegrationCodecClientPtr codec_client;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  FakeRawConnectionPtr fake_upstream_connection;
-  executeActions({[&]() -> void {
-                    codec_client = makeHttpConnection(IntegrationTest::HTTP_PORT,
-                                                      Http::CodecClient::Type::HTTP1);
-                  },
-                  [&]() -> void {
-                    codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                       {":path", "/test/long/url"},
-                                                                       {":authority", "host"}},
-                                               *response);
-                  },
-                  [&]() -> void {
-                    fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
-                  },
-                  // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
-                  // be fixed.
-                  [&]() -> void { fake_upstream_connection->waitForData(187); },
-                  [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
-                  [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
-                  [&]() -> void { codec_client->waitForDisconnect(); }});
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
-}
-
-TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
-  IntegrationTcpClientPtr tcp_client;
-  FakeRawConnectionPtr fake_upstream_connection;
-  executeActions(
-      {[&]() -> void { tcp_client = makeTcpConnection(IntegrationTest::TCP_PROXY_PORT); },
-       [&]() -> void { tcp_client->write("hello"); },
-       [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
-       [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write("world"); },
-       [&]() -> void { fake_upstream_connection->close(); },
-       [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
-       [&]() -> void { tcp_client->waitForDisconnect(); }});
-
-  EXPECT_EQ("world", tcp_client->data());
-}
-
-TEST_F(IntegrationTest, TcpProxyDownstreamDisconnect) {
-  IntegrationTcpClientPtr tcp_client;
-  FakeRawConnectionPtr fake_upstream_connection;
-  executeActions(
-      {[&]() -> void { tcp_client = makeTcpConnection(IntegrationTest::TCP_PROXY_PORT); },
-       [&]() -> void { tcp_client->write("hello"); },
-       [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
-       [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write("world"); },
-       [&]() -> void { tcp_client->waitForData("world"); },
-       [&]() -> void { tcp_client->write("hello"); }, [&]() -> void { tcp_client->close(); },
-       [&]() -> void { fake_upstream_connection->waitForData(10); },
-       [&]() -> void { fake_upstream_connection->waitForDisconnect(); }});
-}
+== network/connection_impl.cc ==
+Vim: Warning: Output is not to a terminal
+[?1002h[?1049h[?1h=[1;42r[34l[34h[?25h[23m[24m[0m[93m[44m[?25l[42;1H[97m[41mE325: ATTENTION[0m[93m[44m                                                                                                                     [42;1H
+                                                                                                                                    [42;1HFound a swap file by the name "~/.vim/cache//%usr%local%google%home%trevors%github%envoy%source%common%network%connection_impl.cc.s
+                                                                                                                                    [41;132Hw[42;1Hp"
+                                                                                                                                    [42;11Howned by: trevors   dated: Fri Mar  3 14:19:08 2017
+                                                                                                                                    [42;10Hfile name: ~trevors/github/envoy/source/common/network/connection_impl.cc
+                                                                                                                                    [42;11Hmodified: YES
+                                                                                                                                    [42;10Huser name: trevors   host name: abnormal.cam.corp.google.com
+                                                                                                                                    [42;9Hprocess ID: 141839
+                                                                                                                                    [42;1HWhile opening file "network/connection_impl.cc"
+                                                                                                                                    [42;14Hdated: Fri Mar  3 12:18:08 2017
+                                                                                                                                    [42;1H
+                                                                                                                                    [42;1H(1) Another program may be editing the same file.  If this is the case,
+                                                                                                                                    [42;5Hbe careful not to end up with two different instances of the same
+                                                                                                                                    [42;5Hfile when making changes.  Quit, or continue with caution.
+                                                                                                                                    [42;1H(2) An edit session for this file crashed.
+                                                                                                                                    [42;5HIf this is the case, use ":recover" or "vim -r network/connection_impl.cc"
+                                                                                                                                    [42;5Hto recover the changes (see ":help recovery").
+                                                                                                                                    [42;5HIf you did this already, delete the swap file "/usr/local/google/home/trevors/.vim/cache//%usr%local%google%home%trevors%github
+                                                                                                                                    [41;132H%[42;1Henvoy%source%common%network%connection_impl.cc.swp"
+                                                                                                                                    [42;5Hto avoid this message.
+                                                                                                                                    [?1002l[42;1H
+                                                                                                                                    [42;1H[92mSwap file "~/.vim/cache//%usr%local%google%home%trevors%github%envoy%source%common%network%connection_impl.cc.swp" already exists![0m[93m[44m
+                                                                                                                                    [42;1H[92m[O]pen Read-Only, (E)dit anyway, (R)ecover, (D)elete it, (Q)uit, (A)bort: [34h[?25h[?1002h[0m[93m[44m                                                                          
+                                                                                                                                    [?1002l[42;1HInterrupt: [92mPress ENTER or type command to continue[?1002h[0m[93m[44m[1;1H[L[?25l[1;1H[30m[47m  [0m[93m[44m                                                                [7m[94m[104m|[2;67H|[3;67H|[4;67H|[5;67H|[6;67H|[7;67H|[8;67H|[9;67H|[10;67H|[11;67H|[12;67H|[13;67H|[14;67H|[15;67H|[16;67H|[17;67H|[18;67H|[19;67H|[20;67H|[21;67H|[22;67H|[23;67H|[24;67H|[25;67H|[26;67H|[27;67H|[28;67H|[29;67H|[30;67H|[31;67H|[32;67H|[33;67H|[34;67H|[35;67H|[36;67H|[37;67H|[38;67H|[39;67H|[40;67H|[0m[93m[44m[2;1H[30m[47m  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  [0m[93m[44m[2;3H[95m~                                                               [3;3H~                                                               [4;3H~                                                               [5;3H~                                                               [6;3H~                                                               [7;3H~                                                               [8;3H~                                                               [9;3H~                                                               [10;3H~                                                               [11;3H~                                                               [12;3H~                                                               [13;3H~                                                               [14;3H~                                                               [15;3H~                                                               [16;3H~                                                               [17;3H~                                                               [18;3H~                                                               [19;3H~                                                               [20;3H~                                                               [21;3H~                                                               [22;3H~                                                               [23;3H~                                                               [24;3H~                                                               [25;3H~                                                               [26;3H~                                                               [27;3H~                                                               [28;3H~                                                               [29;3H~                                                               [30;3H~                                                               [31;3H~                                                               [32;3H~                                                               [33;3H~                                                               [34;3H~                                                               [35;3H~                                                               [36;3H~                                                               [37;3H~                                                               [38;3H~                                                               [39;3H~                                                               [40;3H~                                                               [0m[93m[44m
+[1m[7m[96m[104mnetwork/connection_impl.cc [RO]                 0,0-1          All [0m[93m[44m[1;68H[30m[47m  [0m[93m[44m                                                               [2;68H[30m[47m  [3;68H  [4;68H  [5;68H  [6;68H  [7;68H  [8;68H  [9;68H  [10;68H  [11;68H  [12;68H  [13;68H  [14;68H  [15;68H  [16;68H  [17;68H  [18;68H  [19;68H  [20;68H  [21;68H  [22;68H  [23;68H  [24;68H  [25;68H  [26;68H  [27;68H  [28;68H  [29;68H  [30;68H  [31;68H  [32;68H  [33;68H  [34;68H  [35;68H  [36;68H  [37;68H  [38;68H  [39;68H  [40;68H  [0m[93m[44m[2;70H[95m~                                                              [3;70H~                                                              [4;70H~                                                              [5;70H~                                                              [6;70H~                                                              [7;70H~                                                              [8;70H~                                                              [9;70H~                                                              [10;70H~                                                              [11;70H~                                                              [12;70H~                                                              [13;70H~                                                              [14;70H~                                                              [15;70H~                                                              [16;70H~                                                              [17;70H~                                                              [18;70H~                                                              [19;70H~                                                              [20;70H~                                                              [21;70H~                                                              [22;70H~                                                              [23;70H~                                                              [24;70H~                                                              [25;70H~                                                              [26;70H~                                                              [27;70H~                                                              [28;70H~                                                              [29;70H~                                                              [30;70H~                                                              [31;70H~                                                              [32;70H~                                                              [33;70H~                                                              [34;70H~                                                              [35;70H~                                                              [36;70H~                                                              [37;70H~                                                              [38;70H~                                                              [39;70H~                                                              [40;70H~                                                              [0m[93m[44m[41;68H[7m[30m[104mnetwork/connection_impl.cc [RO]                0,0-1          All[1;3H[34h[?25h[?25l[34h[?25h[42;1H
+[0m[93m[44m[39;49m[?1l>[?1049l[?1002l[?1002h[?1049h[?1h=[34l[34h[?25h[23m[24m[0m[93m[44m[?25l[1;1H[30m[47m  [0m[93m[44m                                                                [7m[94m[104m|[2;67H|[3;67H|[4;67H|[5;67H|[6;67H|[7;67H|[8;67H|[9;67H|[10;67H|[11;67H|[12;67H|[13;67H|[14;67H|[15;67H|[16;67H|[17;67H|[18;67H|[19;67H|[20;67H|[21;67H|[22;67H|[23;67H|[24;67H|[25;67H|[26;67H|[27;67H|[28;67H|[29;67H|[30;67H|[31;67H|[32;67H|[33;67H|[34;67H|[35;67H|[36;67H|[37;67H|[38;67H|[39;67H|[40;67H|[0m[93m[44m[2;1H[30m[47m  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  [0m[93m[44m[2;3H[95m~                                                               [3;3H~                                                               [4;3H~                                                               [5;3H~                                                               [6;3H~                                                               [7;3H~                                                               [8;3H~                                                               [9;3H~                                                               [10;3H~                                                               [11;3H~                                                               [12;3H~                                                               [13;3H~                                                               [14;3H~                                                               [15;3H~                                                               [16;3H~                                                               [17;3H~                                                               [18;3H~                                                               [19;3H~                                                               [20;3H~                                                               [21;3H~                                                               [22;3H~                                                               [23;3H~                                                               [24;3H~                                                               [25;3H~                                                               [26;3H~                                                               [27;3H~                                                               [28;3H~                                                               [29;3H~                                                               [30;3H~                                                               [31;3H~                                                               [32;3H~                                                               [33;3H~                                                               [34;3H~                                                               [35;3H~                                                               [36;3H~                                                               [37;3H~                                                               [38;3H~                                                               [39;3H~                                                               [40;3H~                                                               [0m[93m[44m
+[1m[7m[96m[104mnetwork/connection_impl.cc [RO]                 0,0-1          All [0m[93m[44m[1;68H[30m[47m  [0m[93m[44m                                                               [2;68H[30m[47m  [3;68H  [4;68H  [5;68H  [6;68H  [7;68H  [8;68H  [9;68H  [10;68H  [11;68H  [12;68H  [13;68H  [14;68H  [15;68H  [16;68H  [17;68H  [18;68H  [19;68H  [20;68H  [21;68H  [22;68H  [23;68H  [24;68H  [25;68H  [26;68H  [27;68H  [28;68H  [29;68H  [30;68H  [31;68H  [32;68H  [33;68H  [34;68H  [35;68H  [36;68H  [37;68H  [38;68H  [39;68H  [40;68H  [0m[93m[44m[2;70H[95m~                                                              [3;70H~                                                              [4;70H~                                                              [5;70H~                                                              [6;70H~                                                              [7;70H~                                                              [8;70H~                                                              [9;70H~                                                              [10;70H~                                                              [11;70H~                                                              [12;70H~                                                              [13;70H~                                                              [14;70H~                                                              [15;70H~                                                              [16;70H~                                                              [17;70H~                                                              [18;70H~                                                              [19;70H~                                                              [20;70H~                                                              [21;70H~                                                              [22;70H~                                                              [23;70H~                                                              [24;70H~                                                              [25;70H~                                                              [26;70H~                                                              [27;70H~                                                              [28;70H~                                                              [29;70H~                                                              [30;70H~                                                              [31;70H~                                                              [32;70H~                                                              [33;70H~                                                              [34;70H~                                                              [35;70H~                                                              [36;70H~                                                              [37;70H~                                                              [38;70H~                                                              [39;70H~                                                              [40;70H~                                                              [0m[93m[44m[41;68H[7m[30m[104mnetwork/connection_impl.cc [RO]                0,0-1          All[0m[93m[44m[42;1H                                                                                                                                    [1;3H[34h[?25h[?25l[34h[?25h[42;1H[39;49m[?1l>[?1049lVim: Caught deadly signal HUP
+2 files to edit
+Vim: Finished.
+[42;1H[23m[24m[0m[93m[44m[39;49m

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -11,7 +11,7 @@ namespace Server {
 
 class AdminFilterTest : public testing::Test {
 public:
-  // TODO: Switch to mocks and do not bind to a real port.
+  // TODO(mklein123): Switch to mocks and do not bind to a real port.
   AdminFilterTest()
       : admin_("/dev/null", 9002, server_), filter_(admin_), request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -11,7 +11,7 @@ namespace Server {
 
 class AdminFilterTest : public testing::Test {
 public:
-  // TODO(mklein123): Switch to mocks and do not bind to a real port.
+  // TODO(mattklein123): Switch to mocks and do not bind to a real port.
   AdminFilterTest()
       : admin_("/dev/null", 9002, server_), filter_(admin_), request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);


### PR DESCRIPTION
Quoting the style guide:

TODOs should include the string TODO in all caps, followed by the username or b/buganizer_id of the person or issue with the best context about the problem referenced by the TODO. The main purpose is to have a consistent TODO that can be searched to find out how to get more details upon request. A TODO is not a commitment that the person referenced will fix the problem. Thus when you create a TODO with a name, it is almost always your name that is given.