### PR TITLE
thirdparty: upgrade libevent to 2.1.8

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -29,9 +29,9 @@ export CC=gcc-4.9
 export CXX=g++-4.9
 
 # libevent
-wget https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz
-tar xf libevent-2.0.22-stable.tar.gz
-cd libevent-2.0.22-stable
+wget https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz
+tar xf libevent-2.1.8-stable.tar.gz
+cd libevent-2.1.8-stable
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --disable-libevent-regress --disable-openssl
 make install
 cd ..

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -13,7 +13,7 @@ Envoy has the following requirements:
 * `spdlog <https://github.com/gabime/spdlog>`_ (last tested with 0.11.0)
 * `http-parser <https://github.com/nodejs/http-parser>`_ (last tested with 2.7.0)
 * `nghttp2 <https://github.com/nghttp2/nghttp2>`_ (last tested with 1.20.0)
-* `libevent <http://libevent.org/>`_ (last tested with 2.0.22)
+* `libevent <http://libevent.org/>`_ (last tested with 2.1.8)
 * `tclap <http://tclap.sourceforge.net/>`_ (last tested with 1.2.1)
 * `gperftools <https://github.com/gperftools/gperftools>`_ (last tested with 2.5.0)
 * `boringSSL <https://boringssl.googlesource.com/boringssl>`_ (last tested with sha b87c80300647c2c0311c1489a104470e099f1531).

--- a/thirdparty.cmake
+++ b/thirdparty.cmake
@@ -19,7 +19,7 @@ set(ENVOY_HTTP_PARSER_INCLUDE_DIR "" CACHE FILEPATH "location of http-parser inc
 set(ENVOY_NGHTTP2_INCLUDE_DIR "" CACHE FILEPATH "location of nghttp2 includes")
 
 # http://libevent.org/
-# Last tested with 2.0.22
+# Last tested with 2.1.8
 set(ENVOY_LIBEVENT_INCLUDE_DIR "" CACHE FILEPATH "location of libevent includes")
 
 # http://tclap.sourceforge.net/


### PR DESCRIPTION
NOTE: There are 2 test fixes required. I will fix those in the commit that
uses the new build image.