### PR TITLE
Envoy Rate Limit: Enable stage setting matching.

### DIFF
--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -14,10 +14,10 @@ Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
   }
 
 stage
-  *(optional, integer)* Refers to the stage set in the filter. If set, the rate limit configuration
-  only applies to filters with the same stage number and for filters set to default. If not set,
-  the rate limit configuration will apply for all rate limit filters set to default. The default
-  value is 0.
+  *(optional, integer)* Refers to the stage set in the filter. The rate limit configuration
+  only applies to filters with the same stage number. The default stage number is 0.
+
+  **NOTE:** The filter supports a range of 0 - 10 inclusively for stage numbers.
 
 disable_key
   *(optional, string)* The key to be set in runtime to disable this rate limit configuration.

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -55,7 +55,9 @@ Source Cluster
 
 The following descriptor entry is appended to the descriptor:
 
-  * ("source_cluster", "<local service cluster>")
+.. code-block:: cpp
+
+  ("source_cluster", "<local service cluster>")
 
 <local service cluster> is derived from the :option:`--service-cluster` option.
 
@@ -70,7 +72,9 @@ Destination Cluster
 
 The following descriptor entry is appended to the descriptor:
 
-  * ("destination_cluster", "<routed target cluster>")
+.. code-block:: cpp
+
+  ("destination_cluster", "<routed target cluster>")
 
 Once a request matches against a route table rule, a routed cluster is determined by one of the
 following :ref:`route table configuration <config_http_conn_man_route_table_route_cluster>`
@@ -104,7 +108,9 @@ descriptor_key
 The following descriptor entry is appended when a header contains a key that matches the
 *header_name*:
 
-  * ("<descriptor_key>", "<header_value_queried_from_header>")
+.. code-block:: cpp
+
+  ("<descriptor_key>", "<header_value_queried_from_header>")
 
 Remote Address
 ^^^^^^^^^^^^^^
@@ -118,8 +124,9 @@ Remote Address
 The following descriptor entry is appended to the descriptor and is populated using the trusted
 address from :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`:
 
-    * ("remote_address", "<:ref:`trusted address from x-forwarded-for
-      <config_http_conn_man_headers_x-forwarded-for>`>")
+.. code-block:: cpp
+
+  ("remote_address", "<trusted address from x-forwarded-for>")
 
 Generic Key
 ^^^^^^^^^^^
@@ -137,7 +144,9 @@ descriptor_value
 
 The following descriptor entry is appended to the descriptor:
 
-    * ("generic_key", "<descriptor_value>")
+.. code-block:: cpp
+
+  ("generic_key", "<descriptor_value>")
 
 Header Value Match
 ^^^^^^^^^^^^^^^^^^
@@ -163,7 +172,9 @@ descriptor_value
 The following descriptor entry is appended to the descriptor if the request matches the headers
 specified in the action config:
 
-    * ("header_match", "<descriptor_value>")
+.. code-block:: cpp
+
+  ("header_match", "<descriptor_value>")
 
 .. _config_http_conn_man_route_table_rate_limit_composing_actions:
 
@@ -176,7 +187,9 @@ will be populated in the order the actions are specified in the configuration.
 
 For example, to generate the following descriptor:
 
-  * ("generic_key", "some_value"), ("source_cluster", "from_cluster")
+.. code-block:: cpp
+
+  ("generic_key", "some_value"), ("source_cluster", "from_cluster")
 
 The configuration would be:
 
@@ -218,10 +231,14 @@ generate a few possible descriptors depending on what is present in the request.
 For a request with :ref:`x-forwarded-for<config_http_conn_man_headers_x-forwarded-for>` set and the
 trusted address is for example *127.0.0.1*, the following descriptor would be generated:
 
-  * ("generic_key", "some_value"), ("remote_address", "127.0.0.1"), ("source_cluster",
+.. code-block:: cpp
+
+  ("generic_key", "some_value"), ("remote_address", "127.0.0.1"), ("source_cluster",
     "from_cluster")
 
 If a request did not set :ref:`x-forwarded-for<config_http_conn_man_headers_x-forwarded-for>`, the
 following descriptor would be generated:
 
-  * ("generic_key", "some_value"), ("source_cluster", "from_cluster")
+.. code-block:: cpp
+
+  ("generic_key", "some_value"), ("source_cluster", "from_cluster")

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -19,8 +19,6 @@ stage
   the rate limit configuration will apply for all rate limit filters set to default. The default
   value is 0.
 
-  **NOTE:** This functionality hasn't been implemented yet and stage values are currently ignored.
-
 disable_key
   *(optional, string)* The key to be set in runtime to disable this rate limit configuration.
 

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -28,8 +28,10 @@ domain
   *(required, string)* The rate limit domain to use when calling the rate limit service.
 
 stage
-  *(optional, integer)* If set, rate limit configurations will only be applied with the same stage
-  number. If not set, all rate limit configurations will be applied.
+  *(optional, integer)* Specifies the rate limit configurations to be applied with the same stage
+  number. If not set, the default stage number is 0.
+
+  **NOTE:** The filter supports a range of 0 - 10 inclusively for stage numbers.
 
 Statistics
 ----------

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -38,7 +38,7 @@ public:
   /**
    * @return the stage value that the configuration is applicable to.
    */
-  virtual int64_t stage() const PURE;
+  virtual uint64_t stage() const PURE;
 
   /**
    * @return runtime key to be set to disable the configuration.
@@ -72,7 +72,7 @@ public:
    * @return set of RateLimitPolicyEntry that are applicable for a stage.
    */
   virtual const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&
-  getApplicableRateLimit(int64_t stage) const PURE;
+  getApplicableRateLimit(uint64_t stage) const PURE;
 };
 
 } // Router

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -75,7 +75,7 @@ private:
   struct NullRateLimitPolicy : public Router::RateLimitPolicy {
     // Router::RateLimitPolicy
     const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>&
-        getApplicableRateLimit(int64_t) const override {
+        getApplicableRateLimit(uint64_t) const override {
       return rate_limit_policy_entry_;
     }
 

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -6,19 +6,10 @@
 #include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/http/codes.h"
-#include "common/json/config_schemas.h"
 #include "common/router/config_impl.h"
 
 namespace Http {
 namespace RateLimit {
-
-FilterConfig::FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
-                           Stats::Store& global_store, Runtime::Loader& runtime,
-                           Upstream::ClusterManager& cm)
-    : domain_(config.getString("domain")), stage_(config.getInteger("stage", 0)),
-      local_info_(local_info), global_store_(global_store), runtime_(runtime), cm_(cm) {
-  config.validateSchema(Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA);
-}
 
 const Http::HeaderMapPtr Filter::TOO_MANY_REQUESTS_HEADER{new Http::HeaderMapImpl{
     {Http::Headers::get().Status, std::to_string(enumToInt(Code::TooManyRequests))}}};

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -645,7 +645,11 @@ const std::string Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA(R"EOF(
     },
     "type" : "object",
     "properties" : {
-      "stage" : {"type" : "integer"},
+      "stage" : {
+        "type" : "integer",
+        "minimum" : 0,
+        "maximum" : 10
+      },
       "disable_key" : {"type" : "string"},
       "actions" : {
         "type" : "array",
@@ -756,7 +760,11 @@ const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
     "type" : "object",
     "properties" : {
       "domain" : {"type" : "string"},
-      "stage" : {"type" : "integer"}
+      "stage" : {
+        "type" : "integer",
+        "minimum" : 0,
+        "maximum" : 10
+      }
     },
     "required" : ["domain"],
     "additionalProperties" : false

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -6,8 +6,6 @@
 
 namespace Router {
 
-const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>
-    RateLimitPolicyImpl::empty_rate_limit_;
 const uint64_t RateLimitPolicyImpl::MAX_STAGE_NUMBER = 10UL;
 
 void SourceClusterAction::populateDescriptor(const Router::RouteEntry&,
@@ -125,11 +123,7 @@ RateLimitPolicyImpl::RateLimitPolicyImpl(const Json::Object& config)
 const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>&
 RateLimitPolicyImpl::getApplicableRateLimit(uint64_t stage) const {
   ASSERT(stage <= RateLimitPolicyImpl::MAX_STAGE_NUMBER);
-  if (rate_limit_entries_.empty()) {
-    return empty_rate_limit_;
-  } else {
-    return rate_limit_entries_reference_[stage];
-  }
+  return rate_limit_entries_reference_[stage];
 }
 
 } // Router

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -122,7 +122,7 @@ RateLimitPolicyImpl::RateLimitPolicyImpl(const Json::Object& config)
 
 const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>&
 RateLimitPolicyImpl::getApplicableRateLimit(uint64_t stage) const {
-  ASSERT(stage <= RateLimitPolicyImpl::MAX_STAGE_NUMBER);
+  ASSERT(stage < rate_limit_entries_reference_.size());
   return rate_limit_entries_reference_[stage];
 }
 

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -4,6 +4,7 @@
 #include "envoy/router/router_ratelimit.h"
 
 #include "common/http/filter/ratelimit.h"
+#include "common/json/json_validator.h"
 #include "common/router/config_utility.h"
 
 namespace Router {
@@ -97,15 +98,13 @@ private:
 /*
  * Implementation of RateLimitPolicyEntry that holds the action for the configuration.
  */
-class RateLimitPolicyEntryImpl : public RateLimitPolicyEntry {
+class RateLimitPolicyEntryImpl : public RateLimitPolicyEntry, Json::JsonValidator {
 public:
   RateLimitPolicyEntryImpl(const Json::Object& config);
 
   // Router::RateLimitPolicyEntry
   int64_t stage() const override { return stage_; }
   const std::string& disableKey() const override { return disable_key_; }
-
-  // Router::RateLimitAction
   void populateDescriptors(const Router::RouteEntry& route,
                            std::vector<::RateLimit::Descriptor>& descriptors,
                            const std::string& local_service_cluster, const Http::HeaderMap&,
@@ -130,7 +129,9 @@ public:
 
 private:
   std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
-  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> default_rate_limit_entries_;
+  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>
+      default_rate_limit_entries_reference_;
+  // Holds reference to rate limit policies applicable to non-default stage settings.
   std::unordered_map<int64_t, std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
   static const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> empty_rate_limit_;

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -128,12 +128,13 @@ public:
   getApplicableRateLimit(uint64_t stage = 0) const override;
 
 private:
-  std::vector<std::vector<std::unique_ptr<RateLimitPolicyEntry>>> rate_limit_entries_;
+  std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
   std::vector<std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
   static const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> empty_rate_limit_;
-  // The maximum stage number supported. When changing this value, update the HTTP Rate Limit filter
-  // and Rate Limit configuration schemas to all match.
+  // The maximum stage number supported. This value should match the maximum stage number in
+  // Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA and
+  // Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA from common/json/config_schemas.cc.
   static const uint64_t MAX_STAGE_NUMBER;
 };
 

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -103,7 +103,7 @@ public:
   RateLimitPolicyEntryImpl(const Json::Object& config);
 
   // Router::RateLimitPolicyEntry
-  int64_t stage() const override { return stage_; }
+  uint64_t stage() const override { return stage_; }
   const std::string& disableKey() const override { return disable_key_; }
   void populateDescriptors(const Router::RouteEntry& route,
                            std::vector<::RateLimit::Descriptor>& descriptors,
@@ -112,7 +112,7 @@ public:
 
 private:
   const std::string disable_key_;
-  int64_t stage_;
+  uint64_t stage_;
   std::vector<RateLimitActionPtr> actions_;
 };
 
@@ -125,16 +125,16 @@ public:
 
   // Router::RateLimitPolicy
   const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&
-  getApplicableRateLimit(int64_t stage = 0) const override;
+  getApplicableRateLimit(uint64_t stage = 0) const override;
 
 private:
-  std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
-  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>
-      default_rate_limit_entries_reference_;
-  // Holds reference to rate limit policies applicable to non-default stage settings.
-  std::unordered_map<int64_t, std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
+  std::vector<std::vector<std::unique_ptr<RateLimitPolicyEntry>>> rate_limit_entries_;
+  std::vector<std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
   static const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> empty_rate_limit_;
+  // The maximum stage number supported. When changing this value, update the HTTP Rate Limit filter
+  // and Rate Limit configuration schemas to all match.
+  static const uint64_t MAX_STAGE_NUMBER;
 };
 
 } // Router

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -131,7 +131,6 @@ private:
   std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
   std::vector<std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
-  static const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> empty_rate_limit_;
   // The maximum stage number supported. This value should match the maximum stage number in
   // Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA and
   // Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA from common/json/config_schemas.cc.

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -129,8 +129,9 @@ public:
   getApplicableRateLimit(int64_t stage = 0) const override;
 
 private:
-  std::vector<std::vector<std::unique_ptr<RateLimitPolicyEntry>>> rate_limit_entries_;
-  std::vector<std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
+  std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;
+  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> default_rate_limit_entries_;
+  std::unordered_map<int64_t, std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>>
       rate_limit_entries_reference_;
   static const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> empty_rate_limit_;
 };

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -323,12 +323,17 @@ TEST_F(HttpRateLimitFilterTest, RateLimitStageTest) {
   std::string stage_filter_config = R"EOF(
   {
     "domain": "foo",
-    "stage": 1
+    "stage": 5
   }
   )EOF";
 
   SetUpTest(stage_filter_config);
   InSequence s;
+
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(5))
+      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
+              getApplicableRateLimit(5)).Times(1);
 
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -649,6 +649,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
     route->routeEntry()->shadowPolicy();
     route->routeEntry()->virtualCluster(headers);
     route->routeEntry()->virtualHost();
+    route->routeEntry()->virtualHost().rateLimitPolicy();
   }
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -323,7 +323,7 @@ TEST_F(RateLimitConfiguration, Stages) {
   EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"remote_address", address}}}}),
               testing::ContainerEq(descriptors));
 
-  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(11UL);
+  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(10UL);
   EXPECT_TRUE(rate_limits.empty());
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -302,20 +302,19 @@ TEST_F(RateLimitConfiguration, Stages) {
   route_ = config_->route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
-  EXPECT_EQ(3U, rate_limits.size());
+  EXPECT_EQ(2U, rate_limits.size());
 
   std::vector<::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_, address);
   }
   EXPECT_THAT(std::vector<::RateLimit::Descriptor>(
-                  {{{{"remote_address", address}}},
-                   {{{"destination_cluster", "www2test"}}},
+                  {{{{"destination_cluster", "www2test"}}},
                    {{{"destination_cluster", "www2test"}, {"source_cluster", "service_cluster"}}}}),
               testing::ContainerEq(descriptors));
 
   descriptors.clear();
-  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(1);
+  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(1UL);
   EXPECT_EQ(1U, rate_limits.size());
 
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
@@ -324,7 +323,7 @@ TEST_F(RateLimitConfiguration, Stages) {
   EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"remote_address", address}}}}),
               testing::ContainerEq(descriptors));
 
-  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(10);
+  rate_limits = route_->rateLimitPolicy().getApplicableRateLimit(11UL);
   EXPECT_TRUE(rate_limits.empty());
 }
 
@@ -357,7 +356,7 @@ TEST_F(RateLimitPolicyEntryTest, RateLimitPolicyEntryMembers) {
 
   SetUpTest(json);
 
-  EXPECT_EQ(2, rate_limit_entry_->stage());
+  EXPECT_EQ(2UL, rate_limit_entry_->stage());
   EXPECT_EQ("no_ratelimit", rate_limit_entry_->disableKey());
 }
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -46,17 +46,15 @@ public:
   ~MockRateLimitPolicyEntry();
 
   // Router::RateLimitPolicyEntry
-  MOCK_CONST_METHOD0(stage, int64_t());
+  MOCK_CONST_METHOD0(stage, uint64_t());
   MOCK_CONST_METHOD0(disableKey, const std::string&());
-
-  // Router::RateLimitAction
   MOCK_CONST_METHOD5(populateDescriptors,
                      void(const RouteEntry& route,
                           std::vector<::RateLimit::Descriptor>& descriptors,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
                           const std::string& remote_address));
 
-  int64_t stage_{};
+  uint64_t stage_{};
   std::string disable_key_;
 };
 
@@ -68,7 +66,7 @@ public:
   // Router::RateLimitPolicy
   MOCK_CONST_METHOD1(
       getApplicableRateLimit,
-      std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&(int64_t stage));
+      std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&(uint64_t stage));
 
   std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>> rate_limit_policy_entry_;
 };


### PR DESCRIPTION
- Update documentation to reflect new behaviour.
- `getApplicableRateLimit()` returns all rate limits for default stage settings, a set of rate limits for a specific stage setting or an empty vector if there are no rate limits or a stage setting that doesn't exist.