### PR TITLE
thirdparty: use libevent 2.1.8

### DIFF
--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=c980e0936bc12092930ef1f9a3cb471f5e40af49
+ENVOY_BUILD_SHA=d3a3d93f304fe1cf28023b293913649e2024f297
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -56,7 +56,7 @@ TEST_F(FileEventImplTest, LevelTrigger) {
   int count = 2;
   Event::FileEventPtr file_event =
       dispatcher.createFileEvent(fds_[0], [&](uint32_t events) -> void {
-        if (--count == 0) {
+        if (count-- == 0) {
           dispatcher.exit();
           return;
         }

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -34,9 +34,7 @@ public:
     connection_->addReadFilter(Network::ReadFilterPtr{new ReadFilter(*this)});
   }
 
-  ~TestDnsServerQuery() {
-    connection_->close(ConnectionCloseType::NoFlush);
-  }
+  ~TestDnsServerQuery() { connection_->close(ConnectionCloseType::NoFlush); }
 
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -34,6 +34,10 @@ public:
     connection_->addReadFilter(Network::ReadFilterPtr{new ReadFilter(*this)});
   }
 
+  ~TestDnsServerQuery() {
+    connection_->close(ConnectionCloseType::NoFlush);
+  }
+
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {
     ReadFilter(TestDnsServerQuery& parent) : parent_(parent) {}


### PR DESCRIPTION
This fixes two tests. I believe they passed previously due to how event
loop exiting happens in libevent 2.1.