### PR TITLE
LoadBalancing: Header to force Envoy to do canary only routing

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -188,6 +188,7 @@ private:
   HEADER_FUNC(EnvoyExternalAddress)                                                                \
   HEADER_FUNC(EnvoyForceTrace)                                                                     \
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
+  HEADER_FUNC(EnvoyLbHint)                                                                         \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
   HEADER_FUNC(EnvoyRetryOn)                                                                        \

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -20,7 +20,7 @@ public:
 
   /**
    * @return bool whether we should prefer canary routing or not. In majority of the cases
-   * this should be false.
+   *         this should be false.
    */
   virtual bool preferCanary() const PURE;
 };

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -17,6 +17,12 @@ public:
    * @return const Optional<uint64_t>& the optional hash key to use during load balancing.
    */
   virtual const Optional<uint64_t>& hashKey() const PURE;
+
+  /**
+   * @return bool whether we should prefer canary routing or not. In majority of the cases
+   * this should be false.
+   */
+  virtual bool preferCanary() const PURE;
 };
 
 /**

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -21,6 +21,7 @@ public:
   const LowerCaseString EnvoyExternalAddress{"x-envoy-external-address"};
   const LowerCaseString EnvoyForceTrace{"x-envoy-force-trace"};
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
+  const LowerCaseString EnvoyLbHint{"x-envoy-lb-hint"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
@@ -96,6 +97,10 @@ public:
   struct {
     const std::string EnvoyHealthChecker{"Envoy/HC"};
   } UserAgentValues;
+
+  struct {
+    const std::string PreferCanary{"canary"};
+  } EnvoyLbHintValues;
 
   static Headers& get() {
     static Headers instance;

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -130,8 +130,10 @@ private:
 
     // Upstream::LoadBalancerContext
     const Optional<uint64_t>& hashKey() const override { return hash_key_; }
+    bool preferCanary() const override { return prefer_canary_; }
 
     const Optional<uint64_t> hash_key_;
+    bool prefer_canary_{};
   };
 
   Upstream::ClusterManager& cm_;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -169,12 +169,15 @@ private:
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;
 
   struct LoadBalancerContextImpl : public Upstream::LoadBalancerContext {
-    LoadBalancerContextImpl(const Optional<uint64_t>& hash) : hash_(hash) {}
+    LoadBalancerContextImpl(const Optional<uint64_t>& hash, bool prefer_canary)
+        : hash_(hash), prefer_canary_(prefer_canary) {}
 
     // Upstream::LoadBalancerContext
     const Optional<uint64_t>& hashKey() const override { return hash_; }
+    bool preferCanary() const override { return prefer_canary_; }
 
     const Optional<uint64_t> hash_;
+    const bool prefer_canary_;
   };
 
   enum class UpstreamResetType { Reset, GlobalTimeout, PerTryTimeout };

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -29,12 +29,17 @@ protected:
 
   /**
    * Pick the host list to use (healthy or all depending on how many in the set are not healthy).
+   * @param context provides load balancing context.
+   * @return list of hosts for routing.
    */
-  const std::vector<HostPtr>& hostsToUse();
+  const std::vector<HostPtr>& hostsToUse(const LoadBalancerContext* context);
 
   ClusterStats& stats_;
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;
+  // Host list containing canary instance. Ideally this contains single instance, but
+  // we may end up adding new canary instance before removing the old one, so we keep a list here.
+  std::vector<HostPtr> canary_host_;
 
 private:
   enum class ZoneRoutingState { NoZoneRouting, ZoneDirect, ZoneResidual };

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -3,6 +3,7 @@
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/mocks.h"
 
 using testing::NiceMock;
@@ -11,8 +12,8 @@ using testing::Return;
 namespace Upstream {
 
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url,
-                           uint32_t weight = 1) {
-  return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, weight, "")};
+                           uint32_t weight = 1, bool canary = false) {
+  return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), canary, weight, "")};
 }
 
 class RoundRobinLoadBalancerTest : public testing::Test {
@@ -57,6 +58,41 @@ TEST_F(RoundRobinLoadBalancerTest, Normal) {
                              newTestHost(cluster_.info_, "tcp://127.0.0.1:81")};
   cluster_.hosts_ = cluster_.healthy_hosts_;
   EXPECT_EQ(cluster_.healthy_hosts_[0], lb_->chooseHost(nullptr));
+}
+
+TEST_F(RoundRobinLoadBalancerTest, SelectCanaryHost) {
+  init(false);
+  cluster_.healthy_hosts_ = {newTestHost(cluster_.info_, "tcp://127.0.0.1:80", 1, false),
+                             newTestHost(cluster_.info_, "tcp://127.0.0.1:81", 1, false),
+                             newTestHost(cluster_.info_, "tcp://127.0.0.1:82", 1, false),
+                             newTestHost(cluster_.info_, "tcp://127.0.0.1:83", 1, false),
+                             newTestHost(cluster_.info_, "tcp://127.0.0.1:84", 1, false)};
+  cluster_.hosts_ = cluster_.healthy_hosts_;
+
+  // Add new canary host.
+  std::vector<HostPtr> added{newTestHost(cluster_.info_, "tcp://127.0.0.1:86", 1, true)};
+  // Do not remove anything.
+  std::vector<HostPtr> removed;
+
+  cluster_.runCallbacks(added, removed);
+
+  Optional<uint64_t> no_hash;
+  Upstream::LoadBalancerContext* context = new TestLoadBalancerContext(no_hash, true);
+  // Select canary host consequently.
+  EXPECT_EQ(added[0], lb_->chooseHost(context));
+  EXPECT_EQ(added[0], lb_->chooseHost(context));
+
+  // Remove canary host and run again.
+  std::vector<HostPtr> no_added;
+  std::vector<HostPtr> remove_canary{added[0]};
+  cluster_.runCallbacks(no_added, remove_canary);
+
+  // Provide context for canary, but no canary to route to.
+  EXPECT_EQ(cluster_.healthy_hosts_[2], lb_->chooseHost(context));
+  EXPECT_EQ(cluster_.healthy_hosts_[3], lb_->chooseHost(context));
+
+  // Provide null context, normal RR will be applied.
+  EXPECT_EQ(cluster_.healthy_hosts_[4], lb_->chooseHost(nullptr));
 }
 
 TEST_F(RoundRobinLoadBalancerTest, MaxUnhealthyPanic) {

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -77,10 +77,11 @@ TEST_F(RoundRobinLoadBalancerTest, SelectCanaryHost) {
   cluster_.runCallbacks(added, removed);
 
   Optional<uint64_t> no_hash;
-  Upstream::LoadBalancerContext* context = new TestLoadBalancerContext(no_hash, true);
+  std::unique_ptr<Upstream::LoadBalancerContext> context(
+      new TestLoadBalancerContext(no_hash, true));
   // Select canary host consequently.
-  EXPECT_EQ(added[0], lb_->chooseHost(context));
-  EXPECT_EQ(added[0], lb_->chooseHost(context));
+  EXPECT_EQ(added[0], lb_->chooseHost(context.get()));
+  EXPECT_EQ(added[0], lb_->chooseHost(context.get()));
 
   // Remove canary host and run again.
   std::vector<HostPtr> no_added;
@@ -88,8 +89,8 @@ TEST_F(RoundRobinLoadBalancerTest, SelectCanaryHost) {
   cluster_.runCallbacks(no_added, remove_canary);
 
   // Provide context for canary, but no canary to route to.
-  EXPECT_EQ(cluster_.healthy_hosts_[2], lb_->chooseHost(context));
-  EXPECT_EQ(cluster_.healthy_hosts_[3], lb_->chooseHost(context));
+  EXPECT_EQ(cluster_.healthy_hosts_[2], lb_->chooseHost(context.get()));
+  EXPECT_EQ(cluster_.healthy_hosts_[3], lb_->chooseHost(context.get()));
 
   // Provide null context, normal RR will be applied.
   EXPECT_EQ(cluster_.healthy_hosts_[4], lb_->chooseHost(nullptr));

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -3,6 +3,7 @@
 #include "common/upstream/ring_hash_lb.h"
 
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/mocks.h"
 
 using testing::_;
@@ -14,16 +15,6 @@ namespace Upstream {
 static HostPtr newTestHost(Upstream::ClusterInfoPtr cluster, const std::string& url) {
   return HostPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, 1, "")};
 }
-
-class TestLoadBalancerContext : public LoadBalancerContext {
-public:
-  TestLoadBalancerContext(uint64_t hash_key) : hash_key_(hash_key) {}
-
-  // Upstream::LoadBalancerContext
-  const Optional<uint64_t>& hashKey() const override { return hash_key_; }
-
-  Optional<uint64_t> hash_key_;
-};
 
 class RingHashLoadBalancerTest : public testing::Test {
 public:

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace Upstream {
+
+class TestLoadBalancerContext : public LoadBalancerContext {
+public:
+  TestLoadBalancerContext(uint64_t hash_key, bool prefer_canary = false)
+      : hash_key_(hash_key), prefer_canary_(prefer_canary) {}
+
+  TestLoadBalancerContext(Optional<uint64_t>& hash_key, bool prefer_canary = false)
+      : hash_key_(hash_key), prefer_canary_(prefer_canary) {}
+
+  // Upstream::LoadBalancerContext
+  const Optional<uint64_t>& hashKey() const override { return hash_key_; }
+  bool preferCanary() const override { return prefer_canary_; }
+
+  Optional<uint64_t> hash_key_;
+  bool prefer_canary_;
+};
+
+} // Upstream


### PR DESCRIPTION
Documentation is pending for this change.
Canary routing might be useful in a situation when you want to force request flow to hit canary only instances, for example, after canary deploy you might want to verify that flows are working fine.

**We need to clean x-envoy-lb-hint HTTP header from external/edge requests** - small change to this PR, adding here to not forget.

@lyft/network-team 