### PR TITLE
Allow healthchecks to be performed on another port

### DIFF
--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -90,6 +90,12 @@ public:
   virtual const std::string& asString() const PURE;
 
   /**
+   * @param port
+   * @return returns the same address but bound on the given port.
+   */
+  virtual std::unique_ptr<Instance> withPort(uint16_t port) const PURE;
+
+  /**
    * Bind a socket to this address. The socket should have been created with a call to socket() on
    * this object.
    * @param fd supplies the platform socket handle.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -42,6 +42,18 @@ public:
   virtual CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const PURE;
 
   /**
+   * Create a connection for this host on a specific port.
+   * @param dispatcher supplies the owning dispatcher.
+   * @return the connection data which includes the raw network connection as well as the *real*
+   *         host that backs it. The reason why a 2nd host is returned is that some hosts are
+   *         logical and wrap multiple real network destinations. In this case, a different host
+   *         will be returned along with the connection vs. the host the method was called on.
+   *         If it matters, callers should not assume that the returned host will be the same.
+   */
+  virtual CreateConnectionData
+  createConnectionWithNewPort(uint16_t port, Event::Dispatcher& dispatcher) const PURE;
+
+  /**
    * @return host specific gauges.
    */
   virtual std::list<Stats::GaugePtr> gauges() const PURE;

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -938,6 +938,11 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
             "type" : "string",
             "enum" : ["http", "tcp"]
           },
+          "port": {
+            "type" : "integer",
+            "minimum" : 1,
+            "exclusiveMinimum" : true
+          },
           "timeout_ms" : {
             "type" : "integer",
             "minimum" : 0,

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -153,6 +153,7 @@ private:
                              const std::vector<HostPtr>& hosts_removed) override;
 
   const std::string path_;
+  const uint16_t port_;
   std::unordered_map<HostPtr, HttpActiveHealthCheckSessionPtr> active_sessions_;
   Optional<std::string> service_name_;
 };

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -76,6 +76,8 @@ public:
   // Upstream::Host
   std::list<Stats::CounterPtr> counters() const override { return stats_store_.counters(); }
   CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const override;
+  CreateConnectionData createConnectionWithNewPort(uint16_t port,
+                                                   Event::Dispatcher& dispatcher) const override;
   std::list<Stats::GaugePtr> gauges() const override { return stats_store_.gauges(); }
   void healthFlagClear(HealthFlag flag) override { health_flags_ &= ~enumToInt(flag); }
   bool healthFlagGet(HealthFlag flag) const override { return health_flags_ & enumToInt(flag); }
@@ -90,7 +92,8 @@ public:
 protected:
   static Network::ClientConnectionPtr createConnection(Event::Dispatcher& dispatcher,
                                                        const ClusterInfo& cluster,
-                                                       Network::Address::InstancePtr address);
+                                                       Network::Address::InstancePtr address,
+                                                       uint16_t port = 0);
 
 private:
   std::atomic<uint64_t> health_flags_{};

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -84,6 +84,13 @@ public:
     return {Network::ClientConnectionPtr{data.connection_}, data.host_};
   }
 
+  // XXX: mock me
+  CreateConnectionData createConnectionWithNewPort(uint16_t,
+                                                   Event::Dispatcher& dispatcher) const override {
+    MockCreateConnectionData data = createConnection_(dispatcher);
+    return {Network::ClientConnectionPtr{data.connection_}, data.host_};
+  }
+
   void setOutlierDetector(Outlier::DetectorHostSinkPtr&& outlier_detector) override {
     setOutlierDetector_(outlier_detector);
   }


### PR DESCRIPTION
Please find a pull request to allow one to configure a specific port for the health checks.

fixes https://github.com/lyft/envoy/issues/439