### PR TITLE
Minimal Bazel infrastructure (#415).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /build
 /docs/landing_source/.bundle
 /generated
+/bazel-*
+/ci/bazel-*
+/ci/prebuilt/thirdparty
+/ci/prebuilt/thirdparty_build
 cscope.*
 BROWSE

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "envoy")
+
 load("//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,13 @@
+load("//bazel:repositories.bzl", "envoy_dependencies")
+
+envoy_dependencies()
+
+bind(
+    name = "googletest_main",
+    actual = "@googletest//:googletest_main",
+)
+
+bind(
+    name = "spdlog",
+    actual = "@spdlog_git//:spdlog",
+)

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,0 +1,41 @@
+# References to Envoy external dependencies should be wrapped with this function.
+def envoy_external_dep_path(dep):
+    return "//external:%s" % dep
+
+ENVOY_COPTS = [
+    "-ggdb3", "-fno-omit-frame-pointer", "-Wall", "-Wextra", "-Werror",
+    "-Wnon-virtual-dtor", "-Woverloaded-virtual", "-Wold-style-cast",
+    "-std=c++0x", "-includesource/precompiled/precompiled.h",
+    "-isystem", "include", "-isystem", "source"
+]
+
+ENVOY_LINKOPTS = ["-static-libstdc++", "-static-libgcc"]
+
+# Envoy C++ library targets should be specified with this function.
+def envoy_cc_library(name,
+                     srcs = [],
+                     public_hdrs = [],
+                     hdrs = [],
+                     external_deps = [],
+                     deps = []):
+    native.cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs + public_hdrs,
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] +
+               ["//source/precompiled:precompiled_includes"],
+        copts = ENVOY_COPTS,
+    )
+
+# Envoy C++ test targets should be specified with this function.
+def envoy_cc_test(name,
+                  srcs = [],
+                  deps = []):
+    native.cc_test(
+        name = name,
+        srcs = srcs,
+        deps = deps + ["//source/precompiled:precompiled_includes",
+                       "//test/precompiled:precompiled_includes"],
+        copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
+        linkopts = ["-pthread"]
+    )

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -19,16 +19,20 @@ def envoy_external_dep_path(dep):
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
                      srcs = [],
-                     public_hdrs = [],
                      hdrs = [],
+                     public_hdrs = [],
+                     copts = [],
+                     alwayslink = None,
+                     visibility = None,
                      external_deps = [],
-                     deps = [],
-                     copts = []):
+                     deps = []):
     native.cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
         copts = ENVOY_COPTS + copts,
+        alwayslink = alwayslink,
+        visibility = visibility,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             "//source/precompiled:precompiled_includes",
         ],

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,7 +1,3 @@
-# References to Envoy external dependencies should be wrapped with this function.
-def envoy_external_dep_path(dep):
-    return "//external:%s" % dep
-
 ENVOY_COPTS = [
     "-fno-omit-frame-pointer",
     "-Wall",
@@ -16,6 +12,10 @@ ENVOY_COPTS = [
     "-iquotesource",
 ]
 
+# References to Envoy external dependencies should be wrapped with this function.
+def envoy_external_dep_path(dep):
+    return "//external:%s" % dep
+
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
                      srcs = [],
@@ -28,9 +28,10 @@ def envoy_cc_library(name,
         name = name,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
-        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] +
-               ["//source/precompiled:precompiled_includes"],
         copts = ENVOY_COPTS + copts,
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+            "//source/precompiled:precompiled_includes",
+        ],
     )
 
 # Envoy C++ test targets should be specified with this function.
@@ -40,8 +41,10 @@ def envoy_cc_test(name,
     native.cc_test(
         name = name,
         srcs = srcs,
-        deps = deps + ["//source/precompiled:precompiled_includes",
-                       "//test/precompiled:precompiled_includes"],
         copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
-        linkopts = ["-pthread"]
+        linkopts = ["-pthread"],
+        deps = deps + [
+            "//source/precompiled:precompiled_includes",
+            "//test/precompiled:precompiled_includes",
+        ],
     )

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -3,9 +3,17 @@ def envoy_external_dep_path(dep):
     return "//external:%s" % dep
 
 ENVOY_COPTS = [
-    "-fno-omit-frame-pointer", "-Wall", "-Wextra", "-Werror", "-Wnon-virtual-dtor",
-    "-Woverloaded-virtual", "-Wold-style-cast", "-std=c++0x",
-    "-includesource/precompiled/precompiled.h", "-iquote", "include", "-iquote", "source"
+    "-fno-omit-frame-pointer",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-Wnon-virtual-dtor",
+    "-Woverloaded-virtual",
+    "-Wold-style-cast",
+    "-std=c++0x",
+    "-includesource/precompiled/precompiled.h",
+    "-iquoteinclude",
+    "-iquotesource",
 ]
 
 # Envoy C++ library targets should be specified with this function.

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -31,11 +31,11 @@ def envoy_cc_library(name,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
         copts = ENVOY_COPTS + copts,
-        alwayslink = alwayslink,
         visibility = visibility,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             "//source/precompiled:precompiled_includes",
         ],
+        alwayslink = alwayslink,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -3,13 +3,10 @@ def envoy_external_dep_path(dep):
     return "//external:%s" % dep
 
 ENVOY_COPTS = [
-    "-ggdb3", "-fno-omit-frame-pointer", "-Wall", "-Wextra", "-Werror",
-    "-Wnon-virtual-dtor", "-Woverloaded-virtual", "-Wold-style-cast",
-    "-std=c++0x", "-includesource/precompiled/precompiled.h",
-    "-isystem", "include", "-isystem", "source"
+    "-fno-omit-frame-pointer", "-Wall", "-Wextra", "-Werror", "-Wnon-virtual-dtor",
+    "-Woverloaded-virtual", "-Wold-style-cast", "-std=c++0x",
+    "-includesource/precompiled/precompiled.h", "-iquote", "include", "-iquote", "source"
 ]
-
-ENVOY_LINKOPTS = ["-static-libstdc++", "-static-libgcc"]
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
@@ -17,14 +14,15 @@ def envoy_cc_library(name,
                      public_hdrs = [],
                      hdrs = [],
                      external_deps = [],
-                     deps = []):
+                     deps = [],
+                     copts = []):
     native.cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] +
                ["//source/precompiled:precompiled_includes"],
-        copts = ENVOY_COPTS,
+        copts = ENVOY_COPTS + copts,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -61,7 +61,7 @@ cc_library(
 
 def spdlog_repositories():
     BUILD = """
-package(default_visibility=["//visibility:public"])
+package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "spdlog",
@@ -69,16 +69,17 @@ cc_library(
         "include/**/*.h",
         "include/**/*.cc",
     ]),
-    strip_include_prefix = "include"
+    strip_include_prefix = "include",
 )
 """
 
     native.new_git_repository(
         name = "spdlog_git",
-        remote = "https://github.com/gabime/spdlog.git",
+        build_file_content = BUILD,
         # v0.11.0 release
         commit = "1f1f6a5f3b424203a429e9cb78e6548037adefa8",
-        build_file_content = BUILD,)
+        remote = "https://github.com/gabime/spdlog.git",
+    )
 
 def envoy_dependencies():
     googletest_repositories()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,85 @@
+# The build rules below for external dependencies build rules are maintained
+# on a best effort basis. The rules are provided for developer convenience. For production builds,
+# we recommend building the libraries according to their canonical build systems and expressing the
+# dependencies in a manner similar to ci/WORKSPACE.
+
+def googletest_repositories():
+    BUILD = """
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+cc_library(
+    name = "googletest",
+    srcs = [
+        "googlemock/src/gmock-all.cc",
+        "googletest/src/gtest-all.cc",
+    ],
+    hdrs = glob([
+        "googletest/include/**/*.h",
+        "googlemock/include/**/*.h",
+        "googletest/src/*.cc",
+        "googletest/src/*.h",
+        "googlemock/src/*.cc",
+    ]),
+    includes = [
+        "googlemock",
+        "googlemock/include",
+        "googletest",
+        "googletest/include",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "googletest_main",
+    srcs = ["googlemock/src/gmock_main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [":googletest"],
+)
+"""
+    native.new_git_repository(
+        name = "googletest",
+        build_file_content = BUILD,
+        # v1.8.0 release
+        commit = "ec44c6c1675c25b9827aacd08c02433cccde7780",
+        remote = "https://github.com/google/googletest.git",
+    )
+
+def spdlog_repositories():
+    BUILD = """
+package(default_visibility=["//visibility:public"])
+
+cc_library(
+    name = "spdlog",
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.cc",
+    ]),
+    strip_include_prefix = "include"
+)
+"""
+
+    native.new_git_repository(
+        name = "spdlog_git",
+        remote = "https://github.com/gabime/spdlog.git",
+        # v0.11.0 release
+        commit = "1f1f6a5f3b424203a429e9cb78e6548037adefa8",
+        build_file_content = BUILD,)
+
+def envoy_dependencies():
+    googletest_repositories()
+    spdlog_repositories()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -5,23 +5,6 @@
 
 def googletest_repositories():
     BUILD = """
-# Copyright 2016 Google Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-#
-
 cc_library(
     name = "googletest",
     srcs = [

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
-# The build rules below for external dependencies build rules are maintained
-# on a best effort basis. The rules are provided for developer convenience. For production builds,
-# we recommend building the libraries according to their canonical build systems and expressing the
-# dependencies in a manner similar to ci/WORKSPACE.
+# The build rules below for external dependencies build rules are maintained on a best effort basis.
+# The rules are provided for developer convenience. For production builds, we recommend building the
+# libraries according to their canonical build systems and expressing the dependencies in a manner
+# similar to ci/WORKSPACE.
 
 def googletest_repositories():
     BUILD = """
@@ -29,11 +29,11 @@ cc_library(
         "googletest/src/gtest-all.cc",
     ],
     hdrs = glob([
-        "googletest/include/**/*.h",
         "googlemock/include/**/*.h",
+        "googlemock/src/*.cc",
+        "googletest/include/**/*.h",
         "googletest/src/*.cc",
         "googletest/src/*.h",
-        "googlemock/src/*.cc",
     ]),
     includes = [
         "googlemock",
@@ -66,8 +66,8 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "spdlog",
     hdrs = glob([
-        "include/**/*.h",
         "include/**/*.cc",
+        "include/**/*.h",
     ]),
     strip_include_prefix = "include",
 )

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -1,0 +1,9 @@
+bind(
+    name = "googletest_main",
+    actual = "//ci/prebuilt:googletest_main"
+)
+
+bind(
+    name = "spdlog",
+    actual = "//ci/prebuilt:spdlog"
+)

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -1,9 +1,9 @@
 bind(
     name = "googletest_main",
-    actual = "//ci/prebuilt:googletest_main"
+    actual = "//ci/prebuilt:googletest_main",
 )
 
 bind(
     name = "spdlog",
-    actual = "//ci/prebuilt:spdlog"
+    actual = "//ci/prebuilt:spdlog",
 )

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -15,14 +15,14 @@ if [[ "$1" == "bazel.debug" ]]; then
   echo "Building..."
   export CC=gcc-4.9
   export CXX=g++-4.9
-  TEST_TMPDIR=/source/build USER=bazel bazel build --strategy=CppCompile=standalone \
-    --strategy=CppLink=standalone --verbose_failures --package_path %workspace%:.. \
-    //source/...
+  export USER=bazel
+  export TEST_TMPDIR=/source
+  BAZEL_OPTIONS="--strategy=CppCompile=standalone --strategy=CppLink=standalone \
+    --strategy=TestRunner=standalone --verbose_failures --package_path %workspace%:.."
+  [[ "$BAZEL_INTERACTIVE" == "1" ]] && BAZEL_BATCH="" || BAZEL_BATCH="--batch"
+  bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/...
   echo "Testing..."
-  TEST_TMPDIR=/source/build USER=bazel bazel test --strategy=CppCompile=standalone \
-    --strategy=CppLink=standalone --strategy=TestRunner=standalone \
-    --verbose_failures --test_output=all --package_path %workspace%:.. \
-    //test/...
+  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --test_output=all //test/...
   exit 0
 fi
 

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "googletest_main",
+    hdrs = glob([
+        "thirdparty_build/include/gmock/**/*.h",
+        "thirdparty_build/include/gtest/**/*.h",
+    ]),
+    srcs = [
+        "thirdparty_build/lib/libgmock.a",
+        "thirdparty_build/lib/libgtest.a",
+        "thirdparty_build/lib/libgtest_main.a",
+    ],
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "spdlog",
+    hdrs = glob([
+        "thirdparty/spdlog-0.11.0/include/**/*.h",
+        "thirdparty/spdlog-0.11.0/include/**/*.cc",
+    ]),
+    strip_include_prefix = "thirdparty/spdlog-0.11.0/include",
+)

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -2,15 +2,15 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "googletest_main",
-    hdrs = glob([
-        "thirdparty_build/include/gmock/**/*.h",
-        "thirdparty_build/include/gtest/**/*.h",
-    ]),
     srcs = [
         "thirdparty_build/lib/libgmock.a",
         "thirdparty_build/lib/libgtest.a",
         "thirdparty_build/lib/libgtest_main.a",
     ],
+    hdrs = glob([
+        "thirdparty_build/include/gmock/**/*.h",
+        "thirdparty_build/include/gtest/**/*.h",
+    ]),
     strip_include_prefix = "thirdparty_build/include",
 )
 

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -17,8 +17,8 @@ cc_library(
 cc_library(
     name = "spdlog",
     hdrs = glob([
-        "thirdparty/spdlog-0.11.0/include/**/*.h",
         "thirdparty/spdlog-0.11.0/include/**/*.cc",
+        "thirdparty/spdlog-0.11.0/include/**/*.h",
     ]),
     strip_include_prefix = "thirdparty/spdlog-0.11.0/include",
 )

--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "base_includes",
+    hdrs = [
+        "exception.h",
+        "pure.h",
+    ],
+)
+
+envoy_cc_library(
+    name = "time_includes",
+    hdrs = ["time.h"],
+    deps = [":base_includes"],
+)
+
+envoy_cc_library(
+    name = "optional_includes",
+    hdrs = ["optional.h"],
+)

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -6,7 +6,5 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    deps = [
-        "//include/envoy/common:time_includes",
-    ],
+    deps = ["//include/envoy/common:time_includes"],
 )

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    deps = [
+        "//include/envoy/common:time_includes",
+    ],
+)

--- a/source/precompiled/BUILD
+++ b/source/precompiled/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
+
+cc_library(
+    name = "precompiled_includes",
+    hdrs = ["precompiled.h"],
+    deps = [envoy_external_dep_path("spdlog")],
+)

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -1,0 +1,7 @@
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+envoy_cc_test(
+    name = "utility_test",
+    srcs = ["utility_test.cc"],
+    deps = ["//source/common/common:utility_lib"],
+)

--- a/test/precompiled/BUILD
+++ b/test/precompiled/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
+
+cc_library(
+    name = "precompiled_includes",
+    hdrs = ["precompiled_test.h"],
+    deps = [envoy_external_dep_path("googletest_main")],
+)

--- a/test/precompiled/BUILD
+++ b/test/precompiled/BUILD
@@ -5,5 +5,8 @@ load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
 cc_library(
     name = "precompiled_includes",
     hdrs = ["precompiled_test.h"],
-    deps = [envoy_external_dep_path("googletest_main")],
+    deps = [
+        envoy_external_dep_path("googletest_main"),
+        "//test/test_common:printers_includes",
+    ],
 )

--- a/test/precompiled/precompiled_test.h
+++ b/test/precompiled/precompiled_test.h
@@ -2,7 +2,5 @@
 
 #include "precompiled/precompiled.h"
 
-#include "test/test_common/printers.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/precompiled/precompiled_test.h
+++ b/test/precompiled/precompiled_test.h
@@ -2,5 +2,7 @@
 
 #include "precompiled/precompiled.h"
 
+#include "test/test_common/printers.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "printers_includes",
+    hdrs = ["printers.h"],
+)


### PR DESCRIPTION
This patch introduces the minimal Bazel infrastructure required to build and execute utility_test,
as a step towards conversion of the cmake build system to Bazel (#415). The main contributions are:

* Machinery for declaring Envoy C++ library and test targets (envoy_cc_library, envoy_cc_test).

* External dependency management that works both inside the Docker CI environment (using prebuilts)
  and with developer-local dependency fetch/build (based on #416).

* Handling of the implicit dependencies that are today sourced via prebuilts.

* Simple example of building and running a unit test with only its dependencies built. With the
  cmake system, we would need to build all of Envoy and all tests to run utility_test. E.g.

  blaze test //test/common/common:utility_test

This is not intended to be used by anyone other than those working with the Bazel conversion at this
point. The plan is to add "ci/do_ci.sh bazel.debug" as a Travis target to ensure we don't bit rot.