### PR TITLE
Fix AF_INET6 bug, add full test in address_impl_tests for socket, bind and connect.

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -90,7 +90,7 @@ Ipv6Instance::Ipv6Instance(const std::string& address) : Ipv6Instance(address, 0
 
 Ipv6Instance::Ipv6Instance(const std::string& address, uint32_t port) : InstanceBase(Type::Ip) {
   memset(&ip_.ipv6_.address_, 0, sizeof(ip_.ipv6_.address_));
-  ip_.ipv6_.address_.sin6_family = AF_INET;
+  ip_.ipv6_.address_.sin6_family = AF_INET6;
   ip_.ipv6_.address_.sin6_port = htons(port);
   if (!address.empty()) {
     if (1 != inet_pton(AF_INET6, address.c_str(), &ip_.ipv6_.address_.sin6_addr)) {
@@ -117,7 +117,7 @@ int Ipv6Instance::connect(int fd) const {
 }
 
 int Ipv6Instance::socket(SocketType type) const {
-  return ::socket(AF_INET, flagsFromSocketType(type), 0);
+  return ::socket(AF_INET6, flagsFromSocketType(type), 0);
 }
 
 PipeInstance::PipeInstance(const sockaddr_un* address) : InstanceBase(Type::Pipe) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,7 @@ add_executable(envoy-test
   server/http/health_check_test.cc
   server/options_impl_test.cc
   server/server_test.cc
+  test_common/network_utility.cc
   test_common/printers.cc
   test_common/utility.cc)
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -11,15 +11,6 @@
 namespace Network {
 namespace Address {
 namespace {
-class ScopedFdCloser {
-public:
-  ScopedFdCloser(int fd) : fd_(fd) {}
-  ~ScopedFdCloser() { close(fd_); }
-
-private:
-  int fd_;
-};
-
 void makeFdBlocking(int fd) {
   const int flags = ::fcntl(fd, F_GETFL, 0);
   ASSERT_GE(flags, 0);

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -1,11 +1,63 @@
 #include "envoy/common/exception.h"
 
 #include "common/network/address_impl.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include <sys/un.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 namespace Network {
 namespace Address {
+namespace {
+class ScopedFdCloser {
+public:
+  ScopedFdCloser(int fd) : fd_(fd) {}
+  ~ScopedFdCloser() { close(fd_); }
+
+private:
+  int fd_;
+};
+
+void makeFdBlocking(int fd) {
+  const int flags = ::fcntl(fd, F_GETFL, 0);
+  ASSERT_GE(flags, 0);
+  ASSERT_EQ(::fcntl(fd, F_SETFL, flags & (~O_NONBLOCK)), 0);
+}
+
+void testSocketBindAndConnect(const Instance& loopbackPort) {
+  // Create a socket on which we'll listen for connections from clients.
+  const int listen_fd = loopbackPort.socket(SocketType::Stream);
+  ASSERT_GE(listen_fd, 0) << loopbackPort.asString();
+  ScopedFdCloser closer1(listen_fd);
+
+  // Bind the socket to the desired address and port.
+  int rc = loopbackPort.bind(listen_fd);
+  int err = errno;
+  ASSERT_EQ(rc, 0) << loopbackPort.asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
+
+  // Do a bare listen syscall. Not bothering to accept connections as that would
+  // require another thread.
+  ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+  // Create a client socket and connect to the server.
+  const int client_fd = loopbackPort.socket(SocketType::Stream);
+  ASSERT_GE(client_fd, 0) << loopbackPort.asString();
+  ScopedFdCloser closer2(client_fd);
+
+  // Instance::socket creates a non-blocking socket, which that extends all the way to the
+  // operation of ::connect(), so connect returns with errno==EWOULDBLOCK before the tcp
+  // handshake can complete. For testing convenience, re-enable blocking on the socket
+  // so that connect will wait for the handshake to complete.
+  makeFdBlocking(client_fd);
+
+  // Connect to the server.
+  rc = loopbackPort.connect(client_fd);
+  err = errno;
+  ASSERT_EQ(rc, 0) << loopbackPort.asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
+}
+}
 
 TEST(Ipv4InstanceTest, SocketAddress) {
   sockaddr_in addr4;
@@ -53,6 +105,12 @@ TEST(Ipv4InstanceTest, BadAddress) {
   EXPECT_THROW(Ipv4Instance("bar", 1), EnvoyException);
 }
 
+TEST(Ipv4InstanceTest, SocketBindAndConnect) {
+  // Test listening on and connecting to an unused port on the IPv4 loopback address.
+  Ipv4Instance loopbackPort("127.0.0.1", ::Network::Test::getUnusedPort());
+  testSocketBindAndConnect(loopbackPort);
+}
+
 TEST(Ipv6InstanceTest, SocketAddress) {
   sockaddr_in6 addr6;
   addr6.sin6_family = AF_INET6;
@@ -97,6 +155,12 @@ TEST(Ipv6InstanceTest, PortOnly) {
 TEST(Ipv6InstanceTest, BadAddress) {
   EXPECT_THROW(Ipv6Instance("foo"), EnvoyException);
   EXPECT_THROW(Ipv6Instance("bar", 1), EnvoyException);
+}
+
+TEST(Ipv6InstanceTest, SocketBindAndConnect) {
+  // Test listening on and connecting to an unused port on the IPv4 loopback address.
+  Ipv6Instance loopbackPort("::1", ::Network::Test::getUnusedPort());
+  testSocketBindAndConnect(loopbackPort);
 }
 
 TEST(PipeInstanceTest, Basic) {

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -1,0 +1,33 @@
+#include "network_utility.h"
+
+#include "common/runtime/runtime_impl.h"
+
+#include <mutex>
+
+namespace Network {
+namespace Test {
+namespace {
+const int kFirstEphemeralPort = 40152;
+const int kLastEphemeralPort = 65535;
+
+int selectFirstPort() {
+  uint64_t range = kLastEphemeralPort - kFirstEphemeralPort + 1;
+  Runtime::RandomGeneratorImpl rng;
+  uint64_t rand_port = (rng.random() % range) + kFirstEphemeralPort;
+  return static_cast<int>(rand_port);
+}
+} // namespace
+
+int getUnusedPort() {
+  static int next_port = selectFirstPort();
+  static std::mutex m;
+  std::lock_guard<std::mutex> lock(m);
+  if (next_port > kLastEphemeralPort) {
+    next_port = kFirstEphemeralPort;
+  }
+  // HACK ALERT: For now, we're just returning the next port, not checking if it is free.
+  return next_port++;
+}
+
+} // Test
+} // Network

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -1,25 +1,15 @@
 #include "network_utility.h"
 
-#include "common/runtime/runtime_impl.h"
-
-#include <mutex>
-
 namespace Network {
 namespace Test {
 namespace {
 const int kFirstEphemeralPort = 40152;
 const int kLastEphemeralPort = 65535;
-
-int selectFirstPort() {
-  uint64_t range = kLastEphemeralPort - kFirstEphemeralPort + 1;
-  Runtime::RandomGeneratorImpl rng;
-  uint64_t rand_port = (rng.random() % range) + kFirstEphemeralPort;
-  return static_cast<int>(rand_port);
-}
+const int kNumEphemeralPorts = kLastEphemeralPort - kFirstEphemeralPort + 1;
 } // namespace
 
 int getUnusedPort() {
-  static int next_port = selectFirstPort();
+  static int next_port = kFirstEphemeralPort;
   static std::mutex m;
   std::lock_guard<std::mutex> lock(m);
   if (next_port > kLastEphemeralPort) {

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Network {
+namespace Test {
+
+/**
+ * @returns an unused port, either be getting one from a port server, or by searching
+ * through the ports for an unused port.
+ */
+int getUnusedPort();
+
+} // Test
+} // Network

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -71,6 +71,9 @@ void ConditionalInitializer::waitReady() {
   EXPECT_TRUE(ready_);
 }
 
+ScopedFdCloser::ScopedFdCloser(int fd) : fd_(fd) {}
+ScopedFdCloser::~ScopedFdCloser() { ::close(fd_); }
+
 namespace Http {
 
 TestHeaderMapImpl::TestHeaderMapImpl() : HeaderMapImpl() {}

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -51,6 +51,15 @@ private:
   bool ready_{false};
 };
 
+class ScopedFdCloser {
+public:
+  ScopedFdCloser(int fd);
+  ~ScopedFdCloser();
+
+private:
+  int fd_;
+};
+
 namespace Http {
 
 /**


### PR DESCRIPTION
Fix bug in Ipv6Instance ctor where it specified AF_INET (i.e. IPv4) as the address family instead of AF_INET6. Doh!

Add getUnusedPort in test/test_common/network_utility.*, which for now just selects a port at random in the ephemeral range.

Add testSocketBindAndConnect, and apply to both Ipv4Instance and Ipv6Instance.