### PR TITLE
Remove CRLF so MD parser interprets bracketed text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,7 @@ We welcome contributions from the community. Here are some guidelines.
   issues are taken care of automatically. The Travis tests will automatically check
   the code format and fail. There are make targets that can both check the format 
   (check_format) as well as fix the code format for you (fix_format).
-* Beyond code formatting, for the most part Envoy uses the [Google C++ style guidelines]
-  (https://google.github.io/styleguide/cppguide.html). The following section covers the 
+* Beyond code formatting, for the most part Envoy uses the [Google C++ style guidelines]  (https://google.github.io/styleguide/cppguide.html). The following section covers the 
   major areas where we deviate from the Google guidelines.
 
 # Deviations from Google C++ Style guidelines


### PR DESCRIPTION
The formatting as it was had an extra blacnkspace (newline) between `[Google C++ style guidelines]` and `(https://google.github.io/styleguide/cppguide.html)` causing the following to be displayed: ` [Google C++ style guidelines]  (https://google.github.io/styleguide/cppguide.html)` instead of `Google C++ style guidelines`.