### PR TITLE
Fix config generation regression (#587).

### DIFF
--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT_DIR=`dirname $0`
 BUILD_DIR=$2/configgen
 if [ ! -d $BUILD_DIR/venv ]; then

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -12,3 +12,5 @@ fi
 mkdir -p $1
 $BUILD_DIR/venv/bin/python $SCRIPT_DIR/configgen.py $1
 cp -f $SCRIPT_DIR/google_com_proxy.json $1
+cp -f $SCRIPT_DIR/../examples/front-proxy/{front-envoy,service-envoy}.json $1
+cp -f $SCRIPT_DIR/../examples/grpc-bridge/config/*.json $1

--- a/configs/envoy_double_proxy.template.json
+++ b/configs/envoy_double_proxy.template.json
@@ -1,6 +1,6 @@
 {% macro listener(address,ssl,proxy_proto) %}
   {
-    "address": {{ address }},
+    "address": "{{ address }}",
     {% if ssl -%}
     "ssl_context": {
       "alpn_protocols": "h2,http/1.1",
@@ -87,7 +87,7 @@
   ],
 
   "admin": { "access_log_path": "/var/log/envoy/admin_access.log",
-             "tcp://127.0.0.1:9901" },
+             "address": "tcp://127.0.0.1:9901" },
   "flags_path": "/etc/envoy/flags",
   "statsd_tcp_cluster_name": "statsd",
 

--- a/configs/envoy_front_proxy.template.json
+++ b/configs/envoy_front_proxy.template.json
@@ -2,7 +2,7 @@
 
 {% macro listener(address) %}
   {
-    "address": {{ address }},
+    "address": "{{ address }}",
     {% if kwargs['ssl'] -%}
     "ssl_context": {
       "alpn_protocols": "h2,http/1.1",
@@ -82,7 +82,7 @@
   ],
 
   "admin": { "access_log_path": "/var/log/envoy/admin_access.log",
-             "port": 9901 },
+             "address": "tcp://0.0.0.0:9901" },
   "flags_path": "/etc/envoy/flags",
   "statsd_tcp_cluster_name": "statsd",
 

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -3,7 +3,7 @@
 
 {% macro ingress_listener(address) %}
 {
-  "address": {{ address }},
+  "address": "{{ address }}",
   "filters": [
   {
     "type": "read",
@@ -161,7 +161,7 @@
 
   {% for mapping in external_virtual_hosts -%}
   {
-    "address": {{ mapping['address'] }},
+    "address": "{{ mapping['address'] }}",
     "filters": [
     {
       "type": "read",
@@ -220,7 +220,7 @@
 
   {% for key, value in mongos_servers.iteritems() -%}
   {
-    "address": {{ value['address'] }},
+    "address": "{{ value['address'] }}",
     "filters": [
     {% if value.get('ratelimit', False) %}
     {
@@ -260,7 +260,7 @@
   ],
 
   "admin": { "access_log_path": "/var/log/envoy/admin_access.log",
-             "port": 9901 },
+             "address": "tcp://0.0.0.0:9901" },
   "flags_path": "/etc/envoy/flags",
   "statsd_tcp_cluster_name": "statsd",
 

--- a/configs/google_com_proxy.json
+++ b/configs/google_com_proxy.json
@@ -31,7 +31,7 @@
     }],
     "admin": {
         "access_log_path": "/tmp/admin_access.log",
-        "port": 9901
+        "address": "tcp://127.0.0.1:9901"
     },
     "cluster_manager": {
         "clusters": [{

--- a/docs/configuration/overview/admin.rst
+++ b/docs/configuration/overview/admin.rst
@@ -16,5 +16,7 @@ access_log_path
   *(required, string)* The path to write the access log for the administration server. If no
   access log is desired specify '/dev/null'.
 
-port
-  *(required, integer)* The TCP port that the administration server will listen on.
+address
+  *(required, string)* The TCP address that the administration server will listen on, e.g.,
+  "tcp://127.0.0.1:1234". Note, "tcp://0.0.0.0:1234" is the wild card match for any IPv4 address
+  with port 1234.

--- a/examples/front-proxy/front-envoy.json
+++ b/examples/front-proxy/front-envoy.json
@@ -44,7 +44,7 @@
   ],
   "admin": {
     "access_log_path": "/dev/null",
-    "port": 8001
+    "address": "tcp://0.0.0.0:8001"
   },
   "cluster_manager": {
     "clusters": [

--- a/examples/front-proxy/service-envoy.json
+++ b/examples/front-proxy/service-envoy.json
@@ -38,7 +38,7 @@
   ],
   "admin": {
     "access_log_path": "/dev/null",
-    "port": 8001
+    "address": "tcp://0.0.0.0:8001"
   },
   "cluster_manager": {
     "clusters": [

--- a/examples/grpc-bridge/config/s2s-grpc-envoy.json
+++ b/examples/grpc-bridge/config/s2s-grpc-envoy.json
@@ -43,7 +43,7 @@
   ],
   "admin": {
     "access_log_path": "/var/log/envoy/admin_access.log",
-    "port": 9901
+    "address": "tcp://0.0.0.0:9901"
   },
   "cluster_manager": {
     "clusters": [

--- a/examples/grpc-bridge/config/s2s-python-envoy.json
+++ b/examples/grpc-bridge/config/s2s-python-envoy.json
@@ -52,7 +52,7 @@
   ],
   "admin": {
     "access_log_path": "/var/log/envoy/admin_access.log",
-    "port": 9901
+    "address": "tcp://0.0.0.0:9901"
   },
   "cluster_manager": {
     "clusters": [

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -142,9 +142,9 @@ public:
   virtual const std::string& accessLogPath() PURE;
 
   /**
-   * @return uint32_t the server admin HTTP port.
+   * @return const std::string& the server address.
    */
-  virtual uint32_t port() PURE;
+  virtual const std::string& address() PURE;
 };
 
 /**

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -23,7 +23,7 @@ public:
   virtual Network::FilterChainFactory& filterChainFactory() PURE;
 
   /**
-   * @return std::string the address.
+   * @return Network::Address::InstancePtr the address.
    */
   virtual Network::Address::InstancePtr address() PURE;
 
@@ -142,9 +142,9 @@ public:
   virtual const std::string& accessLogPath() PURE;
 
   /**
-   * @return const std::string& the server address.
+   * @return Network::Address::InstancePtr the server address.
    */
-  virtual const std::string& address() PURE;
+  virtual Network::Address::InstancePtr address() PURE;
 };
 
 /**

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -899,9 +899,9 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
         "type" : "object",
         "properties" : {
           "access_log_path" : {"type" : "string"},
-          "port" : {"type" : "integer"}
+          "address" : {"type" : "string"}
         },
-        "required" : ["access_log_path", "port"],
+        "required" : ["access_log_path", "address"],
         "additionalProperties" : false
       },
       "cluster_manager" : {"type" : "object"},

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -180,7 +180,7 @@ bool MainImpl::ListenerConfig::createFilterChain(Network::Connection& connection
 InitialImpl::InitialImpl(const Json::Object& json) {
   Json::ObjectPtr admin = json.getObject("admin");
   admin_.access_log_path_ = admin->getString("access_log_path");
-  admin_.port_ = admin->getInteger("port");
+  admin_.address_ = admin->getString("address");
 
   if (json.hasObject("flags_path")) {
     flags_path_.value(json.getString("flags_path"));

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -180,7 +180,7 @@ bool MainImpl::ListenerConfig::createFilterChain(Network::Connection& connection
 InitialImpl::InitialImpl(const Json::Object& json) {
   Json::ObjectPtr admin = json.getObject("admin");
   admin_.access_log_path_ = admin->getString("access_log_path");
-  admin_.address_ = admin->getString("address");
+  admin_.address_ = Network::Utility::resolveUrl(admin->getString("address"));
 
   if (json.hasObject("flags_path")) {
     flags_path_.value(json.getString("flags_path"));

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -156,10 +156,10 @@ private:
   struct AdminImpl : public Admin {
     // Server::Configuration::Initial::Admin
     const std::string& accessLogPath() override { return access_log_path_; }
-    uint32_t port() override { return port_; }
+    const std::string& address() override { return address_; }
 
     std::string access_log_path_;
-    uint32_t port_;
+    std::string address_;
   };
 
   struct RuntimeImpl : public Runtime {

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -156,10 +156,10 @@ private:
   struct AdminImpl : public Admin {
     // Server::Configuration::Initial::Admin
     const std::string& accessLogPath() override { return access_log_path_; }
-    const std::string& address() override { return address_; }
+    Network::Address::InstancePtr address() override { return address_; }
 
     std::string access_log_path_;
-    std::string address_;
+    Network::Address::InstancePtr address_;
   };
 
   struct RuntimeImpl : public Runtime {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -295,10 +295,9 @@ void AdminFilter::onComplete() {
 AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider()
     : config_(new Router::NullConfigImpl()) {}
 
-AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& address,
+AdminImpl::AdminImpl(const std::string& access_log_path, Network::Address::InstancePtr address,
                      Server::Instance& server)
-    : server_(server),
-      socket_(new Network::TcpListenSocket(Network::Utility::resolveUrl(address), true)),
+    : server_(server), socket_(new Network::TcpListenSocket(address, true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
                                                                        server_.stats())),

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -295,8 +295,10 @@ void AdminFilter::onComplete() {
 AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider()
     : config_(new Router::NullConfigImpl()) {}
 
-AdminImpl::AdminImpl(const std::string& access_log_path, uint32_t port, Server::Instance& server)
-    : server_(server), socket_(new Network::TcpListenSocket(port, true)),
+AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& address,
+                     Server::Instance& server)
+    : server_(server),
+      socket_(new Network::TcpListenSocket(Network::Utility::resolveUrl(address), true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
                                                                        server_.stats())),

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -22,7 +22,8 @@ class AdminImpl : public Admin,
                   public Http::ConnectionManagerConfig,
                   Logger::Loggable<Logger::Id::admin> {
 public:
-  AdminImpl(const std::string& access_log_path, uint32_t port, Server::Instance& server);
+  AdminImpl(const std::string& access_log_path, const std::string& address,
+            Server::Instance& server);
 
   Http::Code runCallback(const std::string& path, Buffer::Instance& response);
   Network::ListenSocket& socket() { return *socket_; }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -22,7 +22,7 @@ class AdminImpl : public Admin,
                   public Http::ConnectionManagerConfig,
                   Logger::Loggable<Logger::Id::admin> {
 public:
-  AdminImpl(const std::string& access_log_path, const std::string& address,
+  AdminImpl(const std::string& access_log_path, Network::Address::InstancePtr address,
             Server::Instance& server);
 
   Http::Code runCallback(const std::string& path, Buffer::Instance& response);

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -162,7 +162,7 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   Json::ObjectPtr config_json = Json::Factory::LoadFromFile(options.configPath());
   config_json->validateSchema(Json::Schema::TOP_LEVEL_CONFIG_SCHEMA);
   Configuration::InitialImpl initial_config(*config_json);
-  log().info("admin address: {}", initial_config.admin().address());
+  log().info("admin address: {}", initial_config.admin().address()->asString());
 
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -162,15 +162,15 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   Json::ObjectPtr config_json = Json::Factory::LoadFromFile(options.configPath());
   config_json->validateSchema(Json::Schema::TOP_LEVEL_CONFIG_SCHEMA);
   Configuration::InitialImpl initial_config(*config_json);
-  log().info("admin port: {}", initial_config.admin().port());
+  log().info("admin address: {}", initial_config.admin().address());
 
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;
   restarter_.shutdownParentAdmin(info);
   drain_manager_->startParentShutdownSequence();
   original_start_time_ = info.original_start_time_;
-  admin_.reset(
-      new AdminImpl(initial_config.admin().accessLogPath(), initial_config.admin().port(), *this));
+  admin_.reset(new AdminImpl(initial_config.admin().accessLogPath(),
+                             initial_config.admin().address(), *this));
   handler_.addListener(*admin_, admin_->socket(),
                        Network::ListenerOptions::listenerOptionsWithBindToPort());
 

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -244,7 +244,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
   "flags_path": "/invalid_flags",
   "statsd_local_udp_port": 8125,
   "statsd_tcp_cluster_name": "statsd",

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -193,7 +193,7 @@
     ]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
   "statsd_local_udp_port": 8125,
   "statsd_tcp_cluster_name": "statsd",
   "tracing": {

--- a/test/config/integration/server_http2_upstream.json
+++ b/test/config/integration/server_http2_upstream.json
@@ -255,7 +255,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
 
   "cluster_manager": {
     "clusters": [

--- a/test/config/integration/server_proxy_proto.json
+++ b/test/config/integration/server_proxy_proto.json
@@ -82,7 +82,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
   "statsd_local_udp_port": 8125,
 
   "cluster_manager": {

--- a/test/config/integration/server_ssl.json
+++ b/test/config/integration/server_ssl.json
@@ -89,7 +89,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
   "statsd_local_udp_port": 8125,
 
   "cluster_manager": {

--- a/test/config/integration/server_uds.json
+++ b/test/config/integration/server_uds.json
@@ -81,7 +81,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "port": 10003 },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:10003" },
   "statsd_local_udp_port": 8125,
 
   "cluster_manager": {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -13,7 +13,8 @@ class AdminFilterTest : public testing::Test {
 public:
   // TODO(mattklein123): Switch to mocks and do not bind to a real port.
   AdminFilterTest()
-      : admin_("/dev/null", 9002, server_), filter_(admin_), request_headers_{{":path", "/"}} {
+      : admin_("/dev/null", "tcp://127.0.0.1:9002", server_), filter_(admin_),
+        request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
 
@@ -44,4 +45,4 @@ TEST_F(AdminFilterTest, Trailers) {
   filter_.decodeTrailers(request_headers_);
 }
 
-} // Server
+} // namespace Server

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -13,8 +13,8 @@ class AdminFilterTest : public testing::Test {
 public:
   // TODO(mattklein123): Switch to mocks and do not bind to a real port.
   AdminFilterTest()
-      : admin_("/dev/null", "tcp://127.0.0.1:9002", server_), filter_(admin_),
-        request_headers_{{":path", "/"}} {
+      : admin_("/dev/null", Network::Utility::resolveUrl("tcp://127.0.0.1:9002"), server_),
+        filter_(admin_), request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
 


### PR DESCRIPTION
Also added a "set -e" to configgen.sh to ensure we catch this in presubmit in the future. As a
bonus, plumbed in arbitrary address binding to admin server config, since we had some configs that
had been updated to this already and it seems a generally useful thing to have.

fixes https://github.com/lyft/envoy/issues/587