### PR TITLE
fix SSL write crash when write buffer has a very large chain

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -231,6 +231,12 @@ void ConnectionImpl::write(Buffer::Instance& data) {
 
   if (data.length() > 0) {
     conn_log_trace("writing {} bytes", *this, data.length());
+    // TODO(mattklein123): All data currently gets moved from the source buffer to the write buffer.
+    // This can lead to inefficient behavior if writing a bunch of small chunks. In this case, it
+    // would likely be more efficient to copy data below a certain size. VERY IMPORTANT: If this is
+    // ever changed, read the comment in Ssl::ConnectionImpl::doWriteToSocket() VERY carefully.
+    // That code assumes that we never change existing write_buffer_ chain elements between calls
+    // to SSL_write(). That code will have to change if we ever copy here.
     write_buffer_.move(data);
     if (!(state_ & InternalState::Connecting)) {
       file_event_->activate(Event::FileReadyType::Write);

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -136,7 +136,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
 
   uint64_t total_bytes_written = 0;
   bool keep_writing = true;
-  while (write_buffer_.length() && keep_writing) {
+  while ((write_buffer_.length() > 0) && keep_writing) {
     // Protect against stack overflow if the buffer has a very large buffer chain.
     // TODO(mattklein123): The current evbuffer Buffer::Instance implementation will iterate through
     // the entire chain each time this is called to determine how many slices would be needed. In
@@ -178,6 +178,8 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
       }
     }
 
+    // Draining must be done within the inner loop, otherwise we will keep getting the same slices
+    // at the beginning of the buffer.
     if (inner_bytes_written > 0) {
       write_buffer_.drain(inner_bytes_written);
     }


### PR DESCRIPTION
Previously, we would get all buffer slices on the stack and stack overflow
if the chain was very large. This change limits the number of slices that we
write during each iteration. There are a number of potential improvements
possible in terms of collapsing small moves, enforcing fairness in terms of
number of iterations, etc.

This commit also removes a bunch of RawSlice to evbuffer_iovec conversions
for performance reasons.

NOTE: The added test repros the crash before the fix.

fixes https://github.com/lyft/envoy/issues/585