### PR TITLE
remove ':' from listener stats

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -78,13 +78,13 @@ public:
    * @param conn_handler supplies the handler for connections received by the listener
    * @param socket supplies the socket to listen on.
    * @param cb supplies the callbacks to invoke for listener events.
-   * @param stats_store supplies the Stats::Store to use.
+   * @param scope supplies the Stats::Scope to use.
    * @param listener_options listener configuration options.
    * @return Network::ListenerPtr a new listener that is owned by the caller.
    */
   virtual Network::ListenerPtr
   createListener(Network::ConnectionHandler& conn_handler, Network::ListenSocket& socket,
-                 Network::ListenerCallbacks& cb, Stats::Store& stats_store,
+                 Network::ListenerCallbacks& cb, Stats::Scope& scope,
                  const Network::ListenerOptions& listener_options) PURE;
 
   /**
@@ -93,15 +93,14 @@ public:
    * @param ssl_ctx supplies the SSL context to use.
    * @param socket supplies the socket to listen on.
    * @param cb supplies the callbacks to invoke for listener events.
-   * @param stats_store supplies the Stats::Store to use.
+   * @param scope supplies the Stats::Scope to use.
    * @param listener_options listener configuration options.
    * @return Network::ListenerPtr a new listener that is owned by the caller.
    */
   virtual Network::ListenerPtr
   createSslListener(Network::ConnectionHandler& conn_handler, Ssl::ServerContext& ssl_ctx,
                     Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                    Stats::Store& stats_store,
-                    const Network::ListenerOptions& listener_options) PURE;
+                    Stats::Scope& scope, const Network::ListenerOptions& listener_options) PURE;
 
   /**
    * Allocate a timer. @see Event::Timer for docs on how to use the timer.

--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -21,19 +21,22 @@ public:
    * Adds listener to the handler.
    * @param factory supplies the configuration factory for new connections.
    * @param socket supplies the already bound socket to listen on.
+   * @param scope supplies the stats scope to use for listener specific stats.
    * @param listener_options listener configuration options.
    */
   virtual void addListener(Network::FilterChainFactory& factory, Network::ListenSocket& socket,
+                           Stats::Scope& scope,
                            const Network::ListenerOptions& listener_options) PURE;
 
   /**
    * Adds listener to the handler.
    * @param factory supplies the configuration factory for new connections.
    * @param socket supplies the already bound socket to listen on.
+   * @param scope supplies the stats scope to use for listener specific stats.
    * @param listener_options listener configuration options.
    */
   virtual void addSslListener(Network::FilterChainFactory& factory, Ssl::ServerContext& ssl_ctx,
-                              Network::ListenSocket& socket,
+                              Network::ListenSocket& socket, Stats::Scope& scope,
                               const Network::ListenerOptions& listener_options) PURE;
 
   /**

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -56,6 +56,11 @@ public:
    *         buffers.
    */
   virtual uint32_t perConnectionBufferLimitBytes() PURE;
+
+  /**
+   * @return Stats::Scope& the stats scope to use for all listener specific stats.
+   */
+  virtual Stats::Scope& scope() PURE;
 };
 
 typedef std::unique_ptr<Listener> ListenerPtr;

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -82,19 +82,19 @@ Filesystem::WatcherPtr DispatcherImpl::createFilesystemWatcher() {
 Network::ListenerPtr
 DispatcherImpl::createListener(Network::ConnectionHandler& conn_handler,
                                Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                               Stats::Store& stats_store,
+                               Stats::Scope& scope,
                                const Network::ListenerOptions& listener_options) {
   return Network::ListenerPtr{
-      new Network::ListenerImpl(conn_handler, *this, socket, cb, stats_store, listener_options)};
+      new Network::ListenerImpl(conn_handler, *this, socket, cb, scope, listener_options)};
 }
 
 Network::ListenerPtr
 DispatcherImpl::createSslListener(Network::ConnectionHandler& conn_handler,
                                   Ssl::ServerContext& ssl_ctx, Network::ListenSocket& socket,
-                                  Network::ListenerCallbacks& cb, Stats::Store& stats_store,
+                                  Network::ListenerCallbacks& cb, Stats::Scope& scope,
                                   const Network::ListenerOptions& listener_options) {
   return Network::ListenerPtr{new Network::SslListenerImpl(conn_handler, *this, ssl_ctx, socket, cb,
-                                                           stats_store, listener_options)};
+                                                           scope, listener_options)};
 }
 
 TimerPtr DispatcherImpl::createTimer(TimerCb cb) { return TimerPtr{new TimerImpl(*this, cb)}; }

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -36,11 +36,11 @@ public:
   Filesystem::WatcherPtr createFilesystemWatcher() override;
   Network::ListenerPtr createListener(Network::ConnectionHandler& conn_handler,
                                       Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                                      Stats::Store& stats_store,
+                                      Stats::Scope& scope,
                                       const Network::ListenerOptions& listener_options) override;
   Network::ListenerPtr createSslListener(Network::ConnectionHandler& conn_handler,
                                          Ssl::ServerContext& ssl_ctx, Network::ListenSocket& socket,
-                                         Network::ListenerCallbacks& cb, Stats::Store& stats_store,
+                                         Network::ListenerCallbacks& cb, Stats::Scope& scope,
                                          const Network::ListenerOptions& listener_options) override;
   TimerPtr createTimer(TimerCb cb) override;
   void deferredDelete(DeferredDeletablePtr&& to_delete) override;

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -64,10 +64,10 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
 
 ListenerImpl::ListenerImpl(Network::ConnectionHandler& conn_handler,
                            Event::DispatcherImpl& dispatcher, ListenSocket& socket,
-                           ListenerCallbacks& cb, Stats::Store& stats_store,
+                           ListenerCallbacks& cb, Stats::Scope& scope,
                            const Network::ListenerOptions& listener_options)
     : connection_handler_(conn_handler), dispatcher_(dispatcher), socket_(socket), cb_(cb),
-      proxy_protocol_(stats_store), options_(listener_options), listener_(nullptr) {
+      proxy_protocol_(scope), options_(listener_options), listener_(nullptr) {
 
   if (options_.bind_to_port_) {
     listener_.reset(

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -19,7 +19,7 @@ namespace Network {
 class ListenerImpl : public Listener {
 public:
   ListenerImpl(Network::ConnectionHandler& conn_handler, Event::DispatcherImpl& dispatcher,
-               ListenSocket& socket, ListenerCallbacks& cb, Stats::Store& stats_store,
+               ListenSocket& socket, ListenerCallbacks& cb, Stats::Scope& scope,
                const ListenerOptions& listener_options);
 
   /**
@@ -57,8 +57,8 @@ class SslListenerImpl : public ListenerImpl {
 public:
   SslListenerImpl(Network::ConnectionHandler& conn_handler, Event::DispatcherImpl& dispatcher,
                   Ssl::Context& ssl_ctx, ListenSocket& socket, ListenerCallbacks& cb,
-                  Stats::Store& stats_store, const Network::ListenerOptions& listener_options)
-      : ListenerImpl(conn_handler, dispatcher, socket, cb, stats_store, listener_options),
+                  Stats::Scope& scope, const Network::ListenerOptions& listener_options)
+      : ListenerImpl(conn_handler, dispatcher, socket, cb, scope, listener_options),
         ssl_ctx_(ssl_ctx) {}
 
   // ListenerImpl

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -14,8 +14,8 @@ namespace Network {
 
 const std::string ProxyProtocol::ActiveConnection::PROXY_TCP4 = "PROXY TCP4 ";
 
-ProxyProtocol::ProxyProtocol(Stats::Store& stats_store)
-    : stats_{ALL_PROXY_PROTOCOL_STATS(POOL_COUNTER(stats_store))} {}
+ProxyProtocol::ProxyProtocol(Stats::Scope& scope)
+    : stats_{ALL_PROXY_PROTOCOL_STATS(POOL_COUNTER(scope))} {}
 
 void ProxyProtocol::newConnection(Event::Dispatcher& dispatcher, int fd, ListenerImpl& listener) {
   std::unique_ptr<ActiveConnection> p{new ActiveConnection(*this, dispatcher, fd, listener)};

--- a/source/common/network/proxy_protocol.h
+++ b/source/common/network/proxy_protocol.h
@@ -66,7 +66,7 @@ public:
     char buf_[MAX_PROXY_PROTO_LEN];
   };
 
-  ProxyProtocol(Stats::Store& stats_store);
+  ProxyProtocol(Stats::Scope& scope);
 
   void newConnection(Event::Dispatcher& dispatcher, int fd, ListenerImpl& listener);
 

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -26,6 +26,7 @@ void HeapRawStatDataAllocator::free(RawStatData& data) {
 void RawStatData::initialize(const std::string& name) {
   ASSERT(!initialized());
   ASSERT(name.size() <= MAX_NAME_SIZE);
+  ASSERT(std::string::npos == name.find(':'));
   ref_count_ = 1;
   StringUtil::strlcpy(name_, name.substr(0, MAX_NAME_SIZE).c_str(), MAX_NAME_SIZE + 1);
 }

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -97,6 +97,7 @@ private:
     bool useProxyProto() override { return use_proxy_proto_; }
     bool useOriginalDst() override { return use_original_dst_; }
     uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
+    Stats::Scope& scope() override { return *scope_; }
 
     // Network::FilterChainFactory
     bool createFilterChain(Network::Connection& connection) override;

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -57,10 +57,10 @@ public:
   uint64_t numConnections() override { return num_connections_; }
 
   void addListener(Network::FilterChainFactory& factory, Network::ListenSocket& socket,
-                   const Network::ListenerOptions& listener_options) override;
+                   Stats::Scope& scope, const Network::ListenerOptions& listener_options) override;
 
   void addSslListener(Network::FilterChainFactory& factory, Ssl::ServerContext& ssl_ctx,
-                      Network::ListenSocket& socket,
+                      Network::ListenSocket& socket, Stats::Scope& scope,
                       const Network::ListenerOptions& listener_options) override;
 
   Network::Listener* findListenerByAddress(const Network::Address::Instance& address) override;
@@ -73,11 +73,11 @@ private:
    */
   struct ActiveListener : public Network::ListenerCallbacks {
     ActiveListener(ConnectionHandlerImpl& parent, Network::ListenSocket& socket,
-                   Network::FilterChainFactory& factory,
+                   Network::FilterChainFactory& factory, Stats::Scope& scope,
                    const Network::ListenerOptions& listener_options);
 
     ActiveListener(ConnectionHandlerImpl& parent, Network::ListenerPtr&& listener,
-                   Network::FilterChainFactory& factory, const std::string& stats_prefix);
+                   Network::FilterChainFactory& factory, Stats::Scope& scope);
 
     /**
      * Fires when a new connection is received from the listener.
@@ -94,7 +94,7 @@ private:
   struct SslActiveListener : public ActiveListener {
     SslActiveListener(ConnectionHandlerImpl& parent, Ssl::ServerContext& ssl_ctx,
                       Network::ListenSocket& socket, Network::FilterChainFactory& factory,
-                      const Network::ListenerOptions& listener_options);
+                      Stats::Scope& scope, const Network::ListenerOptions& listener_options);
   };
 
   typedef std::unique_ptr<ActiveListener> ActiveListenerPtr;
@@ -132,9 +132,8 @@ private:
    */
   void removeConnection(ActiveConnection& connection);
 
-  static ListenerStats generateStats(const std::string& prefix, Stats::Store& store);
+  static ListenerStats generateStats(Stats::Scope& scope);
 
-  Stats::Store& stats_store_;
   spdlog::logger& logger_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -171,7 +171,8 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   original_start_time_ = info.original_start_time_;
   admin_.reset(new AdminImpl(initial_config.admin().accessLogPath(),
                              initial_config.admin().address(), *this));
-  handler_.addListener(*admin_, admin_->socket(),
+  admin_scope_ = stats_store_.createScope("listener.admin.");
+  handler_.addListener(*admin_, admin_->socket(), *admin_scope_,
                        Network::ListenerOptions::listenerOptionsWithBindToPort());
 
   loadServerFlags(initial_config.flagsPath());

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -154,6 +154,7 @@ private:
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
   std::unique_ptr<Configuration::Main> config_;
   std::list<WorkerPtr> workers_;
+  Stats::ScopePtr admin_scope_;
   std::unique_ptr<AdminImpl> admin_;
   Event::SignalEventPtr sigterm_;
   Event::SignalEventPtr sig_usr_1_;

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -27,10 +27,10 @@ void Worker::initializeConfiguration(Server::Configuration::Main& config,
         .per_connection_buffer_limit_bytes_ = listener->perConnectionBufferLimitBytes()};
     if (listener->sslContext()) {
       handler_->addSslListener(listener->filterChainFactory(), *listener->sslContext(),
-                               *socket_map.at(listener.get()), listener_options);
+                               *socket_map.at(listener.get()), listener->scope(), listener_options);
     } else {
       handler_->addListener(listener->filterChainFactory(), *socket_map.at(listener.get()),
-                            listener_options);
+                            listener->scope(), listener_options);
     }
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -222,10 +222,10 @@ bool FakeUpstream::createFilterChain(Network::Connection& connection) {
 
 void FakeUpstream::threadRoutine() {
   if (ssl_ctx_) {
-    handler_.addSslListener(*this, *ssl_ctx_, *socket_,
+    handler_.addSslListener(*this, *ssl_ctx_, *socket_, stats_store_,
                             Network::ListenerOptions::listenerOptionsWithBindToPort());
   } else {
-    handler_.addListener(*this, *socket_,
+    handler_.addListener(*this, *socket_, stats_store_,
                          Network::ListenerOptions::listenerOptionsWithBindToPort());
   }
 

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -82,8 +82,7 @@ Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool al
 }
 
 void SslIntegrationTest::checkStats() {
-  Stats::Counter& counter =
-      test_server_->store().counter("listener.tcp://127.0.0.1:10001.ssl.handshake");
+  Stats::Counter& counter = test_server_->store().counter("listener.127.0.0.1_10001.ssl.handshake");
   EXPECT_EQ(1U, counter.value());
   counter.reset();
 }

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -44,19 +44,18 @@ public:
 
   Network::ListenerPtr createListener(Network::ConnectionHandler& conn_handler,
                                       Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                                      Stats::Store& stats_store,
+                                      Stats::Scope& scope,
                                       const Network::ListenerOptions& listener_options) override {
-    return Network::ListenerPtr{
-        createListener_(conn_handler, socket, cb, stats_store, listener_options)};
+    return Network::ListenerPtr{createListener_(conn_handler, socket, cb, scope, listener_options)};
   }
 
   Network::ListenerPtr
   createSslListener(Network::ConnectionHandler& conn_handler, Ssl::ServerContext& ssl_ctx,
                     Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                    Stats::Store& stats_store,
+                    Stats::Scope& scope,
                     const Network::ListenerOptions& listener_options) override {
     return Network::ListenerPtr{
-        createSslListener_(conn_handler, ssl_ctx, socket, cb, stats_store, listener_options)};
+        createSslListener_(conn_handler, ssl_ctx, socket, cb, scope, listener_options)};
   }
 
   TimerPtr createTimer(TimerCb cb) override { return TimerPtr{createTimer_(cb)}; }
@@ -86,12 +85,12 @@ public:
   MOCK_METHOD5(createListener_,
                Network::Listener*(Network::ConnectionHandler& conn_handler,
                                   Network::ListenSocket& socket, Network::ListenerCallbacks& cb,
-                                  Stats::Store& stats_store,
+                                  Stats::Scope& scope,
                                   const Network::ListenerOptions& listener_options));
   MOCK_METHOD6(createSslListener_,
                Network::Listener*(Network::ConnectionHandler& conn_handler,
                                   Ssl::ServerContext& ssl_ctx, Network::ListenSocket& socket,
-                                  Network::ListenerCallbacks& cb, Stats::Store& stats_store,
+                                  Network::ListenerCallbacks& cb, Stats::Scope& scope,
                                   const Network::ListenerOptions& listener_options));
   MOCK_METHOD1(createTimer_, Timer*(TimerCb cb));
   MOCK_METHOD1(deferredDelete_, void(DeferredDeletablePtr& to_delete));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -213,12 +213,13 @@ public:
   ~MockConnectionHandler();
 
   MOCK_METHOD0(numConnections, uint64_t());
-  MOCK_METHOD3(addListener,
+  MOCK_METHOD4(addListener,
                void(Network::FilterChainFactory& factory, Network::ListenSocket& socket,
+                    Stats::Scope& scope, const Network::ListenerOptions& listener_options));
+  MOCK_METHOD5(addSslListener,
+               void(Network::FilterChainFactory& factory, Ssl::ServerContext& ssl_ctx,
+                    Network::ListenSocket& socket, Stats::Scope& scope,
                     const Network::ListenerOptions& listener_options));
-  MOCK_METHOD4(addSslListener, void(Network::FilterChainFactory& factory,
-                                    Ssl::ServerContext& ssl_ctx, Network::ListenSocket& socket,
-                                    const Network::ListenerOptions& listener_options));
   MOCK_METHOD1(findListenerByAddress,
                Network::Listener*(const Network::Address::Instance& address));
   MOCK_METHOD0(closeListeners, void());

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -33,13 +33,14 @@ TEST_F(ConnectionHandlerTest, CloseDuringFilterChainCreate) {
   Network::ListenerCallbacks* listener_callbacks;
   EXPECT_CALL(*dispatcher, createListener_(_, _, _, _, _))
       .WillOnce(Invoke([&](Network::ConnectionHandler&, Network::ListenSocket&,
-                           Network::ListenerCallbacks& cb, Stats::Store&,
+                           Network::ListenerCallbacks& cb, Stats::Scope&,
                            const Network::ListenerOptions&) -> Network::Listener* {
         listener_callbacks = &cb;
         return listener;
 
       }));
-  handler.addListener(factory, socket, Network::ListenerOptions::listenerOptionsWithBindToPort());
+  handler.addListener(factory, socket, stats_store,
+                      Network::ListenerOptions::listenerOptionsWithBindToPort());
 
   Network::MockConnection* connection = new NiceMock<Network::MockConnection>();
   EXPECT_CALL(factory, createFilterChain(_));
@@ -65,13 +66,14 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
   Network::ListenerCallbacks* listener_callbacks;
   EXPECT_CALL(*dispatcher, createListener_(_, _, _, _, _))
       .WillOnce(Invoke([&](Network::ConnectionHandler&, Network::ListenSocket&,
-                           Network::ListenerCallbacks& cb, Stats::Store&,
+                           Network::ListenerCallbacks& cb, Stats::Scope&,
                            const Network::ListenerOptions&) -> Network::Listener* {
         listener_callbacks = &cb;
         return listener;
 
       }));
-  handler.addListener(factory, socket, Network::ListenerOptions::listenerOptionsWithBindToPort());
+  handler.addListener(factory, socket, stats_store,
+                      Network::ListenerOptions::listenerOptionsWithBindToPort());
 
   Network::MockConnection* connection = new NiceMock<Network::MockConnection>();
   EXPECT_CALL(factory, createFilterChain(_)).WillOnce(Return(false));
@@ -96,13 +98,14 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
   Network::ListenerCallbacks* listener_callbacks;
   EXPECT_CALL(*dispatcher, createListener_(_, _, _, _, _))
       .WillOnce(Invoke([&](Network::ConnectionHandler&, Network::ListenSocket&,
-                           Network::ListenerCallbacks& cb, Stats::Store&,
+                           Network::ListenerCallbacks& cb, Stats::Scope&,
                            const Network::ListenerOptions&) -> Network::Listener* {
         listener_callbacks = &cb;
         return listener;
 
       }));
-  handler.addListener(factory, socket, Network::ListenerOptions::listenerOptionsWithBindToPort());
+  handler.addListener(factory, socket, stats_store,
+                      Network::ListenerOptions::listenerOptionsWithBindToPort());
 
   EXPECT_EQ(listener, handler.findListenerByAddress(ByRef(*alt_address)));
 
@@ -115,13 +118,14 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
   Network::Listener* listener2 = new Network::MockListener();
   EXPECT_CALL(*dispatcher, createListener_(_, _, _, _, _))
       .WillOnce(Invoke([&](Network::ConnectionHandler&, Network::ListenSocket&,
-                           Network::ListenerCallbacks& cb, Stats::Store&,
+                           Network::ListenerCallbacks& cb, Stats::Scope&,
                            const Network::ListenerOptions&) -> Network::Listener* {
         listener_callbacks = &cb;
         return listener2;
 
       }));
-  handler.addListener(factory, socket2, Network::ListenerOptions::listenerOptionsWithBindToPort());
+  handler.addListener(factory, socket2, stats_store,
+                      Network::ListenerOptions::listenerOptionsWithBindToPort());
 
   EXPECT_EQ(listener, handler.findListenerByAddress(ByRef(*alt_address)));
   EXPECT_EQ(listener2, handler.findListenerByAddress(ByRef(*alt_address2)));


### PR DESCRIPTION
This breaks statsd. I also took the opportunity to plumb through Stats::Scope
properly in a bunch of places which will be needed for LDS.