### PR TITLE
Bazel support for //test/common/{common,event}/... (#415).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 BUILD
 cscope.*
 BROWSE
+.deps

--- a/BUILD.wip
+++ b/BUILD.wip
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+genrule(
+    name = "envoy_version",
+    srcs = glob([".git/**"]),
+    outs = ["version_generated.cc"],
+    cmd = "touch $@ && $(location tools/gen_git_sha.sh) $$(dirname $(location tools/gen_git_sha.sh)) $@",
+    local = 1,
+    tools = ["tools/gen_git_sha.sh"],
+)
+
+envoy_cc_library(
+    name = "version_generated",
+    srcs = ["version_generated.cc"],
+    deps = ["//source/common/common:version_includes"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,36 @@ load("//bazel:repositories.bzl", "envoy_dependencies")
 envoy_dependencies()
 
 bind(
-    name = "googletest_main",
-    actual = "@googletest//:googletest_main",
+    name = "ares",
+    actual = "@cares_git//:ares",
+)
+
+bind(
+    name = "event",
+    actual = "@libevent_git//:event",
+)
+
+bind(
+    name = "event_pthreads",
+    actual = "@libevent_git//:event_pthreads",
+)
+
+bind(
+    name = "googletest",
+    actual = "@googletest_git//:googletest",
 )
 
 bind(
     name = "spdlog",
     actual = "@spdlog_git//:spdlog",
+)
+
+bind(
+    name = "ssl",
+    actual = "@boringssl//:ssl",
+)
+
+bind(
+    name = "tclap",
+    actual = "@tclap_archive//:tclap",
 )

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -1,11 +1,15 @@
 ENVOY_COPTS = [
+    # TODO(htuch): Remove this when Bazel bringup is done.
+    "-DBAZEL_BRINGUP",
     "-fno-omit-frame-pointer",
     "-Wall",
     "-Wextra",
     "-Werror",
     "-Wnon-virtual-dtor",
     "-Woverloaded-virtual",
-    "-Wold-style-cast",
+    # TODO(htuch): Figure out how to use this in the presence of headers in
+    # openssl/tclap which use old style casts.
+    # "-Wold-style-cast",
     "-std=c++0x",
     "-includeprecompiled/precompiled.h",
 ]
@@ -20,7 +24,7 @@ def envoy_external_dep_path(dep):
 def envoy_include_prefix(path):
   if path.startswith('source/') or path.startswith('include/'):
     return '/'.join(path.split('/')[1:])
-  return path
+  return None
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
@@ -54,6 +58,7 @@ def envoy_cc_test(name,
         srcs = srcs,
         copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
         linkopts = ["-pthread"],
+        linkstatic = 1,
         deps = deps + [
             "//source/precompiled:precompiled_includes",
             "//test/precompiled:precompiled_includes",

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -1,9 +1,34 @@
 bind(
-    name = "googletest_main",
-    actual = "//ci/prebuilt:googletest_main",
+    name = "ares",
+    actual = "//ci/prebuilt:ares",
+)
+
+bind(
+    name = "event",
+    actual = "//ci/prebuilt:event",
+)
+
+bind(
+    name = "event_pthreads",
+    actual = "//ci/prebuilt:event_pthreads",
+)
+
+bind(
+    name = "googletest",
+    actual = "//ci/prebuilt:googletest",
 )
 
 bind(
     name = "spdlog",
     actual = "//ci/prebuilt:spdlog",
+)
+
+bind(
+    name = "ssl",
+    actual = "//ci/prebuilt:ssl",
+)
+
+bind(
+    name = "tclap",
+    actual = "//ci/prebuilt:tclap",
 )

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -14,10 +14,11 @@ if [[ "$1" == "bazel.debug" ]]; then
   export CC=gcc-4.9
   export CXX=g++-4.9
   export USER=bazel
-  export TEST_TMPDIR=/source
+  export TEST_TMPDIR=/source/build
   BAZEL_OPTIONS="--strategy=CppCompile=standalone --strategy=CppLink=standalone \
     --strategy=TestRunner=standalone --verbose_failures --package_path %workspace%:.."
   [[ "$BAZEL_INTERACTIVE" == "1" ]] && BAZEL_BATCH="" || BAZEL_BATCH="--batch"
+  [[ "$BAZEL_EXPUNGE" == "1" ]] && bazel clean --expunge
   bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/...
   echo "Testing..."
   bazel $BAZEL_BATCH test $BAZEL_OPTIONS --test_output=all //test/...

--- a/ci/prebuilt/BUILD.wip
+++ b/ci/prebuilt/BUILD.wip
@@ -1,11 +1,37 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "googletest_main",
+    name = "ares",
+    srcs = ["thirdparty_build/lib/libcares.a"],
+    hdrs = glob(["thirdparty_build/include/ares*.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "crypto",
+    srcs = ["thirdparty_build/lib/libcrypto.a"],
+    hdrs = glob(["thirdparty_build/include/openssl/**/*.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "event",
+    srcs = ["thirdparty_build/lib/libevent.a"],
+    hdrs = glob(["thirdparty_build/include/event2/**/*.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "event_pthreads",
+    srcs = ["thirdparty_build/lib/libevent_pthreads.a"],
+    deps = [":event"],
+)
+
+cc_library(
+    name = "googletest",
     srcs = [
         "thirdparty_build/lib/libgmock.a",
         "thirdparty_build/lib/libgtest.a",
-        "thirdparty_build/lib/libgtest_main.a",
     ],
     hdrs = glob([
         "thirdparty_build/include/gmock/**/*.h",
@@ -21,4 +47,16 @@ cc_library(
         "thirdparty/spdlog-0.11.0/include/**/*.h",
     ]),
     strip_include_prefix = "thirdparty/spdlog-0.11.0/include",
+)
+
+cc_library(
+    name = "ssl",
+    srcs = ["thirdparty_build/lib/libssl.a"],
+    deps = [":crypto"],
+)
+
+cc_library(
+    name = "tclap",
+    hdrs = glob(["thirdparty/tclap-1.2.1/include/**/*.h"]),
+    strip_include_prefix = "thirdparty/tclap-1.2.1/include",
 )

--- a/include/envoy/buffer/BUILD.wip
+++ b/include/envoy/buffer/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "buffer_includes",
+    hdrs = ["buffer.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/common/BUILD.wip
+++ b/include/envoy/common/BUILD.wip
@@ -19,4 +19,5 @@ envoy_cc_library(
 envoy_cc_library(
     name = "optional_includes",
     hdrs = ["optional.h"],
+    deps = [":base_includes"],
 )

--- a/include/envoy/event/BUILD.wip
+++ b/include/envoy/event/BUILD.wip
@@ -1,0 +1,42 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "deferred_deletable",
+    hdrs = ["deferred_deletable.h"],
+)
+
+envoy_cc_library(
+    name = "dispatcher_includes",
+    hdrs = ["dispatcher.h"],
+    deps = [
+        ":deferred_deletable",
+        ":file_event_includes",
+        ":signal_includes",
+        ":timer_includes",
+        "//include/envoy/filesystem:filesystem_includes",
+        "//include/envoy/network:connection_handler_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:dns_includes",
+        "//include/envoy/network:listen_socket_includes",
+        "//include/envoy/network:listener_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "file_event_includes",
+    hdrs = ["file_event.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "signal_includes",
+    hdrs = ["signal.h"],
+)
+
+envoy_cc_library(
+    name = "timer_includes",
+    hdrs = ["timer.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/filesystem/BUILD.wip
+++ b/include/envoy/filesystem/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "filesystem_includes",
+    hdrs = ["filesystem.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/json/BUILD.wip
+++ b/include/envoy/json/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "json_object_includes",
+    hdrs = ["json_object.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/network/BUILD.wip
+++ b/include/envoy/network/BUILD.wip
@@ -1,0 +1,64 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "address_includes",
+    hdrs = ["address.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "connection_includes",
+    hdrs = ["connection.h"],
+    deps = [
+        ":address_includes",
+        ":filter_includes",
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/ssl:connection_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "connection_handler_includes",
+    hdrs = ["connection_handler.h"],
+    deps = [
+        ":listen_socket_includes",
+        ":listener_includes",
+        "//include/envoy/ssl:context_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "dns_includes",
+    hdrs = ["dns.h"],
+    deps = [
+        "//include/envoy/common:base_includes",
+        "//include/envoy/network:address_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_includes",
+    hdrs = ["filter.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/upstream:host_description_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "listen_socket_includes",
+    hdrs = ["listen_socket.h"],
+    deps = [
+        "//include/envoy/common:base_includes",
+        "//include/envoy/network:address_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "listener_includes",
+    hdrs = ["listener.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/exception.h"
+#include "envoy/network/connection.h"
 
 namespace Network {
 

--- a/include/envoy/runtime/BUILD.wip
+++ b/include/envoy/runtime/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "runtime_includes",
+    hdrs = ["runtime.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/server/BUILD.wip
+++ b/include/envoy/server/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "options_includes",
+    hdrs = ["options.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/ssl/BUILD.wip
+++ b/include/envoy/ssl/BUILD.wip
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "connection_includes",
+    hdrs = ["connection.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "context_includes",
+    hdrs = ["context.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "context_config_includes",
+    hdrs = ["context_config.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "context_manager_includes",
+    hdrs = ["context_manager.h"],
+    deps = [
+        ":context_config_includes",
+        ":context_includes",
+        "//include/envoy/common:base_includes",
+        "//include/envoy/stats:stats_includes",
+    ],
+)

--- a/include/envoy/stats/BUILD.wip
+++ b/include/envoy/stats/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "stats_includes",
+    hdrs = ["stats.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)
+
+envoy_cc_library(
+    name = "stats_macros",
+    hdrs = ["stats_macros.h"],
+    deps = [":stats_includes"],
+)

--- a/include/envoy/thread/BUILD.wip
+++ b/include/envoy/thread/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "thread_includes",
+    hdrs = ["thread.h"],
+    deps = ["//include/envoy/common:base_includes"],
+)

--- a/include/envoy/upstream/BUILD.wip
+++ b/include/envoy/upstream/BUILD.wip
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "host_description_includes",
+    hdrs = ["host_description.h"],
+    deps = [
+        ":outlier_detection_includes",
+        "//include/envoy/network:address_includes",
+        "//include/envoy/stats:stats_macros",
+    ],
+)
+
+envoy_cc_library(
+    name = "outlier_detection_includes",
+    hdrs = ["outlier_detection.h"],
+    deps = [
+        "//include/envoy/common:base_includes",
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/common:time_includes",
+    ],
+)

--- a/source/common/buffer/BUILD.wip
+++ b/source/common/buffer/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "buffer_lib",
+    srcs = ["buffer_impl.cc"],
+    hdrs = ["buffer_impl.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//source/common/event:libevent_lib",
+    ],
+)

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -1,4 +1,5 @@
 #include "common/buffer/buffer_impl.h"
+
 #include "common/common/assert.h"
 
 #include "event2/buffer.h"

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -1,5 +1,4 @@
-#include "buffer_impl.h"
-
+#include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 
 #include "event2/buffer.h"

--- a/source/common/common/BUILD.wip
+++ b/source/common/common/BUILD.wip
@@ -3,8 +3,95 @@ package(default_visibility = ["//visibility:public"])
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
 envoy_cc_library(
+    name = "assert_lib",
+    hdrs = ["assert.h"],
+    deps = [":logger_lib"],
+)
+
+envoy_cc_library(
+    name = "base64_lib",
+    srcs = ["base64.cc"],
+    hdrs = ["base64.h"],
+    deps = [
+        ":empty_string_lib",
+        "//include/envoy/buffer:buffer_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "c_smart_ptr_lib",
+    hdrs = ["c_smart_ptr.h"],
+)
+
+envoy_cc_library(
+    name = "empty_string_lib",
+    hdrs = ["empty_string.h"],
+)
+
+envoy_cc_library(
+    name = "enum_to_int_lib",
+    hdrs = ["enum_to_int.h"],
+)
+
+envoy_cc_library(
+    name = "hex_lib",
+    srcs = ["hex.cc"],
+    hdrs = ["hex.h"],
+    deps = [
+        ":utility_lib",
+        "//include/envoy/common:base_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "linked_object_lib",
+    hdrs = ["linked_object.h"],
+    deps = [":assert_lib"],
+)
+
+envoy_cc_library(
+    name = "logger_lib",
+    srcs = ["logger.cc"],
+    hdrs = ["logger.h"],
+    deps = [
+        ":macros_lib",
+        "//include/envoy/thread:thread_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "thread_lib",
+    srcs = ["thread.cc"],
+    hdrs = ["thread.h"],
+    deps = [
+        ":assert_lib",
+        ":macros_lib",
+        "//include/envoy/thread:thread_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "macros_lib",
+    hdrs = ["macros.h"],
+)
+
+envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
     deps = ["//include/envoy/common:time_includes"],
+)
+
+envoy_cc_library(
+    name = "version_includes",
+    hdrs = ["version.h"],
+)
+
+envoy_cc_library(
+    name = "version_lib",
+    srcs = ["version.cc"],
+    deps = [
+        ":version_includes",
+        "//:version_generated",
+    ],
 )

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "logger.h"
+#include "common/common/logger.h"
 
 /**
  * assert macro that uses our builtin logging which gives us thread ID and can log to various

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -1,4 +1,5 @@
 #include "common/common/base64.h"
+
 #include "common/common/empty_string.h"
 
 static constexpr char CHAR_TABLE[] =

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -1,5 +1,5 @@
-#include "base64.h"
-#include "empty_string.h"
+#include "common/common/base64.h"
+#include "common/common/empty_string.h"
 
 static constexpr char CHAR_TABLE[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -1,6 +1,7 @@
+#include "common/common/hex.h"
+
 #include "envoy/common/exception.h"
 
-#include "common/common/hex.h"
 #include "common/common/utility.h"
 
 std::string Hex::encode(const uint8_t* data, size_t length) {

--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -1,7 +1,7 @@
-#include "hex.h"
-#include "utility.h"
-
 #include "envoy/common/exception.h"
+
+#include "common/common/hex.h"
+#include "common/common/utility.h"
 
 std::string Hex::encode(const uint8_t* data, size_t length) {
   static const char* const digits = "0123456789abcdef";

--- a/source/common/common/linked_object.h
+++ b/source/common/common/linked_object.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "assert.h"
+#include "common/common/assert.h"
 
 /**
  * Mixin class that allows an object contained in a unique pointer to be easily linked and unlinked

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -1,4 +1,4 @@
-#include "logger.h"
+#include "common/common/logger.h"
 
 #include "envoy/thread/thread.h"
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "macros.h"
-
 #include "envoy/thread/thread.h"
+
+#include "common/common/macros.h"
 
 namespace Logger {
 

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -1,5 +1,6 @@
-#include "assert.h"
-#include "thread.h"
+#include "common/common/assert.h"
+#include "common/common/macros.h"
+#include "common/common/thread.h"
 
 #include <sys/syscall.h>
 

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -1,6 +1,7 @@
+#include "common/common/thread.h"
+
 #include "common/common/assert.h"
 #include "common/common/macros.h"
-#include "common/common/thread.h"
 
 #include <sys/syscall.h>
 

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -1,4 +1,4 @@
-#include "version.h"
+#include "common/common/version.h"
 
 std::string VersionInfo::version() {
   return fmt::format("{}/{}", GIT_SHA.substr(0, 6),

--- a/source/common/event/BUILD.wip
+++ b/source/common/event/BUILD.wip
@@ -1,0 +1,55 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+# Needed to break circular dependency between DispatcherImpl/ConnectionImpl/ListenerImpl/
+# TODO(htuch): Can we reorganize packages and hierarchy to avoid the need for this hack?
+envoy_cc_library(
+    name = "dispatcher_lib_includes",
+    hdrs = [
+        "dispatcher_impl.h",
+        "event_impl_base.h",
+        "file_event_impl.h",
+    ],
+    deps = [
+        ":libevent_lib",
+        "//include/envoy/event:dispatcher_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "dispatcher_lib",
+    srcs = [
+        "dispatcher_impl.cc",
+        "event_impl_base.cc",
+        "file_event_impl.cc",
+        "signal_impl.cc",
+        "timer_impl.cc",
+    ],
+    hdrs = [
+        "signal_impl.h",
+        "timer_impl.h",
+    ],
+    deps = [
+        ":dispatcher_lib_includes",
+        "//include/envoy/event:file_event_includes",
+        "//source/common/filesystem:watcher_lib",
+        "//source/common/network:connection_lib",
+        "//source/common/network:dns_lib",
+        "//source/common/network:listener_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "libevent_lib",
+    srcs = ["libevent.cc"],
+    hdrs = ["libevent.h"],
+    external_deps = [
+        "event",
+        "event_pthreads",
+    ],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:c_smart_ptr_lib",
+    ],
+)

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -1,7 +1,8 @@
+#include "common/event/dispatcher_impl.h"
+
 #include "envoy/network/listener.h"
 #include "envoy/network/listen_socket.h"
 
-#include "common/event/dispatcher_impl.h"
 #include "common/event/file_event_impl.h"
 #include "common/event/signal_impl.h"
 #include "common/event/timer_impl.h"

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -1,11 +1,10 @@
-#include "dispatcher_impl.h"
-#include "file_event_impl.h"
-#include "signal_impl.h"
-#include "timer_impl.h"
-
 #include "envoy/network/listener.h"
 #include "envoy/network/listen_socket.h"
 
+#include "common/event/dispatcher_impl.h"
+#include "common/event/file_event_impl.h"
+#include "common/event/signal_impl.h"
+#include "common/event/timer_impl.h"
 #include "common/filesystem/watcher_impl.h"
 #include "common/network/connection_impl.h"
 #include "common/network/dns_impl.h"

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "libevent.h"
-
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection_handler.h"
 
 #include "common/common/logger.h"
+#include "common/event/libevent.h"
 
 namespace Event {
 

--- a/source/common/event/event_impl_base.cc
+++ b/source/common/event/event_impl_base.cc
@@ -1,4 +1,4 @@
-#include "event_impl_base.h"
+#include "common/event/event_impl_base.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -1,9 +1,8 @@
-#include "dispatcher_impl.h"
-#include "file_event_impl.h"
+#include "common/common/assert.h"
+#include "common/event/dispatcher_impl.h"
+#include "common/event/file_event_impl.h"
 
 #include "event2/event.h"
-
-#include "common/common/assert.h"
 
 namespace Event {
 

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -1,6 +1,7 @@
+#include "common/event/file_event_impl.h"
+
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
-#include "common/event/file_event_impl.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "event_impl_base.h"
-
 #include "envoy/event/file_event.h"
+
+#include "common/event/dispatcher_impl.h"
+#include "common/event/event_impl_base.h"
 
 namespace Event {
 

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -1,5 +1,6 @@
-#include "common/common/assert.h"
 #include "common/event/libevent.h"
+
+#include "common/common/assert.h"
 
 #include "event2/thread.h"
 

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -1,6 +1,5 @@
-#include "libevent.h"
-
 #include "common/common/assert.h"
+#include "common/event/libevent.h"
 
 #include "event2/thread.h"
 

--- a/source/common/event/signal_impl.cc
+++ b/source/common/event/signal_impl.cc
@@ -1,5 +1,5 @@
-#include "dispatcher_impl.h"
-#include "signal_impl.h"
+#include "common/event/dispatcher_impl.h"
+#include "common/event/signal_impl.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/signal_impl.cc
+++ b/source/common/event/signal_impl.cc
@@ -1,5 +1,6 @@
-#include "common/event/dispatcher_impl.h"
 #include "common/event/signal_impl.h"
+
+#include "common/event/dispatcher_impl.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/signal_impl.h
+++ b/source/common/event/signal_impl.h
@@ -2,6 +2,7 @@
 
 #include "envoy/event/signal.h"
 
+#include "common/event/dispatcher_impl.h"
 #include "common/event/event_impl_base.h"
 
 namespace Event {

--- a/source/common/event/signal_impl.h
+++ b/source/common/event/signal_impl.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "event_impl_base.h"
-
 #include "envoy/event/signal.h"
+
+#include "common/event/event_impl_base.h"
 
 namespace Event {
 

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -1,7 +1,6 @@
-#include "dispatcher_impl.h"
-#include "timer_impl.h"
-
 #include "common/common/assert.h"
+#include "common/event/dispatcher_impl.h"
+#include "common/event/timer_impl.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -1,6 +1,7 @@
+#include "common/event/timer_impl.h"
+
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
-#include "common/event/timer_impl.h"
 
 #include "event2/event.h"
 

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "event_impl_base.h"
-
 #include "envoy/event/timer.h"
+
+#include "common/event/event_impl_base.h"
 
 namespace Event {
 

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -2,6 +2,7 @@
 
 #include "envoy/event/timer.h"
 
+#include "common/event/dispatcher_impl.h"
 #include "common/event/event_impl_base.h"
 
 namespace Event {

--- a/source/common/filesystem/BUILD.wip
+++ b/source/common/filesystem/BUILD.wip
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "watcher_lib",
+    srcs = ["watcher_impl.cc"],
+    hdrs = ["watcher_impl.h"],
+    deps = [
+        "//include/envoy/common:base_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/common:utility_lib",
+    ],
+)

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -1,10 +1,11 @@
+#include "common/filesystem/watcher_impl.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
-#include "common/filesystem/watcher_impl.h"
 
 #include <sys/inotify.h>
 

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -1,11 +1,10 @@
-#include "watcher_impl.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
+#include "common/filesystem/watcher_impl.h"
 
 #include <sys/inotify.h>
 

--- a/source/common/network/BUILD.wip
+++ b/source/common/network/BUILD.wip
@@ -1,0 +1,104 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "address_lib",
+    srcs = ["address_impl.cc"],
+    hdrs = ["address_impl.h"],
+    deps = [
+        "//include/envoy/network:address_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "connection_lib",
+    srcs = ["connection_impl.cc"],
+    hdrs = ["connection_impl.h"],
+    deps = [
+        ":filter_manager_lib",
+        ":utility_lib",
+        "//include/envoy/network:connection_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:empty_string_lib",
+        "//source/common/common:enum_to_int_lib",
+        "//source/common/event:dispatcher_lib_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "dns_lib",
+    srcs = ["dns_impl.cc"],
+    hdrs = ["dns_impl.h"],
+    external_deps = ["ares"],
+    deps = [
+        ":address_lib",
+        ":utility_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/network:dns_includes",
+        "//source/common/common:linked_object_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_manager_lib",
+    srcs = ["filter_manager_impl.cc"],
+    hdrs = ["filter_manager_impl.h"],
+    deps = [
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:filter_includes",
+        "//source/common/common:linked_object_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "listener_lib",
+    srcs = [
+        "listener_impl.cc",
+        "proxy_protocol.cc",
+    ],
+    hdrs = [
+        "listener_impl.h",
+        "proxy_protocol.h",
+    ],
+    deps = [
+        ":listen_socket_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/network:listener_includes",
+        "//source/common/common:empty_string_lib",
+        "//source/common/common:linked_object_lib",
+        "//source/common/event:dispatcher_lib_includes",
+        "//source/common/network:address_lib",
+        "//source/common/network:connection_lib",
+        "//source/common/ssl:connection_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "listen_socket_lib",
+    srcs = ["listen_socket_impl.cc"],
+    hdrs = ["listen_socket_impl.h"],
+    deps = [
+        ":utility_lib",
+        "//include/envoy/network:listen_socket_includes",
+        "//source/common/common:utility_lib",
+        "//source/common/network:address_lib",
+        "//source/common/ssl:context_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    deps = [
+        "//include/envoy/json:json_object_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/stats:stats_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/network:address_lib",
+    ],
+)

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,8 +1,9 @@
+#include "common/network/address_impl.h"
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
-#include "common/network/address_impl.h"
 
 namespace Network {
 namespace Address {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,9 +1,8 @@
-#include "address_impl.h"
-
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
+#include "common/network/address_impl.h"
 
 namespace Network {
 namespace Address {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1,6 +1,3 @@
-#include "connection_impl.h"
-#include "utility.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/filter.h"
@@ -10,6 +7,7 @@
 #include "common/common/enum_to_int.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/network/address_impl.h"
+#include "common/network/connection_impl.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1,3 +1,5 @@
+#include "common/network/connection_impl.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/filter.h"
@@ -7,7 +9,6 @@
 #include "common/common/enum_to_int.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/network/address_impl.h"
-#include "common/network/connection_impl.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "filter_manager_impl.h"
-
 #include "envoy/network/connection.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/logger.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/event/libevent.h"
+#include "common/network/filter_manager_impl.h"
 
 namespace Network {
 

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -1,5 +1,6 @@
-#include "common/common/assert.h"
 #include "common/network/dns_impl.h"
+
+#include "common/common/assert.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -1,6 +1,5 @@
-#include "dns_impl.h"
-
 #include "common/common/assert.h"
+#include "common/network/dns_impl.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -1,8 +1,7 @@
-#include "filter_manager_impl.h"
-
 #include "envoy/network/connection.h"
 
 #include "common/common/assert.h"
+#include "common/network/filter_manager_impl.h"
 
 namespace Network {
 

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -1,7 +1,8 @@
+#include "common/network/filter_manager_impl.h"
+
 #include "envoy/network/connection.h"
 
 #include "common/common/assert.h"
-#include "common/network/filter_manager_impl.h"
 
 namespace Network {
 

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -1,8 +1,9 @@
+#include "common/network/listen_socket_impl.h"
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
 #include "common/network/address_impl.h"
-#include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -1,10 +1,8 @@
-#include "listen_socket_impl.h"
-#include "utility.h"
-
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
 #include "common/network/address_impl.h"
+#include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -1,3 +1,5 @@
+#include "common/network/listener_impl.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/network/connection_handler.h"
 
@@ -6,7 +8,6 @@
 #include "common/event/file_event_impl.h"
 #include "common/network/address_impl.h"
 #include "common/network/connection_impl.h"
-#include "common/network/listener_impl.h"
 #include "common/network/utility.h"
 #include "common/ssl/connection_impl.h"
 

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -1,6 +1,3 @@
-#include "listener_impl.h"
-#include "utility.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/network/connection_handler.h"
 
@@ -9,6 +6,8 @@
 #include "common/event/file_event_impl.h"
 #include "common/network/address_impl.h"
 #include "common/network/connection_impl.h"
+#include "common/network/listener_impl.h"
+#include "common/network/utility.h"
 #include "common/ssl/connection_impl.h"
 
 #include "event2/listener.h"

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "listen_socket_impl.h"
-#include "proxy_protocol.h"
-
 #include "envoy/network/listener.h"
 #include "envoy/network/connection_handler.h"
 
 #include "common/event/dispatcher_impl.h"
 #include "common/event/libevent.h"
+#include "common/network/listen_socket_impl.h"
+#include "common/network/proxy_protocol.h"
 
 #include "event2/event.h"
 

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -1,3 +1,5 @@
+#include "common/network/proxy_protocol.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
@@ -6,7 +8,6 @@
 #include "common/common/empty_string.h"
 #include "common/network/address_impl.h"
 #include "common/network/listener_impl.h"
-#include "common/network/proxy_protocol.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -1,13 +1,12 @@
-#include "address_impl.h"
-#include "listener_impl.h"
-#include "proxy_protocol.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/empty_string.h"
+#include "common/network/address_impl.h"
+#include "common/network/listener_impl.h"
+#include "common/network/proxy_protocol.h"
 #include "common/network/utility.h"
 
 namespace Network {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -1,5 +1,3 @@
-#include "utility.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
@@ -7,6 +5,7 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/network/address_impl.h"
+#include "common/network/utility.h"
 
 #include <ifaddrs.h>
 #include <linux/netfilter_ipv4.h>

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -1,3 +1,5 @@
+#include "common/network/utility.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
@@ -5,7 +7,6 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/network/address_impl.h"
-#include "common/network/utility.h"
 
 #include <ifaddrs.h>
 #include <linux/netfilter_ipv4.h>

--- a/source/common/ssl/BUILD.wip
+++ b/source/common/ssl/BUILD.wip
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "connection_lib",
+    srcs = ["connection_impl.cc"],
+    hdrs = ["connection_impl.h"],
+    deps = [
+        ":context_lib",
+        "//source/common/common:empty_string_lib",
+        "//source/common/event:dispatcher_lib_includes",
+        "//source/common/network:connection_lib",
+        "//source/common/network:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "context_lib",
+    srcs = [
+        "context_impl.cc",
+        "context_manager_impl.cc",
+    ],
+    hdrs = [
+        "context_impl.h",
+        "context_manager_impl.h",
+    ],
+    deps = [
+        ":openssl_lib",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/ssl:context_includes",
+        "//include/envoy/ssl:context_manager_includes",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/common:hex_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "openssl_lib",
+    srcs = ["openssl.cc"],
+    hdrs = ["openssl.h"],
+    external_deps = ["ssl"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:c_smart_ptr_lib",
+    ],
+)

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -1,9 +1,8 @@
-#include "connection_impl.h"
-
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/hex.h"
 #include "common/network/utility.h"
+#include "common/ssl/connection_impl.h"
 
 #include "openssl/err.h"
 #include "openssl/x509v3.h"

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -1,8 +1,9 @@
+#include "common/ssl/connection_impl.h"
+
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/hex.h"
 #include "common/network/utility.h"
-#include "common/ssl/connection_impl.h"
 
 #include "openssl/err.h"
 #include "openssl/x509v3.h"

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "context_impl.h"
-
 #include "common/network/connection_impl.h"
+#include "common/ssl/context_impl.h"
 
 namespace Ssl {
 

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -1,10 +1,9 @@
-#include "context_impl.h"
-
 #include "envoy/common/exception.h"
 #include "envoy/runtime/runtime.h"
 
 #include "common/common/assert.h"
 #include "common/common/hex.h"
+#include "common/ssl/context_impl.h"
 
 #include "openssl/x509v3.h"
 

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -1,9 +1,10 @@
+#include "common/ssl/context_impl.h"
+
 #include "envoy/common/exception.h"
 #include "envoy/runtime/runtime.h"
 
 #include "common/common/assert.h"
 #include "common/common/hex.h"
-#include "common/ssl/context_impl.h"
 
 #include "openssl/x509v3.h"
 

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "context_impl.h"
-#include "context_manager_impl.h"
-#include "openssl.h"
+#include "common/ssl/context_impl.h"
+#include "common/ssl/context_manager_impl.h"
+#include "common/ssl/openssl.h"
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/ssl/context.h"

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -1,5 +1,6 @@
-#include "common/ssl/context_impl.h"
 #include "common/ssl/context_manager_impl.h"
+
+#include "common/ssl/context_impl.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -1,5 +1,5 @@
-#include "context_impl.h"
-#include "context_manager_impl.h"
+#include "common/ssl/context_impl.h"
+#include "common/ssl/context_manager_impl.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/ssl/openssl.cc
+++ b/source/common/ssl/openssl.cc
@@ -1,6 +1,5 @@
-#include "openssl.h"
-
 #include "common/common/assert.h"
+#include "common/ssl/openssl.h"
 
 #include "openssl/rand.h"
 #include "openssl/ssl.h"

--- a/source/common/ssl/openssl.cc
+++ b/source/common/ssl/openssl.cc
@@ -1,5 +1,6 @@
-#include "common/common/assert.h"
 #include "common/ssl/openssl.h"
+
+#include "common/common/assert.h"
 
 #include "openssl/rand.h"
 #include "openssl/ssl.h"

--- a/source/server/BUILD.wip
+++ b/source/server/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "options_lib",
+    srcs = ["options_impl.cc"],
+    hdrs = ["options_impl.h"],
+    external_deps = ["tclap"],
+    deps = [
+        "//include/envoy/server:options_includes",
+        "//source/common/common:macros_lib",
+        "//source/common/common:version_lib",
+    ],
+)

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -1,4 +1,4 @@
-#include "options_impl.h"
+#include "server/options_impl.h"
 
 #include "common/common/macros.h"
 #include "common/common/version.h"

--- a/test/BUILD.wip
+++ b/test/BUILD.wip
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "main",
+    srcs = ["main.cc"],
+    external_deps = ["googletest"],
+    deps = [
+        "//source/common/common:thread_lib",
+        "//source/common/common:version_lib",
+        "//source/common/event:libevent_lib",
+        "//source/common/ssl:openssl_lib",
+        "//source/server:options_lib",
+    ],
+)

--- a/test/common/common/BUILD.wip
+++ b/test/common/common/BUILD.wip
@@ -1,6 +1,27 @@
 load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
 
 envoy_cc_test(
+    name = "base64_test",
+    srcs = ["base64_test.cc"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:base64_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "hex_test",
+    srcs = ["hex_test.cc"],
+    deps = ["//source/common/common:hex_lib"],
+)
+
+envoy_cc_test(
+    name = "optional_test",
+    srcs = ["optional_test.cc"],
+    deps = ["//include/envoy/common:optional_includes"],
+)
+
+envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
     deps = ["//source/common/common:utility_lib"],

--- a/test/common/event/BUILD.wip
+++ b/test/common/event/BUILD.wip
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+envoy_cc_test(
+    name = "dispatcher_impl_test",
+    srcs = ["dispatcher_impl_test.cc"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//test/mocks:common_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "file_event_impl_test",
+    srcs = ["file_event_impl_test.cc"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//test/mocks:common_lib",
+    ],
+)

--- a/test/main.cc
+++ b/test/main.cc
@@ -5,7 +5,12 @@
 #include "common/event/libevent.h"
 #include "common/ssl/openssl.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#ifndef BAZEL_BRINGUP
 #include "test/integration/integration.h"
+#endif
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleMock(&argc, argv);
@@ -15,8 +20,10 @@ int main(int argc, char** argv) {
   OptionsImpl options(argc, argv, "1", spdlog::level::err);
   Thread::MutexBasicLockable lock;
   Logger::Registry::initialize(options.logLevel(), lock);
+#ifndef BAZEL_BRINGUP
   BaseIntegrationTest::default_log_level_ =
       static_cast<spdlog::level::level_enum>(options.logLevel());
+#endif
 
   return RUN_ALL_TESTS();
 }

--- a/test/mocks/BUILD.wip
+++ b/test/mocks/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "common_lib",
+    srcs = ["common.cc"],
+    hdrs = ["common.h"],
+    deps = [
+        "//include/envoy/common:time_includes",
+        "//test/precompiled:precompiled_includes",
+    ],
+)

--- a/test/mocks/common.cc
+++ b/test/mocks/common.cc
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "test/mocks/common.h"
 
 ReadyWatcher::ReadyWatcher() {}
 ReadyWatcher::~ReadyWatcher() {}

--- a/test/precompiled/BUILD.wip
+++ b/test/precompiled/BUILD.wip
@@ -1,12 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
-cc_library(
+envoy_cc_library(
     name = "precompiled_includes",
     hdrs = ["precompiled_test.h"],
+    external_deps = ["googletest"],
     deps = [
-        envoy_external_dep_path("googletest_main"),
+        "//test:main",
         "//test/test_common:printers_includes",
     ],
 )


### PR DESCRIPTION
In addition to the handful of additional tests, this patch introduces additional rules covering ~30%
of the build targets we will need for Envoy build/test, which are transitiviely depended on by the
tests. External deps added for boringssl, c-ares, libevent and tclap.