### PR TITLE
bazel: eliminate compiler relative paths from copts (#415).

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -7,14 +7,20 @@ ENVOY_COPTS = [
     "-Woverloaded-virtual",
     "-Wold-style-cast",
     "-std=c++0x",
-    "-includesource/precompiled/precompiled.h",
-    "-iquoteinclude",
-    "-iquotesource",
+    "-includeprecompiled/precompiled.h",
 ]
 
 # References to Envoy external dependencies should be wrapped with this function.
 def envoy_external_dep_path(dep):
     return "//external:%s" % dep
+
+# Transform the package path (e.g. include/envoy/common) into a path for
+# exporting the package headers at (e.g. envoy/common). Source files can then
+# include using this path scheme (e.g. #include "envoy/common/time.h").
+def envoy_include_prefix(path):
+  if path.startswith('source/') or path.startswith('include/'):
+    return '/'.join(path.split('/')[1:])
+  return path
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
@@ -36,6 +42,7 @@ def envoy_cc_library(name,
             "//source/precompiled:precompiled_includes",
         ],
         alwayslink = alwayslink,
+        include_prefix = envoy_include_prefix(PACKAGE_NAME),
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/sync-from-wip.sh
+++ b/bazel/sync-from-wip.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Copy all BUILD.wip files to BUILD.
+for n in `find . -name BUILD.wip`;
+do
+  cp -f $n $(dirname $n)/BUILD
+done

--- a/bazel/sync-to-wip.sh
+++ b/bazel/sync-to-wip.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Copy all BUILD files to BUILD.wip and stage in git index.
+for n in `find . -name BUILD`;
+do
+  cp -f $n $n.wip
+  git add $n.wip
+done

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -1,4 +1,4 @@
-#include "utility.h"
+#include "common/common/utility.h"
 
 std::string DateFormatter::fromTime(const SystemTime& time) {
   return fromTimeT(std::chrono::system_clock::to_time_t(time));

--- a/source/precompiled/BUILD.wip
+++ b/source/precompiled/BUILD.wip
@@ -5,5 +5,6 @@ load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
 cc_library(
     name = "precompiled_includes",
     hdrs = ["precompiled.h"],
+    include_prefix = "precompiled",
     deps = [envoy_external_dep_path("spdlog")],
 )


### PR DESCRIPTION
Previously, when Envoy was included as an external dependency in the Istio build, the use of
compiler relative paths broke the build, since something like "-iquoteinclude" actually needed to be
"-iquoteexternal/envoy_git/include", and Bazel isn't able to transform raw copts.

This patch makes use of include_prefix to preserve the current Envoy #include idioms for include/
and source/ without having to resort to -iquote. The only drawback is we lose the ability to have
foo.cc refer to foo.h in something like source/common/common via #include "foo.h" - it must be
expressed as #include "common/common/foo.h". We will need to make these changes across the code base
as we Bazelify.

As a bonus, added some scripts to make it easier to deal with syncing BUILD files post #602.