### PR TITLE
Increase test coverage for server InstanceImpl

### DIFF
--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -8,7 +8,11 @@ using testing::SaveArg;
 
 namespace Server {
 
-MockOptions::MockOptions() {}
+MockOptions::MockOptions(const std::string& path) : path_(path) {
+  ON_CALL(*this, fileFlushIntervalMsec()).WillByDefault(Return(std::chrono::milliseconds(1000)));
+  ON_CALL(*this, restartEpoch()).WillByDefault(Return(0));
+  ON_CALL(*this, configPath()).WillByDefault(ReturnRef(path_));
+}
 MockOptions::~MockOptions() {}
 
 MockAdmin::MockAdmin() {}

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -9,8 +9,6 @@ using testing::SaveArg;
 namespace Server {
 
 MockOptions::MockOptions(const std::string& path) : path_(path) {
-  ON_CALL(*this, fileFlushIntervalMsec()).WillByDefault(Return(std::chrono::milliseconds(1000)));
-  ON_CALL(*this, restartEpoch()).WillByDefault(Return(0));
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(path_));
 }
 MockOptions::~MockOptions() {}

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -27,7 +27,9 @@ namespace Server {
 
 class MockOptions : public Options {
 public:
-  MockOptions();
+  // If it is not provided the configPath will be an empty string in the mock.
+  MockOptions() : MockOptions(std::string()) {}
+  MockOptions(const std::string& path);
   ~MockOptions();
 
   MOCK_METHOD0(baseId, uint64_t());
@@ -38,6 +40,8 @@ public:
   MOCK_METHOD0(parentShutdownTime, std::chrono::seconds());
   MOCK_METHOD0(restartEpoch, uint64_t());
   MOCK_METHOD0(fileFlushIntervalMsec, std::chrono::milliseconds());
+
+  std::string path_;
 };
 
 class MockAdmin : public Admin {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -27,7 +27,6 @@ namespace Server {
 
 class MockOptions : public Options {
 public:
-  // If it is not provided the configPath will be an empty string in the mock.
   MockOptions() : MockOptions(std::string()) {}
   MockOptions(const std::string& path);
   ~MockOptions();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1,11 +1,10 @@
 #include "server/server.h"
 
+#include "test/integration/server.h"
 #include "test/mocks/common.h"
 #include "test/mocks/init/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
-
-#include "test/integration/server.h" // for TestDrainManager, TestIsolatedStoreImpl
 
 using testing::_;
 using testing::InSequence;
@@ -67,8 +66,7 @@ protected:
 };
 
 TEST_F(ServerInstanceImplTest, NoListenSocketFds) {
-  std::string bad_tcp_url("tcp://255.255.255.255:80");
-  EXPECT_EQ(server_.getListenSocketFd(bad_tcp_url), -1);
+  EXPECT_EQ(server_.getListenSocketFd("tcp://255.255.255.255:80"), -1);
 }
 
 } // Server

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -2,6 +2,10 @@
 
 #include "test/mocks/common.h"
 #include "test/mocks/init/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/stats/mocks.h"
+
+#include "test/integration/server.h" // for TestDrainManager, TestIsolatedStoreImpl
 
 using testing::_;
 using testing::InSequence;
@@ -27,6 +31,44 @@ TEST(InitManagerImplTest, Targets) {
   manager.initialize([&]() -> void { initialized.ready(); });
   EXPECT_CALL(initialized, ready());
   target.callback_();
+}
+
+class TestComponentFactory : public ComponentFactory {
+public:
+  Server::DrainManagerPtr createDrainManager(Server::Instance&) override {
+    return Server::DrainManagerPtr{new Server::TestDrainManager()};
+  }
+  Runtime::LoaderPtr createRuntime(Server::Instance& server,
+                                   Server::Configuration::Initial& config) override {
+    return Server::InstanceUtil::createRuntime(server, config);
+  }
+};
+
+// Class creates minimally viable server instance for testing.
+class ServerInstanceImplTest : public testing::Test {
+protected:
+  ServerInstanceImplTest()
+      : options_(std::string("test/config/integration/server.json")),
+        server_(options_, hooks_, restart_, stats_store_, fakelock_, component_factory_,
+                local_info_) {}
+  void TearDown() {
+    server_.clusterManager().shutdown();
+    server_.threadLocal().shutdownThread();
+  }
+
+  testing::NiceMock<MockOptions> options_;
+  DefaultTestHooks hooks_;
+  testing::NiceMock<MockHotRestart> restart_;
+  Stats::TestIsolatedStoreImpl stats_store_;
+  Thread::MutexBasicLockable fakelock_;
+  TestComponentFactory component_factory_;
+  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  InstanceImpl server_;
+};
+
+TEST_F(ServerInstanceImplTest, NoListenSocketFds) {
+  std::string bad_tcp_url("tcp://255.255.255.255:80");
+  EXPECT_EQ(server_.getListenSocketFd(bad_tcp_url), -1);
 }
 
 } // Server


### PR DESCRIPTION
The failed-to-find case of InstanceImpl::getListenSocketFd() was
previously not covered by testing.  This change introduces fixture &
mocking changes required to unit test the server itself (InstanceImpl)
and create a test case that exercises the return -1 case in
getListenSocketFd().