### PR TITLE
Rate limit filter: Specify applicable request types

### DIFF
--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -36,8 +36,11 @@ stage
 
 request_type
   *(optional, string)* The type of requests the filter should apply to. The supported
-  types are *internal*, *external* or *both*. The filter defaults to *both*, and it
-  will apply to all requests.
+  types are *internal*, *external* or *both*. A request is considered internal, if
+  :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is set to true. If
+  :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
+  request is considered external. The filter defaults to *both*, and it will apply to all request
+  types.
 
 Statistics
 ----------

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -20,7 +20,8 @@ If the rate limit service is called, and the response for any of the descriptors
     "name": "rate_limit",
     "config": {
       "domain": "...",
-      "stage": "..."
+      "stage": "...",
+      "request_type": "..."
     }
   }
 
@@ -32,6 +33,13 @@ stage
   number. If not set, the default stage number is 0.
 
   **NOTE:** The filter supports a range of 0 - 10 inclusively for stage numbers.
+
+request_type
+  *(optional, string)* The types of requests that the filter should apply to. The supported
+  types are *internal*, *external* or *both*. If not specified, the filter will default to *both*.
+  A request is internal, if
+  :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>` respects RFC1918 or is a
+  loopback address.
 
 Statistics
 ----------

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -35,11 +35,9 @@ stage
   **NOTE:** The filter supports a range of 0 - 10 inclusively for stage numbers.
 
 request_type
-  *(optional, string)* The types of requests that the filter should apply to. The supported
-  types are *internal*, *external* or *both*. If not specified, the filter will default to *both*.
-  A request is internal, if
-  :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>` respects RFC1918 or is a
-  loopback address.
+  *(optional, string)* The type of requests the filter should apply to. The supported
+  types are *internal*, *external* or *both*. The filter defaults to *both*, and it
+  will apply to all requests.
 
 Statistics
 ----------

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -36,7 +36,7 @@ stage
 
 request_type
   *(optional, string)* The type of requests the filter should apply to. The supported
-  types are *internal*, *external* or *both*. A request is considered internal, if
+  types are *internal*, *external* or *both*. A request is considered internal if
   :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is set to true. If
   :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   request is considered external. The filter defaults to *both*, and it will apply to all request

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -17,7 +17,8 @@ const std::unique_ptr<const Http::HeaderMap> Filter::TOO_MANY_REQUESTS_HEADER{
         {Http::Headers::get().Status, std::to_string(enumToInt(Code::TooManyRequests))}}};
 
 void Filter::initiateCall(const HeaderMap& headers) {
-  bool is_internal_request = Http::Utility::isInternalRequest(headers);
+  bool is_internal_request =
+      headers.EnvoyInternalRequest() && (headers.EnvoyInternalRequest()->value() == "true");
 
   if ((is_internal_request && config_->requestType() == FilterRequestType::External) ||
       (!is_internal_request && config_->requestType() == FilterRequestType::Internal)) {

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -6,7 +6,6 @@
 #include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/http/codes.h"
-#include "common/http/utility.h"
 #include "common/router/config_impl.h"
 
 namespace Http {

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -6,6 +6,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/common/assert.h"
 #include "common/http/header_map_impl.h"
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
@@ -47,6 +48,7 @@ private:
     } else if (request_type == "external") {
       return FilterRequestType::External;
     } else {
+      ASSERT(request_type == "both");
       return FilterRequestType::Both;
     }
   }

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -46,16 +46,14 @@ private:
       return FilterRequestType::Internal;
     } else if (request_type == "external") {
       return FilterRequestType::External;
-    } else if (request_type == "both") {
-      return FilterRequestType::Both;
     } else {
-      throw EnvoyException(fmt::format("invalid filter request type '{}'", request_type));
+      return FilterRequestType::Both;
     }
   }
 
   const std::string domain_;
-  uint64_t stage_;
-  FilterRequestType request_type_;
+  const uint64_t stage_;
+  const FilterRequestType request_type_;
   const LocalInfo::LocalInfo& local_info_;
   Stats::Store& global_store_;
   Runtime::Loader& runtime_;

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -774,6 +774,10 @@ const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
         "type" : "integer",
         "minimum" : 0,
         "maximum" : 10
+      },
+      "request_type" : {
+        "type" : "string",
+        "enum" : ["internal", "external", "both"]
       }
     },
     "required" : ["domain"],


### PR DESCRIPTION
The rate limit filter configuration will provide which type of requests it should apply to. The supported types of requests are internal, external or both. When the rate limit filter is decoding headers, the filter will check if the request is internal (using Http::Utility:: isInternalRequest) and will make a call to the Ratelimit service if an only if the types match. If the request type is both, all requests will be parsed by the filter.