### PR TITLE
bazel: additional build targets and tests (#415).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,16 @@ bind(
 )
 
 bind(
+    name = "cc_wkt_protos_genproto",
+    actual = "@protobuf_git//:cc_wkt_protos_genproto",
+)
+
+bind(
+    name = "cc_wkt_protos",
+    actual = "@protobuf_git//:cc_wkt_protos",
+)
+
+bind(
     name = "event",
     actual = "@libevent_git//:event",
 )
@@ -22,6 +32,36 @@ bind(
 bind(
     name = "googletest",
     actual = "@googletest_git//:googletest",
+)
+
+bind(
+    name = "http_parser",
+    actual = "@http_parser_git//:http_parser",
+)
+
+bind(
+    name = "lightstep",
+    actual = "@lightstep_git//:lightstep_core",
+)
+
+bind(
+    name = "nghttp2",
+    actual = "@nghttp2_tar//:nghttp2",
+)
+
+bind(
+    name = "protobuf",
+    actual = "@protobuf_git//:protobuf",
+)
+
+bind(
+    name = "protoc",
+    actual = "@protobuf_git//:protoc",
+)
+
+bind(
+    name = "rapidjson",
+    actual = "@rapidjson_git//:rapidjson",
 )
 
 bind(

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -29,7 +29,6 @@ def envoy_include_prefix(path):
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
-                     testonly = 0,
                      srcs = [],
                      hdrs = [],
                      public_hdrs = [],
@@ -40,7 +39,6 @@ def envoy_cc_library(name,
                      deps = []):
     native.cc_library(
         name = name,
-        testonly = testonly,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
         copts = ENVOY_COPTS + copts,

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -29,6 +29,7 @@ def envoy_include_prefix(path):
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
+                     testonly = 0,
                      srcs = [],
                      hdrs = [],
                      public_hdrs = [],
@@ -39,11 +40,13 @@ def envoy_cc_library(name,
                      deps = []):
     native.cc_library(
         name = name,
+        testonly = testonly,
         srcs = srcs,
         hdrs = hdrs + public_hdrs,
         copts = ENVOY_COPTS + copts,
         visibility = visibility,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
+            "//include/envoy/common:base_includes",
             "//source/precompiled:precompiled_includes",
         ],
         alwayslink = alwayslink,
@@ -65,3 +68,28 @@ def envoy_cc_test(name,
             "//test/precompiled:precompiled_includes",
         ],
     )
+
+# Envoy C++ test related libraries (that want gtest, gmock) should be specified with this function.
+def envoy_cc_test_library(name,
+                  srcs = [],
+                  hdrs = [],
+                  deps = []):
+    native.cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs,
+        copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
+        testonly = 1,
+        alwayslink = 1,
+        deps = deps + [
+            "//source/precompiled:precompiled_includes",
+            "//test/precompiled:precompiled_includes",
+        ],
+    )
+
+# Envoy C++ mock targets should be specified with this function.
+def envoy_cc_mock(name,
+                  srcs = [],
+                  hdrs = [],
+                  deps = []):
+    envoy_cc_test_library(name, srcs, hdrs, deps)

--- a/include/envoy/access_log/BUILD.wip
+++ b/include/envoy/access_log/BUILD.wip
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "access_log_includes",
+    hdrs = ["access_log.h"],
+    deps = [
+        "//include/envoy/filesystem:filesystem_includes",
+    ],
+)

--- a/include/envoy/api/BUILD.wip
+++ b/include/envoy/api/BUILD.wip
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "api_includes",
+    hdrs = ["api.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/thread:thread_includes",
+    ],
+)

--- a/include/envoy/buffer/BUILD.wip
+++ b/include/envoy/buffer/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "buffer_includes",
     hdrs = ["buffer.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/common/BUILD.wip
+++ b/include/envoy/common/BUILD.wip
@@ -2,22 +2,21 @@ package(default_visibility = ["//visibility:public"])
 
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
-envoy_cc_library(
+cc_library(
     name = "base_includes",
     hdrs = [
         "exception.h",
         "pure.h",
     ],
+    include_prefix = "envoy/common",
 )
 
 envoy_cc_library(
     name = "time_includes",
     hdrs = ["time.h"],
-    deps = [":base_includes"],
 )
 
 envoy_cc_library(
     name = "optional_includes",
     hdrs = ["optional.h"],
-    deps = [":base_includes"],
 )

--- a/include/envoy/event/BUILD.wip
+++ b/include/envoy/event/BUILD.wip
@@ -27,7 +27,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "file_event_includes",
     hdrs = ["file_event.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(
@@ -38,5 +37,4 @@ envoy_cc_library(
 envoy_cc_library(
     name = "timer_includes",
     hdrs = ["timer.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/filesystem/BUILD.wip
+++ b/include/envoy/filesystem/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "filesystem_includes",
     hdrs = ["filesystem.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/http/BUILD.wip
+++ b/include/envoy/http/BUILD.wip
@@ -1,0 +1,81 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "access_log_includes",
+    hdrs = ["access_log.h"],
+    deps = [
+        ":header_map_includes",
+        ":protocol_includes",
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/common:time_includes",
+        "//include/envoy/upstream:upstream_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "async_client_includes",
+    hdrs = ["async_client.h"],
+    deps = [
+        ":message_includes",
+        "//include/envoy/common:optional_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "codec_includes",
+    hdrs = ["codec.h"],
+    deps = [
+        ":header_map_includes",
+        ":protocol_includes",
+        "//include/envoy/buffer:buffer_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "codes_includes",
+    hdrs = ["codes.h"],
+)
+
+envoy_cc_library(
+    name = "conn_pool_includes",
+    hdrs = ["conn_pool.h"],
+    deps = [
+        ":codec_includes",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/upstream:upstream_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_includes",
+    hdrs = ["filter.h"],
+    deps = [
+        ":access_log_includes",
+        ":codec_includes",
+        ":header_map_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/router:router_includes",
+        "//include/envoy/ssl:connection_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "header_map_includes",
+    hdrs = ["header_map.h"],
+)
+
+envoy_cc_library(
+    name = "message_includes",
+    hdrs = ["message.h"],
+    deps = [
+        ":header_map_includes",
+        "//include/envoy/buffer:buffer_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "protocol_includes",
+    hdrs = ["protocol.h"],
+)

--- a/include/envoy/json/BUILD.wip
+++ b/include/envoy/json/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "json_object_includes",
     hdrs = ["json_object.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/local_info/BUILD.wip
+++ b/include/envoy/local_info/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "local_info_includes",
+    hdrs = ["local_info.h"],
+    deps = ["//include/envoy/network:address_includes"],
+)

--- a/include/envoy/network/BUILD.wip
+++ b/include/envoy/network/BUILD.wip
@@ -5,7 +5,6 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "address_includes",
     hdrs = ["address.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(
@@ -33,10 +32,12 @@ envoy_cc_library(
 envoy_cc_library(
     name = "dns_includes",
     hdrs = ["dns.h"],
-    deps = [
-        "//include/envoy/common:base_includes",
-        "//include/envoy/network:address_includes",
-    ],
+    deps = ["//include/envoy/network:address_includes"],
+)
+
+envoy_cc_library(
+    name = "drain_decision_includes",
+    hdrs = ["drain_decision.h"],
 )
 
 envoy_cc_library(
@@ -51,14 +52,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "listen_socket_includes",
     hdrs = ["listen_socket.h"],
-    deps = [
-        "//include/envoy/common:base_includes",
-        "//include/envoy/network:address_includes",
-    ],
+    deps = ["//include/envoy/network:address_includes"],
 )
 
 envoy_cc_library(
     name = "listener_includes",
     hdrs = ["listener.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/ratelimit/BUILD.wip
+++ b/include/envoy/ratelimit/BUILD.wip
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "ratelimit_includes",
+    hdrs = ["ratelimit.h"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/tracing:context_includes",
+    ],
+)

--- a/include/envoy/router/BUILD.wip
+++ b/include/envoy/router/BUILD.wip
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "rds_includes",
+    hdrs = ["rds.h"],
+    deps = [":router_includes"],
+)
+
+envoy_cc_library(
+    name = "router_includes",
+    hdrs = ["router.h"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/upstream:resource_manager_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "router_ratelimit_includes",
+    hdrs = ["router_ratelimit.h"],
+    deps = [
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/ratelimit:ratelimit_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "shadow_writer_includes",
+    hdrs = ["shadow_writer.h"],
+    deps = ["//include/envoy/http:message_includes"],
+)

--- a/include/envoy/runtime/BUILD.wip
+++ b/include/envoy/runtime/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "runtime_includes",
     hdrs = ["runtime.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/server/BUILD.wip
+++ b/include/envoy/server/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "options_includes",
     hdrs = ["options.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/ssl/BUILD.wip
+++ b/include/envoy/ssl/BUILD.wip
@@ -5,19 +5,16 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "connection_includes",
     hdrs = ["connection.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(
     name = "context_includes",
     hdrs = ["context.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(
     name = "context_config_includes",
     hdrs = ["context_config.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(
@@ -26,7 +23,6 @@ envoy_cc_library(
     deps = [
         ":context_config_includes",
         ":context_includes",
-        "//include/envoy/common:base_includes",
         "//include/envoy/stats:stats_includes",
     ],
 )

--- a/include/envoy/stats/BUILD.wip
+++ b/include/envoy/stats/BUILD.wip
@@ -5,7 +5,6 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "stats_includes",
     hdrs = ["stats.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )
 
 envoy_cc_library(

--- a/include/envoy/thread/BUILD.wip
+++ b/include/envoy/thread/BUILD.wip
@@ -5,5 +5,4 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 envoy_cc_library(
     name = "thread_includes",
     hdrs = ["thread.h"],
-    deps = ["//include/envoy/common:base_includes"],
 )

--- a/include/envoy/thread_local/BUILD.wip
+++ b/include/envoy/thread_local/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "thread_local_includes",
+    hdrs = ["thread_local.h"],
+    deps = ["//include/envoy/event:dispatcher_includes"],
+)

--- a/include/envoy/tracing/BUILD.wip
+++ b/include/envoy/tracing/BUILD.wip
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "context_includes",
+    hdrs = ["context.h"],
+)
+
+envoy_cc_library(
+    name = "http_tracer_includes",
+    hdrs = ["http_tracer.h"],
+    deps = [
+        "//include/envoy/http:access_log_includes",
+        "//include/envoy/http:header_map_includes",
+    ],
+)

--- a/include/envoy/upstream/BUILD.wip
+++ b/include/envoy/upstream/BUILD.wip
@@ -3,6 +3,25 @@ package(default_visibility = ["//visibility:public"])
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
 envoy_cc_library(
+    name = "cluster_manager_includes",
+    hdrs = ["cluster_manager.h"],
+    deps = [
+        ":load_balancer_includes",
+        ":thread_local_cluster_includes",
+        ":upstream_includes",
+        "//include/envoy/http:async_client_includes",
+        "//include/envoy/http:conn_pool_includes",
+        "//include/envoy/json:json_object_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "health_checker_includes",
+    hdrs = ["health_checker.h"],
+    deps = [":upstream_includes"],
+)
+
+envoy_cc_library(
     name = "host_description_includes",
     hdrs = ["host_description.h"],
     deps = [
@@ -13,11 +32,43 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "load_balancer_includes",
+    hdrs = ["load_balancer.h"],
+    deps = [":upstream_includes"],
+)
+
+envoy_cc_library(
+    name = "load_balancer_type_includes",
+    hdrs = ["load_balancer_type.h"],
+)
+
+envoy_cc_library(
     name = "outlier_detection_includes",
     hdrs = ["outlier_detection.h"],
     deps = [
-        "//include/envoy/common:base_includes",
         "//include/envoy/common:optional_includes",
         "//include/envoy/common:time_includes",
+    ],
+)
+
+envoy_cc_library(
+    name = "resource_manager_includes",
+    hdrs = ["resource_manager.h"],
+)
+
+envoy_cc_library(
+    name = "thread_local_cluster_includes",
+    hdrs = ["thread_local_cluster.h"],
+)
+
+envoy_cc_library(
+    name = "upstream_includes",
+    hdrs = ["upstream.h"],
+    deps = [
+        ":load_balancer_type_includes",
+        ":resource_manager_includes",
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/ssl:context_includes",
     ],
 )

--- a/source/common/access_log/BUILD.wip
+++ b/source/common/access_log/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "access_log_manager_lib",
+    srcs = ["access_log_manager_impl.cc"],
+    hdrs = ["access_log_manager_impl.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_includes",
+        "//include/envoy/api:api_includes",
+    ],
+)

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -1,4 +1,4 @@
-#include "access_log_manager_impl.h"
+#include "common/access_log/access_log_manager_impl.h"
 
 namespace AccessLog {
 

--- a/source/common/api/BUILD.wip
+++ b/source/common/api/BUILD.wip
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "api_lib",
+    srcs = ["api_impl.cc"],
+    hdrs = ["api_impl.h"],
+    deps = [
+        "//include/envoy/api:api_includes",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/filesystem:filesystem_lib",
+    ],
+)

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -1,4 +1,4 @@
-#include "api_impl.h"
+#include "common/api/api_impl.h"
 
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/filesystem_impl.h"

--- a/source/common/common/BUILD.wip
+++ b/source/common/common/BUILD.wip
@@ -13,7 +13,7 @@ envoy_cc_library(
     srcs = ["base64.cc"],
     hdrs = ["base64.h"],
     deps = [
-        ":empty_string_lib",
+        ":empty_string",
         "//include/envoy/buffer:buffer_includes",
     ],
 )
@@ -24,12 +24,12 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "empty_string_lib",
+    name = "empty_string",
     hdrs = ["empty_string.h"],
 )
 
 envoy_cc_library(
-    name = "enum_to_int_lib",
+    name = "enum_to_int",
     hdrs = ["enum_to_int.h"],
 )
 
@@ -37,14 +37,11 @@ envoy_cc_library(
     name = "hex_lib",
     srcs = ["hex.cc"],
     hdrs = ["hex.h"],
-    deps = [
-        ":utility_lib",
-        "//include/envoy/common:base_includes",
-    ],
+    deps = [":utility_lib"],
 )
 
 envoy_cc_library(
-    name = "linked_object_lib",
+    name = "linked_object",
     hdrs = ["linked_object.h"],
     deps = [":assert_lib"],
 )
@@ -54,9 +51,14 @@ envoy_cc_library(
     srcs = ["logger.cc"],
     hdrs = ["logger.h"],
     deps = [
-        ":macros_lib",
+        ":macros",
         "//include/envoy/thread:thread_includes",
     ],
+)
+
+envoy_cc_library(
+    name = "non_copyable",
+    hdrs = ["non_copyable.h"],
 )
 
 envoy_cc_library(
@@ -65,13 +67,13 @@ envoy_cc_library(
     hdrs = ["thread.h"],
     deps = [
         ":assert_lib",
-        ":macros_lib",
+        ":macros",
         "//include/envoy/thread:thread_includes",
     ],
 )
 
 envoy_cc_library(
-    name = "macros_lib",
+    name = "macros",
     hdrs = ["macros.h"],
 )
 

--- a/source/common/dynamo/BUILD.wip
+++ b/source/common/dynamo/BUILD.wip
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "dynamo_filter_lib",
+    srcs = ["dynamo_filter.cc"],
+    hdrs = ["dynamo_filter.h"],
+    deps = [
+        ":dynamo_request_parser_lib",
+        ":dynamo_utility_lib",
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:exception_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "dynamo_request_parser_lib",
+    srcs = ["dynamo_request_parser.cc"],
+    hdrs = ["dynamo_request_parser.h"],
+    deps = [
+        "//include/envoy/http:header_map_includes",
+        "//source/common/common:utility_lib",
+        "//source/common/json:json_loader_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "dynamo_utility_lib",
+    srcs = ["dynamo_utility.cc"],
+    hdrs = ["dynamo_utility.h"],
+    deps = ["//source/common/stats:stats_lib"],
+)

--- a/source/common/dynamo/dynamo_filter.cc
+++ b/source/common/dynamo/dynamo_filter.cc
@@ -1,8 +1,8 @@
-#include "dynamo_filter.h"
-#include "dynamo_utility.h"
+#include "common/dynamo/dynamo_filter.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/dynamo/dynamo_request_parser.h"
+#include "common/dynamo/dynamo_utility.h"
 #include "common/http/codes.h"
 #include "common/http/exception.h"
 #include "common/http/utility.h"

--- a/source/common/dynamo/dynamo_filter.h
+++ b/source/common/dynamo/dynamo_filter.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "dynamo_request_parser.h"
-
 #include "envoy/http/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
 
+#include "common/dynamo/dynamo_request_parser.h"
 #include "common/json/json_loader.h"
 
 namespace Dynamo {

--- a/source/common/dynamo/dynamo_request_parser.cc
+++ b/source/common/dynamo/dynamo_request_parser.cc
@@ -1,4 +1,4 @@
-#include "dynamo_request_parser.h"
+#include "common/dynamo/dynamo_request_parser.h"
 
 #include "common/common/utility.h"
 

--- a/source/common/dynamo/dynamo_utility.cc
+++ b/source/common/dynamo/dynamo_utility.cc
@@ -1,4 +1,4 @@
-#include "dynamo_utility.h"
+#include "common/dynamo/dynamo_utility.h"
 
 #include "common/stats/stats_impl.h"
 

--- a/source/common/event/BUILD.wip
+++ b/source/common/event/BUILD.wip
@@ -2,21 +2,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
-# Needed to break circular dependency between DispatcherImpl/ConnectionImpl/ListenerImpl/
-# TODO(htuch): Can we reorganize packages and hierarchy to avoid the need for this hack?
-envoy_cc_library(
-    name = "dispatcher_lib_includes",
-    hdrs = [
-        "dispatcher_impl.h",
-        "event_impl_base.h",
-        "file_event_impl.h",
-    ],
-    deps = [
-        ":libevent_lib",
-        "//include/envoy/event:dispatcher_includes",
-    ],
-)
-
 envoy_cc_library(
     name = "dispatcher_lib",
     srcs = [
@@ -32,11 +17,33 @@ envoy_cc_library(
     ],
     deps = [
         ":dispatcher_lib_includes",
-        "//include/envoy/event:file_event_includes",
+        "//include/envoy/event:signal_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/network:listen_socket_includes",
+        "//include/envoy/network:listener_includes",
+        "//source/common/common:assert_lib",
         "//source/common/filesystem:watcher_lib",
         "//source/common/network:connection_lib",
         "//source/common/network:dns_lib",
         "//source/common/network:listener_lib",
+        "//source/common/ssl:connection_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "dispatcher_lib_includes",
+    hdrs = [
+        "dispatcher_impl.h",
+        "event_impl_base.h",
+        "file_event_impl.h",
+    ],
+    deps = [
+        ":libevent_lib",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:file_event_includes",
+        "//include/envoy/network:connection_handler_includes",
+        "//source/common/common:logger_lib",
     ],
 )
 

--- a/source/common/filesystem/BUILD.wip
+++ b/source/common/filesystem/BUILD.wip
@@ -3,11 +3,22 @@ package(default_visibility = ["//visibility:public"])
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
 envoy_cc_library(
+    name = "filesystem_lib",
+    srcs = ["filesystem_impl.cc"],
+    hdrs = ["filesystem_impl.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/filesystem:filesystem_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:thread_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "watcher_lib",
     srcs = ["watcher_impl.cc"],
     hdrs = ["watcher_impl.h"],
     deps = [
-        "//include/envoy/common:base_includes",
         "//include/envoy/event:dispatcher_includes",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -1,4 +1,4 @@
-#include "filesystem_impl.h"
+#include "common/filesystem/filesystem_impl.h"
 
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/grpc/BUILD.wip
+++ b/source/common/grpc/BUILD.wip
@@ -1,0 +1,64 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "codec_lib",
+    srcs = ["codec.cc"],
+    hdrs = ["codec.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "common_lib",
+    srcs = ["common.cc"],
+    hdrs = ["common.h"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/http:message_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:message_lib",
+        "//source/common/http:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http1_bridge_filter_lib",
+    srcs = ["http1_bridge_filter.cc"],
+    hdrs = ["http1_bridge_filter.h"],
+    deps = [
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http/http1:codec_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "rpc_channel_lib",
+    srcs = ["rpc_channel_impl.cc"],
+    hdrs = ["rpc_channel_impl.h"],
+    deps = [
+        "//include/envoy/grpc:rpc_channel_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:message_lib",
+        "//source/common/http:utility_lib",
+    ],
+)

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "common/grpc/common.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/empty_string.h"

--- a/source/common/http/BUILD.wip
+++ b/source/common/http/BUILD.wip
@@ -1,0 +1,226 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "async_client_lib",
+    srcs = ["async_client_impl.cc"],
+    hdrs = ["async_client_impl.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/http:async_client_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/http:message_includes",
+        "//include/envoy/router:router_includes",
+        "//include/envoy/router:router_ratelimit_includes",
+        "//include/envoy/router:shadow_writer_includes",
+        "//include/envoy/ssl:connection_includes",
+        "//source/common/common:empty_string",
+        "//source/common/common:linked_object",
+        "//source/common/http/access_log:request_info_lib",
+        "//source/common/router:router_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "codec_client_lib",
+    srcs = ["codec_client.cc"],
+    hdrs = ["codec_client.h"],
+    deps = [
+        ":codec_wrappers_lib",
+        ":exception_lib",
+        ":utility_lib",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:filter_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:linked_object",
+        "//source/common/common:logger_lib",
+        "//source/common/http/http1:codec_lib",
+        "//source/common/http/http2:codec_lib",
+        "//source/common/network:filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "codec_helper_lib",
+    hdrs = ["codec_helper.h"],
+)
+
+envoy_cc_library(
+    name = "codec_wrappers_lib",
+    hdrs = ["codec_wrappers.h"],
+    deps = ["//include/envoy/http:codec_includes"],
+)
+
+envoy_cc_library(
+    name = "codes_lib",
+    srcs = ["codes.cc"],
+    hdrs = ["codes.h"],
+    deps = [
+        ":headers_lib",
+        ":utility_lib",
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/stats:stats_includes",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "conn_manager_lib",
+    srcs = [
+        "conn_manager_impl.cc",
+        "conn_manager_utility.cc",
+    ],
+    hdrs = [
+        "conn_manager_impl.h",
+        "conn_manager_utility.h",
+    ],
+    deps = [
+        ":codes_lib",
+        ":date_provider_lib",
+        ":exception_lib",
+        ":header_map_lib",
+        ":headers_lib",
+        ":user_agent_lib",
+        ":utility_lib",
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/http:access_log_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:drain_decision_includes",
+        "//include/envoy/network:filter_includes",
+        "//include/envoy/router:rds_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/ssl:connection_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/stats:stats_macros",
+        "//include/envoy/tracing:http_tracer_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:linked_object",
+        "//source/common/common:utility_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
+        "//source/common/http/access_log:request_info_lib",
+        "//source/common/http/http1:codec_lib",
+        "//source/common/http/http2:codec_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/runtime:uuid_util_lib",
+        "//source/common/tracing:http_tracer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "date_provider_lib",
+    srcs = ["date_provider_impl.cc"],
+    hdrs = [
+        "date_provider.h",
+        "date_provider_impl.h",
+    ],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "exception_lib",
+    hdrs = ["exception.h"],
+    deps = ["//include/envoy/http:header_map_includes"],
+)
+
+envoy_cc_library(
+    name = "header_map_lib",
+    srcs = ["header_map_impl.cc"],
+    hdrs = ["header_map_impl.h"],
+    deps = [
+        ":headers_lib",
+        "//include/envoy/http:header_map_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:non_copyable",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "headers_lib",
+    hdrs = ["headers.h"],
+    deps = ["//include/envoy/http:header_map_includes"],
+)
+
+envoy_cc_library(
+    name = "message_lib",
+    srcs = ["message_impl.cc"],
+    hdrs = ["message_impl.h"],
+    deps = [
+        ":header_map_lib",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/http:message_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:non_copyable",
+    ],
+)
+
+envoy_cc_library(
+    name = "rest_api_fetcher_lib",
+    srcs = ["rest_api_fetcher.cc"],
+    hdrs = ["rest_api_fetcher.h"],
+    deps = [
+        ":message_lib",
+        ":utility_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//source/common/common:enum_to_int",
+    ],
+)
+
+envoy_cc_library(
+    name = "user_agent_lib",
+    srcs = ["user_agent.cc"],
+    hdrs = ["user_agent.h"],
+    deps = [
+        ":headers_lib",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/stats:stats_macros",
+    ],
+)
+
+envoy_cc_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    deps = [
+        ":exception_lib",
+        ":header_map_lib",
+        ":headers_lib",
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/http:header_map_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/network:utility_lib",
+    ],
+)

--- a/source/common/http/access_log/BUILD.wip
+++ b/source/common/http/access_log/BUILD.wip
@@ -1,0 +1,42 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "access_log_formatter_lib",
+    srcs = ["access_log_formatter.cc"],
+    hdrs = ["access_log_formatter.h"],
+    deps = [
+        "//include/envoy/http:access_log_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "access_log_lib",
+    srcs = ["access_log_impl.cc"],
+    hdrs = ["access_log_impl.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_includes",
+        "//include/envoy/filesystem:filesystem_includes",
+        "//include/envoy/http:access_log_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/runtime:uuid_util_lib",
+        "//source/common/tracing:http_tracer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "request_info_lib",
+    hdrs = ["request_info_impl.h"],
+    deps = ["//include/envoy/http:access_log_includes"],
+)

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -1,4 +1,4 @@
-#include "access_log_formatter.h"
+#include "common/http/access_log/access_log_formatter.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -1,4 +1,4 @@
-#include "codec_client.h"
+#include "common/http/codec_client.h"
 
 #include "common/common/enum_to_int.h"
 #include "common/http/exception.h"

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "codec_wrappers.h"
-
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
@@ -10,6 +8,7 @@
 #include "common/common/assert.h"
 #include "common/common/linked_object.h"
 #include "common/common/logger.h"
+#include "common/http/codec_wrappers.h"
 #include "common/network/filter_impl.h"
 
 namespace Http {

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -1,12 +1,12 @@
-#include "codes.h"
-#include "headers.h"
-#include "utility.h"
+#include "common/http/codes.h"
 
 #include "envoy/http/header_map.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
+#include "common/http/headers.h"
+#include "common/http/utility.h"
 
 namespace Http {
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1,6 +1,4 @@
-#include "conn_manager_impl.h"
-#include "conn_manager_utility.h"
-#include "headers.h"
+#include "common/http/conn_manager_impl.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
@@ -15,8 +13,10 @@
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
 #include "common/http/codes.h"
+#include "common/http/conn_manager_utility.h"
 #include "common/http/exception.h"
 #include "common/http/header_map_impl.h"
+#include "common/http/headers.h"
 #include "common/http/http1/codec_impl.h"
 #include "common/http/http2/codec_impl.h"
 #include "common/http/utility.h"

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "date_provider.h"
-#include "user_agent.h"
-
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/access_log.h"
 #include "envoy/http/codec.h"
@@ -19,6 +16,8 @@
 
 #include "common/common/linked_object.h"
 #include "common/http/access_log/request_info_impl.h"
+#include "common/http/date_provider.h"
+#include "common/http/user_agent.h"
 #include "common/tracing/http_tracer_impl.h"
 
 namespace Http {

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -1,4 +1,4 @@
-#include "conn_manager_utility.h"
+#include "common/http/conn_manager_utility.h"
 
 #include "common/common/empty_string.h"
 #include "common/http/access_log/access_log_formatter.h"

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "conn_manager_impl.h"
-
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
+
+#include "common/http/conn_manager_impl.h"
 
 namespace Http {
 

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -1,4 +1,4 @@
-#include "date_provider_impl.h"
+#include "common/http/date_provider_impl.h"
 
 namespace Http {
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -1,4 +1,4 @@
-#include "header_map_impl.h"
+#include "common/http/header_map_impl.h"
 
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "headers.h"
-
 #include "envoy/http/header_map.h"
 
 #include "common/common/non_copyable.h"
+#include "common/http/headers.h"
 
 namespace Http {
 

--- a/source/common/http/http1/BUILD.wip
+++ b/source/common/http/http1/BUILD.wip
@@ -1,0 +1,50 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "codec_lib",
+    srcs = ["codec_impl.cc"],
+    hdrs = ["codec_impl.h"],
+    external_deps = ["http_parser"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/network:connection_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:codec_helper_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:exception_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "conn_pool_lib",
+    srcs = ["conn_pool.cc"],
+    hdrs = ["conn_pool.h"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/http:conn_pool_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/common:linked_object",
+        "//source/common/common:utility_lib",
+        "//source/common/http:codec_client_lib",
+        "//source/common/http:codec_wrappers_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_lib",
+    ],
+)

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1,4 +1,4 @@
-#include "codec_impl.h"
+#include "common/http/http1/codec_impl.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"

--- a/source/common/http/http2/BUILD.wip
+++ b/source/common/http/http2/BUILD.wip
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "codec_lib",
+    srcs = ["codec_impl.cc"],
+    hdrs = ["codec_impl.h"],
+    external_deps = ["nghttp2"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/http:header_map_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:linked_object",
+        "//source/common/common:logger_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:codec_helper_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:exception_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "conn_pool_lib",
+    srcs = ["conn_pool.cc"],
+    hdrs = ["conn_pool.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/http:conn_pool_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/http:codec_client_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:upstream_lib",
+    ],
+)

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1,4 +1,4 @@
-#include "codec_impl.h"
+#include "common/http/http2/codec_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/codes.h"

--- a/source/common/http/message_impl.cc
+++ b/source/common/http/message_impl.cc
@@ -1,4 +1,4 @@
-#include "message_impl.h"
+#include "common/http/message_impl.h"
 
 namespace Http {
 

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -1,8 +1,8 @@
-#include "rest_api_fetcher.h"
-#include "utility.h"
+#include "common/http/rest_api_fetcher.h"
 
 #include "common/common/enum_to_int.h"
 #include "common/http/message_impl.h"
+#include "common/http/utility.h"
 
 namespace Http {
 

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -1,4 +1,4 @@
-#include "user_agent.h"
+#include "common/http/user_agent.h"
 
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1,4 +1,4 @@
-#include "utility.h"
+#include "common/http/utility.h"
 
 #include "envoy/http/header_map.h"
 

--- a/source/common/json/BUILD.wip
+++ b/source/common/json/BUILD.wip
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "config_schemas_lib",
+    srcs = ["config_schemas.cc"],
+    hdrs = ["config_schemas.h"],
+)
+
+envoy_cc_library(
+    name = "json_loader_lib",
+    srcs = ["json_loader.cc"],
+    hdrs = ["json_loader.h"],
+    external_deps = ["rapidjson"],
+    deps = ["//include/envoy/json:json_object_includes"],
+)
+
+envoy_cc_library(
+    name = "json_validator_lib",
+    hdrs = ["json_validator.h"],
+    deps = ["//include/envoy/json:json_object_includes"],
+)

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1,4 +1,4 @@
-#include "config_schemas.h"
+#include "common/json/config_schemas.h"
 
 const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
   {

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -1,4 +1,4 @@
-#include "json_loader.h"
+#include "common/json/json_loader.h"
 
 // Do not let RapidJson leak outside of this file.
 #include "rapidjson/document.h"

--- a/source/common/network/BUILD.wip
+++ b/source/common/network/BUILD.wip
@@ -14,17 +14,36 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "cidr_range_lib",
+    srcs = ["cidr_range.cc"],
+    hdrs = ["cidr_range.h"],
+    deps = [
+        ":address_lib",
+        ":utility_lib",
+        "//include/envoy/network:address_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "connection_lib",
     srcs = ["connection_impl.cc"],
     hdrs = ["connection_impl.h"],
     deps = [
+        ":address_lib",
         ":filter_manager_lib",
         ":utility_lib",
+        "//include/envoy/event:timer_includes",
         "//include/envoy/network:connection_includes",
+        "//include/envoy/network:filter_includes",
         "//source/common/buffer:buffer_lib",
-        "//source/common/common:empty_string_lib",
-        "//source/common/common:enum_to_int_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:logger_lib",
         "//source/common/event:dispatcher_lib_includes",
+        "//source/common/event:libevent_lib",
     ],
 )
 
@@ -37,9 +56,16 @@ envoy_cc_library(
         ":address_lib",
         ":utility_lib",
         "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:file_event_includes",
         "//include/envoy/network:dns_includes",
-        "//source/common/common:linked_object_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:linked_object",
     ],
+)
+
+envoy_cc_library(
+    name = "filter_lib",
+    hdrs = ["filter_impl.h"],
 )
 
 envoy_cc_library(
@@ -49,7 +75,21 @@ envoy_cc_library(
     deps = [
         "//include/envoy/network:connection_includes",
         "//include/envoy/network:filter_includes",
-        "//source/common/common:linked_object_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:linked_object",
+    ],
+)
+
+envoy_cc_library(
+    name = "listen_socket_lib",
+    srcs = ["listen_socket_impl.cc"],
+    hdrs = ["listen_socket_impl.h"],
+    deps = [
+        ":address_lib",
+        ":utility_lib",
+        "//include/envoy/network:listen_socket_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/ssl:context_lib",
     ],
 )
 
@@ -64,28 +104,21 @@ envoy_cc_library(
         "proxy_protocol.h",
     ],
     deps = [
+        ":address_lib",
+        ":connection_lib",
         ":listen_socket_lib",
-        "//include/envoy/event:dispatcher_includes",
-        "//include/envoy/network:listener_includes",
-        "//source/common/common:empty_string_lib",
-        "//source/common/common:linked_object_lib",
-        "//source/common/event:dispatcher_lib_includes",
-        "//source/common/network:address_lib",
-        "//source/common/network:connection_lib",
-        "//source/common/ssl:connection_lib",
-    ],
-)
-
-envoy_cc_library(
-    name = "listen_socket_lib",
-    srcs = ["listen_socket_impl.cc"],
-    hdrs = ["listen_socket_impl.h"],
-    deps = [
         ":utility_lib",
-        "//include/envoy/network:listen_socket_includes",
-        "//source/common/common:utility_lib",
-        "//source/common/network:address_lib",
-        "//source/common/ssl:context_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:file_event_includes",
+        "//include/envoy/network:connection_handler_includes",
+        "//include/envoy/network:listener_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/common:empty_string",
+        "//source/common/common:linked_object",
+        "//source/common/event:dispatcher_lib_includes",
+        "//source/common/event:libevent_lib",
+        "//source/common/ssl:connection_lib",
     ],
 )
 
@@ -94,11 +127,11 @@ envoy_cc_library(
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
     deps = [
+        ":address_lib",
         "//include/envoy/json:json_object_includes",
         "//include/envoy/network:connection_includes",
         "//include/envoy/stats:stats_includes",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
-        "//source/common/network:address_lib",
     ],
 )

--- a/source/common/runtime/BUILD.wip
+++ b/source/common/runtime/BUILD.wip
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "runtime_lib",
+    srcs = ["runtime_impl.cc"],
+    hdrs = ["runtime_impl.h"],
+    deps = [
+        "//include/envoy/common:optional_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/stats:stats_macros",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//source/common/common:empty_string",
+        "//source/common/common:logger_lib",
+        "//source/common/common:thread_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/filesystem:filesystem_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "uuid_util_lib",
+    srcs = ["uuid_util.cc"],
+    hdrs = ["uuid_util.h"],
+    deps = [
+        ":runtime_lib",
+        "//source/common/common:utility_lib",
+    ],
+)

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -1,4 +1,4 @@
-#include "runtime_impl.h"
+#include "common/runtime/runtime_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/stats.h"

--- a/source/common/runtime/uuid_util.cc
+++ b/source/common/runtime/uuid_util.cc
@@ -1,7 +1,7 @@
-#include "runtime_impl.h"
-#include "uuid_util.h"
+#include "common/runtime/uuid_util.h"
 
 #include "common/common/utility.h"
+#include "common/runtime/runtime_impl.h"
 
 bool UuidUtils::uuidModBy(const std::string& uuid, uint16_t& out, uint16_t mod) {
   if (uuid.length() < 8) {

--- a/source/common/ssl/BUILD.wip
+++ b/source/common/ssl/BUILD.wip
@@ -8,10 +8,21 @@ envoy_cc_library(
     hdrs = ["connection_impl.h"],
     deps = [
         ":context_lib",
-        "//source/common/common:empty_string_lib",
-        "//source/common/event:dispatcher_lib_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:hex_lib",
         "//source/common/network:connection_lib",
         "//source/common/network:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "context_config_lib",
+    srcs = ["context_config_impl.cc"],
+    hdrs = ["context_config_impl.h"],
+    deps = [
+        "//include/envoy/ssl:context_config_includes",
+        "//source/common/json:json_loader_lib",
     ],
 )
 
@@ -28,9 +39,12 @@ envoy_cc_library(
     deps = [
         ":openssl_lib",
         "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/ssl:context_config_includes",
         "//include/envoy/ssl:context_includes",
         "//include/envoy/ssl:context_manager_includes",
+        "//include/envoy/stats:stats_includes",
         "//include/envoy/stats:stats_macros",
+        "//source/common/common:assert_lib",
         "//source/common/common:hex_lib",
     ],
 )

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -1,4 +1,4 @@
-#include "context_config_impl.h"
+#include "common/ssl/context_config_impl.h"
 
 namespace Ssl {
 

--- a/source/common/stats/BUILD.wip
+++ b/source/common/stats/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "stats_lib",
+    srcs = ["stats_impl.cc"],
+    hdrs = ["stats_impl.h"],
+    deps = [
+        "//include/envoy/common:time_includes",
+        "//include/envoy/stats:stats_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+    ],
+)

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -1,4 +1,4 @@
-#include "stats_impl.h"
+#include "common/stats/stats_impl.h"
 
 #include "common/common/utility.h"
 

--- a/source/common/tracing/BUILD.wip
+++ b/source/common/tracing/BUILD.wip
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "http_tracer_lib",
+    srcs = ["http_tracer_impl.cc"],
+    hdrs = ["http_tracer_impl.h"],
+    external_deps = ["lightstep"],
+    deps = [
+        "//include/envoy/local_info:local_info_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//include/envoy/tracing:http_tracer_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//source/common/common:base64_lib",
+        "//source/common/common:macros",
+        "//source/common/common:utility_lib",
+        "//source/common/grpc:common_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:message_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/runtime:uuid_util_lib",
+    ],
+)

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -1,4 +1,4 @@
-#include "http_tracer_impl.h"
+#include "common/tracing/http_tracer_impl.h"
 
 #include "common/common/base64.h"
 #include "common/common/macros.h"

--- a/source/common/upstream/BUILD.wip
+++ b/source/common/upstream/BUILD.wip
@@ -1,0 +1,208 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "cds_api_lib",
+    srcs = ["cds_api_impl.cc"],
+    hdrs = ["cds_api_impl.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/json:json_object_includes",
+        "//include/envoy/local_info:local_info_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:rest_api_fetcher_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/json:json_loader_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "cluster_manager_lib",
+    srcs = ["cluster_manager_impl.cc"],
+    hdrs = ["cluster_manager_impl.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/local_info:local_info_includes",
+        "//include/envoy/network:dns_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/http:async_client_lib",
+        "//source/common/http/http1:conn_pool_lib",
+        "//source/common/http/http2:conn_pool_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/router:shadow_writer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "health_checker_lib",
+    srcs = ["health_checker_impl.cc"],
+    hdrs = ["health_checker_impl.h"],
+    deps = [
+        ":host_utility_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:codes_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:filter_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/upstream:health_checker_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:empty_string",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:hex_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:codec_client_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/network:filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "host_utility_lib",
+    srcs = ["host_utility.cc"],
+    hdrs = ["host_utility.h"],
+    deps = ["//include/envoy/upstream:upstream_includes"],
+)
+
+envoy_cc_library(
+    name = "load_balancer_lib",
+    srcs = ["load_balancer_impl.cc"],
+    hdrs = ["load_balancer_impl.h"],
+    deps = [
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/upstream:load_balancer_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "logical_dns_cluster_lib",
+    srcs = ["logical_dns_cluster.cc"],
+    hdrs = ["logical_dns_cluster.h"],
+    deps = [
+        ":upstream_lib_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//source/common/common:empty_string",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "outlier_detection_lib",
+    srcs = ["outlier_detection_impl.cc"],
+    hdrs = ["outlier_detection_impl.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/upstream:outlier_detection_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/json:json_loader_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "resource_manager_lib",
+    hdrs = ["resource_manager_impl.h"],
+    deps = [
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/upstream:resource_manager_includes",
+        "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "ring_hash_lb_lib",
+    srcs = ["ring_hash_lb.cc"],
+    hdrs = ["ring_hash_lb.h"],
+    deps = [
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/upstream:load_balancer_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "sds_lib",
+    srcs = ["sds.cc"],
+    hdrs = ["sds.h"],
+    deps = [
+        ":upstream_lib_includes",
+        "//include/envoy/local_info:local_info_includes",
+        "//source/common/http:headers_lib",
+        "//source/common/http:rest_api_fetcher_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "upstream_lib",
+    srcs = ["upstream_impl.cc"],
+    deps = [
+        ":health_checker_lib",
+        ":logical_dns_cluster_lib",
+        ":sds_lib",
+        ":upstream_lib_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/network:dns_includes",
+        "//include/envoy/ssl:context_includes",
+        "//include/envoy/upstream:health_checker_includes",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:utility_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/ssl:connection_lib",
+        "//source/common/ssl:context_config_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "upstream_lib_includes",
+    hdrs = ["upstream_impl.h"],
+    deps = [
+        ":outlier_detection_lib",
+        ":resource_manager_lib",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/local_info:local_info_includes",
+        "//include/envoy/network:dns_includes",
+        "//include/envoy/runtime:runtime_includes",
+        "//include/envoy/ssl:context_manager_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//include/envoy/upstream:health_checker_includes",
+        "//include/envoy/upstream:load_balancer_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/common:enum_to_int",
+        "//source/common/common:logger_lib",
+        "//source/common/stats:stats_lib",
+    ],
+)

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -1,4 +1,4 @@
-#include "health_checker_impl.h"
+#include "common/upstream/health_checker_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -1,4 +1,4 @@
-#include "host_utility.h"
+#include "common/upstream/host_utility.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -1,4 +1,4 @@
-#include "logical_dns_cluster.h"
+#include "common/upstream/logical_dns_cluster.h"
 
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "upstream_impl.h"
-
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/empty_string.h"
+#include "common/upstream/upstream_impl.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -1,4 +1,4 @@
-#include "outlier_detection_impl.h"
+#include "common/upstream/outlier_detection_impl.h"
 
 #include "envoy/event/dispatcher.h"
 

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -1,4 +1,4 @@
-#include "sds.h"
+#include "common/upstream/sds.h"
 
 #include "common/http/headers.h"
 #include "common/json/config_schemas.h"

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "upstream_impl.h"
-
 #include "envoy/local_info/local_info.h"
 
 #include "common/http/rest_api_fetcher.h"
+#include "common/upstream/upstream_impl.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1,7 +1,4 @@
-#include "health_checker_impl.h"
-#include "logical_dns_cluster.h"
-#include "sds.h"
-#include "upstream_impl.h"
+#include "common/upstream/upstream_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
@@ -18,6 +15,9 @@
 #include "common/network/utility.h"
 #include "common/ssl/connection_impl.h"
 #include "common/ssl/context_config_impl.h"
+#include "common/upstream/health_checker_impl.h"
+#include "common/upstream/logical_dns_cluster.h"
+#include "common/upstream/sds.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "outlier_detection_impl.h"
-#include "resource_manager_impl.h"
-
 #include "envoy/event/timer.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/dns.h"
@@ -17,6 +14,8 @@
 #include "common/common/enum_to_int.h"
 #include "common/common/logger.h"
 #include "common/stats/stats_impl.h"
+#include "common/upstream/outlier_detection_impl.h"
+#include "common/upstream/resource_manager_impl.h"
 
 namespace Upstream {
 

--- a/source/server/BUILD.wip
+++ b/source/server/BUILD.wip
@@ -9,7 +9,7 @@ envoy_cc_library(
     external_deps = ["tclap"],
     deps = [
         "//include/envoy/server:options_includes",
-        "//source/common/common:macros_lib",
+        "//source/common/common:macros",
         "//source/common/common:version_lib",
     ],
 )

--- a/test/BUILD.wip
+++ b/test/BUILD.wip
@@ -12,5 +12,6 @@ envoy_cc_library(
         "//source/common/event:libevent_lib",
         "//source/common/ssl:openssl_lib",
         "//source/server:options_lib",
+        "//test/test_common:printers_lib",
     ],
 )

--- a/test/common/access_log/BUILD.wip
+++ b/test/common/access_log/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+envoy_cc_test(
+    name = "access_log_manager_impl_test",
+    srcs = ["access_log_manager_impl_test.cc"],
+    deps = [
+        "//source/common/access_log:access_log_manager_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/access_log:access_log_mocks",
+        "//test/mocks/api:api_mocks",
+        "//test/mocks/event:event_mocks",
+    ],
+)

--- a/test/common/api/BUILD.wip
+++ b/test/common/api/BUILD.wip
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+envoy_cc_test(
+    name = "api_impl_test",
+    srcs = ["api_impl_test.cc"],
+    deps = ["//source/common/api:api_lib"],
+)

--- a/test/common/dynamo/BUILD.wip
+++ b/test/common/dynamo/BUILD.wip
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+envoy_cc_test(
+    name = "dynamo_filter_test",
+    srcs = ["dynamo_filter_test.cc"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/dynamo:dynamo_filter_lib",
+        "//source/common/http:header_map_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "dynamo_request_parser_test",
+    srcs = ["dynamo_request_parser_test.cc"],
+    deps = [
+        "//source/common/dynamo:dynamo_request_parser_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/json:json_loader_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "dynamo_utility_test",
+    srcs = ["dynamo_utility_test.cc"],
+    deps = [
+        "//source/common/dynamo:dynamo_utility_lib",
+        "//source/common/stats:stats_lib",
+    ],
+)

--- a/test/mocks/BUILD.wip
+++ b/test/mocks/BUILD.wip
@@ -1,14 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test_library")
 
-envoy_cc_library(
+envoy_cc_test_library(
     name = "common_lib",
-    testonly = 1,
     srcs = ["common.cc"],
     hdrs = ["common.h"],
-    deps = [
-        "//include/envoy/common:time_includes",
-        "//test/precompiled:precompiled_includes",
-    ],
+    deps = ["//include/envoy/common:time_includes"],
 )

--- a/test/mocks/BUILD.wip
+++ b/test/mocks/BUILD.wip
@@ -4,6 +4,7 @@ load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
 
 envoy_cc_library(
     name = "common_lib",
+    testonly = 1,
     srcs = ["common.cc"],
     hdrs = ["common.h"],
     deps = [

--- a/test/mocks/access_log/BUILD.wip
+++ b/test/mocks/access_log/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "access_log_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_includes",
+        "//test/mocks/filesystem:filesystem_mocks",
+    ],
+)

--- a/test/mocks/access_log/mocks.cc
+++ b/test/mocks/access_log/mocks.cc
@@ -1,4 +1,4 @@
-#include "mocks.h"
+#include "test/mocks/access_log/mocks.h"
 
 using testing::_;
 using testing::Return;

--- a/test/mocks/api/BUILD.wip
+++ b/test/mocks/api/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "api_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/api:api_includes",
+        "//test/mocks/filesystem:filesystem_mocks",
+    ],
+)

--- a/test/mocks/event/BUILD.wip
+++ b/test/mocks/event/BUILD.wip
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "event_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/event:deferred_deletable",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/event:file_event_includes",
+        "//include/envoy/event:signal_includes",
+        "//include/envoy/event:timer_includes",
+        "//include/envoy/network:connection_handler_includes",
+        "//include/envoy/network:connection_includes",
+        "//include/envoy/network:dns_includes",
+        "//include/envoy/network:listener_includes",
+        "//include/envoy/ssl:context_includes",
+        "//source/common/network:listen_socket_lib",
+        "//source/common/stats:stats_lib",
+    ],
+)

--- a/test/mocks/filesystem/BUILD.wip
+++ b/test/mocks/filesystem/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "filesystem_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/filesystem:filesystem_includes",
+        "//source/common/common:thread_lib",
+    ],
+)

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -1,4 +1,4 @@
-#include "mocks.h"
+#include "test/mocks/filesystem/mocks.h"
 
 namespace Filesystem {
 

--- a/test/mocks/http/BUILD.wip
+++ b/test/mocks/http/BUILD.wip
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "http_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/http:access_log_includes",
+        "//include/envoy/http:async_client_includes",
+        "//include/envoy/http:codec_includes",
+        "//include/envoy/http:conn_pool_includes",
+        "//include/envoy/http:filter_includes",
+        "//include/envoy/ssl:connection_includes",
+        "//source/common/http:conn_manager_lib",
+        "//source/common/http:header_map_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/router:router_mocks",
+        "//test/mocks/upstream:host_mocks",
+    ],
+)

--- a/test/mocks/router/BUILD.wip
+++ b/test/mocks/router/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "router_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/router:router_includes",
+        "//include/envoy/router:router_ratelimit_includes",
+        "//include/envoy/router:shadow_writer_includes",
+        "//test/mocks:common_lib",
+    ],
+)

--- a/test/mocks/runtime/BUILD.wip
+++ b/test/mocks/runtime/BUILD.wip
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "runtime_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/runtime:runtime_includes",
+        "//test/mocks:common_lib",
+    ],
+)

--- a/test/mocks/stats/BUILD.wip
+++ b/test/mocks/stats/BUILD.wip
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "stats_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/stats:stats_includes",
+        "//include/envoy/thread_local:thread_local_includes",
+        "//source/common/stats:stats_lib",
+        "//test/mocks:common_lib",
+    ],
+)

--- a/test/mocks/upstream/BUILD.wip
+++ b/test/mocks/upstream/BUILD.wip
@@ -1,0 +1,45 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_mock")
+
+envoy_cc_mock(
+    name = "cluster_info_mocks",
+    hdrs = ["cluster_info.h"],
+    deps = [
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)
+
+envoy_cc_mock(
+    name = "host_mocks",
+    hdrs = ["host.h"],
+    deps = [
+        ":cluster_info_mocks",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/stats:stats_lib",
+    ],
+)
+
+envoy_cc_mock(
+    name = "upstream_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    deps = [
+        "//include/envoy/http:async_client_includes",
+        "//include/envoy/upstream:cluster_manager_includes",
+        "//include/envoy/upstream:health_checker_includes",
+        "//include/envoy/upstream:load_balancer_includes",
+        "//include/envoy/upstream:upstream_includes",
+        "//source/common/network:utility_lib",
+        "//source/common/stats:stats_lib",
+        "//source/common/upstream:upstream_lib",
+        "//source/common/upstream:upstream_lib_includes",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "cluster_info.h"
+#include "test/mocks/upstream/cluster_info.h"
 
 #include "envoy/upstream/upstream.h"
 

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -1,4 +1,4 @@
-#include "mocks.h"
+#include "test/mocks/upstream/mocks.h"
 
 #include "envoy/upstream/load_balancer.h"
 

--- a/test/test_common/BUILD.wip
+++ b/test/test_common/BUILD.wip
@@ -1,6 +1,31 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_cc_test_library")
+
 cc_library(
     name = "printers_includes",
     hdrs = ["printers.h"],
+)
+
+envoy_cc_library(
+    name = "printers_lib",
+    srcs = ["printers.cc"],
+    deps = [
+        ":printers_includes",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/http:header_map_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_includes",
+        "//include/envoy/network:address_includes",
+        "//source/common/common:empty_string",
+        "//source/common/http:header_map_lib",
+        "//source/common/network:address_lib",
+    ],
 )

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/buffer/buffer.h"
 #include "envoy/network/address.h"
 
 #include "common/http/header_map_impl.h"


### PR DESCRIPTION
This takes us to ~65% of targets. I've switched to machine generating the BUILD files based on
header analysis, the Envoy file naming conventions and a hardcoded list of exceptions. The remaining
targets should be much faster.