### PR TITLE
Increase consistency w.r.t. tests checking for nullptr.

### DIFF
--- a/test/common/network/cidr_range_test.cc
+++ b/test/common/network/cidr_range_test.cc
@@ -61,14 +61,14 @@ TEST(TruncateIpAddressAndLength, Various) {
   test_cases.size();
   for (const auto& kv : test_cases) {
     InstanceConstSharedPtr inPtr = parseInternetAddress(kv.first.first);
-    EXPECT_TRUE(inPtr != nullptr) << kv.first.first;
+    EXPECT_NE(inPtr, nullptr) << kv.first.first;
     int length_io = kv.first.second;
     InstanceConstSharedPtr outPtr = CidrRange::truncateIpAddressAndLength(inPtr, &length_io);
     if (kv.second.second == -1) {
       EXPECT_EQ(outPtr, nullptr) << outPtr->asString() << "\n" << kv;
       EXPECT_EQ(length_io, -1) << kv;
     } else {
-      ASSERT_TRUE(outPtr != nullptr) << kv;
+      ASSERT_NE(outPtr, nullptr) << kv;
       EXPECT_EQ(outPtr->ip()->addressAsString(), kv.second.first) << kv;
       EXPECT_EQ(length_io, kv.second.second) << kv;
     }

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -143,7 +143,7 @@ TEST(NetworkUtility, loopbackAddress) {
 TEST(NetworkUtility, AnyAddress) {
   {
     Address::InstanceConstSharedPtr any = Utility::getIpv4AnyAddress();
-    ASSERT_TRUE(any != nullptr);
+    ASSERT_NE(any, nullptr);
     EXPECT_EQ(any->type(), Address::Type::Ip);
     EXPECT_EQ(any->ip()->version(), Address::IpVersion::v4);
     EXPECT_EQ(any->asString(), "0.0.0.0:0");
@@ -151,7 +151,7 @@ TEST(NetworkUtility, AnyAddress) {
   }
   {
     Address::InstanceConstSharedPtr any = Utility::getIpv6AnyAddress();
-    ASSERT_TRUE(any != nullptr);
+    ASSERT_NE(any, nullptr);
     EXPECT_EQ(any->type(), Address::Type::Ip);
     EXPECT_EQ(any->ip()->version(), Address::IpVersion::v6);
     EXPECT_EQ(any->asString(), "[::]:0");

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -22,9 +22,9 @@ TEST(SslContextImplTest, TestdNSNameMatching) {
 
 TEST(SslContextImplTest, TestVerifySubjectAltNameDNSMatched) {
   FILE* fp = fopen("test/common/ssl/test_data/san_dns.crt", "r");
-  EXPECT_TRUE(fp != nullptr);
+  EXPECT_NE(fp, nullptr);
   X509* cert = PEM_read_X509(fp, nullptr, nullptr, nullptr);
-  EXPECT_TRUE(cert != nullptr);
+  EXPECT_NE(cert, nullptr);
   std::vector<std::string> verify_subject_alt_name_list = {"foo.com", "test.com"};
   EXPECT_TRUE(ContextImpl::verifySubjectAltName(cert, verify_subject_alt_name_list));
   X509_free(cert);
@@ -33,9 +33,9 @@ TEST(SslContextImplTest, TestVerifySubjectAltNameDNSMatched) {
 
 TEST(SslContextImplTest, TestVerifySubjectAltNameURIMatched) {
   FILE* fp = fopen("test/common/ssl/test_data/san_uri.crt", "r");
-  EXPECT_TRUE(fp != nullptr);
+  EXPECT_NE(fp, nullptr);
   X509* cert = PEM_read_X509(fp, nullptr, nullptr, nullptr);
-  EXPECT_TRUE(cert != nullptr);
+  EXPECT_NE(cert, nullptr);
   std::vector<std::string> verify_subject_alt_name_list = {"istio:account.test.com",
                                                            "istio:account2.test.com"};
   EXPECT_TRUE(ContextImpl::verifySubjectAltName(cert, verify_subject_alt_name_list));
@@ -45,9 +45,9 @@ TEST(SslContextImplTest, TestVerifySubjectAltNameURIMatched) {
 
 TEST(SslContextImplTest, TestVerifySubjectAltNameNotMatched) {
   FILE* fp = fopen("test/common/ssl/test_data/san_dns.crt", "r");
-  EXPECT_TRUE(fp != nullptr);
+  EXPECT_NE(fp, nullptr);
   X509* cert = PEM_read_X509(fp, nullptr, nullptr, nullptr);
-  EXPECT_TRUE(cert != nullptr);
+  EXPECT_NE(cert, nullptr);
   std::vector<std::string> verify_subject_alt_name_list = {"foo", "bar"};
   EXPECT_FALSE(ContextImpl::verifySubjectAltName(cert, verify_subject_alt_name_list));
   X509_free(cert);


### PR DESCRIPTION
Following Harvey's recent feedback, I looked around and found a few more asserts to fixup.