### PR TITLE
perf: gRPC zero copy write path

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -167,6 +167,11 @@ public:
    */
   virtual const HeaderString& value() const PURE;
 
+  /**
+   * @return the header value.
+   */
+  virtual HeaderString& value() PURE;
+
 private:
   void value(const char*); // Do not allow auto conversion to std::string
 };

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -37,6 +37,7 @@ Buffer::InstancePtr Common::serializeBody(const google::protobuf::Message& messa
   iovec.len_ = alloc_size;
   uint8_t* current = reinterpret_cast<uint8_t*>(iovec.mem_);
 
+  // TODO(fengli79): Make this less ugly.
   *current++ = 0; // flags
   *reinterpret_cast<uint32_t*>(current) = htonl(size);
   current += sizeof(uint32_t);

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -70,6 +70,7 @@ protected:
     void value(uint64_t value) override;
     void value(const HeaderEntry& header) override;
     const HeaderString& value() const override { return value_; }
+    HeaderString& value() override { return value_; }
 
     HeaderString key_;
     HeaderString value_;


### PR DESCRIPTION
Read is more complicated since we need a custom zero copy implementation
for Buffer::Instance. It will also have less impact. I will do this in a
follow up.