### PR TITLE
test: programatically derive temporary and generated paths for tests.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(envoy-test
   server/http/health_check_test.cc
   server/options_impl_test.cc
   server/server_test.cc
+  test_common/environment.cc
   test_common/network_utility.cc
   test_common/printers.cc
   test_common/utility.cc)

--- a/test/certs/gen_test_certs.sh
+++ b/test/certs/gen_test_certs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Create a test certificate with a 15-day expiration for SSL tests
+
+set -e
+
+TEST_CERT_DIR=$1
+
+mkdir -p $TEST_CERT_DIR
+openssl genrsa -out $TEST_CERT_DIR/unittestkey.pem 1024
+openssl genrsa -out $TEST_CERT_DIR/unittestkey_expired.pem 1024
+openssl req -new -key $TEST_CERT_DIR/unittestkey.pem -out $TEST_CERT_DIR/unittestcert.csr \
+    -sha256 <<EOF
+US
+California
+San Francisco
+Lyft
+Test
+Unit Test CA
+unittest@lyft.com
+
+
+EOF
+openssl req -new -key $TEST_CERT_DIR/unittestkey_expired.pem -out $TEST_CERT_DIR/unittestcert_expired.csr \
+    -sha256 <<EOF
+US
+California
+San Francisco
+Lyft
+Test
+Unit Test CA
+unittest@lyft.com
+
+
+EOF
+openssl x509 -req -days 15 -in $TEST_CERT_DIR/unittestcert.csr -sha256 -signkey \
+    $TEST_CERT_DIR/unittestkey.pem -out $TEST_CERT_DIR/unittestcert.pem
+openssl x509 -req -days -365 -in $TEST_CERT_DIR/unittestcert_expired.csr -sha256 -signkey \
+    $TEST_CERT_DIR/unittestkey_expired.pem -out $TEST_CERT_DIR/unittestcert_expired.pem

--- a/test/common/api/api_impl_test.cc
+++ b/test/common/api/api_impl_test.cc
@@ -1,11 +1,13 @@
 #include "common/api/api_impl.h"
 
+#include "test/test_common/environment.h"
+
 namespace Api {
 
 TEST(ApiImplTest, readFileToEnd) {
   Impl api(std::chrono::milliseconds(10000));
 
-  const std::string file_path = "/tmp/test_api_envoy";
+  const std::string file_path = TestEnvironment::temporaryPath("test_api_envoy");
   unlink(file_path.c_str());
 
   std::ofstream file(file_path);

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
+#include "test/test_common/environment.h"
 
 using testing::_;
 using testing::InSequence;
@@ -37,7 +38,7 @@ TEST(FileSystemImpl, directoryExists) {
 }
 
 TEST(FileSystemImpl, fileReadToEndSuccess) {
-  const std::string file_path = "/tmp/test_envoy";
+  const std::string file_path = TestEnvironment::temporaryPath("test_envoy");
   unlink(file_path.c_str());
   std::ofstream file(file_path);
 
@@ -49,8 +50,9 @@ TEST(FileSystemImpl, fileReadToEndSuccess) {
 }
 
 TEST(FileSystemImpl, fileReadToEndDoesNotExist) {
-  unlink("/tmp/envoy_this_not_exist");
-  EXPECT_THROW(Filesystem::fileReadToEnd("/tmp/envoy_this_not_exist"), EnvoyException);
+  unlink(TestEnvironment::temporaryPath("envoy_this_not_exist").c_str());
+  EXPECT_THROW(Filesystem::fileReadToEnd(TestEnvironment::temporaryPath("envoy_this_not_exist")),
+               EnvoyException);
 }
 
 TEST(FileSystemImpl, flushToLogFilePeriodically) {

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -52,4 +52,4 @@ TEST(WatcherImplTest, All) {
   dispatcher.run(Event::Dispatcher::RunType::Block);
 }
 
-} // namespace Filesystem
+} // Filesystem

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -2,6 +2,8 @@
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/watcher_impl.h"
 
+#include "test/test_common/environment.h"
+
 namespace Filesystem {
 
 class WatchCallback {
@@ -13,36 +15,41 @@ TEST(WatcherImplTest, All) {
   Event::DispatcherImpl dispatcher;
   Filesystem::WatcherPtr watcher = dispatcher.createFilesystemWatcher();
 
-  unlink("/tmp/envoy_test/watcher_target");
-  unlink("/tmp/envoy_test/watcher_link");
-  unlink("/tmp/envoy_test/watcher_new_target");
-  unlink("/tmp/envoy_test/watcher_new_link");
+  unlink(TestEnvironment::temporaryPath("envoy_test/watcher_target").c_str());
+  unlink(TestEnvironment::temporaryPath("envoy_test/watcher_link").c_str());
+  unlink(TestEnvironment::temporaryPath("envoy_test/watcher_new_target").c_str());
+  unlink(TestEnvironment::temporaryPath("envoy_test/watcher_new_link").c_str());
 
-  mkdir("/tmp/envoy_test", S_IRWXU);
-  { std::ofstream file("/tmp/envoy_test/watcher_target"); }
-  int rc = symlink("/tmp/envoy_test/watcher_target", "/tmp/envoy_test/watcher_link");
+  mkdir(TestEnvironment::temporaryPath("envoy_test").c_str(), S_IRWXU);
+  { std::ofstream file(TestEnvironment::temporaryPath("envoy_test/watcher_target")); }
+  int rc = symlink(TestEnvironment::temporaryPath("envoy_test/watcher_target").c_str(),
+                   TestEnvironment::temporaryPath("envoy_test/watcher_link").c_str());
   RELEASE_ASSERT(0 == rc);
   UNREFERENCED_PARAMETER(rc);
 
-  { std::ofstream file("/tmp/envoy_test/watcher_new_target"); }
-  rc = symlink("/tmp/envoy_test/watcher_new_target", "/tmp/envoy_test/watcher_new_link");
+  { std::ofstream file(TestEnvironment::temporaryPath("envoy_test/watcher_new_target")); }
+  rc = symlink(TestEnvironment::temporaryPath("envoy_test/watcher_new_target").c_str(),
+               TestEnvironment::temporaryPath("envoy_test/watcher_new_link").c_str());
   RELEASE_ASSERT(0 == rc);
 
   WatchCallback callback;
   EXPECT_CALL(callback, called(Watcher::Events::MovedTo)).Times(2);
-  watcher->addWatch("/tmp/envoy_test/watcher_link", Watcher::Events::MovedTo,
-                    [&](uint32_t events) -> void {
+  watcher->addWatch(TestEnvironment::temporaryPath("envoy_test/watcher_link"),
+                    Watcher::Events::MovedTo, [&](uint32_t events) -> void {
                       callback.called(events);
                       dispatcher.exit();
                     });
 
-  rename("/tmp/envoy_test/watcher_new_link", "/tmp/envoy_test/watcher_link");
+  rename(TestEnvironment::temporaryPath("envoy_test/watcher_new_link").c_str(),
+         TestEnvironment::temporaryPath("envoy_test/watcher_link").c_str());
   dispatcher.run(Event::Dispatcher::RunType::Block);
 
-  rc = symlink("/tmp/envoy_test/watcher_new_target", "/tmp/envoy_test/watcher_new_link");
+  rc = symlink(TestEnvironment::temporaryPath("envoy_test/watcher_new_target").c_str(),
+               TestEnvironment::temporaryPath("envoy_test/watcher_new_link").c_str());
   RELEASE_ASSERT(0 == rc);
-  rename("/tmp/envoy_test/watcher_new_link", "/tmp/envoy_test/watcher_link");
+  rename(TestEnvironment::temporaryPath("envoy_test/watcher_new_link").c_str(),
+         TestEnvironment::temporaryPath("envoy_test/watcher_link").c_str());
   dispatcher.run(Event::Dispatcher::RunType::Block);
 }
 
-} // Filesystem
+} // namespace Filesystem

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -21,18 +21,12 @@ namespace Ssl {
 
 namespace {
 
-Json::ObjectPtr jsonLoad(const std::string& raw_json) {
-  const std::regex test_cert_regex("#test_certs#");
-  return Json::Factory::LoadFromString(
-      std::regex_replace(raw_json, test_cert_regex, TestEnvironment::runfilesPath("test/certs")));
-}
-
 void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_json,
               const std::string& expected_digest, const std::string& expected_uri) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
 
-  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -45,7 +39,7 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
       dispatcher.createSslListener(connection_handler, *server_ctx, socket, callbacks, stats_store,
                                    Network::ListenerOptions::listenerOptionsWithBindToPort());
 
-  Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
+  Json::ObjectPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
@@ -85,8 +79,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca_with_uri_san.crt"
   }
   )EOF";
@@ -104,8 +98,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca_with_dns_san.crt"
   }
   )EOF";
@@ -122,8 +116,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": ""
   }
   )EOF";
@@ -140,8 +134,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt"
   }
   )EOF";
@@ -156,14 +150,14 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt",
     "verify_certificate_hash": "7B:0C:3F:0D:97:0E:FC:16:70:11:7A:0C:35:75:54:6B:17:AB:CF:20:D8:AA:A0:ED:87:08:0F:FB:60:4C:40:77"
   }
   )EOF";
 
-  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -183,7 +177,7 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
   }
   )EOF";
 
-  Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
+  Json::ObjectPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
@@ -213,14 +207,14 @@ TEST(SslConnectionImplTest, SslError) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "#test_certs#/unittestcert.pem",
-    "private_key_file": "#test_certs#/unittestkey.pem",
+    "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+    "private_key_file": "{{ test_certs }}/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt",
     "verify_certificate_hash": "7B:0C:3F:0D:97:0E:FC:16:70:11:7A:0C:35:75:54:6B:17:AB:CF:20:D8:AA:A0:ED:87:08:0F:FB:60:4C:40:77"
   }
   )EOF";
 
-  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -268,12 +262,12 @@ public:
 
     std::string server_ctx_json = R"EOF(
     {
-      "cert_chain_file": "#test_certs#/unittestcert.pem",
-      "private_key_file": "#test_certs#/unittestkey.pem",
+      "cert_chain_file": "{{ test_certs }}/unittestcert.pem",
+      "private_key_file": "{{ test_certs }}/unittestkey.pem",
       "ca_cert_file": "test/common/ssl/test_data/ca.crt"
     }
     )EOF";
-    Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
+    Json::ObjectPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
     ContextConfigImpl server_ctx_config(*server_ctx_loader);
     Runtime::MockLoader runtime;
     ContextManagerImpl manager(runtime);
@@ -293,7 +287,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
+    Json::ObjectPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
     ContextConfigImpl client_ctx_config(*client_ctx_loader);
     ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
 

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -12,18 +12,27 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/environment.h"
 
 using testing::_;
 using testing::Invoke;
 
 namespace Ssl {
 
-static void testUtil(std::string client_ctx_json, std::string server_ctx_json,
-                     std::string expected_digest, std::string expected_uri) {
+namespace {
+
+Json::ObjectPtr jsonLoad(const std::string& raw_json) {
+  const std::regex test_cert_regex("#test_certs#");
+  return Json::Factory::LoadFromString(
+      std::regex_replace(raw_json, test_cert_regex, TestEnvironment::runfilesPath("test/certs")));
+}
+
+void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_json,
+              const std::string& expected_digest, const std::string& expected_uri) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
 
-  Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -36,7 +45,7 @@ static void testUtil(std::string client_ctx_json, std::string server_ctx_json,
       dispatcher.createSslListener(connection_handler, *server_ctx, socket, callbacks, stats_store,
                                    Network::ListenerOptions::listenerOptionsWithBindToPort());
 
-  Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
+  Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
@@ -64,6 +73,8 @@ static void testUtil(std::string client_ctx_json, std::string server_ctx_json,
   dispatcher.run(Event::Dispatcher::RunType::Block);
 }
 
+} // namespace
+
 TEST(SslConnectionImplTest, ClientAuth) {
   std::string client_ctx_json = R"EOF(
   {
@@ -74,8 +85,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca_with_uri_san.crt"
   }
   )EOF";
@@ -93,8 +104,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca_with_dns_san.crt"
   }
   )EOF";
@@ -111,8 +122,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": ""
   }
   )EOF";
@@ -129,8 +140,8 @@ TEST(SslConnectionImplTest, ClientAuth) {
 
   server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt"
   }
   )EOF";
@@ -145,14 +156,14 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt",
     "verify_certificate_hash": "7B:0C:3F:0D:97:0E:FC:16:70:11:7A:0C:35:75:54:6B:17:AB:CF:20:D8:AA:A0:ED:87:08:0F:FB:60:4C:40:77"
   }
   )EOF";
 
-  Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -172,7 +183,7 @@ TEST(SslConnectionImplTest, ClientAuthBadVerification) {
   }
   )EOF";
 
-  Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
+  Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
   ContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Network::ClientConnectionPtr client_connection = dispatcher.createSslClientConnection(
@@ -202,14 +213,14 @@ TEST(SslConnectionImplTest, SslError) {
 
   std::string server_ctx_json = R"EOF(
   {
-    "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-    "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+    "cert_chain_file": "#test_certs#/unittestcert.pem",
+    "private_key_file": "#test_certs#/unittestkey.pem",
     "ca_cert_file": "test/common/ssl/test_data/ca.crt",
     "verify_certificate_hash": "7B:0C:3F:0D:97:0E:FC:16:70:11:7A:0C:35:75:54:6B:17:AB:CF:20:D8:AA:A0:ED:87:08:0F:FB:60:4C:40:77"
   }
   )EOF";
 
-  Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
+  Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
   ContextConfigImpl server_ctx_config(*server_ctx_loader);
   ContextManagerImpl manager(runtime);
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
@@ -257,12 +268,12 @@ public:
 
     std::string server_ctx_json = R"EOF(
     {
-      "cert_chain_file": "/tmp/envoy_test/unittestcert.pem",
-      "private_key_file": "/tmp/envoy_test/unittestkey.pem",
+      "cert_chain_file": "#test_certs#/unittestcert.pem",
+      "private_key_file": "#test_certs#/unittestkey.pem",
       "ca_cert_file": "test/common/ssl/test_data/ca.crt"
     }
     )EOF";
-    Json::ObjectPtr server_ctx_loader = Json::Factory::LoadFromString(server_ctx_json);
+    Json::ObjectPtr server_ctx_loader = jsonLoad(server_ctx_json);
     ContextConfigImpl server_ctx_config(*server_ctx_loader);
     Runtime::MockLoader runtime;
     ContextManagerImpl manager(runtime);
@@ -282,7 +293,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr client_ctx_loader = Json::Factory::LoadFromString(client_ctx_json);
+    Json::ObjectPtr client_ctx_loader = jsonLoad(client_ctx_json);
     ContextConfigImpl client_ctx_config(*client_ctx_loader);
     ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
 

--- a/test/config/integration/gen_test_configs.sh
+++ b/test/config/integration/gen_test_configs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Eventually this will fill in port info and temp paths for the test JSON configs. Today, it just
+# does a simple sed to handle the test temp path.
+
+set -e
+
+CONFIG_IN_DIR=$1
+CONFIG_OUT_DIR=$2
+
+mkdir -p "${CONFIG_OUT_DIR}"
+
+for f in $(find "${CONFIG_IN_DIR}" -name "*.json");
+do
+  cat $f | sed -e "s#{{ test_tmpdir }}#$TEST_TMPDIR#g" | \
+    cat > "${CONFIG_OUT_DIR}"/"$(basename "$f")"
+done

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -244,7 +244,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "profile_path": "/tmp/envoy.prof", "address": "tcp://127.0.0.1:10003" },
+  "admin": { "access_log_path": "/dev/null", "profile_path": "{{ test_tmpdir }}/envoy.prof", "address": "tcp://127.0.0.1:10003" },
   "flags_path": "/invalid_flags",
   "statsd_local_udp_port": 8125,
   "statsd_tcp_cluster_name": "statsd",

--- a/test/config/integration/server_uds.json
+++ b/test/config/integration/server_uds.json
@@ -91,14 +91,14 @@
       "connect_timeout_ms": 250,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "unix:///tmp/udstest.1.sock"}]
+      "hosts": [{"url": "unix://{{ test_tmpdir }}/udstest.1.sock"}]
     },
     {
       "name": "cluster_2",
       "connect_timeout_ms": 250,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "unix:///tmp/udstest.2.sock"}]
+      "hosts": [{"url": "unix://{{ test_tmpdir }}/udstest.2.sock"}]
     }]
   }
 }

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -8,6 +8,8 @@
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"
 
+#include "test/test_common/environment.h"
+
 namespace Server {
 
 class TestHotRestart : public HotRestart {
@@ -25,7 +27,8 @@ public:
 } // Server
 
 IntegrationTestServerPtr IntegrationTestServer::create(const std::string& config_path) {
-  IntegrationTestServerPtr server{new IntegrationTestServer(config_path)};
+  IntegrationTestServerPtr server{
+      new IntegrationTestServer(TestEnvironment::runfilesPath(config_path))};
   server->start();
   return server;
 }

--- a/test/integration/uds_integration_test.h
+++ b/test/integration/uds_integration_test.h
@@ -3,6 +3,7 @@
 #include "test/integration/fake_upstream.h"
 #include "test/integration/integration.h"
 #include "test/integration/server.h"
+#include "test/test_common/environment.h"
 
 #include "common/http/codec_client.h"
 #include "common/stats/stats_impl.h"
@@ -14,10 +15,10 @@ public:
    */
   static void SetUpTestCase() {
     test_server_ = IntegrationTestServer::create("test/config/integration/server_uds.json");
-    fake_upstreams_.emplace_back(
-        new FakeUpstream("/tmp/udstest.1.sock", FakeHttpConnection::Type::HTTP1));
-    fake_upstreams_.emplace_back(
-        new FakeUpstream("/tmp/udstest.2.sock", FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(TestEnvironment::temporaryPath("udstest.1.sock"),
+                                                  FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(TestEnvironment::temporaryPath("udstest.2.sock"),
+                                                  FakeHttpConnection::Type::HTTP1));
   }
 
   /**

--- a/test/main.cc
+++ b/test/main.cc
@@ -18,6 +18,10 @@ int main(int argc, char** argv) {
   Ssl::OpenSsl::initialize();
   Event::Libevent::Global::initialize();
 
+  // Set gtest properties
+  // (https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#logging-additional-information),
+  // they are available in the test XML.
+  // TODO(htuch): Log these as well?
   ::testing::Test::RecordProperty("TemporaryDirectory", TestEnvironment::temporaryDirectory());
   ::testing::Test::RecordProperty("RunfilesDirectory", TestEnvironment::runfilesDirectory());
 

--- a/test/main.cc
+++ b/test/main.cc
@@ -11,11 +11,15 @@
 #ifndef BAZEL_BRINGUP
 #include "test/integration/integration.h"
 #endif
+#include "test/test_common/environment.h"
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleMock(&argc, argv);
   Ssl::OpenSsl::initialize();
   Event::Libevent::Global::initialize();
+
+  ::testing::Test::RecordProperty("TemporaryDirectory", TestEnvironment::temporaryDirectory());
+  ::testing::Test::RecordProperty("RunfilesDirectory", TestEnvironment::runfilesDirectory());
 
   OptionsImpl options(argc, argv, "1", spdlog::level::err);
   Thread::MutexBasicLockable lock;

--- a/test/run_envoy_tests.sh
+++ b/test/run_envoy_tests.sh
@@ -5,39 +5,19 @@ set -e
 SOURCE_DIR=$1
 BINARY_DIR=$2
 
-# Create a test certificate with a 15-day expiration for SSL tests
-TEST_CERT_DIR=/tmp/envoy_test
-mkdir -p $TEST_CERT_DIR
-openssl genrsa -out $TEST_CERT_DIR/unittestkey.pem 1024
-openssl genrsa -out $TEST_CERT_DIR/unittestkey_expired.pem 1024
-openssl req -new -key $TEST_CERT_DIR/unittestkey.pem -out $TEST_CERT_DIR/unittestcert.csr \
-    -sha256 <<EOF
-US
-California
-San Francisco
-Lyft
-Test
-Unit Test CA
-unittest@lyft.com
+# These directories have the Bazel meaning described at
+# https://bazel.build/versions/master/docs/test-encyclopedia.html. In particular, TEST_SRCDIR is
+# where we expect to find the generated outputs of various scripts preparing input data (these is
+# not only the actual source files!).
+: ${TEST_TMPDIR:=/tmp/envoy_test_tmp}
+: ${TEST_SRCDIR:=/tmp/envoy_test_runfiles}
+export TEST_TMPDIR TEST_SRCDIR
 
+mkdir -p $TEST_TMPDIR
 
-EOF
-openssl req -new -key $TEST_CERT_DIR/unittestkey_expired.pem -out $TEST_CERT_DIR/unittestcert_expired.csr \
-    -sha256 <<EOF
-US
-California
-San Francisco
-Lyft
-Test
-Unit Test CA
-unittest@lyft.com
-
-
-EOF
-openssl x509 -req -days 15 -in $TEST_CERT_DIR/unittestcert.csr -sha256 -signkey \
-    $TEST_CERT_DIR/unittestkey.pem -out $TEST_CERT_DIR/unittestcert.pem
-openssl x509 -req -days -365 -in $TEST_CERT_DIR/unittestcert_expired.csr -sha256 -signkey \
-    $TEST_CERT_DIR/unittestkey_expired.pem -out $TEST_CERT_DIR/unittestcert_expired.pem
+$SOURCE_DIR/test/certs/gen_test_certs.sh $TEST_SRCDIR/test/certs
+$SOURCE_DIR/test/config/integration/gen_test_configs.sh $SOURCE_DIR/test/config/integration \
+  $TEST_SRCDIR/test/config/integration
 
 # First run the normal unit test suite
 cd $SOURCE_DIR
@@ -51,7 +31,7 @@ fi
 # Now start the real server, hot restart it twice, and shut it all down as a basic hot restart
 # sanity test.
 echo "Starting epoch 0"
-$BINARY_DIR/source/exe/envoy -c test/config/integration/server.json \
+$BINARY_DIR/source/exe/envoy -c $TEST_SRCDIR/test/config/integration/server.json \
     --restart-epoch 0 --base-id 1 --service-cluster cluster --service-node node &
 
 FIRST_SERVER_PID=$!
@@ -64,7 +44,7 @@ kill -SIGHUP $FIRST_SERVER_PID
 sleep 3
 
 echo "Starting epoch 1"
-$BINARY_DIR/source/exe/envoy -c test/config/integration/server.json \
+$BINARY_DIR/source/exe/envoy -c $TEST_SRCDIR/test/config/integration/server.json \
     --restart-epoch 1 --base-id 1 --service-cluster cluster --service-node node &
 
 SECOND_SERVER_PID=$!
@@ -72,7 +52,7 @@ SECOND_SERVER_PID=$!
 sleep 7
 
 echo "Starting epoch 2"
-$BINARY_DIR/source/exe/envoy -c test/config/integration/server.json \
+$BINARY_DIR/source/exe/envoy -c $TEST_SRCDIR/test/config/integration/server.json \
     --restart-epoch 2 --base-id 1 --service-cluster cluster --service-node node &
 
 THIRD_SERVER_PID=$!

--- a/test/run_envoy_tests.sh
+++ b/test/run_envoy_tests.sh
@@ -7,7 +7,7 @@ BINARY_DIR=$2
 
 # These directories have the Bazel meaning described at
 # https://bazel.build/versions/master/docs/test-encyclopedia.html. In particular, TEST_SRCDIR is
-# where we expect to find the generated outputs of various scripts preparing input data (these is
+# where we expect to find the generated outputs of various scripts preparing input data (these are
 # not only the actual source files!).
 : ${TEST_TMPDIR:=/tmp/envoy_test_tmp}
 : ${TEST_SRCDIR:=/tmp/envoy_test_runfiles}

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -3,6 +3,7 @@
 #include "server/http/admin.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
 using testing::_;
@@ -13,10 +14,9 @@ namespace Server {
 class AdminFilterTest : public testing::Test {
 public:
   // TODO(mattklein123): Switch to mocks and do not bind to a real port.
-  // TODO(htuch): Use proper temporary path allocation method.
   AdminFilterTest()
-      : admin_("/dev/null", "/tmp/envoy.prof", Network::Utility::resolveUrl("tcp://127.0.0.1:9002"),
-               server_),
+      : admin_("/dev/null", TestEnvironment::temporaryPath("envoy.prof"),
+               Network::Utility::resolveUrl("tcp://127.0.0.1:9002"), server_),
         filter_(admin_), request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
@@ -65,7 +65,8 @@ TEST_F(AdminFilterTest, AdminProfiler) {
 
 TEST_F(AdminFilterTest, AdminBadProfiler) {
   Buffer::OwnedImpl data;
-  AdminImpl admin_bad_profile_path("/dev/null", "/some/unlikely/bad/path.prof",
+  AdminImpl admin_bad_profile_path("/dev/null",
+                                   TestEnvironment::temporaryPath("some/unlikely/bad/path.prof"),
                                    Network::Utility::resolveUrl("tcp://127.0.0.1:9002"), server_);
   admin_bad_profile_path.runCallback("/cpuprofiler?enable=y", data);
   EXPECT_FALSE(Profiler::Cpu::profilerEnabled());

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -22,3 +22,13 @@ const std::string& TestEnvironment::runfilesDirectory() {
   static const std::string* runfiles_directory = getCheckedEnvVar("TEST_SRCDIR");
   return *runfiles_directory;
 }
+
+std::string TestEnvironment::substitute(const std::string str) {
+  // TODO(htuch): Add support for {{ test_tmpdir }} etc. as needed for tests.
+  const std::regex test_cert_regex("\\{\\{ test_certs \\}\\}");
+  return std::regex_replace(str, test_cert_regex, TestEnvironment::runfilesPath("test/certs"));
+}
+
+Json::ObjectPtr TestEnvironment::jsonLoadFromString(const std::string& json) {
+  return Json::Factory::LoadFromString(substitute(json));
+}

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -1,0 +1,24 @@
+#include "test/test_common/environment.h"
+
+#include "common/common/assert.h"
+
+namespace {
+
+std::string* getCheckedEnvVar(const std::string& var) {
+  // Bazel style temp dirs. Should be set by test runner or Bazel.
+  const char* path = ::getenv(var.c_str());
+  RELEASE_ASSERT(path != nullptr);
+  return new std::string(path);
+}
+
+} // namespace
+
+const std::string& TestEnvironment::temporaryDirectory() {
+  static const std::string* temporary_directory = getCheckedEnvVar("TEST_TMPDIR");
+  return *temporary_directory;
+}
+
+const std::string& TestEnvironment::runfilesDirectory() {
+  static const std::string* runfiles_directory = getCheckedEnvVar("TEST_SRCDIR");
+  return *runfiles_directory;
+}

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -1,0 +1,34 @@
+#pragma once
+
+class TestEnvironment {
+public:
+  /**
+   * Obtain a private writable temporary directory.
+   * @return const std::string& with the path to the temporary directory.
+   */
+  static const std::string& temporaryDirectory();
+
+  /**
+   * Prefix a given path with the private writable test temporary directory.
+   * @param path path suffix.
+   * @return std::string path qualified with temporary directory.
+   */
+  static std::string temporaryPath(const std::string& path) {
+    return temporaryDirectory() + "/" + path;
+  }
+
+  /**
+   * Obtain read-only test input data directory.
+   * @return const std::string& with the path to the read-only test input directory.
+   */
+  static const std::string& runfilesDirectory();
+
+  /**
+   * Prefix a given path with the read-only test input data directory.
+   * @param path path suffix.
+   * @return std::string path qualified with read-only test input data directory.
+   */
+  static std::string runfilesPath(const std::string& path) {
+    return runfilesDirectory() + "/" + path;
+  }
+};

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/json/json_loader.h"
+
 class TestEnvironment {
 public:
   /**
@@ -31,4 +33,25 @@ public:
   static std::string runfilesPath(const std::string& path) {
     return runfilesDirectory() + "/" + path;
   }
+
+  /**
+   * Obtain pregenerated test ssl key/certificate directory.
+   * @return std::string& with the path to the pregenerated test ssl key/certificate
+   *         directory.
+   */
+  static std::string certsDirectory() { return runfilesPath("test/certs"); }
+
+  /**
+   * String environment path substitution.
+   * @param str string with template patterns including {{ test_certs }}.
+   * @return std::string with patterns replaced with environment values.
+   */
+  static std::string substitute(const std::string str);
+
+  /**
+   * Build JSON object from a string subject to environment path substitution.
+   * @param json JSON with template patterns including {{ test_certs }}.
+   * @return Json::ObjectPtr with built JSON object.
+   */
+  static Json::ObjectPtr jsonLoadFromString(const std::string& json);
 };


### PR DESCRIPTION
Previously, there were some hardcoded /tmp paths for both generated artifacts and intermediate test
objects. This patch provides a TestEnvironment API to obtain these paths from the test runner, which
will assist with #415. In addition, the generation scripts and paths have been moved around a bit in
anticipation of #415.

Fixes #605.