### PR TITLE
cleanup: switch to new header convention.

### DIFF
--- a/include/envoy/mongo/codec.h
+++ b/include/envoy/mongo/codec.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "bson.h"
+#include "envoy/mongo/bson.h"
 
 /**
  * General implementation of https://docs.mongodb.org/manual/reference/mongodb-wire-protocol/

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -1,4 +1,4 @@
-#include "client_ssl.h"
+#include "common/filter/auth/client_ssl.h"
 
 #include "envoy/network/connection.h"
 

--- a/source/common/filter/echo.cc
+++ b/source/common/filter/echo.cc
@@ -1,4 +1,4 @@
-#include "echo.h"
+#include "common/filter/echo.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/network/connection.h"

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -1,4 +1,4 @@
-#include "ratelimit.h"
+#include "common/filter/ratelimit.h"
 
 #include "common/common/empty_string.h"
 #include "common/json/config_schemas.h"

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -1,4 +1,4 @@
-#include "tcp_proxy.h"
+#include "common/filter/tcp_proxy.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -1,10 +1,10 @@
-#include "common.h"
-#include "http1_bridge_filter.h"
+#include "common/grpc/http1_bridge_filter.h"
 
 #include "envoy/http/codes.h"
 
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
+#include "common/grpc/common.h"
 #include "common/http/headers.h"
 #include "common/http/http1/codec_impl.h"
 

--- a/source/common/grpc/rpc_channel_impl.cc
+++ b/source/common/grpc/rpc_channel_impl.cc
@@ -1,8 +1,8 @@
-#include "common.h"
-#include "rpc_channel_impl.h"
+#include "common/grpc/rpc_channel_impl.h"
 
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
+#include "common/grpc/common.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -1,5 +1,4 @@
-#include "access_log_impl.h"
-#include "access_log_formatter.h"
+#include "common/http/access_log/access_log_impl.h"
 
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/http/header_map.h"
@@ -8,6 +7,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
+#include "common/http/access_log/access_log_formatter.h"
 #include "common/http/headers.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/utility.h"

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -1,5 +1,6 @@
-#include "async_client_impl.h"
-#include "utility.h"
+#include "common/http/async_client_impl.h"
+
+#include "common/http/utility.h"
 
 namespace Http {
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "message_impl.h"
-
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/codec.h"
@@ -15,6 +13,7 @@
 #include "common/common/empty_string.h"
 #include "common/common/linked_object.h"
 #include "common/http/access_log/request_info_impl.h"
+#include "common/http/message_impl.h"
 #include "common/router/router.h"
 
 namespace Http {

--- a/source/common/http/filter/buffer_filter.cc
+++ b/source/common/http/filter/buffer_filter.cc
@@ -1,4 +1,4 @@
-#include "buffer_filter.h"
+#include "common/http/filter/buffer_filter.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -1,4 +1,4 @@
-#include "fault_filter.h"
+#include "common/http/filter/fault_filter.h"
 
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -1,4 +1,4 @@
-#include "ratelimit.h"
+#include "common/http/filter/ratelimit.h"
 
 #include "envoy/http/codes.h"
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -1,4 +1,4 @@
-#include "conn_pool.h"
+#include "common/http/http1/conn_pool.h"
 
 #include "envoy/http/header_map.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -1,10 +1,10 @@
-#include "codec_impl.h"
-#include "conn_pool.h"
+#include "common/http/http2/conn_pool.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/upstream/upstream.h"
 
+#include "common/http/http2/codec_impl.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -1,4 +1,4 @@
-#include "stats.h"
+#include "common/memory/stats.h"
 
 #ifdef TCMALLOC
 

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -1,4 +1,4 @@
-#include "bson_impl.h"
+#include "common/mongo/bson_impl.h"
 
 #include "common/common/assert.h"
 #include "common/common/hex.h"

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -1,11 +1,11 @@
-#include "bson_impl.h"
-#include "codec_impl.h"
+#include "common/mongo/codec_impl.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
 #include "common/common/base64.h"
+#include "common/mongo/bson_impl.h"
 
 namespace Mongo {
 

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -1,5 +1,4 @@
-#include "codec_impl.h"
-#include "proxy.h"
+#include "common/mongo/proxy.h"
 
 #include "envoy/common/exception.h"
 #include "envoy/filesystem/filesystem.h"
@@ -7,6 +6,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
+#include "common/mongo/codec_impl.h"
 
 namespace Mongo {
 

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "utility.h"
-
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/time.h"
 #include "envoy/mongo/codec.h"
@@ -13,6 +11,7 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/common/logger.h"
+#include "common/mongo/utility.h"
 #include "common/network/filter_impl.h"
 
 namespace Mongo {

--- a/source/common/mongo/utility.cc
+++ b/source/common/mongo/utility.cc
@@ -1,4 +1,4 @@
-#include "utility.h"
+#include "common/mongo/utility.h"
 
 #include "envoy/common/exception.h"
 

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -1,4 +1,4 @@
-#include "cidr_range.h"
+#include "common/network/cidr_range.h"
 
 #include "envoy/common/exception.h"
 

--- a/source/common/profiler/profiler.cc
+++ b/source/common/profiler/profiler.cc
@@ -1,4 +1,4 @@
-#include "profiler.h"
+#include "common/profiler/profiler.h"
 
 #ifdef TCMALLOC
 

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -1,4 +1,4 @@
-#include "ratelimit_impl.h"
+#include "common/ratelimit/ratelimit_impl.h"
 
 #include "envoy/tracing/context.h"
 

--- a/source/common/ratelimit/ratelimit_impl.h
+++ b/source/common/ratelimit/ratelimit_impl.h
@@ -5,7 +5,11 @@
 #include "envoy/tracing/context.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#ifdef BAZEL_BRINGUP
+#include "common/ratelimit/ratelimit.pb.h"
+#else
 #include "common/generated/ratelimit.pb.h"
+#endif
 #include "common/json/json_loader.h"
 
 namespace RateLimit {

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -1,4 +1,4 @@
-#include "codec_impl.h"
+#include "common/redis/codec_impl.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -1,4 +1,4 @@
-#include "conn_pool_impl.h"
+#include "common/redis/conn_pool_impl.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/redis/proxy_filter.cc
+++ b/source/common/redis/proxy_filter.cc
@@ -1,4 +1,4 @@
-#include "proxy_filter.h"
+#include "common/redis/proxy_filter.h"
 
 #include "common/common/assert.h"
 #include "common/json/config_schemas.h"

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1,5 +1,4 @@
-#include "config_impl.h"
-#include "retry_state_impl.h"
+#include "common/router/config_impl.h"
 
 #include "envoy/http/header_map.h"
 #include "envoy/runtime/runtime.h"
@@ -13,6 +12,7 @@
 #include "common/http/utility.h"
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
+#include "common/router/retry_state_impl.h"
 
 namespace Router {
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "router_ratelimit.h"
-
 #include "envoy/common/optional.h"
 #include "envoy/router/router.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/router/config_utility.h"
+#include "common/router/router_ratelimit.h"
 
 namespace Router {
 

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -1,4 +1,4 @@
-#include "config_utility.h"
+#include "common/router/config_utility.h"
 
 namespace Router {
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -1,8 +1,8 @@
-#include "config_impl.h"
-#include "rds_impl.h"
+#include "common/router/rds_impl.h"
 
 #include "common/common/assert.h"
 #include "common/json/config_schemas.h"
+#include "common/router/config_impl.h"
 
 namespace Router {
 

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -1,4 +1,4 @@
-#include "retry_state_impl.h"
+#include "common/router/retry_state_impl.h"
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1,6 +1,4 @@
-#include "config_impl.h"
-#include "retry_state_impl.h"
-#include "router.h"
+#include "common/router/router.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
@@ -19,6 +17,8 @@
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
+#include "common/router/config_impl.h"
+#include "common/router/retry_state_impl.h"
 
 namespace Router {
 

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -1,4 +1,4 @@
-#include "router_ratelimit.h"
+#include "common/router/router_ratelimit.h"
 
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -1,4 +1,4 @@
-#include "shadow_writer_impl.h"
+#include "common/router/shadow_writer_impl.h"
 
 #include "common/common/assert.h"
 #include "common/http/headers.h"

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -1,4 +1,4 @@
-#include "statsd.h"
+#include "common/stats/statsd.h"
 
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -1,4 +1,4 @@
-#include "thread_local_store.h"
+#include "common/stats/thread_local_store.h"
 
 namespace Stats {
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "stats_impl.h"
-
 #include "envoy/thread_local/thread_local.h"
+
+#include "common/stats/stats_impl.h"
 
 namespace Stats {
 

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -1,4 +1,4 @@
-#include "thread_local_impl.h"
+#include "common/thread_local/thread_local_impl.h"
 
 #include "envoy/event/dispatcher.h"
 

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -1,4 +1,4 @@
-#include "cds_api_impl.h"
+#include "common/upstream/cds_api_impl.h"
 
 #include "common/common/assert.h"
 #include "common/http/headers.h"

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1,7 +1,4 @@
-#include "cds_api_impl.h"
-#include "cluster_manager_impl.h"
-#include "load_balancer_impl.h"
-#include "ring_hash_lb.h"
+#include "common/upstream/cluster_manager_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
@@ -14,6 +11,9 @@
 #include "common/http/async_client_impl.h"
 #include "common/json/config_schemas.h"
 #include "common/router/shadow_writer_impl.h"
+#include "common/upstream/cds_api_impl.h"
+#include "common/upstream/load_balancer_impl.h"
+#include "common/upstream/ring_hash_lb.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "sds.h"
-
 #include "envoy/http/codes.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
@@ -10,6 +8,7 @@
 
 #include "common/http/async_client_impl.h"
 #include "common/json/json_loader.h"
+#include "common/upstream/sds.h"
 
 namespace Upstream {
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1,4 +1,4 @@
-#include "load_balancer_impl.h"
+#include "common/upstream/load_balancer_impl.h"
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -1,7 +1,7 @@
-#include "load_balancer_impl.h"
-#include "ring_hash_lb.h"
+#include "common/upstream/ring_hash_lb.h"
 
 #include "common/common/assert.h"
+#include "common/upstream/load_balancer_impl.h"
 
 namespace Upstream {
 

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -1,4 +1,4 @@
-#include "hot_restart.h"
+#include "exe/hot_restart.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,10 +1,9 @@
-#include "hot_restart.h"
-
 #include "common/event/libevent.h"
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"
 #include "common/ssl/openssl.h"
 #include "common/stats/thread_local_store.h"
+#include "exe/hot_restart.h"
 #include "server/drain_manager_impl.h"
 #include "server/options_impl.h"
 #include "server/server.h"

--- a/source/server/config/http/buffer.cc
+++ b/source/server/config/http/buffer.cc
@@ -1,4 +1,4 @@
-#include "buffer.h"
+#include "server/config/http/buffer.h"
 
 #include "common/http/filter/buffer_filter.h"
 #include "common/json/config_schemas.h"

--- a/source/server/config/http/dynamo.cc
+++ b/source/server/config/http/dynamo.cc
@@ -1,4 +1,4 @@
-#include "dynamo.h"
+#include "server/config/http/dynamo.h"
 
 #include "common/dynamo/dynamo_filter.h"
 

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -1,4 +1,4 @@
-#include "fault.h"
+#include "server/config/http/fault.h"
 
 #include "common/http/filter/fault_filter.h"
 #include "common/json/config_schemas.h"

--- a/source/server/config/http/grpc_http1_bridge.cc
+++ b/source/server/config/http/grpc_http1_bridge.cc
@@ -1,4 +1,4 @@
-#include "grpc_http1_bridge.h"
+#include "server/config/http/grpc_http1_bridge.h"
 
 #include "common/grpc/http1_bridge_filter.h"
 

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -1,4 +1,4 @@
-#include "ratelimit.h"
+#include "server/config/http/ratelimit.h"
 
 #include "common/http/filter/ratelimit.h"
 

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -1,4 +1,4 @@
-#include "router.h"
+#include "server/config/http/router.h"
 
 #include "common/json/config_schemas.h"
 #include "common/router/router.h"

--- a/source/server/config/network/client_ssl_auth.cc
+++ b/source/server/config/network/client_ssl_auth.cc
@@ -1,4 +1,4 @@
-#include "client_ssl_auth.h"
+#include "server/config/network/client_ssl_auth.h"
 
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -1,4 +1,4 @@
-#include "http_connection_manager.h"
+#include "server/config/network/http_connection_manager.h"
 
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/network/connection.h"

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -1,4 +1,4 @@
-#include "mongo_proxy.h"
+#include "server/config/network/mongo_proxy.h"
 
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"

--- a/source/server/config/network/ratelimit.cc
+++ b/source/server/config/network/ratelimit.cc
@@ -1,4 +1,4 @@
-#include "ratelimit.h"
+#include "server/config/network/ratelimit.h"
 
 #include "envoy/network/connection.h"
 

--- a/source/server/config/network/redis_proxy.cc
+++ b/source/server/config/network/redis_proxy.cc
@@ -1,4 +1,4 @@
-#include "redis_proxy.h"
+#include "server/config/network/redis_proxy.h"
 
 #include "common/redis/codec_impl.h"
 #include "common/redis/command_splitter_impl.h"

--- a/source/server/config/network/tcp_proxy.cc
+++ b/source/server/config/network/tcp_proxy.cc
@@ -1,4 +1,4 @@
-#include "tcp_proxy.h"
+#include "server/config/network/tcp_proxy.h"
 
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -1,4 +1,4 @@
-#include "configuration_impl.h"
+#include "server/configuration_impl.h"
 
 #include "envoy/network/connection.h"
 #include "envoy/runtime/runtime.h"

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -1,4 +1,4 @@
-#include "connection_handler_impl.h"
+#include "server/connection_handler_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -1,4 +1,4 @@
-#include "drain_manager_impl.h"
+#include "server/drain_manager_impl.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1,4 +1,4 @@
-#include "admin.h"
+#include "server/http/admin.h"
 
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/server/hot_restart.h"

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -1,4 +1,4 @@
-#include "health_check.h"
+#include "server/http/health_check.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1,7 +1,4 @@
-#include "configuration_impl.h"
-#include "server.h"
-#include "test_hooks.h"
-#include "worker.h"
+#include "server/server.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/signal.h"
@@ -19,6 +16,10 @@
 #include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/stats/statsd.h"
+
+#include "server/configuration_impl.h"
+#include "server/test_hooks.h"
+#include "server/worker.h"
 
 namespace Server {
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "connection_handler_impl.h"
-#include "worker.h"
-
 #include "envoy/common/optional.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/instance.h"
@@ -14,8 +11,10 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/ssl/context_manager_impl.h"
 #include "common/thread_local/thread_local_impl.h"
+#include "server/connection_handler_impl.h"
 #include "server/http/admin.h"
 #include "server/test_hooks.h"
+#include "server/worker.h"
 
 namespace Server {
 

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -1,4 +1,4 @@
-#include "worker.h"
+#include "server/worker.h"
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/server/worker.h
+++ b/source/server/worker.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "connection_handler_impl.h"
-
 #include "envoy/server/configuration.h"
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/thread.h"
 #include "common/network/listen_socket_impl.h"
+
+#include "server/connection_handler_impl.h"
 
 typedef std::map<Server::Configuration::Listener*, Network::TcpListenSocketPtr> SocketMap;
 

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -1,7 +1,11 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/grpc/codec.h"
 
+#ifdef BAZEL_BRINGUP
+#include "test/proto/helloworld.pb.h"
+#else
 #include "test/generated/helloworld.pb.h"
+#endif
 
 namespace Grpc {
 

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -1,7 +1,11 @@
 #include "common/grpc/common.h"
 #include "common/http/headers.h"
 
+#ifdef BAZEL_BRINGUP
+#include "test/proto/helloworld.pb.h"
+#else
 #include "test/generated/helloworld.pb.h"
+#endif
 #include "test/mocks/upstream/mocks.h"
 
 namespace Grpc {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1,9 +1,9 @@
-#include "http2_integration_test.h"
-#include "utility.h"
+#include "test/integration/http2_integration_test.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/http/header_map_impl.h"
 
+#include "test/integration/utility.h"
 #include "test/mocks/http/mocks.h"
 #include "test/test_common/utility.h"
 

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "integration.h"
+#include "test/integration/integration.h"
 
 class Http2IntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -1,4 +1,4 @@
-#include "http2_upstream_integration_test.h"
+#include "test/integration/http2_upstream_integration_test.h"
 
 #include "common/http/header_map_impl.h"
 

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "integration.h"
+#include "test/integration/integration.h"
 
 class Http2UpstreamIntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "fake_upstream.h"
-#include "server.h"
-
 #include "common/http/codec_client.h"
 #include "common/network/filter_impl.h"
 #include "common/stats/stats_impl.h"
+
+#include "test/integration/fake_upstream.h"
+#include "test/integration/server.h"
 
 /**
  * Stream decoder wrapper used during integration testing.

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -1,7 +1,7 @@
-#include "integration.h"
-#include "utility.h"
-
 #include "envoy/http/header_map.h"
+
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
 
 TEST_F(IntegrationTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1,9 +1,8 @@
-#include "integration.h"
-#include "utility.h"
+#include "test/integration/integration.h"
 
-#include "common/buffer/buffer_impl.h"
 #include "common/http/header_map_impl.h"
 
+#include "test/integration/utility.h"
 #include "test/test_common/utility.h"
 
 TEST_F(IntegrationTest, Echo) {

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -1,4 +1,4 @@
-#include "proxy_proto_integration_test.h"
+#include "test/integration/proxy_proto_integration_test.h"
 
 #include "common/buffer/buffer_impl.h"
 

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -1,6 +1,4 @@
-#include "integration.h"
-#include "server.h"
-#include "utility.h"
+#include "test/integration/server.h"
 
 #include "envoy/http/header_map.h"
 #include "envoy/server/hot_restart.h"
@@ -8,6 +6,8 @@
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"
 
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
 #include "test/test_common/environment.h"
 
 namespace Server {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -50,7 +50,7 @@ protected:
       : options_(std::string("test/config/integration/server.json")),
         server_(options_, hooks_, restart_, stats_store_, fakelock_, component_factory_,
                 local_info_) {}
-  void TearDown() {
+  void TearDown() override {
     server_.clusterManager().shutdown();
     server_.threadLocal().shutdownThread();
   }


### PR DESCRIPTION
Removing relative path references to support #415. Also some #ifdef BAZEL_BRINGUP.