### PR TITLE
test: some minor build fixes that correct issues discovered during #415.

### DIFF
--- a/test/common/grpc/rpc_channel_impl_test.cc
+++ b/test/common/grpc/rpc_channel_impl_test.cc
@@ -2,7 +2,11 @@
 #include "common/grpc/rpc_channel_impl.h"
 #include "common/http/message_impl.h"
 
+#ifdef BAZEL_BRINGUP
+#include "test/proto/helloworld.pb.h"
+#else
 #include "test/generated/helloworld.pb.h"
+#endif
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -37,7 +37,8 @@ public:
 
   Http2CodecImplTest()
       : client_(client_connection_, client_callbacks_, stats_store_, GetParam()),
-        server_(server_connection_, server_callbacks_, stats_store_, GetParam()) {
+        server_(server_connection_, server_callbacks_, stats_store_, GetParam()),
+        request_encoder_(client_.newStream(response_decoder_)) {
     setupDefaultConnectionMocks();
 
     EXPECT_CALL(server_callbacks_, newStream(_))
@@ -67,7 +68,7 @@ public:
   ServerConnectionImpl server_;
   ConnectionWrapper server_wrapper_;
   MockStreamDecoder response_decoder_;
-  StreamEncoder& request_encoder_{client_.newStream(response_decoder_)};
+  StreamEncoder& request_encoder_;
   MockStreamDecoder request_decoder_;
   StreamEncoder* response_encoder_{};
   MockStreamCallbacks callbacks_;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1,4 +1,5 @@
 #include "envoy/api/api.h"
+#include "envoy/http/codec.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/json/config_schemas.h"
@@ -135,7 +136,8 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_EQ(3U, cluster.info()->resourceManager(ResourcePriority::High).requests().max());
   EXPECT_EQ(4U, cluster.info()->resourceManager(ResourcePriority::High).retries().max());
   EXPECT_EQ(3U, cluster.info()->maxRequestsPerConnection());
-  EXPECT_EQ(Http::CodecOptions::NoCompression, cluster.info()->httpCodecOptions());
+  EXPECT_EQ(static_cast<uint64_t>(Http::CodecOptions::NoCompression),
+            cluster.info()->httpCodecOptions());
 
   cluster.info()->stats().upstream_rq_total_.inc();
   EXPECT_EQ(1UL, stats.counter("cluster.name.upstream_rq_total").value());


### PR DESCRIPTION
Mostly C++ nits that Bazel's fastbuild compiler options triggered.