### PR TITLE
Tracing: fix config for lightstep driver

### DIFF
--- a/configs/envoy_double_proxy.template.json
+++ b/configs/envoy_double_proxy.template.json
@@ -95,8 +95,8 @@
     "http": {
       "driver": {
           "type": "lightstep",
-          "access_token_file": "/etc/envoy/lightstep_access_token",
           "config": {
+            "access_token_file": "/etc/envoy/lightstep_access_token",
             "collector_cluster": "lightstep_saas"
           }
       }

--- a/configs/envoy_front_proxy.template.json
+++ b/configs/envoy_front_proxy.template.json
@@ -90,8 +90,8 @@
     "http": {
       "driver": {
           "type": "lightstep",
-          "access_token_file": "/etc/envoy/lightstep_access_token",
           "config": {
+            "access_token_file": "/etc/envoy/lightstep_access_token",
             "collector_cluster": "lightstep_saas"
           }
       }

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -268,8 +268,8 @@
     "http": {
       "driver": {
         "type": "lightstep",
-        "access_token_file": "/etc/envoy/lightstep_access_token",
         "config": {
+          "access_token_file": "/etc/envoy/lightstep_access_token",
           "collector_cluster": "lightstep_saas"
         }
       }

--- a/docs/configuration/overview/tracing.rst
+++ b/docs/configuration/overview/tracing.rst
@@ -31,8 +31,8 @@ LightStep driver
 
   {
     "type": "lightstep",
-    "access_token_file": "...",
     "config": {
+      "access_token_file": "...",
       "collector_cluster": "..."
     }
   }

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -860,17 +860,17 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
             "type" : "string",
             "enum" : ["lightstep"]
           },
-          "access_token_file" : {"type" : "string"},
           "config" : {
             "type" : "object",
             "properties" : {
-              "collector_cluster" : {"type" : "string"}
+              "collector_cluster" : {"type" : "string"},
+              "access_token_file" : {"type" : "string"}
             },
-            "required": ["collector_cluster"],
+            "required": ["collector_cluster", "access_token_file"],
             "additionalProperties" : false
           }
         },
-        "required" : ["type", "access_token_file", "config"],
+        "required" : ["type", "config"],
         "additionalProperties" : false
       },
       "rate_limit_service" : {

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -252,8 +252,8 @@
     "http": {
       "driver": {
         "type": "lightstep",
-        "access_token_file": "test/config/integration/lightstep_access_token",
         "config": {
+          "access_token_file": "test/config/integration/lightstep_access_token",
           "collector_cluster": "lightstep_saas"
         }
       }

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -200,9 +200,9 @@
     "http": {
       "driver": {
         "type": "lightstep",
-        "access_token_file": "test/config/integration/lightstep_access_token",
         "config": {
-          "collector_cluster": "lightstep_saas"
+          "collector_cluster": "lightstep_saas",
+          "access_token_file": "test/config/integration/lightstep_access_token"
         }
       }
     }

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -280,7 +280,9 @@ TEST(ConfigurationImplTest, ServiceClusterNotSetWhenLSTracing) {
       "http": {
         "driver": {
           "type": "lightstep",
-          "access_token_file": "/etc/envoy/envoy.cfg"
+          "config": {
+            "access_token_file": "/etc/envoy/envoy.cfg"
+          }
         }
       }
     }
@@ -311,7 +313,9 @@ TEST(ConfigurationImplTest, UnsupportedDriverType) {
       "http": {
         "driver": {
           "type": "unknown",
-          "access_token_file": "/etc/envoy/envoy.cfg"
+          "config": {
+            "access_token_file": "/etc/envoy/envoy.cfg"
+          }
         }
       }
     }


### PR DESCRIPTION
access_token should be defined on the LS config level vs on the driver level.

This is a config breaking change!