### PR TITLE
test: fix race condition in integration test server.

### DIFF
--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -37,7 +37,13 @@ void IntegrationTestServer::start() {
   log().info("starting integration test server");
   ASSERT(!thread_);
   thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
+  // First, we want to wait until we know the server's worker threads are all
+  // started.
   server_initialized_.waitReady();
+  // Then we need to make sure the thread with
+  // IntegrationTestServer::threadRoutine has set server_, since integration
+  // tests might rely on the value of server().
+  server_set_.waitReady();
 }
 
 IntegrationTestServer::~IntegrationTestServer() {
@@ -59,6 +65,7 @@ void IntegrationTestServer::threadRoutine() {
                                       "cluster_name", "node_name");
   server_.reset(
       new Server::InstanceImpl(options, *this, restarter, stats_store_, lock, *this, local_info));
+  server_set_.setReady();
   server_->run();
   server_.reset();
 }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -113,7 +113,10 @@ public:
   ~IntegrationTestServer();
 
   Server::TestDrainManager& drainManager() { return *drain_manager_; }
-  Server::InstanceImpl& server() { return *server_; }
+  Server::InstanceImpl& server() {
+    RELEASE_ASSERT(server_ != nullptr);
+    return *server_;
+  }
   void start();
   Stats::Store& store() { return stats_store_; }
 
@@ -142,6 +145,7 @@ private:
   const std::string config_path_;
   Thread::ThreadPtr thread_;
   ConditionalInitializer server_initialized_;
+  ConditionalInitializer server_set_;
   std::unique_ptr<Server::InstanceImpl> server_;
   Server::TestDrainManager* drain_manager_{};
   Stats::TestIsolatedStoreImpl stats_store_;


### PR DESCRIPTION
Previously, there was an issue where the server initialization might complete, triggering
onServerInitialized(). At this point, we would return from IntegrationTestServer::create() to the
caller, but the test server thread may not have actually set the value of server_ via
server_.reset() yet. Any test that then tried to access test_server_.server() would seg fault. This
resulted in integration test flakes while working on #574. Added an additional notification for
this.