### PR TITLE
Tracing: span name depending on ingress/egress

### DIFF
--- a/docs/configuration/http_conn_man/tracing.rst
+++ b/docs/configuration/http_conn_man/tracing.rst
@@ -12,5 +12,7 @@ Tracing
   }
  
 operation_name
-  *(required, string)* Span name that will be emitted on completed request.
+  *(required, string)* Span name will be derived from operation_name. "ingress" and "egress"
+  are the only supported values.
+
 

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -6,6 +6,8 @@
 
 namespace Tracing {
 
+enum class OperationName { Ingress, Egress };
+
 /*
  * Tracing configuration, it carries additional data needed to populate the span.
  */
@@ -13,7 +15,7 @@ class Config {
 public:
   virtual ~Config() {}
 
-  virtual const std::string& operationName() const PURE;
+  virtual OperationName operationName() const PURE;
 };
 
 /*

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -744,7 +744,7 @@ void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason) {
       removeFromList(connection_manager_.streams_));
 }
 
-const std::string& ConnectionManagerImpl::ActiveStream::operationName() const {
+Tracing::OperationName ConnectionManagerImpl::ActiveStream::operationName() const {
   return connection_manager_.config_.tracingConfig().value().operation_name_;
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -103,7 +103,7 @@ struct ConnectionManagerTracingStats {
  * Here we specify some specific for connection manager settings.
  */
 struct TracingConnectionManagerConfig {
-  std::string operation_name_;
+  Tracing::OperationName operation_name_;
 };
 
 /**
@@ -383,7 +383,7 @@ private:
     void addAccessLogHandler(Http::AccessLog::InstanceSharedPtr handler) override;
 
     // Tracing::TracingConfig
-    virtual const std::string& operationName() const override;
+    virtual Tracing::OperationName operationName() const override;
 
     // All state for the stream. Put here for readability. We could move this to a bit field
     // eventually if we want.

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -211,8 +211,10 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
       "tracing" : {
         "type" : "object",
         "properties" : {
-          "operation_name" : {"type" : "string"},
-          "enum": ["ingress", "egress"]
+          "operation_name" : {
+            "type" : "string",
+            "enum": ["ingress", "egress"]
+          }
         },
         "required" : ["operation_name"],
         "additionalProperties" : false

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -211,7 +211,8 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
       "tracing" : {
         "type" : "object",
         "properties" : {
-          "operation_name" : {"type" : "string"}
+          "operation_name" : {"type" : "string"},
+          "enum": ["ingress", "egress"]
         },
         "required" : ["operation_name"],
         "additionalProperties" : false

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -153,7 +153,8 @@ SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request
   std::string span_name = HttpTracerUtility::toString(config.operationName());
 
   if (config.operationName() == OperationName::Egress) {
-    span_name += " " + std::string(request_headers.Host()->value().c_str());
+    span_name.append(" ");
+    span_name.append(request_headers.Host()->value().c_str());
   }
 
   SpanPtr active_span = driver_->startSpan(request_headers, span_name, request_info.startTime());

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -74,7 +74,7 @@ void HttpTracerUtility::mutateHeaders(Http::HeaderMap& request_headers, Runtime:
 const std::string HttpTracerUtility::INGRESS_OPERATION = "ingress";
 const std::string HttpTracerUtility::EGRESS_OPERATION = "egress";
 
-std::string HttpTracerUtility::toString(OperationName operation_name) {
+const std::string& HttpTracerUtility::toString(OperationName operation_name) {
   switch (operation_name) {
   case OperationName::Ingress:
     return INGRESS_OPERATION;

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -39,8 +39,10 @@ class HttpTracerUtility {
 public:
   /**
    * Get string representation of operation name.
+   * @param operation name to convert.
+   * @return string representation of operation.
    */
-  static std::string toString(OperationName operation_name);
+  static const std::string& toString(OperationName operation_name);
 
   /**
    * Request might be traceable if x-request-id is traceable uuid or we do sampling tracing.

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -38,9 +38,9 @@ struct Decision {
 class HttpTracerUtility {
 public:
   /**
-   * Get string representation of operation name.
+   * Get string representation of the operation.
    * @param operation name to convert.
-   * @return string representation of operation.
+   * @return string representation of the operation.
    */
   static const std::string& toString(OperationName operation_name);
 

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -38,6 +38,11 @@ struct Decision {
 class HttpTracerUtility {
 public:
   /**
+   * Get string representation of operation name.
+   */
+  static std::string toString(OperationName operation_name);
+
+  /**
    * Request might be traceable if x-request-id is traceable uuid or we do sampling tracing.
    * Note: there is a global switch which turns off tracing completely on server side.
    *
@@ -57,6 +62,9 @@ public:
    */
   static void finalizeSpan(Span& active_span, const Http::HeaderMap& request_headers,
                            const Http::AccessLog::RequestInfo& request_info);
+
+  static const std::string INGRESS_OPERATION;
+  static const std::string EGRESS_OPERATION;
 };
 
 class HttpNullTracer : public HttpTracer {

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -87,7 +87,11 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
 
   if (config.hasObject("tracing")) {
     const std::string operation_name = config.getObject("tracing")->getString("operation_name");
-    tracing_config_.value({operation_name});
+    if (operation_name == "ingress") {
+      tracing_config_.value({Tracing::OperationName::Ingress});
+    } else {
+      tracing_config_.value({Tracing::OperationName::Egress});
+    }
   }
 
   if (config.hasObject("idle_timeout_s")) {

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -90,6 +90,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
     if (operation_name == "ingress") {
       tracing_config_.value({Tracing::OperationName::Ingress});
     } else {
+      ASSERT(operation_name == "egress");
       tracing_config_.value({Tracing::OperationName::Egress});
     }
   }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -54,7 +54,7 @@ public:
                "",
                fake_stats_},
         tracing_stats_{CONN_MAN_TRACING_STATS(POOL_COUNTER(fake_stats_))} {
-    tracing_config_.value({"operation"});
+    tracing_config_.value({Tracing::OperationName::Ingress});
   }
 
   ~HttpConnectionManagerImplTest() {
@@ -216,7 +216,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   EXPECT_CALL(tracer_, startSpan_(_, _, _))
       .WillOnce(Invoke([&](const Tracing::Config& config, const Http::HeaderMap&,
                            const Http::AccessLog::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ("operation", config.operationName());
+        EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
         return span;
       }));

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -24,7 +24,7 @@ public:
   ConnectionManagerUtilityTest() {
     ON_CALL(config_, userAgent()).WillByDefault(ReturnRef(user_agent_));
 
-    tracing_config_.value({"operation"});
+    tracing_config_.value({Tracing::OperationName::Ingress});
     ON_CALL(config_, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
   }
 

--- a/test/mocks/tracing/mocks.cc
+++ b/test/mocks/tracing/mocks.cc
@@ -1,15 +1,13 @@
 #include "mocks.h"
 
-using testing::ReturnRef;
+using testing::Return;
 
 namespace Tracing {
 
 MockSpan::MockSpan() {}
 MockSpan::~MockSpan() {}
 
-MockConfig::MockConfig() {
-  ON_CALL(*this, operationName()).WillByDefault(ReturnRef(operation_name_));
-}
+MockConfig::MockConfig() { ON_CALL(*this, operationName()).WillByDefault(Return(operation_name_)); }
 MockConfig::~MockConfig() {}
 
 MockHttpTracer::MockHttpTracer() {}

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -14,9 +14,9 @@ public:
   MockConfig();
   ~MockConfig();
 
-  MOCK_CONST_METHOD0(operationName, const std::string&());
+  MOCK_CONST_METHOD0(operationName, OperationName());
 
-  std::string operation_name_{"operation"};
+  OperationName operation_name_{OperationName::Ingress};
 };
 
 class MockSpan : public Span {


### PR DESCRIPTION
For ingress just keep "ingress" span name.
For egress, make egress host_header.

@lyft/network-team 