### PR TITLE
getLastAddressFromXFF splits on `, `

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -78,9 +78,18 @@ size_t StringUtil::strlcpy(char* dst, const char* src, size_t size) {
 }
 
 std::vector<std::string> StringUtil::split(const std::string& source, char split) {
+  return StringUtil::split(source, std::string{split});
+}
+
+std::vector<std::string> StringUtil::split(const std::string& source, const std::string& split) {
   std::vector<std::string> ret;
   size_t last_index = 0;
   size_t next_index;
+
+  if (split.empty()) {
+    ret.emplace_back(source);
+    return ret;
+  }
 
   do {
     next_index = source.find(split, last_index);
@@ -92,7 +101,7 @@ std::vector<std::string> StringUtil::split(const std::string& source, char split
       ret.emplace_back(subspan(source, last_index, next_index));
     }
 
-    last_index = next_index + 1;
+    last_index = next_index + split.size();
   } while (next_index != source.size());
 
   return ret;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -99,6 +99,7 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the char to split on.
+   * @return vector of strings after splitting `source` around `split`.
    */
   static std::vector<std::string> split(const std::string& source, char split);
 
@@ -106,6 +107,7 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the string to split on.
+   * @return vector of strings after splitting `source` around `split`.
    */
   static std::vector<std::string> split(const std::string& source, const std::string& split);
 

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -103,6 +103,13 @@ public:
   static std::vector<std::string> split(const std::string& source, char split);
 
   /**
+   * Split a string.
+   * @param source supplies the string to split.
+   * @param split supplies the string to split on.
+   */
+  static std::vector<std::string> split(const std::string& source, const std::string& split);
+
+  /**
    * Version of substr() that operates on a start and end index instead of a start index and a
    * length.
    */

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -99,7 +99,7 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the char to split on.
-   * @return vector of strings after splitting `source` around `split`.
+   * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
   static std::vector<std::string> split(const std::string& source, char split);
 
@@ -107,7 +107,7 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the string to split on.
-   * @return vector of strings after splitting `source` around `split`.
+   * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
   static std::vector<std::string> split(const std::string& source, const std::string& split);
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -164,7 +164,7 @@ std::string Utility::getLastAddressFromXFF(const Http::HeaderMap& request_header
   }
 
   std::vector<std::string> xff_address_list =
-      StringUtil::split(request_headers.ForwardedFor()->value().c_str(), ',');
+      StringUtil::split(request_headers.ForwardedFor()->value().c_str(), ", ");
 
   if (xff_address_list.empty()) {
     return EMPTY_STRING;

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -100,12 +100,14 @@ TEST(StringUtil, strlcpy) {
 }
 
 TEST(StringUtil, split) {
-  EXPECT_EQ(std::vector<std::string>{}, StringUtil::split("", ','));
-  EXPECT_EQ(std::vector<std::string>{"a"}, StringUtil::split("a", ','));
   EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split(",hello", ','));
-  EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello,", ','));
-  EXPECT_EQ(std::vector<std::string>{}, StringUtil::split(",,", ','));
-  EXPECT_EQ((std::vector<std::string>{"hello", "world"}), StringUtil::split("hello,world", ','));
+  EXPECT_EQ(std::vector<std::string>{}, StringUtil::split("", ","));
+  EXPECT_EQ(std::vector<std::string>{"a"}, StringUtil::split("a", ","));
+  EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello,", ","));
+  EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split(",hello", ","));
+  EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello, ", ", "));
+  EXPECT_EQ(std::vector<std::string>{}, StringUtil::split(",,", ","));
+  EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello", ""));
 }
 
 TEST(StringUtil, endsWith) {

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -104,7 +104,7 @@ TEST(HttpUtility, TwoAddressesInXFF) {
   const std::string first_address = "34.0.0.1";
   const std::string second_address = "10.0.0.1";
   TestHeaderMapImpl request_headers{
-      {"x-forwarded-for", fmt::format("{0},{1}", first_address, second_address)}};
+      {"x-forwarded-for", fmt::format("{0}, {0}, {1}", first_address, second_address)}};
   EXPECT_EQ(second_address, Utility::getLastAddressFromXFF(request_headers));
 }
 


### PR DESCRIPTION
getLastAddressFromXFF had a bug that split on `,` instead of `,<space>`. Fixed this by adding new StringUtil::split that splits on a string.