### PR TITLE
test: fix race condition in FakeUpstream.

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -74,7 +74,7 @@ public:
 
 protected:
   FakeConnectionBase(Network::Connection& connection) : connection_(connection) {
-    connection.addConnectionCallbacks(*this);
+    connection_.dispatcher().post([this]() -> void { connection_.addConnectionCallbacks(*this); });
   }
 
   Network::Connection& connection_;


### PR DESCRIPTION
Dispatcher and client threads were racing on connection callback registration, leaving the callback
list in a bad state. This fixes the hangs we see from time to time in the integration tests.

Validated with bazel test //test/integration/... --runs_per_test=1000.