### PR TITLE
bazel/ci: restore support for Bazel build in Docker CI (#415).

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,3 +16,8 @@ envoy_cc_library(
     srcs = ["version_generated.cc"],
     deps = ["//source/common/common:version_includes"],
 )
+
+config_setting(
+    name = "force_test_link_static",
+    values = {"define": "FORCE_TEST_LINK_STATIC=yes"},
+)

--- a/BUILD
+++ b/BUILD
@@ -19,5 +19,5 @@ envoy_cc_library(
 
 config_setting(
     name = "force_test_link_static",
-    values = {"define": "FORCE_TEST_LINK_STATIC=yes"},
+    values = {"define": "force_test_link_static=yes"},
 )

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -6,7 +6,9 @@ ENVOY_COPTS = [
     "-fno-omit-frame-pointer",
     "-fmax-errors=3",
     "-Wall",
-    "-Wextra",
+    # TODO(htuch): Figure out why protobuf-3.2.0 causes the CI build to fail
+    # with this but not the developer-local build.
+    #"-Wextra",
     "-Werror",
     "-Wnon-virtual-dtor",
     "-Woverloaded-virtual",
@@ -95,6 +97,10 @@ def envoy_cc_test(name,
         data = data,
         copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
         linkopts = ["-pthread"],
+        linkstatic = select({
+            "//:force_test_link_static": 1,
+            "//conditions:default": 0,
+        }),
         args = args,
         deps = deps + [
             "//source/precompiled:precompiled_includes",

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -19,6 +19,41 @@ bind(
 )
 
 bind(
+    name = "http_parser",
+    actual = "//ci/prebuilt:http_parser",
+)
+
+bind(
+    name = "lightstep",
+    actual = "//ci/prebuilt:lightstep",
+)
+
+bind(
+    name = "nghttp2",
+    actual = "//ci/prebuilt:nghttp2",
+)
+
+bind(
+    name = "protobuf",
+    actual = "//ci/prebuilt:protobuf",
+)
+
+local_repository(
+    name = "protobuf_git",
+    path = "/thirdparty/protobuf-3.2.0",
+)
+
+bind(
+    name = "protoc",
+    actual = "//ci/prebuilt:protoc",
+)
+
+bind(
+    name = "rapidjson",
+    actual = "//ci/prebuilt:rapidjson",
+)
+
+bind(
     name = "spdlog",
     actual = "//ci/prebuilt:spdlog",
 )

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -10,18 +10,19 @@ if [[ "$1" == "bazel.debug" ]]; then
   ln -sf /thirdparty prebuilt
   ln -sf /thirdparty_build prebuilt
   # Not sandboxing, since non-privileged Docker can't do nested namespaces.
-  echo "Building..."
   export CC=gcc-4.9
-  export CXX=g++-4.9
   export USER=bazel
   export TEST_TMPDIR=/source/build
   BAZEL_OPTIONS="--strategy=CppCompile=standalone --strategy=CppLink=standalone \
-    --strategy=TestRunner=standalone --verbose_failures --package_path %workspace%:.."
+    --strategy=TestRunner=standalone --strategy=ProtoCompile=standalone \
+    --strategy=Genrule=standalone --verbose_failures --package_path %workspace%:.."
   [[ "$BAZEL_INTERACTIVE" == "1" ]] && BAZEL_BATCH="" || BAZEL_BATCH="--batch"
   [[ "$BAZEL_EXPUNGE" == "1" ]] && bazel clean --expunge
-  bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/...
+  echo "Building..."
+  bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/exe:envoy-static
   echo "Testing..."
-  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --test_output=all //test/...
+  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --define FORCE_TEST_LINK_STATIC=yes --test_output=all \
+    //test/...
   exit 0
 fi
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,10 +9,12 @@ if [[ "$1" == "bazel.debug" ]]; then
   cd ci
   ln -sf /thirdparty prebuilt
   ln -sf /thirdparty_build prebuilt
-  # Not sandboxing, since non-privileged Docker can't do nested namespaces.
+  # Only CC is required to find g++, see
+  # https://www.bazel.build/blog/2016/03/31/autoconfiguration.html#implementation
   export CC=gcc-4.9
   export USER=bazel
   export TEST_TMPDIR=/source/build
+  # Not sandboxing, since non-privileged Docker can't do nested namespaces.
   BAZEL_OPTIONS="--strategy=CppCompile=standalone --strategy=CppLink=standalone \
     --strategy=TestRunner=standalone --strategy=ProtoCompile=standalone \
     --strategy=Genrule=standalone --verbose_failures --package_path %workspace%:.."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -21,7 +21,7 @@ if [[ "$1" == "bazel.debug" ]]; then
   echo "Building..."
   bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/exe:envoy-static
   echo "Testing..."
-  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --define FORCE_TEST_LINK_STATIC=yes --test_output=all \
+  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --define force_test_link_static=yes --test_output=all \
     //test/...
   exit 0
 fi

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -41,6 +41,52 @@ cc_library(
 )
 
 cc_library(
+    name = "http_parser",
+    srcs = ["thirdparty_build/lib/libhttp_parser.a"],
+    hdrs = glob(["thirdparty_build/include/http_parser.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "lightstep",
+    srcs = ["thirdparty_build/lib/liblightstep_core_cxx11.a"],
+    hdrs = glob([
+        "thirdparty_build/include/lightstep/**/*.h",
+        "thirdparty_build/include/mapbox_variant/**/*.hpp",
+    ]) + [
+        "thirdparty_build/include/collector.pb.h",
+        "thirdparty_build/include/lightstep_carrier.pb.h",
+    ],
+    strip_include_prefix = "thirdparty_build/include",
+    deps = [":protobuf"],
+)
+
+cc_library(
+    name = "nghttp2",
+    srcs = ["thirdparty_build/lib/libnghttp2.a"],
+    hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+cc_library(
+    name = "protobuf",
+    srcs = glob(["thirdparty_build/lib/libproto*.a"]),
+    hdrs = glob(["thirdparty_build/include/google/protobuf/**/*.h"]),
+    strip_include_prefix = "thirdparty_build/include",
+)
+
+filegroup(
+    name = "protoc",
+    srcs = ["thirdparty_build/bin/protoc"],
+)
+
+cc_library(
+    name = "rapidjson",
+    hdrs = glob(["thirdparty/rapidjson-1.1.0/include/**/*.h"]),
+    strip_include_prefix = "thirdparty/rapidjson-1.1.0/include",
+)
+
+cc_library(
     name = "spdlog",
     hdrs = glob([
         "thirdparty/spdlog-0.11.0/include/**/*.cc",

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
         "//source/common/json:config_schemas_lib",
         "//source/server/config/network:http_connection_manager_lib",
     ],
+    alwayslink = 1,
 )
 
 envoy_cc_library(


### PR DESCRIPTION
* Build Bazel static binary and run all tests with the do_ci.sh bazel.debug target.

* Updated the CI WORKSPACES and ci/prebuilt/BUILD for the current set of deps.

* Added a --define FORCE_TEST_STATIC_LINK=yes option for use in the CI.

* Hacked around some compile issues by disabled -Wextra in the Bazel build. Will fix before we drop
  cmake.