### PR TITLE
schema: enforce cluster name length and invalid chars

### DIFF
--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -28,6 +28,7 @@ Cluster
 name
   *(required, string)* Supplies the name of the cluster which must be unique across all clusters.
   The cluster name is used when emitting :ref:`statistics <config_cluster_manager_cluster_stats>`.
+  The cluster name can be at most 60 characters long, and must **not** contain ``:``.
 
 type
   *(required, string)* The :ref:`service discovery type <arch_overview_service_discovery_types>` to

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1032,7 +1032,12 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
     },
     "type" : "object",
     "properties" : {
-      "name" : {"type" : "string"},
+      "name" : {
+        "type" : "string",
+        "pattern" : "^[^:]+$",
+        "minLength" : 1,
+        "maxLength" : 60
+      },
       "type" : {
         "type" : "string",
         "enum" : ["static", "strict_dns", "logical_dns", "sds"]

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -271,14 +271,10 @@ TEST_F(ClusterManagerImplTest, MaxClusterName) {
   )EOF";
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
-  try {
-    create(*loader);
-    ADD_FAILURE() << "Json::Exception should take place. It did not.";
-  } catch (Json::Exception& e) {
-    EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
-              "Invalid keyword: maxLength.\n Invalid document key: #/name",
-              std::string(e.what()));
-  }
+  EXPECT_THROW_WITH_MESSAGE(create(*loader), Json::Exception,
+                            "JSON object doesn't conform to schema.\n Invalid schema: "
+                            "#/properties/name.\n Invalid keyword: maxLength.\n Invalid document "
+                            "key: #/name");
   factory_.tls_.shutdownThread();
 }
 
@@ -293,14 +289,10 @@ TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
   )EOF";
 
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
-  try {
-    create(*loader);
-    ADD_FAILURE() << "Json::Exception should take place. It did not.";
-  } catch (Json::Exception& e) {
-    EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
-              "Invalid keyword: pattern.\n Invalid document key: #/name",
-              std::string(e.what()));
-  }
+  EXPECT_THROW_WITH_MESSAGE(create(*loader), Json::Exception,
+                            "JSON object doesn't conform to schema.\n Invalid schema: "
+                            "#/properties/name.\n Invalid keyword: pattern.\n Invalid document "
+                            "key: #/name");
   factory_.tls_.shutdownThread();
 }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -260,6 +260,46 @@ TEST_F(ClusterManagerImplTest, UnknownHcType) {
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
+TEST_F(ClusterManagerImplTest, MaxClusterName) {
+  std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "clusterwithareallyreallylongnamemorethanmaxcharsallowedbyschema"
+    }]
+  }
+  )EOF";
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  try {
+    create(*loader);
+  } catch (Json::Exception& e) {
+    EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
+              "Invalid keyword: maxLength.\n Invalid document key: #/name",
+              std::string(e.what()));
+  }
+}
+
+TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
+  std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster:"
+    }]
+  }
+  )EOF";
+
+  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  try {
+    create(*loader);
+  } catch (Json::Exception& e) {
+    EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
+              "Invalid keyword: pattern.\n Invalid document key: #/name",
+              std::string(e.what()));
+  }
+}
+
 TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
   std::string json = R"EOF(
   {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -275,7 +275,6 @@ TEST_F(ClusterManagerImplTest, MaxClusterName) {
                             "JSON object doesn't conform to schema.\n Invalid schema: "
                             "#/properties/name.\n Invalid keyword: maxLength.\n Invalid document "
                             "key: #/name");
-  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
@@ -293,7 +292,6 @@ TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
                             "JSON object doesn't conform to schema.\n Invalid schema: "
                             "#/properties/name.\n Invalid keyword: pattern.\n Invalid document "
                             "key: #/name");
-  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, TcpHealthChecker) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -273,11 +273,13 @@ TEST_F(ClusterManagerImplTest, MaxClusterName) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   try {
     create(*loader);
+    ADD_FAILURE() << "Json::Exception should take place. It did not.";
   } catch (Json::Exception& e) {
     EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
               "Invalid keyword: maxLength.\n Invalid document key: #/name",
               std::string(e.what()));
   }
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
@@ -293,11 +295,13 @@ TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   try {
     create(*loader);
+    ADD_FAILURE() << "Json::Exception should take place. It did not.";
   } catch (Json::Exception& e) {
     EXPECT_EQ("JSON object doesn't conform to schema.\n Invalid schema: #/properties/name.\n "
               "Invalid keyword: pattern.\n Invalid document key: #/name",
               std::string(e.what()));
   }
+  factory_.tls_.shutdownThread();
 }
 
 TEST_F(ClusterManagerImplTest, TcpHealthChecker) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -5,8 +5,6 @@
 
 #include "common/http/header_map_impl.h"
 
-using testing::_;
-
 #define EXPECT_THROW_WITH_MESSAGE(statement, expected_exception, message)                          \
   try {                                                                                            \
     statement;                                                                                     \

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -5,6 +5,16 @@
 
 #include "common/http/header_map_impl.h"
 
+using testing::_;
+
+#define EXPECT_THROW_WITH_MESSAGE(statement, expected_exception, message)                          \
+  try {                                                                                            \
+    statement;                                                                                     \
+    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
+  } catch (expected_exception & e) {                                                               \
+    EXPECT_EQ(message, std::string(e.what()));                                                     \
+  }
+
 class TestUtility {
 public:
   /**


### PR DESCRIPTION
@lyft/network-team 

Right now the longest stat prefix and trailing stat that we output for clusters is `cluster.<cluster_name>.outlier_detection.ejections_consecutive_5xx`, which is 52 characters long. In order to have a bit more room to grow 60 characters might be a good limit to have on cluster name length right now.

In addition we can use regex in the schema to enforce the absence of invalid characters, `:` for now.

fixes https://github.com/lyft/envoy/issues/573