### PR TITLE
ssl: increment stat when there is a handshake/connection error

### DIFF
--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -119,8 +119,13 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
 }
 
 void ConnectionImpl::drainErrorQueue() {
-  ctx_.stats().connection_error_.inc();
+  bool saw_error = false;
   while (uint64_t err = ERR_get_error()) {
+    if (!saw_error) {
+      ctx_.stats().connection_error_.inc();
+      saw_error = true;
+    }
+
     conn_log_debug("SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
                    ERR_func_error_string(err), ERR_reason_error_string(err));
     UNREFERENCED_PARAMETER(err);

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -119,6 +119,7 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
 }
 
 void ConnectionImpl::drainErrorQueue() {
+  ctx_.stats().connection_error_.inc();
   while (uint64_t err = ERR_get_error()) {
     conn_log_debug("SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
                    ERR_func_error_string(err), ERR_reason_error_string(err));

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -248,6 +248,8 @@ TEST(SslConnectionImplTest, SslError) {
       }));
 
   dispatcher.run(Event::Dispatcher::RunType::Block);
+
+  EXPECT_EQ(1UL, stats_store.counter("ssl.connection_error").value());
 }
 
 class SslReadBufferLimitTest : public testing::Test {

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -346,6 +346,8 @@ public:
     }
 
     dispatcher.run(Event::Dispatcher::RunType::Block);
+
+    EXPECT_EQ(0UL, stats_store.counter("ssl.connection_error").value());
   }
 };
 


### PR DESCRIPTION
I think this was lost when we did the bufferevent removal.

Fixes https://github.com/lyft/envoy/issues/637