### PR TITLE
guarddog: bazel build files and duration atomic type for portability.

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -30,6 +30,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "guarddog_includes",
+    hdrs = ["guarddog.h"],
+    deps = [
+        "//include/envoy/server:watchdog_includes",
+        "//include/envoy/stats:stats_includes",
+    ],
+)
+
+envoy_cc_library(
     name = "hot_restart_includes",
     hdrs = ["hot_restart.h"],
     deps = ["//include/envoy/event:dispatcher_includes"],
@@ -59,4 +68,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "options_includes",
     hdrs = ["options.h"],
+)
+
+envoy_cc_library(
+    name = "watchdog_includes",
+    hdrs = ["watchdog.h"],
+    deps = ["//include/envoy/event:dispatcher_includes"],
 )

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -65,6 +65,24 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "guarddog_lib",
+    srcs = ["guarddog_impl.cc"],
+    hdrs = ["guarddog_impl.h"],
+    deps = [
+        ":watchdog_lib",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/server:configuration_includes",
+        "//include/envoy/server:guarddog_includes",
+        "//include/envoy/server:watchdog_includes",
+        "//include/envoy/stats:stats_includes",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/common:thread_lib",
+        "//source/common/event:libevent_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "options_lib",
     srcs = ["options_impl.cc"],
     hdrs = ["options_impl.h"],
@@ -121,11 +139,24 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "watchdog_lib",
+    srcs = ["watchdog_impl.cc"],
+    hdrs = ["watchdog_impl.h"],
+    deps = [
+        "//include/envoy/common:time_includes",
+        "//include/envoy/event:dispatcher_includes",
+        "//include/envoy/server:watchdog_includes",
+        "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "worker_lib",
     srcs = ["worker.cc"],
     hdrs = ["worker.h"],
     deps = [
         ":connection_handler_lib",
+        ":guarddog_lib",
         "//include/envoy/event:dispatcher_includes",
         "//include/envoy/event:timer_includes",
         "//include/envoy/server:configuration_includes",

--- a/source/server/watchdog_impl.h
+++ b/source/server/watchdog_impl.h
@@ -9,12 +9,6 @@ namespace Server {
 /**
  * This class stores the actual data about when the WatchDog was last touched
  * along with thread metadata.
- *
- * Implementation note: This currently relies on the convenient fact that
- * std::atomic<SystemTime> works because SystemTime degrades internally to a
- * uint64. If this changes in the future and SystemTime becomes a nontrivial
- * object a compilation error will result and some implementation changes will
- * be required to deal with atomicizable canonical representations.
  */
 class WatchDogImpl : public WatchDog {
 public:
@@ -24,21 +18,24 @@ public:
    */
   WatchDogImpl(int32_t thread_id, SystemTimeSource& tsource, std::chrono::milliseconds interval)
       : thread_id_(thread_id), time_source_(tsource),
-        latest_touch_time_(tsource.currentSystemTime()), timer_interval_(interval) {}
+        latest_touch_time_(tsource.currentSystemTime().time_since_epoch()),
+        timer_interval_(interval) {}
 
-  int32_t threadId() const { return thread_id_; }
-  SystemTime lastTouchTime() const { return latest_touch_time_.load(); }
+  int32_t threadId() const override { return thread_id_; }
+  SystemTime lastTouchTime() const override { return SystemTime(latest_touch_time_.load()); }
 
   // Server::WatchDog
   void startWatchdog(Event::Dispatcher& dispatcher) override;
-  void touch() override { latest_touch_time_.store(time_source_.currentSystemTime()); }
+  void touch() override {
+    latest_touch_time_.store(time_source_.currentSystemTime().time_since_epoch());
+  }
 
 private:
   const int32_t thread_id_;
   SystemTimeSource& time_source_;
-  std::atomic<SystemTime> latest_touch_time_;
+  std::atomic<std::chrono::system_clock::duration> latest_touch_time_;
   Event::TimerPtr timer_;
   const std::chrono::milliseconds timer_interval_;
 };
 
-} // Server
+} // namespace Server

--- a/source/server/watchdog_impl.h
+++ b/source/server/watchdog_impl.h
@@ -18,22 +18,24 @@ public:
    */
   WatchDogImpl(int32_t thread_id, SystemTimeSource& tsource, std::chrono::milliseconds interval)
       : thread_id_(thread_id), time_source_(tsource),
-        latest_touch_time_(tsource.currentSystemTime().time_since_epoch()),
+        latest_touch_time_since_epoch_(tsource.currentSystemTime().time_since_epoch()),
         timer_interval_(interval) {}
 
   int32_t threadId() const override { return thread_id_; }
-  SystemTime lastTouchTime() const override { return SystemTime(latest_touch_time_.load()); }
+  SystemTime lastTouchTime() const override {
+    return SystemTime(latest_touch_time_since_epoch_.load());
+  }
 
   // Server::WatchDog
   void startWatchdog(Event::Dispatcher& dispatcher) override;
   void touch() override {
-    latest_touch_time_.store(time_source_.currentSystemTime().time_since_epoch());
+    latest_touch_time_since_epoch_.store(time_source_.currentSystemTime().time_since_epoch());
   }
 
 private:
   const int32_t thread_id_;
   SystemTimeSource& time_source_;
-  std::atomic<std::chrono::system_clock::duration> latest_touch_time_;
+  std::atomic<std::chrono::system_clock::duration> latest_touch_time_since_epoch_;
   Event::TimerPtr timer_;
   const std::chrono::milliseconds timer_interval_;
 };

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -8,6 +8,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//include/envoy/server:admin_includes",
+        "//include/envoy/server:configuration_includes",
         "//include/envoy/server:drain_manager_includes",
         "//include/envoy/server:instance_includes",
         "//include/envoy/server:options_includes",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -40,6 +40,20 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "guarddog_impl_test",
+    srcs = ["guarddog_impl_test.cc"],
+    deps = [
+        "//include/envoy/common:time_includes",
+        "//source/common/common:utility_lib",
+        "//source/common/stats:stats_lib",
+        "//source/server:guarddog_lib",
+        "//test/mocks/server:server_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/mocks:common_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "options_impl_test",
     srcs = ["options_impl_test.cc"],
     deps = ["//source/server:options_lib"],

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -208,9 +208,9 @@ TEST(WatchDogBasicTest, ThreadIdTest) {
   gd.stopWatching(watched_dog);
 }
 
-// If this test fails it is because the std::time_t type has become nontrivial or we are compiling
-// under a compiler and library combo that makes std::chrono::system_clock::duration require a lock
-// to be atomicly modified.
+// If this test fails it is because the std::chrono::system_clock::duration type has become
+// nontrivial or we are compiling under a compiler and library combo that makes
+// std::chrono::system_clock::duration require a lock to be atomicly modified.
 //
 // The WatchDog/GuardDog relies on this being a lock free atomic for perf reasons so some workaround
 // will be required if this test starts failing.

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -208,17 +208,15 @@ TEST(WatchDogBasicTest, ThreadIdTest) {
   gd.stopWatching(watched_dog);
 }
 
-// If this test fails it is because the SystemTime object has become nontrivial
-// or we are compiling under a compiler and library combo that makes the
-// SystemTime object require a lock to be atomicly modified.
+// If this test fails it is because the std::time_t type has become nontrivial or we are compiling
+// under a compiler and library combo that makes std::chrono::system_clock::duration require a lock
+// to be atomicly modified.
 //
-// The WatchDog/GuardDog relies on this being a lock free atomic for perf
-// reasons so some workaround will be required if this test starts failing.
+// The WatchDog/GuardDog relies on this being a lock free atomic for perf reasons so some workaround
+// will be required if this test starts failing.
 TEST(WatchDogTimeTest, AtomicIsAtomicTest) {
-  // To compile this test the atomic SystemTime must be non-default initialized,
-  // even though we only call the is_lock_free() method.
   ProdSystemTimeSource time_source;
-  std::atomic<SystemTime> atomic_time(time_source.currentSystemTime());
+  std::atomic<std::chrono::system_clock::duration> atomic_time;
   ASSERT_EQ(atomic_time.is_lock_free(), true);
 }
 


### PR DESCRIPTION
While building with various versions of Clang, duration worked better than time_point.