### PR TITLE
ci/bazel: use consistent versions of external deps (#415).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ bind(
 
 bind(
     name = "lightstep",
-    actual = "@lightstep_git//:lightstep_core",
+    actual = "@lightstep_tar//:lightstep_core",
 )
 
 bind(

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -39,6 +39,9 @@ Bazel can also be built with the Docker image used for CI, by installing Docker 
 See also the [documentation](https://github.com/lyft/envoy/tree/master/ci) for developer use of the
 CI Docker image.
 
+The same caveats apply to using this build for production vs. development and testing as to the
+above Bazel quick start developer flow.
+
 ## Using a compiler toolchain in a non-standard location
 
 By setting the `CC` and `LD_LIBRARY_PATH` in the environment that Bazel executes from as

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -3,6 +3,32 @@
 # libraries according to their canonical build systems and expressing the dependencies in a manner
 # similar to ci/WORKSPACE.
 
+load(
+    ":versions.bzl",
+    "BORINGSSL_COMMIT",
+    "BORINGSSL_REMOTE",
+    "CARES_COMMIT",
+    "CARES_REMOTE",
+    "GOOGLETEST_COMMIT",
+    "GOOGLETEST_REMOTE",
+    "HTTP_PARSER_COMMIT",
+    "HTTP_PARSER_REMOTE",
+    "LIBEVENT_HTTP_ARCHIVE",
+    "LIBEVENT_PREFIX",
+    "LIGHTSTEP_HTTP_ARCHIVE",
+    "LIGHTSTEP_PREFIX",
+    "NGHTTP2_HTTP_ARCHIVE",
+    "NGHTTP2_PREFIX",
+    "PROTOBUF_COMMIT",
+    "PROTOBUF_REMOTE",
+    "RAPIDJSON_COMMIT",
+    "RAPIDJSON_REMOTE",
+    "SPDLOG_COMMIT",
+    "SPDLOG_REMOTE",
+    "TCLAP_HTTP_ARCHIVE",
+    "TCLAP_PREFIX",
+)
+
 def ares_repositories():
     BUILD = """
 cc_library(
@@ -116,16 +142,16 @@ genrule(
 
     native.new_git_repository(
         name = "cares_git",
-        remote = "https://github.com/c-ares/c-ares.git",
-        commit = "7691f773af79bf75a62d1863fd0f13ebf9dc51b1", # v1.12.0
+        remote = CARES_REMOTE,
+        commit = CARES_COMMIT,
         build_file_content = BUILD,
     )
 
 def boringssl_repositories():
     native.git_repository(
         name = "boringssl",
-        commit = "bfd36df3da38dbf8828e712f42fbab2a0034bc40",  # 2017-02-02
-        remote = "https://boringssl.googlesource.com/boringssl",
+        remote = BORINGSSL_REMOTE,
+        commit = BORINGSSL_COMMIT,
     )
 
 def googletest_repositories():
@@ -155,9 +181,8 @@ cc_library(
     native.new_git_repository(
         name = "googletest_git",
         build_file_content = BUILD,
-        # v1.8.0 release
-        commit = "ec44c6c1675c25b9827aacd08c02433cccde7780",
-        remote = "https://github.com/google/googletest.git",
+        remote = GOOGLETEST_REMOTE,
+        commit = GOOGLETEST_COMMIT,
     )
 
 def http_parser_repositories():
@@ -176,8 +201,8 @@ cc_library(
 
     native.new_git_repository(
         name = "http_parser_git",
-        remote = "https://github.com/nodejs/http-parser.git",
-        commit = "9b0d5b33ebdaacff1dadd06bad4e198b11ff880e",
+        remote = HTTP_PARSER_REMOTE,
+        commit = HTTP_PARSER_COMMIT,
         build_file_content = BUILD,
     )
 
@@ -286,8 +311,8 @@ cc_library(
 
     native.new_http_archive(
         name = "libevent_git",
-        url = "https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz",
-        strip_prefix = "libevent-2.1.8-stable",
+        url = LIBEVENT_HTTP_ARCHIVE,
+        strip_prefix = LIBEVENT_PREFIX,
         build_file_content = BUILD,
     )
 
@@ -317,57 +342,45 @@ cc_library(
     ],
     copts = [
         "-DPACKAGE_VERSION='\\"0.36\\"'",
-        "-Iexternal/lightstep_git/src/c++11/lightstep",
-        "-Iexternal/lightstep_git/src/c++11/mapbox_variant",
+        "-Iexternal/lightstep_tar/src/c++11/lightstep",
+        "-Iexternal/lightstep_tar/src/c++11/mapbox_variant",
     ],
     includes = ["src/c++11"],
     visibility = ["//visibility:public"],
     deps = [
-        "@lightstep_common_git//:collector_proto",
-        "@lightstep_common_git//:lightstep_carrier_proto",
+        ":collector_proto",
+        ":lightstep_carrier_proto",
         "//external:protobuf",
     ],
-)"""
-
-    COMMON_BUILD = """
-load("@protobuf_git//:protobuf.bzl", "cc_proto_library")
+)
 
 cc_proto_library(
     name = "collector_proto",
-    srcs = ["collector.proto"],
-    include = ".",
+    srcs = ["lightstep-tracer-common/collector.proto"],
+    include = "lightstep-tracer-common",
     deps = [
         "//external:cc_wkt_protos",
     ],
     protoc = "//external:protoc",
     default_runtime = "//external:protobuf",
-    visibility = ["//visibility:public"],
 )
 
 cc_proto_library(
     name = "lightstep_carrier_proto",
-    srcs = ["lightstep_carrier.proto"],
-    include = ".",
+    srcs = ["lightstep-tracer-common/lightstep_carrier.proto"],
+    include = "lightstep-tracer-common",
     deps = [
         "//external:cc_wkt_protos",
     ],
     protoc = "//external:protoc",
     default_runtime = "//external:protobuf",
-    visibility = ["//visibility:public"],
 )
 """
 
-    native.new_git_repository(
-        name = "lightstep_common_git",
-        remote = "https://github.com/lightstep/lightstep-tracer-common.git",
-        commit = "cbbecd671c1ae1f20ae873c5da688c8c14d04ec3",
-        build_file_content = COMMON_BUILD,
-    )
-
-    native.new_git_repository(
-        name = "lightstep_git",
-        remote = "https://github.com/lightstep/lightstep-tracer-cpp.git",
-        commit = "f1dc8f3dfd529350e053fd21273e627f409ae428", # 0.36
+    native.new_http_archive(
+        name = "lightstep_tar",
+        url = LIGHTSTEP_HTTP_ARCHIVE,
+        strip_prefix = LIGHTSTEP_PREFIX,
         build_file_content = BUILD,
     )
 
@@ -403,21 +416,16 @@ cc_library(
 
     native.new_http_archive(
         name = "nghttp2_tar",
-        url = "https://github.com/nghttp2/nghttp2/releases/download/v1.20.0/nghttp2-1.20.0.tar.gz",
-        strip_prefix = "nghttp2-1.20.0",
+        url = NGHTTP2_HTTP_ARCHIVE,
+        strip_prefix = NGHTTP2_PREFIX,
         build_file_content = BUILD,
     )
 
 def protobuf_repositories():
     native.git_repository(
         name = "protobuf_git",
-        # Using a non-canonical repository/branch here. This is a workaround to the lack of
-        # merge on https://github.com/google/protobuf/pull/2508, which is needed for supporting
-        # arbitrary CC compiler locations from the environment. The branch is
-        # https://github.com/htuch/protobuf/tree/v3.2.0-default-shell-env, which is the 3.2.0
-        # release with the above mentioned PR cherry picked.
-        commit = "d490587268931da78c942a6372ef57bb53db80da",
-        remote = "https://github.com/htuch/protobuf.git",
+        remote = PROTOBUF_REMOTE,
+        commit = PROTOBUF_COMMIT,
     )
 
 def rapidjson_repositories():
@@ -438,8 +446,8 @@ cc_library(
 
     native.new_git_repository(
         name = "rapidjson_git",
-        remote = "https://github.com/miloyip/rapidjson.git",
-        commit = "f54b0e47a08782a6131cc3d60f94d038fa6e0a51", # v1.1.0
+        remote = RAPIDJSON_REMOTE,
+        commit = RAPIDJSON_COMMIT,
         build_file_content = BUILD,
     )
 
@@ -460,9 +468,8 @@ cc_library(
     native.new_git_repository(
         name = "spdlog_git",
         build_file_content = BUILD,
-        # v0.11.0 release
-        commit = "1f1f6a5f3b424203a429e9cb78e6548037adefa8",
-        remote = "https://github.com/gabime/spdlog.git",
+        remote = SPDLOG_REMOTE,
+        commit = SPDLOG_COMMIT,
     )
 
 def tclap_repositories():
@@ -505,8 +512,8 @@ cc_library(
 """
     native.new_http_archive(
         name = "tclap_archive",
-        url = "https://storage.googleapis.com/istio-build-deps/tclap-1.2.1.tar.gz",
-        strip_prefix = "tclap-1.2.1",
+        url = TCLAP_HTTP_ARCHIVE,
+        strip_prefix = TCLAP_PREFIX,
         build_file_content = BUILD,
     )
 

--- a/bazel/versions.bzl
+++ b/bazel/versions.bzl
@@ -1,0 +1,47 @@
+# This file needs to be loadable in both Skylark (Bazel Python subset) for the developer-local setup
+# and regular bash for the CI Docker image build. As a result, only common syntax may be used.
+
+CARES_REMOTE="https://github.com/c-ares/c-ares.git"
+CARES_COMMIT="cares-1_12_0"
+
+BORINGSSL_REMOTE="https://boringssl.googlesource.com/boringssl"
+# 2017-02-02
+BORINGSSL_COMMIT="bfd36df3da38dbf8828e712f42fbab2a0034bc40"
+
+GCOVR_HTTP_ARCHIVE="https://github.com/gcovr/gcovr/archive/3.3.tar.gz"
+GCOVR_PREFIX="gcovr-3.3"
+
+GOOGLETEST_REMOTE="https://github.com/google/googletest.git"
+GOOGLETEST_COMMIT="release-1.8.0"
+
+GPERFTOOLS_HTTP_ARCHIVE="https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz"
+GPERFTOOLS_PREFIX="gperftools-2.5"
+
+HTTP_PARSER_REMOTE="https://github.com/nodejs/http-parser.git"
+HTTP_PARSER_COMMIT="v2.7.0"
+
+LIBEVENT_HTTP_ARCHIVE="https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz"
+LIBEVENT_PREFIX="libevent-2.1.8-stable"
+
+LIGHTSTEP_HTTP_ARCHIVE="https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0_36/lightstep-tracer-cpp-0.36.tar.gz"
+LIGHTSTEP_PREFIX="lightstep-tracer-cpp-0.36"
+
+NGHTTP2_HTTP_ARCHIVE="https://github.com/nghttp2/nghttp2/releases/download/v1.20.0/nghttp2-1.20.0.tar.gz"
+NGHTTP2_PREFIX="nghttp2-1.20.0"
+
+# Using a non-canonical repository/branch here. This is a workaround to the lack of merge on
+# https://github.com/google/protobuf/pull/2508, which is needed for supporting arbitrary CC compiler
+# locations from the environment. The branch is
+# https://github.com/htuch/protobuf/tree/v3.2.0-default-shell-env, which is the 3.2.0 release with
+# the above mentioned PR cherry picked.
+PROTOBUF_REMOTE="https://github.com/htuch/protobuf.git"
+PROTOBUF_COMMIT="d490587268931da78c942a6372ef57bb53db80da"
+
+RAPIDJSON_REMOTE="https://github.com/miloyip/rapidjson.git"
+RAPIDJSON_COMMIT="v1.1.0"
+
+SPDLOG_REMOTE="https://github.com/gabime/spdlog.git"
+SPDLOG_COMMIT="v0.11.0"
+
+TCLAP_HTTP_ARCHIVE="https://storage.googleapis.com/istio-build-deps/tclap-1.2.1.tar.gz"
+TCLAP_PREFIX="tclap-1.2.1"

--- a/ci/build_container/Dockerfile
+++ b/ci/build_container/Dockerfile
@@ -1,3 +1,4 @@
 FROM ubuntu:xenial
 COPY ./build_container.sh /
+COPY ./versions.bzl /
 RUN ./build_container.sh

--- a/ci/build_container/gen_build_container.sh
+++ b/ci/build_container/gen_build_container.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# We need versions.bzl for the build, but it's not in ci/build_container. Using Docker relative path
+# workaround from https://github.com/docker/docker/issues/2745#issuecomment-253230025 to get this to
+# work.
+tar cf - . -C ../../bazel versions.bzl | docker build --rm -t lyft/envoy-build:$TAG -

--- a/ci/build_container/update_build_container.sh
+++ b/ci/build_container/update_build_container.sh
@@ -5,7 +5,7 @@ then
   TAG="$(git rev-parse master)"
   docker-machine start default
   eval $(docker-machine env default)
-  docker build --rm -t lyft/envoy-build:$TAG .
+  ./gen_build_container.sh
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   docker push lyft/envoy-build:$TAG
   echo Pushed lyft/envoy-build:$TAG

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -37,14 +37,14 @@ $EXTRA_CMAKE_FLAGS \
 -DENVOY_LIBEVENT_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_CARES_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_NGHTTP2_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_SPDLOG_INCLUDE_DIR:FILEPATH=/thirdparty/spdlog-0.11.0/include \
+-DENVOY_SPDLOG_INCLUDE_DIR:FILEPATH=/thirdparty/spdlog/include \
 -DENVOY_TCLAP_INCLUDE_DIR:FILEPATH=/thirdparty/tclap-1.2.1/include \
 -DENVOY_OPENSSL_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_PROTOBUF_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
 -DENVOY_PROTOBUF_PROTOC:FILEPATH=/thirdparty_build/bin/protoc \
 -DENVOY_GCOVR:FILEPATH=/thirdparty/gcovr-3.3/scripts/gcovr \
--DENVOY_RAPIDJSON_INCLUDE_DIR:FILEPATH=/thirdparty/rapidjson-1.1.0/include \
+-DENVOY_RAPIDJSON_INCLUDE_DIR:FILEPATH=/thirdparty/rapidjson/include \
 -DENVOY_GCOVR_EXTRA_ARGS:STRING="-e test/* -e build/*" \
 -DENVOY_EXE_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \
 -DENVOY_TEST_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \


### PR DESCRIPTION
This refactoring of the references to external deps makes it cleaner to maintain both the CI and
developer-local Bazel flows.