### PR TITLE
Push latest tag for alpine image and udpate documentation.

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -8,6 +8,13 @@ image at [`lyft/envoy:<hash>`](https://hub.docker.com/r/lyft/envoy/) is an image
 corresponds to the master commit at which the binary was compiled. Lastly, `lyft/envoy:latest` contains
 an Envoy binary built from the latest tip of master that passed tests.
 
+# Using alpine envoy image
+
+A minimal image based on alpine is available as lyft/envoy-alpine.
+
+Another image lyft/envoy-alpine-debug has a debug binary of envoy built into it and can be deployed when a requirement to debug envoy issues may arise.
+
+# Building a debug image
 An example basic invocation to build a debug image and run all tests is:
 
 ```bash

--- a/ci/README.md
+++ b/ci/README.md
@@ -14,18 +14,9 @@ binary built from the latest tip of master that passed tests.
 ## Alpine envoy image
 
 Minimal images based on alpine Linux allow for quicker deployment of Envoy. Two alpine based images are built,
-one with an Envoy binary with debug symbols and one stripped of them (and consequently the smallest of the built images).
-
-The Alpine based Envoy Docker image at [`lyft/envoy-alpine:<hash>`](https://hub.docker.com/r/lyft/envoy-alpine/), and the
-Alpine based debug Envoy Docker image at [`lyft/envoy-alpine-debug:<hash>`](https://hub.docker.com/r/lyft/envoy-alpine-debug/) are
-both used for Travis CI checks, where `<hash>` is specified in [ci_steps.sh](https://github.com/lyft/envoy/blob/master/ci/ci_steps.sh).
-
-As with the Ubuntu based images, for the Alpine based images, developers
-may work with `lyft/envoy-alpine:latest` and `lyft/envoy-alpine-debug:latest` to provide a self-contained environment for
-building Envoy binaries and running tests that reflects the latest built Alpine Envoy image.
-Like the Ubuntu based images, the Alpine based images have an Envoy binary at `/usr/local/bin/envoy`, the `<hash>`
-corresponds to the master commit at which the binary was compiled, and `lyft/envoy-alpine:latest` and `lyft/envoy-alpine-debug:latest`
-contain an Envoy binary built from the latest tip of master that passed tests.
+one with an Envoy binary with debug (`lyft/envoy-alpine-debug`) symbols and one stripped of them (`lyft/envoy-alpine`).
+Both images are pushed with two different tags: `<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
+master commit at which the binary was compiled, and `latest` corresponds to a binary built from the latest tip of master that passed tests.
 
 # Building a debug image
 An example basic invocation to build a debug image and run all tests is:

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,18 +1,31 @@
-# Developer use of CI Docker image
+# Developer use of CI Docker images
 
-The Docker image at [`lyft/envoy-build:<hash>`](https://hub.docker.com/r/lyft/envoy-build/) is used for Travis CI checks, where `<hash>` is specified in
-[ci_steps.sh](https://github.com/lyft/envoy/blob/master/ci/ci_steps.sh). Developers
-may work with `lyft/envoy-build:latest` to provide a self-contained environment for
-building Envoy binaries and running tests that reflects the latest built image. Moreover, the Docker
-image at [`lyft/envoy:<hash>`](https://hub.docker.com/r/lyft/envoy/) is an image that has an Envoy binary at `usr/local/bin/envoy`. The `<hash>`
-corresponds to the master commit at which the binary was compiled. Lastly, `lyft/envoy:latest` contains
-an Envoy binary built from the latest tip of master that passed tests.
+Two flavors of Envoy Docker images, based on Ubuntu and Alpine Linux, are built.
 
-# Using alpine envoy image
+## Ubuntu envoy image
+The Ubuntu based Envoy Docker image at [`lyft/envoy-build:<hash>`](https://hub.docker.com/r/lyft/envoy-build/) is used for Travis CI checks,
+where `<hash>` is specified in [ci_steps.sh](https://github.com/lyft/envoy/blob/master/ci/ci_steps.sh). Developers
+may work with `lyft/envoy-build:latest` to provide a self-contained environment for building Envoy binaries and
+running tests that reflects the latest built Ubuntu Envoy image. Moreover, the Docker image
+at [`lyft/envoy:<hash>`](https://hub.docker.com/r/lyft/envoy/) is an image that has an Envoy binary at `/usr/local/bin/envoy`. The `<hash>`
+corresponds to the master commit at which the binary was compiled. Lastly, `lyft/envoy:latest` contains an Envoy
+binary built from the latest tip of master that passed tests.
 
-A minimal image based on alpine is available as lyft/envoy-alpine.
+## Alpine envoy image
 
-Another image lyft/envoy-alpine-debug has a debug binary of envoy built into it and can be deployed when a requirement to debug envoy issues may arise.
+Minimal images based on alpine Linux allow for quicker deployment of Envoy. Two alpine based images are built,
+one with an Envoy binary with debug symbols and one stripped of them (and consequently the smallest of the built images).
+
+The Alpine based Envoy Docker image at [`lyft/envoy-alpine:<hash>`](https://hub.docker.com/r/lyft/envoy-alpine/), and the
+Alpine based debug Envoy Docker image at [`lyft/envoy-alpine-debug:<hash>`](https://hub.docker.com/r/lyft/envoy-alpine-debug/) are
+both used for Travis CI checks, where `<hash>` is specified in [ci_steps.sh](https://github.com/lyft/envoy/blob/master/ci/ci_steps.sh).
+
+As with the Ubuntu based images, for the Alpine based images, developers
+may work with `lyft/envoy-alpine:latest` and `lyft/envoy-alpine-debug:latest` to provide a self-contained environment for
+building Envoy binaries and running tests that reflects the latest built Alpine Envoy image.
+Like the Ubuntu based images, the Alpine based images have an Envoy binary at `/usr/local/bin/envoy`, the `<hash>`
+corresponds to the master commit at which the binary was compiled, and `lyft/envoy-alpine:latest` and `lyft/envoy-alpine-debug:latest`
+contain an Envoy binary built from the latest tip of master that passed tests.
 
 # Building a debug image
 An example basic invocation to build a debug image and run all tests is:

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -25,8 +25,10 @@ then
       make -C ci/build_alpine_container
       docker tag lyft/envoy-alpine:latest lyft/envoy-alpine:$TRAVIS_COMMIT
       docker push lyft/envoy-alpine:$TRAVIS_COMMIT
+      docker push lyft/envoy-alpine:latest
       docker tag lyft/envoy-alpine-debug:latest lyft/envoy-alpine-debug:$TRAVIS_COMMIT
       docker push lyft/envoy-alpine-debug:$TRAVIS_COMMIT
+      docker push lyft/envoy-alpine-debug:latest
   else
       echo 'Ignoring PR branch for docker push.'
   fi

--- a/docs/install/sandboxes.rst
+++ b/docs/install/sandboxes.rst
@@ -315,3 +315,12 @@ the ``FROM`` line in any dockerfile.
 
 This will be particularly useful if you are interested in modifying envoy, and testing
 your changes.
+
+
+Using alpine envay image 
+------------------------
+
+A minimal image based on alpine is available as lyft/envoy-alpine. 
+
+Another image lyft/envoy-alpine-debug has a debug build of envoy built into it and
+can be deployed when a requirement to debug envoy issues may arise.

--- a/docs/install/sandboxes.rst
+++ b/docs/install/sandboxes.rst
@@ -315,4 +315,3 @@ the ``FROM`` line in any dockerfile.
 
 This will be particularly useful if you are interested in modifying envoy, and testing
 your changes.
-

--- a/docs/install/sandboxes.rst
+++ b/docs/install/sandboxes.rst
@@ -317,10 +317,10 @@ This will be particularly useful if you are interested in modifying envoy, and t
 your changes.
 
 
-Using alpine envay image 
+Using alpine envoy image
 ------------------------
 
-A minimal image based on alpine is available as lyft/envoy-alpine. 
+A minimal image based on alpine is available as lyft/envoy-alpine.
 
 Another image lyft/envoy-alpine-debug has a debug build of envoy built into it and
 can be deployed when a requirement to debug envoy issues may arise.

--- a/docs/install/sandboxes.rst
+++ b/docs/install/sandboxes.rst
@@ -316,11 +316,3 @@ the ``FROM`` line in any dockerfile.
 This will be particularly useful if you are interested in modifying envoy, and testing
 your changes.
 
-
-Using alpine envoy image
-------------------------
-
-A minimal image based on alpine is available as lyft/envoy-alpine.
-
-Another image lyft/envoy-alpine-debug has a debug build of envoy built into it and
-can be deployed when a requirement to debug envoy issues may arise.


### PR DESCRIPTION
What this PR does
==============
This is a follow up patch for #659 - this pushes the lyft/envoy-alpine and lyft/envoy-alpine-debug images with the :latest tag. It also makes a note of these images in docs.