### PR TITLE
bazel: asan config and documentation.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -63,6 +63,16 @@ the units tests in
 bazel test //test/common/http:async_client_impl_test
 ```
 
+# Additional Envoy build and test options
+
+To build and run tests with the compiler's address sanitizer (ASAN) enabled:
+
+```
+bazel test -c dbg --config=asan //test/...
+```
+
+The ASAN failure stack traces include numbers as a results of running ASAN with a `dbg` build above.
+
 # Adding or maintaining Envoy build rules
 
 See the [developer guide for writing Envoy Bazel rules](DEVELOPER.md).

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,5 @@
+# Envoy specific Bazel build/test options.
+
+build:asan --copt -fsanitize=address
+build:asan --linkopt -fsanitize=address
+build:asan --linkopt -ldl


### PR DESCRIPTION
Some of the integration tests are actually failing under ASAN, which is surprising given they don't
do this under the cmake ASAN runs. Will investigate further before we rollover to this in CI.