### PR TITLE
bazel: linkstatic always.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,8 +16,3 @@ envoy_cc_library(
     srcs = ["version_generated.cc"],
     deps = ["//source/common/common:version_includes"],
 )
-
-config_setting(
-    name = "force_test_link_static",
-    values = {"define": "force_test_link_static=yes"},
-)

--- a/bazel/DEVELOPER.md
+++ b/bazel/DEVELOPER.md
@@ -156,14 +156,11 @@ with the `envoy_cc_binary` rule, e.g. for a new `tools/hello/world.cc` that depe
 envoy_cc_binary(
     name = "world",
     srcs = ["world.cc"],
-    linkstatic = 1,
     deps = [
         "//source/common/foo:bar_lib",
     ],
 )
 ```
-
-The `linkstatic` attribute controls whether the binary is built statically or dynamically.
 
 ## Filter linking
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -59,7 +59,6 @@ def envoy_cc_library(name,
 def envoy_cc_binary(name,
                     srcs = [],
                     data = [],
-                    linkstatic = 0,
                     visibility = None,
                     deps = []):
     native.cc_binary(
@@ -71,7 +70,7 @@ def envoy_cc_binary(name,
             "-pthread",
             "-lrt",
         ],
-        linkstatic = linkstatic,
+        linkstatic = 1,
         visibility = visibility,
         deps = deps + [
             "//source/precompiled:precompiled_includes",
@@ -98,10 +97,7 @@ def envoy_cc_test(name,
         data = data,
         copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
         linkopts = ["-pthread"],
-        linkstatic = select({
-            "//:force_test_link_static": 1,
-            "//conditions:default": 0,
-        }),
+        linkstatic = 1,
         args = args,
         deps = deps + [
             "//source/precompiled:precompiled_includes",

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -23,7 +23,7 @@ if [[ "$1" == "bazel.debug" ]]; then
   echo "Building..."
   bazel $BAZEL_BATCH build $BAZEL_OPTIONS //source/exe:envoy-static
   echo "Testing..."
-  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --define force_test_link_static=yes --test_output=all \
+  bazel $BAZEL_BATCH test $BAZEL_OPTIONS --test_output=all \
     --cache_test_results=no //test/...
   exit 0
 fi

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -2,14 +2,13 @@ package(default_visibility = ["//visibility:public"])
 
 load("//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_cc_binary")
 
-envoy_cc_binary(
+alias(
     name = "envoy",
-    deps = ["envoy_main_lib"],
+    actual = ":envoy-static",
 )
 
 envoy_cc_binary(
     name = "envoy-static",
-    linkstatic = 1,
     deps = ["envoy_main_lib"],
 )
 


### PR DESCRIPTION
I've had a few reports of obscure link issues with our static prebuilts when not linking tests and
binaries static, so let's just default to this. We can leave it to the future to optimize this when
we have stability in Bazel land.