### PR TITLE
bazel: support using envoy_build_system.bzl macros from consuming pro…

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -39,6 +39,7 @@ def envoy_cc_library(name,
                      copts = [],
                      visibility = None,
                      external_deps = [],
+                     repository = "",
                      deps = [],
                      alwayslink = None):
     native.cc_library(
@@ -48,8 +49,8 @@ def envoy_cc_library(name,
         copts = ENVOY_COPTS + copts,
         visibility = visibility,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
-            "//include/envoy/common:base_includes",
-            "//source/precompiled:precompiled_includes",
+            repository + "//include/envoy/common:base_includes",
+            repository + "//source/precompiled:precompiled_includes",
         ],
         include_prefix = envoy_include_prefix(PACKAGE_NAME),
         alwayslink = alwayslink,
@@ -60,6 +61,7 @@ def envoy_cc_binary(name,
                     srcs = [],
                     data = [],
                     visibility = None,
+                    repository = "",
                     deps = []):
     native.cc_binary(
         name = name,
@@ -73,7 +75,7 @@ def envoy_cc_binary(name,
         linkstatic = 1,
         visibility = visibility,
         deps = deps + [
-            "//source/precompiled:precompiled_includes",
+            repository + "//source/precompiled:precompiled_includes",
         ],
     )
 
@@ -84,6 +86,7 @@ def envoy_cc_test(name,
                   args = [],
                   # List of pairs (Bazel shell script target, shell script args)
                   setup_cmds = [],
+                  repository = "",
                   deps = []):
     if setup_cmds:
         setup_cmd = "; ".join(["$(location " + setup_sh + ") " + " ".join(setup_args) for
@@ -100,29 +103,31 @@ def envoy_cc_test(name,
         linkstatic = 1,
         args = args,
         deps = deps + [
-            "//source/precompiled:precompiled_includes",
-            "//test/precompiled:precompiled_includes",
-            "//test:main",
+            repository + "//source/precompiled:precompiled_includes",
+            repository + "//test/precompiled:precompiled_includes",
+            repository + "//test:main",
         ],
     )
 
 # Envoy C++ test targets that depend on JSON config files subject to template
 # environment substitution should be specified with this function.
 def envoy_cc_test_with_json(name,
-                            srcs = [],
                             data = [],
                             jsons = [],
                             setup_cmds = [],
-                            deps = []):
+                            repository = "",
+                            deps = [],
+                            **kargs):
     envoy_cc_test(
         name = name,
-        srcs = srcs,
         data = data + jsons,
         setup_cmds = setup_cmds + [(
-            "//test/test_common:environment_sub.sh",
+            repository + "//test/test_common:environment_sub.sh",
             ["$(location " + f + ")" for f in jsons],
         )],
+        repository = repository,
         deps = deps,
+        **kargs
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified
@@ -133,6 +138,7 @@ def envoy_cc_test_library(name,
                           data = [],
                           external_deps = [],
                           deps = [],
+                          repository = "",
                           alwayslink = None):
     native.cc_library(
         name = name,
@@ -142,21 +148,15 @@ def envoy_cc_test_library(name,
         copts = ENVOY_COPTS + ["-includetest/precompiled/precompiled_test.h"],
         testonly = 1,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
-            "//source/precompiled:precompiled_includes",
-            "//test/precompiled:precompiled_includes",
+            repository + "//source/precompiled:precompiled_includes",
+            repository + "//test/precompiled:precompiled_includes",
         ],
         alwayslink = alwayslink,
     )
 
 # Envoy C++ mock targets should be specified with this function.
-def envoy_cc_mock(name,
-                  srcs = [],
-                  hdrs = [],
-                  deps = []):
-    envoy_cc_test_library(name = name,
-                          srcs = srcs,
-                          hdrs = hdrs,
-                          deps = deps)
+def envoy_cc_mock(name, **kargs):
+    envoy_cc_test_library(name = name, **kargs)
 
 def _proto_header(proto_path):
   if proto_path.endswith(".proto"):


### PR DESCRIPTION
…jects.

This allows projects that consume Envoy to link in their own filters and write unit/integrations
tests in a similar way to Envoy proper code.

See https://github.com/htuch/envoy-consumer/blob/master/BUILD for how this is used.