### PR TITLE
test: fix JSON test dependencies to support running tests from consum…

### DIFF
--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -12,7 +12,7 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server_http2.json", {"echo", "http", "http_buffer"});
+    createTestServer("server_http2.json", {"echo", "http", "http_buffer"});
   }
 
   /**

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -12,8 +12,7 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server_http2_upstream.json",
-                     {"http", "http_buffer", "http1_buffer"});
+    createTestServer("server_http2_upstream.json", {"http", "http_buffer", "http1_buffer"});
   }
 
   /**

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -12,8 +12,7 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server.json",
-                     {"echo", "http", "http_buffer", "tcp_proxy", "rds"});
+    createTestServer("server.json", {"echo", "http", "http_buffer", "tcp_proxy", "rds"});
   }
 
   /**

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -15,7 +15,7 @@ public:
   static void SetUpTestCase() {
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server_proxy_proto.json", {"http"});
+    createTestServer("server_proxy_proto.json", {"http"});
   }
 
   /**

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -26,9 +26,8 @@ void SslIntegrationTest::SetUpTestCase() {
   fake_upstreams_.emplace_back(
       new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1));
   registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-  test_server_ =
-      MockRuntimeIntegrationTestServer::create(TestEnvironment::temporaryFileSubstitutePorts(
-          "test/config/integration/server_ssl.json", port_map()));
+  test_server_ = MockRuntimeIntegrationTestServer::create(
+      TestEnvironment::temporaryFileSubstitutePorts("server_ssl.json", port_map()));
   registerTestServerPorts({"http"});
   client_ssl_ctx_alpn_ = createClientSslContext(true);
   client_ssl_ctx_no_alpn_ = createClientSslContext(false);

--- a/test/integration/uds_integration_test.h
+++ b/test/integration/uds_integration_test.h
@@ -18,7 +18,7 @@ public:
         TestEnvironment::unixDomainSocketPath("udstest.1.sock"), FakeHttpConnection::Type::HTTP1));
     fake_upstreams_.emplace_back(new FakeUpstream(
         TestEnvironment::unixDomainSocketPath("udstest.2.sock"), FakeHttpConnection::Type::HTTP1));
-    createTestServer("test/config/integration/server_uds.json", {"http"});
+    createTestServer("server_uds.json", {"http"});
   }
 
   /**

--- a/test/run_envoy_tests.sh
+++ b/test/run_envoy_tests.sh
@@ -65,8 +65,8 @@ fi
 # some test behavior lost in #650, when we switched to 0 port binding - the hot restart tests no
 # longer check socket passing. Will need to generate the second server's JSON based on the actual
 # bound ports in the first server.
-HOT_RESTART_JSON="$TEST_SRCDIR"/test/config/integration/hot_restart.json
-cat "$TEST_TMPDIR"/test/config/integration/server.json |
+HOT_RESTART_JSON="$TEST_TMPDIR"/hot_restart.json
+cat "$TEST_TMPDIR"/server.json |
   sed -e "s#{{ upstream_. }}#0#g" | \
   cat > "$HOT_RESTART_JSON"
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -49,7 +49,7 @@ class ServerInstanceImplTest : public testing::Test {
 protected:
   ServerInstanceImplTest()
       : options_(TestEnvironment::temporaryFileSubstitutePorts(
-            "test/config/integration/server.json", {{"upstream_0", 0}, {"upstream_1", 0}})),
+            "server.json", {{"upstream_0", 0}, {"upstream_1", 0}})),
         server_(options_, hooks_, restart_, stats_store_, fakelock_, component_factory_,
                 local_info_) {}
   void TearDown() override {

--- a/test/test_common/environment_sub.sh
+++ b/test/test_common/environment_sub.sh
@@ -2,7 +2,7 @@
 
 JSON=$1
 SRC_FILE="${TEST_SRCDIR}/${TEST_WORKSPACE}/${JSON}"
-DST_FILE="${TEST_TMPDIR}/${JSON}"
+DST_FILE="${TEST_TMPDIR}"/"$(basename "${JSON}")"
 
 mkdir -p "$(dirname "${DST_FILE}")"
 


### PR DESCRIPTION
…ing projects.

Previously, we were copying the fully qualified (including external/envoy) runfile path of the JSONs
to their tmpdir location. This confused tests that were using Envoy relative paths. The simple
solution is to just drop the path entirely and copy the files directly into tmpdir without any
directory nesting.

This now allows "bazel test @envoy//test/..." to pass from somewhere like
https://github.com/htuch/envoy-consumer