### PR TITLE
Optionally include virtual host rate limit configurations

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -160,9 +160,10 @@ priority
 .. _config_http_conn_man_route_table_route_include_vh:
 
 include_vh_rate_limits
-  *(optional, boolean)* Specifies if the rate limit filter should include the virtual host rate limits.
-  The default value is false if
-  :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>` is specified for the route.
+  *(optional, boolean)* Specifies if the rate limit filter should include the virtual host rate
+  limits. By default, if the route configured rate limits, the virtual host
+  :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>` are not applied to the
+  request.
 
 :ref:`hash_policy <config_http_conn_man_route_table_hash_policy>`
   *(optional, array)* Specifies the route's hashing policy if the upstream cluster uses a hashing

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -27,7 +27,7 @@ next (e.g., redirect, forward, rewrite, etc.).
     "priority": "...",
     "headers": [],
     "rate_limits": [],
-    "exclude_vh_rate_limits" : "...",
+    "include_vh_rate_limits" : "...",
     "hash_policy": "{...}",
     "request_headers_to_add" : [],
     "opaque_config": []
@@ -159,9 +159,9 @@ priority
 
 .. _config_http_conn_man_route_table_route_exclude_vh:
 
-exclude_vh_rate_limits
-  *(optional, boolean)* Specifies if the virtual host rate limits should be excluded by the rate
-  limit filter. The default value is true if
+include_vh_rate_limits
+  *(optional, boolean)* Specifies if the virtual host rate limits should be include by the rate
+  limit filter. The default value is false if
   :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>` is specified for the route.
 
 :ref:`hash_policy <config_http_conn_man_route_table_hash_policy>`

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -27,6 +27,7 @@ next (e.g., redirect, forward, rewrite, etc.).
     "priority": "...",
     "headers": [],
     "rate_limits": [],
+    "exclude_vh_rate_limits" : "...",
     "hash_policy": "{...}",
     "request_headers_to_add" : [],
     "opaque_config": []
@@ -155,6 +156,13 @@ priority
 :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>`
   *(optional, array)* Specifies a set of rate limit configurations that could be applied to the
   route.
+
+.. _config_http_conn_man_route_table_route_exclude_vh:
+
+exclude_vh_rate_limits
+  *(optional, boolean)* Specifies if the virtual host rate limits should be excluded by the rate
+  limit filter. The default value is true if
+  :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>` is specified for the route.
 
 :ref:`hash_policy <config_http_conn_man_route_table_hash_policy>`
   *(optional, array)* Specifies the route's hashing policy if the upstream cluster uses a hashing
@@ -369,7 +377,7 @@ Opaque Config
 
 Additional configuration can be provided to filters through the "Opaque Config" mechanism. A
 list of properties are specified in the route config. The configuration is uninterpreted
-by envoy and can be accessed within a user-defined filter. The configuration is a generic 
+by envoy and can be accessed within a user-defined filter. The configuration is a generic
 string map.  Nested objects are not supported.
 
 .. code-block:: json
@@ -377,4 +385,3 @@ string map.  Nested objects are not supported.
   [
     {"...": "..."}
   ]
-

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -157,11 +157,11 @@ priority
   *(optional, array)* Specifies a set of rate limit configurations that could be applied to the
   route.
 
-.. _config_http_conn_man_route_table_route_exclude_vh:
+.. _config_http_conn_man_route_table_route_include_vh:
 
 include_vh_rate_limits
-  *(optional, boolean)* Specifies if the virtual host rate limits should be include by the rate
-  limit filter. The default value is false if
+  *(optional, boolean)* Specifies if the rate limit filter should include the virtual host rate limits.
+  The default value is false if
   :ref:`rate_limits <config_http_conn_man_route_table_rate_limit_config>` is specified for the route.
 
 :ref:`hash_policy <config_http_conn_man_route_table_hash_policy>`

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -9,7 +9,7 @@ The HTTP rate limit filter will call the rate limit service when the request's r
 has one or more :ref:`rate limit configurations<config_http_conn_man_route_table_route_rate_limits>`
 that match the filter stage setting. By default, if the route configured rate limits, the virtual
 host rate limits are not applied to the request. This is configurable in the
-:ref:`route<config_http_conn_man_route_table_route_exclude_vh>`. More than one configuration can
+:ref:`route<config_http_conn_man_route_table_route_include_vh>`. More than one configuration can
 apply to a request. Each configuration results in a descriptor being sent to the rate limit service.
 
 If the rate limit service is called, and the response for any of the descriptors is over limit, a

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -7,9 +7,8 @@ Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
 
 The HTTP rate limit filter will call the rate limit service when the request's route or virtual host
 has one or more :ref:`rate limit configurations<config_http_conn_man_route_table_route_rate_limits>`
-that match the filter stage setting. By default, if the route configured rate limits, the virtual
-host rate limits are not applied to the request. This is configurable in the
-:ref:`route<config_http_conn_man_route_table_route_include_vh>`. More than one configuration can
+that match the filter stage setting. The :ref:`route<config_http_conn_man_route_table_route_include_vh>`
+can optionally include the virtual host rate limit configurations. More than one configuration can
 apply to a request. Each configuration results in a descriptor being sent to the rate limit service.
 
 If the rate limit service is called, and the response for any of the descriptors is over limit, a

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -5,7 +5,7 @@ Rate limit
 
 Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
 
-The HTTP rate limit filter will call the rate limit service when the requests' route or virtual host
+The HTTP rate limit filter will call the rate limit service when the request's route or virtual host
 has one or more :ref:`rate limit configurations<config_http_conn_man_route_table_route_rate_limits>`
 that match the filter stage setting. By default, if the route configured rate limits, the virtual
 host rate limits are not applied to the request. This is configurable in the

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -5,10 +5,12 @@ Rate limit
 
 Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
 
-The HTTP rate limit filter will call the rate limit service when the request's route has one or
-more :ref:`rate limit configurations<config_http_conn_man_route_table_route_rate_limits>` that match the
-filter stage setting. More than one configuration can apply to a request. Each configuration
-results in a descriptor being sent to the rate limit service.
+The HTTP rate limit filter will call the rate limit service when the requests' route or virtual host
+has one or more :ref:`rate limit configurations<config_http_conn_man_route_table_route_rate_limits>`
+that match the filter stage setting. By default, if the route configured rate limits, the virtual
+host rate limits are not applied to the request. This is configurable in the
+:ref:`route<config_http_conn_man_route_table_route_exclude_vh>`. More than one configuration can
+apply to a request. Each configuration results in a descriptor being sent to the rate limit service.
 
 If the rate limit service is called, and the response for any of the descriptors is over limit, a
 429 response is returned.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -233,9 +233,9 @@ public:
   virtual const std::multimap<std::string, std::string>& opaqueConfig() const PURE;
 
   /**
-   * @return bool true if the virtual host rate limits should be excluded.
+   * @return bool true if the virtual host rate limits should be included.
    */
-  virtual bool excludeVirtualHostRateLimits() const PURE;
+  virtual bool includeVirtualHostRateLimits() const PURE;
 };
 
 /**

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -231,6 +231,11 @@ public:
    *         with the route
    */
   virtual const std::multimap<std::string, std::string>& opaqueConfig() const PURE;
+
+  /**
+   * @return bool true if the virtual host rate limits should be excluded.
+   */
+  virtual bool excludeVirtualHostRateLimits() const PURE;
 };
 
 /**

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -69,7 +69,7 @@ public:
   virtual ~RateLimitPolicy() {}
 
   /**
-   * @return true if there is no rate limit policy.
+   * @return true if there is no rate limit policy for all stage settings.
    */
   virtual bool empty() const PURE;
 

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -69,6 +69,11 @@ public:
   virtual ~RateLimitPolicy() {}
 
   /**
+   * @return true if there is no rate limit policy.
+   */
+  virtual bool empty() const PURE;
+
+  /**
    * @param stage the value for finding applicable rate limit configurations.
    * @return set of RateLimitPolicyEntry that are applicable for a stage.
    */

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -133,7 +133,7 @@ private:
     }
     const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
     bool autoHostRewrite() const override { return false; }
-    bool excludeVirtualHostRateLimits() const override { return false; }
+    bool includeVirtualHostRateLimits() const override { return true; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -77,6 +77,7 @@ private:
         getApplicableRateLimit(uint64_t) const override {
       return rate_limit_policy_entry_;
     }
+    bool empty() const override { return true; }
 
     static const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>
         rate_limit_policy_entry_;
@@ -132,6 +133,7 @@ private:
     }
     const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
     bool autoHostRewrite() const override { return false; }
+    bool excludeVirtualHostRateLimits() const override { return false; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -47,9 +47,12 @@ void Filter::initiateCall(const HeaderMap& headers) {
   // Get all applicable rate limit policy entries for the route.
   populateRateLimitDescriptors(route_entry->rateLimitPolicy(), descriptors, route_entry, headers);
 
-  // Get all applicable rate limit policy entries for the virtual host.
-  populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors,
-                               route_entry, headers);
+  // Get all applicable rate limit policy entries for the virtual host if the route opted into
+  // including the virtual host rate limits.
+  if (!route_entry->excludeVirtualHostRateLimits()) {
+    populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors,
+                                 route_entry, headers);
+  }
 
   if (!descriptors.empty()) {
     state_ = State::Calling;

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -49,7 +49,7 @@ void Filter::initiateCall(const HeaderMap& headers) {
 
   // Get all applicable rate limit policy entries for the virtual host if the route opted to
   // include the virtual host rate limits.
-  if (!route_entry->excludeVirtualHostRateLimits()) {
+  if (route_entry->includeVirtualHostRateLimits()) {
     populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors,
                                  route_entry, headers);
   }

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -47,8 +47,8 @@ void Filter::initiateCall(const HeaderMap& headers) {
   // Get all applicable rate limit policy entries for the route.
   populateRateLimitDescriptors(route_entry->rateLimitPolicy(), descriptors, route_entry, headers);
 
-  // Get all applicable rate limit policy entries for the virtual host if the route opted into
-  // including the virtual host rate limits.
+  // Get all applicable rate limit policy entries for the virtual host if the route opted to
+  // include the virtual host rate limits.
   if (!route_entry->excludeVirtualHostRateLimits()) {
     populateRateLimitDescriptors(route_entry->virtualHost().rateLimitPolicy(), descriptors,
                                  route_entry, headers);

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -594,7 +594,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
         }
       },
       "rate_limits" : {"type" : "array"},
-      "exclude_vh_rate_limits" : {"type" : "boolean"},
+      "include_vh_rate_limits" : {"type" : "boolean"},
       "hash_policy" : {
         "type" : "object",
         "properties" : {

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -594,6 +594,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
         }
       },
       "rate_limits" : {"type" : "array"},
+      "exclude_vh_rate_limits" : {"type" : "boolean"},
       "hash_policy" : {
         "type" : "object",
         "properties" : {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -146,11 +146,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
 
   // Only set include_vh_rate_limits_ to true if the rate limit policy for the route is empty
   // or the route set `include_vh_rate_limits` to true.
-  if (rate_limit_policy_.empty() || route.getBoolean("include_vh_rate_limits", false)) {
-    include_vh_rate_limits_ = true;
-  } else {
-    include_vh_rate_limits_ = false;
-  }
+  include_vh_rate_limits_ =
+      (rate_limit_policy_.empty() || route.getBoolean("include_vh_rate_limits", false));
 }
 
 bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -144,13 +144,12 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
     }
   }
 
-  // Only set exclude_vh_rate_limits_ to true if there is a rate limit policy for the route
-  // and the route opted into excluding the virtual host.
-  if (!rate_limit_policy_.getApplicableRateLimit().empty() &&
-      route.getBoolean("exclude_vh_rate_limits", true)) {
-    exclude_vh_rate_limits_ = true;
+  // Only set include_vh_rate_limits_ to true if the rate limit policy for the route is empty
+  // or the route set `include_vh_rate_limits` to true.
+  if (rate_limit_policy_.empty() || route.getBoolean("include_vh_rate_limits", false)) {
+    include_vh_rate_limits_ = true;
   } else {
-    exclude_vh_rate_limits_ = false;
+    include_vh_rate_limits_ = false;
   }
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -143,6 +143,15 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
   }
+
+  // Only set exclude_vh_rate_limits_ to true if there is a rate limit policy for the route
+  // and the route opted into excluding the virtual host.
+  if (!rate_limit_policy_.getApplicableRateLimit().empty() &&
+      route.getBoolean("exclude_vh_rate_limits", true)) {
+    exclude_vh_rate_limits_ = true;
+  } else {
+    exclude_vh_rate_limits_ = false;
+  }
 }
 
 bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -197,6 +197,7 @@ public:
   const std::multimap<std::string, std::string>& opaqueConfig() const override {
     return opaque_config_;
   }
+  bool excludeVirtualHostRateLimits() const override { return exclude_vh_rate_limits_; }
 
   // Router::RedirectEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -209,6 +210,7 @@ protected:
   const bool case_sensitive_;
   const std::string prefix_rewrite_;
   const std::string host_rewrite_;
+  bool exclude_vh_rate_limits_;
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
@@ -248,6 +250,9 @@ private:
 
     const VirtualHost& virtualHost() const override { return parent_->virtualHost(); }
     bool autoHostRewrite() const override { return parent_->autoHostRewrite(); }
+    bool excludeVirtualHostRateLimits() const override {
+      return parent_->excludeVirtualHostRateLimits();
+    }
 
     // Router::Route
     const RedirectEntry* redirectEntry() const override { return nullptr; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -197,7 +197,7 @@ public:
   const std::multimap<std::string, std::string>& opaqueConfig() const override {
     return opaque_config_;
   }
-  bool excludeVirtualHostRateLimits() const override { return exclude_vh_rate_limits_; }
+  bool includeVirtualHostRateLimits() const override { return include_vh_rate_limits_; }
 
   // Router::RedirectEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -210,7 +210,7 @@ protected:
   const bool case_sensitive_;
   const std::string prefix_rewrite_;
   const std::string host_rewrite_;
-  bool exclude_vh_rate_limits_;
+  bool include_vh_rate_limits_;
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
@@ -250,8 +250,8 @@ private:
 
     const VirtualHost& virtualHost() const override { return parent_->virtualHost(); }
     bool autoHostRewrite() const override { return parent_->autoHostRewrite(); }
-    bool excludeVirtualHostRateLimits() const override {
-      return parent_->excludeVirtualHostRateLimits();
+    bool includeVirtualHostRateLimits() const override {
+      return parent_->includeVirtualHostRateLimits();
     }
 
     // Router::Route

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -126,6 +126,7 @@ public:
   // Router::RateLimitPolicy
   const std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&
   getApplicableRateLimit(uint64_t stage = 0) const override;
+  bool empty() const override { return rate_limit_entries_.empty(); }
 
 private:
   std::vector<std::unique_ptr<RateLimitPolicyEntry>> rate_limit_entries_;

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -441,8 +441,8 @@ TEST_F(HttpRateLimitFilterTest, ExcludeVirtualHost) {
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_, excludeVirtualHostRateLimits())
-      .WillOnce(Return(true));
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
+      .WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
               getApplicableRateLimit(0)).Times(0);
 

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -427,6 +427,41 @@ TEST_F(HttpRateLimitFilterTest, ExternalRequestType) {
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.ok").value());
 }
 
+TEST_F(HttpRateLimitFilterTest, ExcludeVirtualHost) {
+  std::string external_filter_config = R"EOF(
+  {
+    "domain": "foo"
+  }
+  )EOF";
+  SetUpTest(external_filter_config);
+  InSequence s;
+
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
+      .Times(1);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+      .WillOnce(SetArgReferee<1>(descriptor_));
+
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_, excludeVirtualHostRateLimits())
+      .WillOnce(Return(true));
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
+              getApplicableRateLimit(0)).Times(0);
+
+  EXPECT_CALL(*client_, limit(_, "foo", testing::ContainerEq(std::vector<::RateLimit::Descriptor>{
+                                            {{{"descriptor_key", "descriptor_value"}}}}),
+                              Tracing::EMPTY_CONTEXT))
+      .WillOnce(WithArgs<0>(Invoke([&](::RateLimit::RequestCallbacks& callbacks) -> void {
+        callbacks.complete(::RateLimit::LimitStatus::OK);
+      })));
+
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers_));
+
+  EXPECT_EQ(1U,
+            cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.ok").value());
+}
+
 TEST_F(HttpRateLimitFilterTest, ConfigValueTest) {
   std::string stage_filter_config = R"EOF(
   {

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -436,8 +436,7 @@ TEST_F(HttpRateLimitFilterTest, ExcludeVirtualHost) {
   SetUpTest(external_filter_config);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1807,11 +1807,11 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+  std::unique_ptr<ConfigImpl> config_ptr;
 
-  ConfigImpl config(*loader, runtime, cm, true);
-  EXPECT_FALSE(config.route(genHeaders("lyft.com", "/foo", "GET"), 0)
-                   ->routeEntry()
-                   ->excludeVirtualHostRateLimits());
+  config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
+  EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
 
   json = R"EOF(
   {
@@ -1840,10 +1840,8 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   )EOF";
 
   loader = Json::Factory::LoadFromString(json);
-  ConfigImpl config1(*loader, runtime, cm, true);
-  EXPECT_TRUE(config1.route(genHeaders("lyft.com", "/foo", "GET"), 0)
-                  ->routeEntry()
-                  ->excludeVirtualHostRateLimits());
+  config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
+  EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
 
   json = R"EOF(
   {
@@ -1873,10 +1871,8 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   )EOF";
 
   loader = Json::Factory::LoadFromString(json);
-  ConfigImpl config2(*loader, runtime, cm, true);
-  EXPECT_FALSE(config2.route(genHeaders("lyft.com", "/foo", "GET"), 0)
-                   ->routeEntry()
-                   ->excludeVirtualHostRateLimits());
+  config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
+  EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
 }
 
 } // Router

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1811,7 +1811,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   std::unique_ptr<ConfigImpl> config_ptr;
 
   config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
-  EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
+  EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 
   json = R"EOF(
   {
@@ -1841,7 +1841,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
 
   loader = Json::Factory::LoadFromString(json);
   config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
-  EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
+  EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 
   json = R"EOF(
   {
@@ -1853,7 +1853,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
           {
             "prefix": "/",
             "cluster": "www2",
-            "exclude_vh_rate_limits": false,
+            "include_vh_rate_limits": true,
             "rate_limits": [
               {
                 "actions": [
@@ -1872,7 +1872,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
 
   loader = Json::Factory::LoadFromString(json);
   config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
-  EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->excludeVirtualHostRateLimits());
+  EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
 } // Router

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -159,11 +159,9 @@ TEST_F(RateLimitConfiguration, NoRateLimitPolicy) {
 
   SetUpTest(json);
 
-  EXPECT_EQ(0U, config_->route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
-                    ->routeEntry()
-                    ->rateLimitPolicy()
-                    .getApplicableRateLimit(0)
-                    .size());
+  route_ = config_->route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry();
+  EXPECT_EQ(0U, route_->rateLimitPolicy().getApplicableRateLimit(0).size());
+  EXPECT_TRUE(route_->rateLimitPolicy().empty());
 }
 
 TEST_F(RateLimitConfiguration, TestGetApplicationRateLimit) {
@@ -197,6 +195,7 @@ TEST_F(RateLimitConfiguration, TestGetApplicationRateLimit) {
   std::string address = "10.0.0.1";
 
   route_ = config_->route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry();
+  EXPECT_FALSE(route_->rateLimitPolicy().empty());
   std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
       route_->rateLimitPolicy().getApplicableRateLimit(0);
   EXPECT_EQ(1U, rate_limits.size());

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -27,7 +27,6 @@ MockRateLimitPolicyEntry::~MockRateLimitPolicyEntry() {}
 
 MockRateLimitPolicy::MockRateLimitPolicy() {
   ON_CALL(*this, getApplicableRateLimit(_)).WillByDefault(ReturnRef(rate_limit_policy_entry_));
-  ON_CALL(*this, empty()).WillByDefault(Return(true));
 }
 
 MockRateLimitPolicy::~MockRateLimitPolicy() {}
@@ -54,6 +53,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, timeout()).WillByDefault(Return(std::chrono::milliseconds(10)));
   ON_CALL(*this, virtualCluster(_)).WillByDefault(Return(&virtual_cluster_));
   ON_CALL(*this, virtualHost()).WillByDefault(ReturnRef(virtual_host_));
+  ON_CALL(*this, excludeVirtualHostRateLimits()).WillByDefault(Return(false));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -27,6 +27,7 @@ MockRateLimitPolicyEntry::~MockRateLimitPolicyEntry() {}
 
 MockRateLimitPolicy::MockRateLimitPolicy() {
   ON_CALL(*this, getApplicableRateLimit(_)).WillByDefault(ReturnRef(rate_limit_policy_entry_));
+  ON_CALL(*this, empty()).WillByDefault(Return(true));
 }
 
 MockRateLimitPolicy::~MockRateLimitPolicy() {}
@@ -53,7 +54,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, timeout()).WillByDefault(Return(std::chrono::milliseconds(10)));
   ON_CALL(*this, virtualCluster(_)).WillByDefault(Return(&virtual_cluster_));
   ON_CALL(*this, virtualHost()).WillByDefault(ReturnRef(virtual_host_));
-  ON_CALL(*this, excludeVirtualHostRateLimits()).WillByDefault(Return(false));
+  ON_CALL(*this, includeVirtualHostRateLimits()).WillByDefault(Return(true));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -27,6 +27,7 @@ MockRateLimitPolicyEntry::~MockRateLimitPolicyEntry() {}
 
 MockRateLimitPolicy::MockRateLimitPolicy() {
   ON_CALL(*this, getApplicableRateLimit(_)).WillByDefault(ReturnRef(rate_limit_policy_entry_));
+  ON_CALL(*this, empty()).WillByDefault(Return(true));
 }
 
 MockRateLimitPolicy::~MockRateLimitPolicy() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -67,6 +67,7 @@ public:
   MOCK_CONST_METHOD1(
       getApplicableRateLimit,
       std::vector<std::reference_wrapper<const RateLimitPolicyEntry>>&(uint64_t stage));
+  MOCK_CONST_METHOD0(empty, bool());
 
   std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>> rate_limit_policy_entry_;
 };
@@ -147,6 +148,7 @@ public:
   MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
   MOCK_CONST_METHOD0(autoHostRewrite, bool());
   MOCK_CONST_METHOD0(opaqueConfig, const std::multimap<std::string, std::string>&());
+  MOCK_CONST_METHOD0(excludeVirtualHostRateLimits, bool());
 
   std::string cluster_name_{"fake_cluster"};
   std::multimap<std::string, std::string> opaque_config_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -148,7 +148,7 @@ public:
   MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
   MOCK_CONST_METHOD0(autoHostRewrite, bool());
   MOCK_CONST_METHOD0(opaqueConfig, const std::multimap<std::string, std::string>&());
-  MOCK_CONST_METHOD0(excludeVirtualHostRateLimits, bool());
+  MOCK_CONST_METHOD0(includeVirtualHostRateLimits, bool());
 
   std::string cluster_name_{"fake_cluster"};
   std::multimap<std::string, std::string> opaque_config_;


### PR DESCRIPTION
A route can optionally include virtual host rate limits from applying in the rate limit filter. By default, if a route has specified a rate limit configuration, virtual host rate limits are excluded.