### PR TITLE
GuardDog: Test: Fix race in mocked time source.

### DIFF
--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -121,10 +121,10 @@ TEST_F(GuardDogDeathTest, NearDeathTest) {
 class GuardDogMissTest : public testing::Test {
 protected:
   GuardDogMissTest() : config_miss_(500, 1000, 0, 0), config_mega_(1000, 500, 0, 0) {
-   ON_CALL(time_source_, currentSystemTime())
-      .WillByDefault(testing::Invoke([&]() {
-        return std::chrono::system_clock::time_point(std::chrono::milliseconds(mock_time_));
-      }));
+    ON_CALL(time_source_, currentSystemTime())
+        .WillByDefault(testing::Invoke([&]() {
+          return std::chrono::system_clock::time_point(std::chrono::milliseconds(mock_time_));
+        }));
   }
 
   NiceMock<Configuration::MockMain> config_miss_;


### PR DESCRIPTION
The guard dog test made additional EXPECT_CALLs to update the time the
mocked time source should return after the mocked object was passed to
the GD thread.  Doing additional EXPECT_CALLs in this way is NOT thread
safe and resulted in 0.5-1% of tests failing when many were executed in
parallel.

The solution is to make the expect call action be to invoke a lambda
that shares access to a safe atomic updated in the main test thread.