### PR TITLE
ci: build external deps with BUILD_DISTINCT=1.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -33,4 +33,10 @@ export CXX=g++-4.9
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty
 export THIRDPARTY_BUILD=/thirdparty_build
+# TODO(htuch): Remove the first build of the libraries in non-distinct locations when cmake is gone.
+# Below we now build/install twice and this requires 2x the space in the Docker image as is to
+# support both Bazel and cmake, but it's not worth fixing up all the cmake stuff since it's going
+# soon.
 "$(dirname "$0")"/build_and_install_deps.sh
+rm -f /tmp/*.dep
+BUILD_DISTINCT=1 "$(dirname "$0")"/build_and_install_deps.sh


### PR DESCRIPTION
This is needed for #716, it's going to temporarily increase the CI image size, but this will go away
when we remove the need for cmake.