### PR TITLE
bazel: add missing redis command_splitter_impl_test target.

### DIFF
--- a/test/common/redis/BUILD
+++ b/test/common/redis/BUILD
@@ -15,6 +15,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "command_splitter_impl_test",
+    srcs = ["command_splitter_impl_test.cc"],
+    deps = [
+        "//source/common/redis:command_splitter_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks:common_lib",
+        "//test/mocks/redis:redis_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "conn_pool_impl_test",
     srcs = ["conn_pool_impl_test.cc"],
     deps = [


### PR DESCRIPTION
This showed up in coverage, pushing it below 98% in the Bazel coverage runs. I think that we'll be
able to easily catch elided tests when we enable Bazel coverage in CI.