### PR TITLE
Fix heap-use-after-free issue when shutting down envoy

### DIFF
--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -52,5 +52,6 @@ int main(int argc, char** argv) {
                               restarter->accessLogLock(), component_factory, local_info);
   server.run();
   ares_library_cleanup();
+  restarter->reset(); // The restarter needs to be deleted before the server.
   return 0;
 }

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -52,6 +52,6 @@ int main(int argc, char** argv) {
                               restarter->accessLogLock(), component_factory, local_info);
   server.run();
   ares_library_cleanup();
-  restarter->reset(); // The restarter needs to be deleted before the server.
+  restarter.reset(); // The restarter needs to be deleted before the server.
   return 0;
 }


### PR DESCRIPTION
Server::HostRestartImpl need to be reset before delete the Server::InstanceImpl, as the Server::InstanceImpl own the dispatcher which will delete the event_base and clean up all associated memory. A further deletion of Server::HostRestartImpl cause a heap use after free error.