### PR TITLE
ci: bazel.coverage support.

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -43,6 +43,7 @@ The `do_ci.sh` targets are:
 * `asan` &mdash; build and run tests with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer).
 * `coverage` &mdash; build and run tests, generating coverage information in `<SOURCE_DIR>/build_coverage/coverage.html`.
 * `debug` &mdash; build debug binary and run tests.
+* `bazel.coverage` &mdash; build and run tests with Bazel, generating coverage information in `<SOURCE_DIR>/generated/coverage/coverage.html`.
 * `bazel.debug` &mdash; build debug binary and run tests with Bazel.
 * `fix_format`&mdash; run `clang-format` 3.6 on entire source tree.
 * `normal` &mdash; build unstripped optimized binary and run tests .

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "ci")
+
 bind(
     name = "ares",
     actual = "//ci/prebuilt:ares",

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -12,42 +12,64 @@ export PPROF_PATH=/thirdparty_build/bin/pprof
 
 NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 
-if [[ "$1" == "coverage" ]]; then
-  EXTRA_CMAKE_FLAGS+=" -DENVOY_CODE_COVERAGE:BOOL=ON"
-elif [[ "$1" == "asan" ]]; then
-  EXTRA_CMAKE_FLAGS+=" -DENVOY_SANITIZE:BOOL=ON -DENVOY_DEBUG:BOOL=OFF"
-elif [[ "$1" == "debug" ]]; then
-  EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=ON"
-elif [[ "$1" == "server_only" ]]; then
-  EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=OFF -DENVOY_STRIP:BOOL=ON"
+if [[ "$1" == bazel* ]]
+then
+  export USER=bazel
+  # Prefixing with bazel- is necessary to prevent creating symlink loops that
+  # confuses gcovr.
+  export TEST_TMPDIR=/source/bazel-build
+  export SRCDIR="$(realpath "${PWD}")"
+  export BAZEL="bazel"
+  export BAZEL_COVERAGE="bazel-coverage"
+  # Not sandboxing, since non-privileged Docker can't do nested namespaces.
+  export BAZEL_BUILD_OPTIONS="--strategy=CppCompile=standalone --strategy=CppLink=standalone \
+    --strategy=TestRunner=standalone --strategy=ProtoCompile=standalone \
+    --strategy=Genrule=standalone --verbose_failures --package_path %workspace%:.."
+  [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
+  mkdir -p "${TEST_TMPDIR}"
+  cp ci/WORKSPACE "${TEST_TMPDIR}"
+  ln -sf /thirdparty ci/prebuilt
+  ln -sf /thirdparty_build ci/prebuilt
+  cd "${TEST_TMPDIR}"
 else
-  EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=OFF"
+  # TODO(htuch): Remove everything below this comment when we turn off cmake.
+  if [[ "$1" == "coverage" ]]; then
+    EXTRA_CMAKE_FLAGS+=" -DENVOY_CODE_COVERAGE:BOOL=ON"
+  elif [[ "$1" == "asan" ]]; then
+    EXTRA_CMAKE_FLAGS+=" -DENVOY_SANITIZE:BOOL=ON -DENVOY_DEBUG:BOOL=OFF"
+  elif [[ "$1" == "debug" ]]; then
+    EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=ON"
+  elif [[ "$1" == "server_only" ]]; then
+    EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=OFF -DENVOY_STRIP:BOOL=ON"
+  else
+    EXTRA_CMAKE_FLAGS+=" -DENVOY_DEBUG:BOOL=OFF"
+  fi
+
+  mkdir -p build_"$1"
+  cd build_"$1"
+
+  cmake \
+  ${EXTRA_CMAKE_FLAGS} \
+  -DENVOY_COTIRE_MODULE_DIR:FILEPATH=/thirdparty/cotire-cotire-1.7.8/CMake \
+  -DENVOY_GMOCK_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_GPERFTOOLS_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_GTEST_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_HTTP_PARSER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_LIBEVENT_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_CARES_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_NGHTTP2_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_SPDLOG_INCLUDE_DIR:FILEPATH=/thirdparty/spdlog-0.11.0/include \
+  -DENVOY_TCLAP_INCLUDE_DIR:FILEPATH=/thirdparty/tclap-1.2.1/include \
+  -DENVOY_OPENSSL_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_PROTOBUF_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
+  -DENVOY_PROTOBUF_PROTOC:FILEPATH=/thirdparty_build/bin/protoc \
+  -DENVOY_GCOVR:FILEPATH=/thirdparty/gcovr-3.3/scripts/gcovr \
+  -DENVOY_RAPIDJSON_INCLUDE_DIR:FILEPATH=/thirdparty/rapidjson-1.1.0/include \
+  -DENVOY_GCOVR_EXTRA_ARGS:STRING="-e test/* -e build/*" \
+  -DENVOY_EXE_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \
+  -DENVOY_TEST_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \
+  ..
+
+  cmake -L || true
 fi
-
-mkdir -p build_"$1"
-cd build_"$1"
-
-cmake \
-$EXTRA_CMAKE_FLAGS \
--DENVOY_COTIRE_MODULE_DIR:FILEPATH=/thirdparty/cotire-cotire-1.7.8/CMake \
--DENVOY_GMOCK_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_GPERFTOOLS_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_GTEST_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_HTTP_PARSER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_LIBEVENT_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_CARES_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_NGHTTP2_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_SPDLOG_INCLUDE_DIR:FILEPATH=/thirdparty/spdlog-0.11.0/include \
--DENVOY_TCLAP_INCLUDE_DIR:FILEPATH=/thirdparty/tclap-1.2.1/include \
--DENVOY_OPENSSL_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_LIGHTSTEP_TRACER_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_PROTOBUF_INCLUDE_DIR:FILEPATH=/thirdparty_build/include \
--DENVOY_PROTOBUF_PROTOC:FILEPATH=/thirdparty_build/bin/protoc \
--DENVOY_GCOVR:FILEPATH=/thirdparty/gcovr-3.3/scripts/gcovr \
--DENVOY_RAPIDJSON_INCLUDE_DIR:FILEPATH=/thirdparty/rapidjson-1.1.0/include \
--DENVOY_GCOVR_EXTRA_ARGS:STRING="-e test/* -e build/*" \
--DENVOY_EXE_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \
--DENVOY_TEST_EXTRA_LINKER_FLAGS:STRING=-L/thirdparty_build/lib \
-..
-
-cmake -L || true

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=b05ce8efcc0ba7957ad6724da83b1ae2abee4600
+ENVOY_BUILD_SHA=3d878d55e05a554514305f26101bd6ad15a4a602
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+[[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+[[ -z "${GCOVR_DIR}" ]] && GCOVR_DIR="${SRCDIR}/bazel-envoy"
+[[ -z "${TESTLOGS_DIR}" ]] && TESTLOGS_DIR="${SRCDIR}/bazel-testlogs"
+[[ -z "${BAZEL_COVERAGE}" ]] && BAZEL_COVERAGE=bazel
+[[ -z "${GCOVR}" ]] && GCOVR=gcovr
+
+# Make sure //test/coverage is up-to-date.
+(cd "${SRCDIR}"; BAZEL_BIN="${BAZEL_COVERAGE}" test/coverage/gen_build.sh)
+
+# Run all tests under bazel coverage.
+"${BAZEL_COVERAGE}" coverage //test/coverage:coverage_tests ${BAZEL_BUILD_OPTIONS} \
+  --cache_test_results=no --instrumentation_filter="" \
+  --coverage_support=@bazel_tools//tools/coverage:coverage_support
+
+# Cleanup any artifacts from previous coverage runs.
+rm -f $(find "${GCOVR_DIR}" -name "*.gcda" -o -name "*.gcov")
+
+# Unpack .gcda.gcno from coverage run. This needs to be done in the Envoy source directory with
+# bazel-out/ underneath it since gcov expects files to be available at their relative build
+# location. This can be done somewhere else, e.g. /tmp, but it involves complex copying or
+# symlinking of files to that location.
+(cd "${GCOVR_DIR}"; tar -xvf "${TESTLOGS_DIR}"/test/coverage/coverage_tests/coverage.dat)
+
+# The Bazel build has a lot of whack in it, in particular generated files, headers from external
+# deps, etc. So, we exclude this from gcov to avoid false reporting of these files in the html and
+# stats. The #foo# pattern is because gcov produces files such as
+# bazel-out#local-fastbuild#bin#external#spdlog_git#_virtual_includes#spdlog#spdlog#details#pattern_formatter_impl.h.gcov.
+# To find these while modifying this regex, perform a gcov run with -k set.
+GCOVR_EXCLUDE_REGEX=".*pb.h.gcov|.*#genfiles#.*|test#.*|external#.*|.*#external#.*|.*#prebuilt#.*"
+
+COVERAGE_DIR="${SRCDIR}"/generated/coverage
+mkdir -p "${COVERAGE_DIR}"
+COVERAGE_SUMMAY="${COVERAGE_DIR}/coverage_summary.txt"
+
+time "${GCOVR}" --gcov-exclude="${GCOVR_EXCLUDE_REGEX}" \
+  --exclude-directories=".*/external/.*" --object-directory="${GCOVR_DIR}" -r "${SRCDIR}" \
+  --html --html-details --exclude-unreachable-branches --print-summary \
+  -o "${COVERAGE_DIR}"/coverage.html > "${COVERAGE_SUMMAY}"
+
+COVERAGE_VALUE=$(grep -Po 'lines: \K(\d|\.)*' "${COVERAGE_SUMMAY}")
+COVERAGE_THRESHOLD=98.0
+COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)
+if test ${COVERAGE_FAILED} -eq 1; then
+    echo Code coverage ${COVERAGE_VALUE} is lower than limit of ${COVERAGE_THRESHOLD}
+    exit 1
+else
+    echo Code coverage ${COVERAGE_VALUE} is good and higher than limit of ${COVERAGE_THRESHOLD}
+fi

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -4,7 +4,7 @@ import os
 import os.path
 import sys
 
-EXCLUDED_PREFIXES = ("./generated/thirdparty", "./thirdparty/", "./build", "./.git/")
+EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/", "./bazel-")
 SUFFIXES = (".cc", ".h", "BUILD")
 
 if len(sys.argv) != 5:


### PR DESCRIPTION
It's reporting 98.1% coverage, an example report is at
http://envoy_examples.storage.googleapis.com/gcovr-example/coverage.html. It seems similar to the
cmake gcovr, modulo some differences a we're not running with TCMALLOC yet. Total code lines is
within a few hundred.