### PR TITLE
stats: maintenance mode stat

### DIFF
--- a/docs/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/configuration/cluster_manager/cluster_stats.rst
@@ -45,6 +45,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_pending_failure_eject, Counter, Total requests that were failed due to a connection pool connection failure
   upstream_rq_pending_active, Gauge, Total active requests pending a connection pool connection
   upstream_rq_cancelled, Counter, Total requests cancelled before obtaining a connection pool connection
+  upstream_rq_maintenance_mode, Counter, Total requests that resulted in an immediate 503 due to :ref:`maintenance mode<config_http_filters_router_runtime_maintenance_mode>`
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
   upstream_rq_per_try_timeout, Counter, Total requests that hit the per try timeout
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -206,6 +206,8 @@ upstream.base_retry_backoff_ms
   Base exponential retry back off time. See :ref:`here <arch_overview_http_routing_retry>` for more
   information. Defaults to 25ms.
 
+.. _config_http_filters_router_runtime_maintenance_mode:
+
 upstream.maintenance_mode.<cluster name>
   % of requests that will result in an immediate 503 response. This overrides any routing behavior
   for requests that would have been destined for <cluster name>. This can be used for load

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -182,6 +182,7 @@ public:
   COUNTER(upstream_rq_pending_failure_eject)                                                       \
   GAUGE  (upstream_rq_pending_active)                                                              \
   COUNTER(upstream_rq_cancelled)                                                                   \
+  COUNTER(upstream_rq_maintenance_mode)                                                            \
   COUNTER(upstream_rq_timeout)                                                                     \
   COUNTER(upstream_rq_per_try_timeout)                                                             \
   COUNTER(upstream_rq_rx_reset)                                                                    \

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -190,6 +190,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::UpstreamOverflow);
     chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr);
     Http::Utility::sendLocalReply(*callbacks_, Http::Code::ServiceUnavailable, "maintenance mode");
+    cluster_->stats().upstream_rq_maintenance_mode_.inc();
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -213,6 +213,10 @@ TEST_F(RouterTest, MaintenanceMode) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_EQ(
+      0U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_maintenance_mode")
+          .value());
   router_.decodeHeaders(headers, true);
   EXPECT_EQ(
       1U,

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -199,6 +199,10 @@ TEST_F(RouterTest, NoHost) {
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
+  EXPECT_EQ(
+      0U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_maintenance_mode")
+          .value());
 }
 
 TEST_F(RouterTest, MaintenanceMode) {
@@ -213,10 +217,6 @@ TEST_F(RouterTest, MaintenanceMode) {
 
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  EXPECT_EQ(
-      0U,
-      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_maintenance_mode")
-          .value());
   router_.decodeHeaders(headers, true);
   EXPECT_EQ(
       1U,

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -214,6 +214,10 @@ TEST_F(RouterTest, MaintenanceMode) {
   Http::TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_maintenance_mode")
+          .value());
 }
 
 TEST_F(RouterTest, ResetDuringEncodeHeaders) {


### PR DESCRIPTION
@lyft/network-team 

Expose stat for requests that are shed due to maintenance mode.