### PR TITLE
ci: make bazel.debug build and test from a consuming project.

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -22,7 +22,7 @@ master commit at which the binary was compiled, and `latest` corresponds to a bi
 An example basic invocation to build a debug image and run all tests is:
 
 ```bash
-docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
+docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v <BUILD_DIR>:/build -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
 ```
 
 On OSX using the command below may work better. Unlike on Linux, users are not
@@ -31,7 +31,7 @@ create artifacts with the same ownership as in the container ([read more about
 osxfs][osxfs]).
 
 ```bash
-docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
+docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v <BUILD_DIR>:/build -v <SOURCE_DIR>:/source lyft/envoy-build:latest /bin/bash -c "cd /source && ci/do_ci.sh debug"
 ```
 
 This bind mounts `<SOURCE_DIR>`, which allows for changes on the local
@@ -52,13 +52,13 @@ The `do_ci.sh` targets are:
 A convenient shell function to define is:
 
 ```bash
-run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
+run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u $(id -u):$(id -g) -v /tmp/envoy-docker-build:/build -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
 ```
 
 Or on OSX.
 
 ```bash
-run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
+run_envoy_docker() { docker pull lyft/envoy-build:latest && docker run -t -i -u root:root -v /tmp/envoy-docker-build:/build -v $PWD:/source lyft/envoy-build:latest /bin/bash -c "cd /source && $*";}
 ```
 
 This then allows for a simple invocation of `run_envoy_docker './ci/do_ci.sh debug'` from the

--- a/ci/WORKSPACE.consumer
+++ b/ci/WORKSPACE.consumer
@@ -1,0 +1,76 @@
+workspace(name = "envoy")
+
+local_repository(
+    name = "envoy",
+    path = "/source",
+)
+
+bind(
+    name = "ares",
+    actual = "@envoy//ci/prebuilt:ares",
+)
+
+bind(
+    name = "event",
+    actual = "@envoy//ci/prebuilt:event",
+)
+
+bind(
+    name = "event_pthreads",
+    actual = "@envoy//ci/prebuilt:event_pthreads",
+)
+
+bind(
+    name = "googletest",
+    actual = "@envoy//ci/prebuilt:googletest",
+)
+
+bind(
+    name = "http_parser",
+    actual = "@envoy//ci/prebuilt:http_parser",
+)
+
+bind(
+    name = "lightstep",
+    actual = "@envoy//ci/prebuilt:lightstep",
+)
+
+bind(
+    name = "nghttp2",
+    actual = "@envoy//ci/prebuilt:nghttp2",
+)
+
+bind(
+    name = "protobuf",
+    actual = "@envoy//ci/prebuilt:protobuf",
+)
+
+local_repository(
+    name = "protobuf_git",
+    path = "/thirdparty/protobuf-3.2.0",
+)
+
+bind(
+    name = "protoc",
+    actual = "@envoy//ci/prebuilt:protoc",
+)
+
+bind(
+    name = "rapidjson",
+    actual = "@envoy//ci/prebuilt:rapidjson",
+)
+
+bind(
+    name = "spdlog",
+    actual = "@envoy//ci/prebuilt:spdlog",
+)
+
+bind(
+    name = "ssl",
+    actual = "@envoy//ci/prebuilt:ssl",
+)
+
+bind(
+    name = "tclap",
+    actual = "@envoy//ci/prebuilt:tclap",
+)

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -17,7 +17,7 @@ then
   export BUILD_DIR=/build
   # Make sure that "docker run" has a -v bind mount for /build, since cmake
   # users will only have a bind mount for /source.
-  if [[ ! -a "${BUILD_DIR}" ]]
+  if [[ ! -d "${BUILD_DIR}" ]]
   then
     echo "${BUILD_DIR} mount missing - did you forget -v <something>:${BUILD_DIR}?"
     exit 1
@@ -62,7 +62,7 @@ then
   # This is the hash on https://github.com/htuch/envoy-consumer.git we pin to.
   (cd "${ENVOY_CONSUMER_SRCDIR}" && git checkout 94e11fa753a1e787c82cccaec642eda5e5b61ed8)
 
-  # Also setup some space for building Envoy standadlone.
+  # Also setup some space for building Envoy standalone.
   export ENVOY_BUILD_DIR="${BUILD_DIR}"/envoy
   mkdir -p "${ENVOY_BUILD_DIR}"
   cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE "${ENVOY_BUILD_DIR}"

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -15,7 +15,8 @@ then
   ./docs/publish.sh
   exit 0
 else
-  docker run -t -i -v $TRAVIS_BUILD_DIR:/source lyft/envoy-build:$ENVOY_BUILD_SHA /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+  docker run -t -i -v /tmp/envoy-docker-build:/build -v $TRAVIS_BUILD_DIR:/source \
+    lyft/envoy-build:$ENVOY_BUILD_SHA /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
 fi
 
 # The following scripts are only relevant on a `normal` run.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,29 +9,31 @@ echo "building using ${NUM_CPUS} CPUs"
 
 if [[ "$1" == "bazel.debug" ]]; then
   echo "bazel debug build with tests..."
-  ${BAZEL} build ${BAZEL_BUILD_OPTIONS} //source/exe:envoy-static
-  ${BAZEL} test ${BAZEL_BUILD_OPTIONS} --test_output=all \
-    --cache_test_results=no //test/...
+  cd "${ENVOY_CONSUMER_SRCDIR}"
+  echo "Building..."
+  bazel build ${BAZEL_BUILD_OPTIONS} @envoy//source/exe:envoy-static
+  echo "Testing..."
+  bazel test ${BAZEL_BUILD_OPTIONS} --test_output=all \
+    --cache_test_results=no @envoy//test/... //:echo2_integration_test
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   echo "bazel coverage build with tests..."
   export GCOVR="/thirdparty/gcovr.dep/gcovr-3.3/scripts/gcovr"
-  export GCOVR_DIR="${PWD}/bazel-bazel-build"
-  export TESTLOGS_DIR="${PWD}/bazel-testlogs"
+  export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"
+  export TESTLOGS_DIR="${ENVOY_BUILD_DIR}/bazel-testlogs"
   export BUILDIFIER_BIN="/usr/lib/go/bin/buildifier"
-  (
-    # There is a bug in gcovr 3.3, where it takes the -r path,
-    # in our case /source, and does a regex replacement of various
-    # source file paths during HTML generation. It attempts to strip
-    # out the prefix (e.g. /source), but because it doesn't do a match
-    # and only strip at the start of the string, it removes /source from
-    # the middle of the string, corrupting the path. The workaround is
-    # to point -r in the gcovr invocation in run_envoy_bazel_coverage.sh at
-    # some Bazel created symlinks to the source directory in its output
-    # directory. Wow.
-    RUN_ENVOY_BAZEL_COVEARGE="${SRCDIR}"/test/run_envoy_bazel_coverage.sh
-    SRCDIR="${GCOVR_DIR}" "${RUN_ENVOY_BAZEL_COVEARGE}"
-  )
+  # There is a bug in gcovr 3.3, where it takes the -r path,
+  # in our case /source, and does a regex replacement of various
+  # source file paths during HTML generation. It attempts to strip
+  # out the prefix (e.g. /source), but because it doesn't do a match
+  # and only strip at the start of the string, it removes /source from
+  # the middle of the string, corrupting the path. The workaround is
+  # to point -r in the gcovr invocation in run_envoy_bazel_coverage.sh at
+  # some Bazel created symlinks to the source directory in its output
+  # directory. Wow.
+  cd "${ENVOY_BUILD_DIR}"
+  SRCDIR="${GCOVR_DIR}" REAL_SRCDIR="${ENVOY_SRCDIR}" \
+    "${ENVOY_SRCDIR}"/test/run_envoy_bazel_coverage.sh
   exit 0
 elif [[ "$1" == "fix_format" ]]; then
   echo "fix_format..."

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -2,5 +2,8 @@
 
 set -e
 
+BUILD_DIR=/tmp/envoy-docker-build
+mkdir -p "${BUILD_DIR}"
 docker pull lyft/envoy-build:latest
-docker run -t -i -u $(id -u):$(id -g) -v "$PWD":/source lyft/envoy-build:latest /bin/bash -c "cd source && $*"
+docker run -t -i -u $(id -u):$(id -g) -v "${BUILD_DIR}":/build \
+  -v "$PWD":/source lyft/envoy-build:latest /bin/bash -c "cd source && $*"

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -3,13 +3,14 @@
 set -e
 
 [[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+[[ -z "${REAL_SRCDIR}" ]] && REAL_SRCDIR="${SRCDIR}"
 [[ -z "${GCOVR_DIR}" ]] && GCOVR_DIR="${SRCDIR}/bazel-envoy"
 [[ -z "${TESTLOGS_DIR}" ]] && TESTLOGS_DIR="${SRCDIR}/bazel-testlogs"
 [[ -z "${BAZEL_COVERAGE}" ]] && BAZEL_COVERAGE=bazel
 [[ -z "${GCOVR}" ]] && GCOVR=gcovr
 
 # Make sure //test/coverage is up-to-date.
-(cd "${SRCDIR}"; BAZEL_BIN="${BAZEL_COVERAGE}" test/coverage/gen_build.sh)
+(cd "${REAL_SRCDIR}"; BAZEL_BIN="${BAZEL_COVERAGE}" test/coverage/gen_build.sh)
 
 # Run all tests under bazel coverage.
 "${BAZEL_COVERAGE}" coverage //test/coverage:coverage_tests ${BAZEL_BUILD_OPTIONS} \
@@ -36,6 +37,9 @@ COVERAGE_DIR="${SRCDIR}"/generated/coverage
 mkdir -p "${COVERAGE_DIR}"
 COVERAGE_SUMMAY="${COVERAGE_DIR}/coverage_summary.txt"
 
+# gcovr is extremely picky about where it is run and where the paths of the
+# original source are relative to its execution location.
+cd "${SRCDIR}"
 time "${GCOVR}" --gcov-exclude="${GCOVR_EXCLUDE_REGEX}" \
   --exclude-directories=".*/external/.*" --object-directory="${GCOVR_DIR}" -r "${SRCDIR}" \
   --html --html-details --exclude-unreachable-branches --print-summary \


### PR DESCRIPTION
This allows us to catch in CI breakages such as those fixed in #732. Also, it allows us to validate
our example and story for other projects that consume Envoy for custom linking of filters keeps
working.

This adds the requirement of bind mounting in docker run with -v <some path>:/build for bazel.debug
and bazel.coverage builds.