### PR TITLE
ssl: allow use of cipher strings.

### DIFF
--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -63,9 +63,10 @@ ContextImpl::ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, Contex
     // verify that all of the specified ciphers were understood by openssl
     ssize_t num_configured = std::count(cipher_suites.begin(), cipher_suites.end(), ':') + 1;
 #ifdef OPENSSL_IS_BORINGSSL
-    if (sk_SSL_CIPHER_num(ctx_->cipher_list->ciphers) != static_cast<size_t>(num_configured)) {
+    num_configured += std::count(cipher_suites.begin(), cipher_suites.end(), '|');
+    if (sk_SSL_CIPHER_num(ctx_->cipher_list->ciphers) < static_cast<size_t>(num_configured)) {
 #else
-    if (sk_SSL_CIPHER_num(ctx_->cipher_list) != num_configured) {
+    if (sk_SSL_CIPHER_num(ctx_->cipher_list) < num_configured) {
 #endif
       throw EnvoyException(
           fmt::format("Unknown cipher specified in cipher suites {}", config.cipherSuites()));


### PR DESCRIPTION
Allow use of "ALL", "HIGH", "EECDH+AES128" and other cipher strings,
which evaluate to more than one cipher suite.

As a side-effect, this allows use of ChaCha20+Poly1305 cipher strings,
which evaluate to two variants of the cipher suite (draft and RFC7539)
in currently linked version of BoringSSL.

While there, account for equal-preference groups when using BoringSSL.