### PR TITLE
ssl: update default cipher suites.

### DIFF
--- a/docs/configuration/cluster_manager/cluster_ssl.rst
+++ b/docs/configuration/cluster_manager/cluster_ssl.rst
@@ -45,8 +45,28 @@ verify_subject_alt_name
   that the server certificate's subject alt name matches one of the specified values.
 
 cipher_suites
-  *(optional, string)* If specified, the TLS connection will only support the specified cipher list.
-  If not specified, a default list will be used.
+  *(optional, string)* If specified, the TLS connection will only support the specified `cipher list
+  <https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration>`_.
+  If not specified, the default list:
+
+.. code-block:: none
+
+  [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+  [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+  ECDHE-ECDSA-AES128-SHA256
+  ECDHE-RSA-AES128-SHA256
+  AES128-GCM-SHA256
+  AES128-SHA256
+  AES128-SHA
+  ECDHE-ECDSA-AES256-GCM-SHA384
+  ECDHE-RSA-AES256-GCM-SHA384
+  ECDHE-ECDSA-AES256-SHA384
+  ECDHE-RSA-AES256-SHA384
+  AES256-GCM-SHA384
+  AES256-SHA256
+  AES256-SHA
+
+will be used.
 
 sni
   *(optional, string)* If specified, the string will be presented as the SNI during the TLS

--- a/docs/configuration/listeners/ssl.rst
+++ b/docs/configuration/listeners/ssl.rst
@@ -53,5 +53,25 @@ verify_subject_alt_name
   that the server certificate's subject alt name matches one of the specified values.
 
 cipher_suites
-  *(optional, string)* If specified, the TLS listener will only support the specified cipher list.
-  If not specified, a default list will be used.
+  *(optional, string)* If specified, the TLS listener will only support the specified `cipher list
+  <https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration>`_.
+  If not specified, the default list:
+
+.. code-block:: none
+
+  [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+  [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+  ECDHE-ECDSA-AES128-SHA256
+  ECDHE-RSA-AES128-SHA256
+  AES128-GCM-SHA256
+  AES128-SHA256
+  AES128-SHA
+  ECDHE-ECDSA-AES256-GCM-SHA384
+  ECDHE-RSA-AES256-GCM-SHA384
+  ECDHE-ECDSA-AES256-SHA384
+  ECDHE-RSA-AES256-SHA384
+  AES256-GCM-SHA384
+  AES256-SHA256
+  AES256-SHA
+
+will be used.

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
     name = "context_config_lib",
     srcs = ["context_config_impl.cc"],
     hdrs = ["context_config_impl.h"],
+    external_deps = ["ssl"],
     deps = [
         "//include/envoy/ssl:context_config_interface",
         "//source/common/json:json_loader_lib",

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -1,18 +1,29 @@
 #include "common/ssl/context_config_impl.h"
 
+#include "openssl/ssl.h"
+
 namespace Ssl {
 
-const std::string ContextConfigImpl::DEFAULT_CIPHER_SUITES = "ECDHE-RSA-AES128-GCM-SHA256:"
-                                                             "ECDHE-RSA-AES128-SHA256:"
-                                                             "ECDHE-RSA-AES128-SHA:"
-                                                             "ECDHE-RSA-AES256-GCM-SHA384:"
-                                                             "ECDHE-RSA-AES256-SHA384:"
-                                                             "ECDHE-RSA-AES256-SHA:"
-                                                             "AES128-GCM-SHA256:"
-                                                             "AES256-GCM-SHA384:"
-                                                             "AES128-SHA256:"
-                                                             "AES256-SHA:"
-                                                             "AES128-SHA";
+const std::string ContextConfigImpl::DEFAULT_CIPHER_SUITES =
+#ifdef OPENSSL_IS_BORINGSSL
+    "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]:"
+    "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]:"
+#else
+    "ECDHE-ECDSA-AES128-GCM-SHA256:"
+    "ECDHE-RSA-AES128-GCM-SHA256:"
+#endif
+    "ECDHE-ECDSA-AES128-SHA256:"
+    "ECDHE-RSA-AES128-SHA256:"
+    "AES128-GCM-SHA256:"
+    "AES128-SHA256:"
+    "AES128-SHA:"
+    "ECDHE-ECDSA-AES256-GCM-SHA384:"
+    "ECDHE-RSA-AES256-GCM-SHA384:"
+    "ECDHE-ECDSA-AES256-SHA384:"
+    "ECDHE-RSA-AES256-SHA384:"
+    "AES256-GCM-SHA384:"
+    "AES256-SHA256:"
+    "AES256-SHA";
 
 ContextConfigImpl::ContextConfigImpl(const Json::Object& config) {
   alpn_protocols_ = config.getString("alpn_protocols", "");


### PR DESCRIPTION
Depends on #751, because of ChaCha20+Poly1305.

Fixes https://github.com/lyft/envoy/issues/705