### PR TITLE
config option for upstream-rq-per-try-timeout

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -224,7 +224,7 @@ num_retries
   :ref:`config_http_filters_router_x-envoy-max-retries`.
 
 per_try_timeout_ms
-  *(optional, integer)* specifies the timeout per retry attempt. This parameter is optional.
+  *(optional, integer)* specifies a non-zero timeout per retry attempt. This parameter is optional.
   These are the same conditions documented for 
   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`.
 

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -210,7 +210,8 @@ HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
 
   {
     "retry_on": "...",
-    "num_retries": "..."
+    "num_retries": "...",
+    "per_try_timeout_ms" : "..."
   }
 
 retry_on
@@ -221,6 +222,17 @@ num_retries
   *(optional, integer)* specifies the allowed number of retries. This parameter is optional and
   defaults to 1. These are the same conditions documented for
   :ref:`config_http_filters_router_x-envoy-max-retries`.
+
+per_try_timeout_ms
+  *(optional, integer)* specifies the timeout per retry attempt. This parameter is optional.
+  These are the same conditions documented for 
+  :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`.
+
+  **Note:** If left unspecified, Envoy will use the global
+  `:ref: route timeout <config_http_conn_man_route_table_route_timeout>` for the request. 
+  Consequently, when using a `:ref: 5xx <config_http_filters_router_x-envoy-retry-on>` based 
+  retry policy, a request that times out will not be retried as the total timeout budget 
+  would have been exhausted.
 
 .. _config_http_conn_man_route_table_route_shadow:
 

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -225,8 +225,8 @@ num_retries
 
 per_try_timeout_ms
   *(optional, integer)* specifies a non-zero timeout per retry attempt. This parameter is optional.
-  These are the same conditions documented for 
-  :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`.
+  The same conditions documented for 
+  :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` apply.
 
   **Note:** If left unspecified, Envoy will use the global
   `:ref: route timeout <config_http_conn_man_route_table_route_timeout>` for the request. 

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -75,14 +75,16 @@ using a ',' delimited list. The supported policies are:
 
 5xx
   Envoy will attempt a retry if the upstream server responds with any 5xx response code, or does not
-  respond at all (disconnect/reset/etc.). (Includes *connect-failure* and *refused-stream*)
+  respond at all (disconnect/reset/read timeout). (Includes *connect-failure* and *refused-stream*)
 
-  * **NOTE:** Envoy will not retry when a request exceeds
+  * **NOTE 1:** Envoy will not retry when a request exceeds
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` (resulting in a 504 error
     code). Use :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` if you want
     to retry when individual attempts take too long.
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` is an outer time limit for a
     request, including any retries that take place.
+
+  * **NOTE 2:** Envoy currently does not support retrying requests on write timeouts.
 
 connect-failure
   Envoy will attempt a retry if a request is failed because of a connection failure to the upstream

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -77,14 +77,12 @@ using a ',' delimited list. The supported policies are:
   Envoy will attempt a retry if the upstream server responds with any 5xx response code, or does not
   respond at all (disconnect/reset/read timeout). (Includes *connect-failure* and *refused-stream*)
 
-  * **NOTE 1:** Envoy will not retry when a request exceeds
+  * **NOTE:** Envoy will not retry when a request exceeds
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` (resulting in a 504 error
     code). Use :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` if you want
     to retry when individual attempts take too long.
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` is an outer time limit for a
     request, including any retries that take place.
-
-  * **NOTE 2:** Envoy currently does not support retrying requests on write timeouts.
 
 connect-failure
   Envoy will attempt a retry if a request is failed because of a connection failure to the upstream

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -37,6 +37,11 @@ public:
   virtual ~RetryPolicy() {}
 
   /**
+   * @return std::chrono::milliseconds timeout per retry attempt.
+   */
+  virtual std::chrono::milliseconds perTryTimeout() const PURE;
+
+  /**
    * @return uint32_t the number of retries to allow against the route.
    */
   virtual uint32_t numRetries() const PURE;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -85,6 +85,9 @@ private:
 
   struct NullRetryPolicy : public Router::RetryPolicy {
     // Router::RetryPolicy
+    std::chrono::milliseconds perTryTimeout() const override {
+      return std::chrono::milliseconds(0);
+    }
     uint32_t numRetries() const override { return 0; }
     uint32_t retryOn() const override { return 0; }
   };

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -567,6 +567,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "retry_policy" : {
         "type" : "object",
         "properties" : {
+          "per_try_timeout_ms" : {"type" : "integer"},
           "num_retries" : {"type" : "integer"},
           "retry_on" : {"type" : "string"}
         },

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -571,7 +571,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
             "type" : "integer",
             "minimum" : 0,
             "exclusiveMinimum" : true
-	  },
+          },
           "num_retries" : {"type" : "integer"},
           "retry_on" : {"type" : "string"}
         },

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -567,7 +567,11 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "retry_policy" : {
         "type" : "object",
         "properties" : {
-          "per_try_timeout_ms" : {"type" : "integer"},
+          "per_try_timeout_ms" : {
+            "type" : "integer",
+            "minimum" : 0,
+            "exclusiveMinimum" : true
+	  },
           "num_retries" : {"type" : "integer"},
           "retry_on" : {"type" : "string"}
         },

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -25,6 +25,8 @@ RetryPolicyImpl::RetryPolicyImpl(const Json::Object& config) {
     return;
   }
 
+  per_try_timeout_ = std::chrono::milliseconds(
+      config.getObject("retry_policy")->getInteger("per_try_timeout_ms", 0));
   num_retries_ = config.getObject("retry_policy")->getInteger("num_retries", 1);
   retry_on_ = RetryStateImpl::parseRetryOn(config.getObject("retry_policy")->getString("retry_on"));
 }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -120,10 +120,12 @@ public:
   RetryPolicyImpl(const Json::Object& config);
 
   // Router::RetryPolicy
+  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
   uint32_t numRetries() const override { return num_retries_; }
   uint32_t retryOn() const override { return retry_on_; }
 
 private:
+  std::chrono::milliseconds per_try_timeout_{0};
   uint32_t num_retries_{};
   uint32_t retry_on_{};
 };

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -51,6 +51,7 @@ FilterUtility::TimeoutData FilterUtility::finalTimeout(const RouteEntry& route,
   // otherwise we use the default.
   TimeoutData timeout;
   timeout.global_timeout_ = route.timeout();
+  timeout.per_try_timeout_ = route.retryPolicy().perTryTimeout();
   Http::HeaderEntry* header_timeout_entry = request_headers.EnvoyUpstreamRequestTimeoutMs();
   uint64_t header_timeout;
   if (header_timeout_entry) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1073,6 +1073,7 @@ TEST(RouteMatcherTest, Retry) {
           "prefix": "/",
           "cluster": "www2",
           "retry_policy": {
+            "per_try_timeout_ms" : 1000,
             "num_retries": 3,
             "retry_on": "5xx,connect-failure"
           }
@@ -1090,6 +1091,10 @@ TEST(RouteMatcherTest, Retry) {
 
   EXPECT_FALSE(config.usesRuntime());
 
+  EXPECT_EQ(std::chrono::milliseconds(0), config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
+                                              ->routeEntry()
+                                              ->retryPolicy()
+                                              .perTryTimeout());
   EXPECT_EQ(1U, config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                     ->routeEntry()
                     ->retryPolicy()
@@ -1100,6 +1105,10 @@ TEST(RouteMatcherTest, Retry) {
                 ->retryPolicy()
                 .retryOn());
 
+  EXPECT_EQ(std::chrono::milliseconds(0), config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
+                                              ->routeEntry()
+                                              ->retryPolicy()
+                                              .perTryTimeout());
   EXPECT_EQ(0U, config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)
                     ->routeEntry()
                     ->retryPolicy()
@@ -1109,6 +1118,10 @@ TEST(RouteMatcherTest, Retry) {
                     ->retryPolicy()
                     .retryOn());
 
+  EXPECT_EQ(std::chrono::milliseconds(1000), config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
+                                                 ->routeEntry()
+                                                 ->retryPolicy()
+                                                 .perTryTimeout());
   EXPECT_EQ(3U, config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                     ->routeEntry()
                     ->retryPolicy()

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -18,9 +18,11 @@ public:
 class TestRetryPolicy : public RetryPolicy {
 public:
   // Router::RetryPolicy
+  std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
   uint32_t numRetries() const override { return num_retries_; }
   uint32_t retryOn() const override { return retry_on_; }
 
+  std::chrono::milliseconds per_try_timeout_{0};
   uint32_t num_retries_{};
   uint32_t retry_on_{};
 };


### PR DESCRIPTION
This PR adds support for configuring the per-retry-timeout via configuration file. 