### PR TITLE
ci: fix gcovr dependency path.

### DIFF
--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=3d878d55e05a554514305f26101bd6ad15a4a602
+ENVOY_BUILD_SHA=98a1276049a3cf4bebc6a0343217444a8675baf8
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "bazel.debug" ]]; then
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   echo "bazel coverage build with tests..."
-  export GCOVR="/thirdparty/gcovr.dep/gcovr-3.3/scripts/gcovr"
+  export GCOVR="/thirdparty/gcovr-3.3/scripts/gcovr"
   export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"
   export TESTLOGS_DIR="${ENVOY_BUILD_DIR}/bazel-testlogs"
   export BUILDIFIER_BIN="/usr/lib/go/bin/buildifier"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+[[ -z "${IMAGE_ID}" ]] && IMAGE_ID="latest"
+
 BUILD_DIR=/tmp/envoy-docker-build
 mkdir -p "${BUILD_DIR}"
-docker pull lyft/envoy-build:latest
+docker pull lyft/envoy-build:"${IMAGE_ID}"
 docker run -t -i -u $(id -u):$(id -g) -v "${BUILD_DIR}":/build \
-  -v "$PWD":/source lyft/envoy-build:latest /bin/bash -c "cd source && $*"
+  -v "$PWD":/source lyft/envoy-build:"${IMAGE_ID}" /bin/bash -c "cd source && $*"

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -9,6 +9,14 @@ BUILD_DIR=/tmp/configgen
 OUT_DIR="$1"
 shift
 
+# Create a fake home. virtualenv tries to do getpwuid(3) if we don't and the CI
+# Docker image gets confused as it has no passwd entry when running non-root
+# unless we do this.
+FAKE_HOME=/tmp/fake_home
+mkdir -p "${FAKE_HOME}"
+export HOME="${FAKE_HOME}"
+export PYTHONUSERBASE="${FAKE_HOME}"
+
 if [ ! -d "$BUILD_DIR"/venv ]; then
   virtualenv "$BUILD_DIR"/venv
   "$BUILD_DIR"/venv/bin/pip install -r "$SCRIPT_DIR"/requirements.txt


### PR DESCRIPTION
After #747, we no longer have the BUILD_DISTINCT=1 set of dependencies in the CI image, so fix the
gcovr path to solve the failures in #760.

Also fixed a snafu in configs/configgen.sh that I hit when running Docker as non-root. It was trying
to peek at the user's home directory, with no passwd entry.