### PR TITLE
bazel: improve developer-local flow UX.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -12,7 +12,7 @@ independently sourced, the following steps should be followed:
    to point Bazel at the Envoy dependencies. An example is provided in the CI Docker image
    [WORKSPACE](https://github.com/lyft/envoy/blob/master/ci/WORKSPACE) and corresponding
    [BUILD](https://github.com/lyft/envoy/blob/master/ci/prebuilt/BUILD) files.
-4. `bazel build --package_path %workspace%:<path to Envoy source tree> //source/exe:envoy-static` 
+4. `bazel build --package_path %workspace%:<path to Envoy source tree> //source/exe:envoy-static`
    from the directory containing your WORKSPACE.
 
 ## Quick start Bazel build for developers
@@ -22,10 +22,10 @@ As a developer convenience, a [WORKSPACE](https://github.com/lyft/envoy/blob/mas
 version](https://github.com/lyft/envoy/blob/master/bazel/repositories.bzl) of the various Envoy
 dependencies are provided. These are provided as is, they are only suitable for development and
 testing purposes. The specific versions of the Envoy dependencies used in this build may not be
-up-to-date with the latest security patches. In addition, Bazel build rules for deps have been
-improvised in some cases and this build is not checked by CI.
+up-to-date with the latest security patches.
 
 1. [Install Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
+2. `bazel fetch //...` to fetch and build all external dependencies. This may take some time.
 2. `bazel build //source/exe:envoy-static` from the Envoy source directory.
 
 ## Building Bazel with the CI Docker image

--- a/bazel/repositories.sh
+++ b/bazel/repositories.sh
@@ -2,18 +2,16 @@
 
 set -e
 
-# When debugging the build, it's helpful to keep the artifacts in /tmp, since they don't get
-# repeatedly clobbered as build recipes are modified. This is controlled by debug_build in
-# bazel/respositories.bzl.
-if [[ "${DEBUG}" == "1" ]]
-then
-  BASEDIR=/tmp/bazel-envoy-deps
-  # Tell build_and_install_deps.sh to build sequentially when performance debugging.
-  # export BUILD_CONCURRENCY=0
-else
-  BASEDIR="${PWD}/build"
-fi
+# Tell build_and_install_deps.sh to build sequentially when performance debugging.
+# export BUILD_CONCURRENCY=0
 
+# Don't build inside the directory Bazel believes the repository_rule output goes. Instead, do so in
+# a parallel directory. This allows the build artifacts to survive Bazel clobbering the repostory
+# directory when a small change to repositories.bzl or a build recipe happens. We then rely on make
+# dependency analysis to detect when stuff needs to be rebuilt.
+BASEDIR="${PWD}_cache"
+
+>&2 echo "External dependency cache directory ${BASEDIR}"
 mkdir -p  "${BASEDIR}"
 
 export THIRDPARTY_DEPS="${BASEDIR}"
@@ -27,16 +25,8 @@ do
 done
 
 set -o pipefail
-(time ./build_and_install_deps.sh ${DEPS}) 2>&1 | \
-  tee "${BASEDIR}"/build.log
+BUILD_LOG="${BASEDIR}"/build.log
+(time ./build_and_install_deps.sh ${DEPS}) 2>&1 | tee "${BUILD_LOG}"
 
-# Need to rsync in debug mode, since the symlinks are into /tmp and cause problems with later build
-# sandboxing.
-if [[ "${DEBUG}" == "1" ]]
-then
-  rsync -a "$(realpath "${THIRDPARTY_SRC}")"/ thirdparty
-  rsync -a "$(realpath "${THIRDPARTY_BUILD}")"/ thirdparty_build
-else
-  ln -sf "$(realpath "${THIRDPARTY_SRC}")" thirdparty
-  ln -sf "$(realpath "${THIRDPARTY_BUILD}")" thirdparty_build
-fi
+ln -sf "$(realpath "${THIRDPARTY_SRC}")" thirdparty
+ln -sf "$(realpath "${THIRDPARTY_BUILD}")" thirdparty_build

--- a/bazel/repositories.sh
+++ b/bazel/repositories.sh
@@ -5,11 +5,14 @@ set -e
 # Tell build_and_install_deps.sh to build sequentially when performance debugging.
 # export BUILD_CONCURRENCY=0
 
+# Hash environment variables we care about to force rebuilds when they change.
+ENV_HASH=$(echo "${CC} ${CXX} ${LD_LIBRARY_PATH}" | md5sum - | cut -f 1 -d\ )
+
 # Don't build inside the directory Bazel believes the repository_rule output goes. Instead, do so in
 # a parallel directory. This allows the build artifacts to survive Bazel clobbering the repostory
 # directory when a small change to repositories.bzl or a build recipe happens. We then rely on make
 # dependency analysis to detect when stuff needs to be rebuilt.
-BASEDIR="${PWD}_cache"
+BASEDIR="${PWD}_cache_${ENV_HASH}"
 
 >&2 echo "External dependency cache directory ${BASEDIR}"
 mkdir -p  "${BASEDIR}"


### PR DESCRIPTION
* Build a recursive make cache in a parallel directory to where Bazel thinks the repository rule
  outputs are. E.g. if Bazel think the deps are in ~/.cache/bazel/89676793239ac96d94294e6c7a44597f/external/envoy_deps,
  the cache lives in ~/.cache/bazel/89676793239ac96d94294e6c7a44597f/external/envoy_deps_cache.
  This allow us to avoid Bazel falsely clobbering all the make build directories everytime it _thinks_
  there is a dependency change (e.g. a single recipe is modified). We then defer to make to figure
  out when it's time to rebuild these deps. If something gets really messed up, bazel clean
  --expunge still works with this cache.

  Underlying issue tracked in https://github.com/bazelbuild/bazel/issues/2792.

* Always output stuff after the build of external deps, to signal what's happened. Otherwise, it
  appears mysterious to the user where all the time went as Bazel doesn't report progress.

  Underlying issue tracked in https://github.com/bazelbuild/bazel/issues/1289.

* Add a `bazel fetch` step to the documentation so that the mystery hang when Bazel first builds
  the external deps is understandable.

  Underlying issue tracked in https://github.com/bazelbuild/bazel/issues/1289.