### PR TITLE
bazel: branch cc_configure from bazel repo to support libstdc++/libgc…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "envoy")
 
 load("//bazel:repositories.bzl", "envoy_dependencies")
+load("//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies()
+cc_configure()

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "ci")
 
 load("//bazel:repositories.bzl", "envoy_dependencies")
+load("//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies(
     path = "//ci/prebuilt",
@@ -13,3 +14,5 @@ new_local_repository(
     # We only want protobuf.bzl, so don't support building out of this repo.
     build_file_content = "",
 )
+
+cc_configure()

--- a/ci/WORKSPACE.consumer
+++ b/ci/WORKSPACE.consumer
@@ -6,5 +6,8 @@ local_repository(
 )
 
 load("//bazel:repositories.bzl", "envoy_dependencies")
+load("//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies(path = "@envoy//ci/prebuilt")
+
+cc_configure()

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+sh_test(
+    name = "envoy_static_test",
+    srcs = ["envoy_static_test.sh"],
+    data = ["//source/exe:envoy-static"],
+)

--- a/test/exe/envoy_static_test.sh
+++ b/test/exe/envoy_static_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+set -e
+
+# Validate we statically link libstdc++ and libgcc.
+DYNDEPS=$(ldd source/exe/envoy-static | grep "libstdc++\|libgcc"; echo)
+[[ -z "$DYNDEPS" ]] || (echo "libstdc++ or libgcc dynamically linked: ${DYNDEPS}"; exit 1)


### PR DESCRIPTION
…c static linking.

We import cc_configure.bzl from https://github.com/bazelbuild/bazel at d6fec93 in this patch.
This allows us to workaround https://github.com/bazelbuild/bazel/issues/2840 (see the header comment for further details).