### PR TITLE
bazel/ci: make non-root docker launch of bazel.* targets work again.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -13,7 +13,7 @@ if [[ "$1" == "bazel.debug" ]]; then
   echo "Building..."
   bazel build ${BAZEL_BUILD_OPTIONS} @envoy//source/exe:envoy-static.stamped
   echo "Testing..."
-  bazel test ${BAZEL_BUILD_OPTIONS} --test_output=all \
+  bazel test ${BAZEL_TEST_OPTIONS} --test_output=all \
     --cache_test_results=no @envoy//test/... //:echo2_integration_test
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -9,14 +9,6 @@ BUILD_DIR=/tmp/configgen
 OUT_DIR="$1"
 shift
 
-# Create a fake home. virtualenv tries to do getpwuid(3) if we don't and the CI
-# Docker image gets confused as it has no passwd entry when running non-root
-# unless we do this.
-FAKE_HOME=/tmp/fake_home
-mkdir -p "${FAKE_HOME}"
-export HOME="${FAKE_HOME}"
-export PYTHONUSERBASE="${FAKE_HOME}"
-
 if [ ! -d "$BUILD_DIR"/venv ]; then
   virtualenv "$BUILD_DIR"/venv
   "$BUILD_DIR"/venv/bin/pip install -r "$SCRIPT_DIR"/requirements.txt

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -29,7 +29,7 @@ echo "Cleanup completed."
 # https://github.com/bazelbuild/bazel/issues/1118). This works today as we have
 # a single coverage test binary and do not require the "bazel coverage" support
 # for collecting multiple traces and glueing them together.
-"${BAZEL_COVERAGE}" test "${COVERAGE_TARGET}" ${BAZEL_BUILD_OPTIONS} \
+"${BAZEL_COVERAGE}" test "${COVERAGE_TARGET}" ${BAZEL_TEST_OPTIONS} \
   --cache_test_results=no --cxxopt="--coverage" --linkopt="--coverage" \
   --test_output=all --strategy=Genrule=standalone --spawn_strategy=standalone
 


### PR DESCRIPTION
Now that we do more in genrules etc. with .py, we need to setup the fake home earlier for the Docker
build, not in configgen.sh but in the ci/build_setup.sh.