### PR TITLE
build: eliminate precompiled headers from bazel build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--build-id=0x${GIT_COMMIT} -static-libstdc++ -st
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_BINARY_DIR}/source)
 include_directories(${PROJECT_SOURCE_DIR}/source)
-include_directories(${ENVOY_SPDLOG_INCLUDE_DIR})
+include_directories(SYSTEM ${ENVOY_SPDLOG_INCLUDE_DIR})
 include_directories(SYSTEM ${ENVOY_PROTOBUF_INCLUDE_DIR})
 
 add_subdirectory(source)

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -12,7 +12,6 @@ def envoy_copts(repository):
         "-Woverloaded-virtual",
         "-Wold-style-cast",
         "-std=c++0x",
-        "-includeprecompiled/precompiled.h",
     ] + select({
         # Bazel adds an implicit -DNDEBUG for opt.
         repository + "//bazel:opt_build": [],
@@ -75,7 +74,7 @@ def envoy_cc_library(name,
         visibility = visibility,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//include/envoy/common:base_includes",
-            repository + "//source/precompiled:precompiled_includes",
+            envoy_external_dep_path('spdlog'),
         ],
         include_prefix = envoy_include_prefix(PACKAGE_NAME),
         alwayslink = 1,
@@ -142,9 +141,7 @@ def envoy_cc_binary(name,
         malloc = tcmalloc_external_dep(repository),
         # See above comment on MD5 hash.
         stamp = 0,
-        deps = deps + [
-            repository + "//source/precompiled:precompiled_includes",
-        ],
+        deps = deps,
     )
 
 # Envoy C++ test targets should be specified with this function.
@@ -197,11 +194,11 @@ def envoy_cc_test_library(name,
         srcs = srcs,
         hdrs = hdrs,
         data = data,
-        copts = envoy_copts(repository) + ["-includetest/precompiled/precompiled_test.h"],
+        copts = envoy_copts(repository),
         testonly = 1,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
-            repository + "//source/precompiled:precompiled_includes",
-            repository + "//test/precompiled:precompiled_includes",
+            envoy_external_dep_path('googletest'),
+            repository + "//test/test_common:printers_includes",
         ],
         tags = tags,
         alwayslink = 1,

--- a/bazel/gen_sh_test_runner.sh
+++ b/bazel/gen_sh_test_runner.sh
@@ -18,6 +18,8 @@ done
   cat << EOF
 #include "test/test_common/environment.h"
 
+#include "gtest/gtest.h"
+
 TEST(ShTest, ${TEST_NAME}) {
   TestEnvironment::exec({${EXEC_ARGS}});
 }

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 #include "envoy/filesystem/filesystem.h"
 

--- a/include/envoy/api/api.h
+++ b/include/envoy/api/api.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/thread/thread.h"

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Buffer {

--- a/include/envoy/common/exception.h
+++ b/include/envoy/common/exception.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdexcept>
+#include <string>
+
 /**
  * Base class for all envoy exceptions.
  */

--- a/include/envoy/common/time.h
+++ b/include/envoy/common/time.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include "envoy/common/pure.h"
 
 /**

--- a/include/envoy/event/deferred_deletable.h
+++ b/include/envoy/event/deferred_deletable.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace Event {
 
 /**

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+
 #include "envoy/event/file_event.h"
 #include "envoy/event/signal.h"
 #include "envoy/event/timer.h"

--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+
 #include "envoy/common/pure.h"
 
 namespace Event {

--- a/include/envoy/event/signal.h
+++ b/include/envoy/event/signal.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
 namespace Event {
 
 /**

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <functional>
+#include <memory>
+
 #include "envoy/common/pure.h"
 
 namespace Event {

--- a/include/envoy/filesystem/filesystem.h
+++ b/include/envoy/filesystem/filesystem.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Filesystem {

--- a/include/envoy/grpc/rpc_channel.h
+++ b/include/envoy/grpc/rpc_channel.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 #include "envoy/http/header_map.h"

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <memory>
+
 #include "envoy/common/optional.h"
 #include "envoy/http/message.h"
 

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/http/header_map.h"

--- a/include/envoy/http/conn_pool.h
+++ b/include/envoy/http/conn_pool.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/access_log.h"
 #include "envoy/http/codec.h"

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <string.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Http {

--- a/include/envoy/http/message.h
+++ b/include/envoy/http/message.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"
 

--- a/include/envoy/init/init.h
+++ b/include/envoy/init/init.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/common/pure.h"
 
 namespace Init {

--- a/include/envoy/json/json_object.h
+++ b/include/envoy/json/json_object.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 

--- a/include/envoy/mongo/bson.h
+++ b/include/envoy/mongo/bson.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <array>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 

--- a/include/envoy/mongo/codec.h
+++ b/include/envoy/mongo/codec.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/mongo/bson.h"
 
 /**

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Network {

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"

--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listen_socket.h"

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 

--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/upstream/host_description.h"
 

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
 

--- a/include/envoy/ratelimit/ratelimit.h
+++ b/include/envoy/ratelimit/ratelimit.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 #include "envoy/tracing/context.h"

--- a/include/envoy/redis/codec.h
+++ b/include/envoy/redis/codec.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 

--- a/include/envoy/redis/command_splitter.h
+++ b/include/envoy/redis/command_splitter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/redis/codec.h"
 

--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <memory>
+#include <string>
+
 #include "envoy/redis/codec.h"
 #include "envoy/upstream/cluster_manager.h"
 

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/router/router.h"
 
 namespace Router {

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+
 #include "envoy/common/optional.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/ratelimit/ratelimit.h"

--- a/include/envoy/router/shadow_writer.h
+++ b/include/envoy/router/shadow_writer.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <memory>
+#include <string>
+
 #include "envoy/http/message.h"
 
 namespace Router {

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Runtime {

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/http/codes.h"

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/ssl/context.h"

--- a/include/envoy/server/drain_manager.h
+++ b/include/envoy/server/drain_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/network/drain_decision.h"
 
 namespace Server {

--- a/include/envoy/server/hot_restart.h
+++ b/include/envoy/server/hot_restart.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
 

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/access_log/access_log.h"
 #include "envoy/api/api.h"
 #include "envoy/init/init.h"

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Server {

--- a/include/envoy/server/watchdog.h
+++ b/include/envoy/server/watchdog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
 

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Ssl {

--- a/include/envoy/ssl/context.h
+++ b/include/envoy/ssl/context.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Ssl {

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "envoy/common/pure.h"
 
 namespace Ssl {

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/stats/stats.h"

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/common/pure.h"
 
 namespace Event {

--- a/include/envoy/stats/stats_macros.h
+++ b/include/envoy/stats/stats_macros.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/stats/stats.h"
 
 /**

--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
 

--- a/include/envoy/tracing/context.h
+++ b/include/envoy/tracing/context.h
@@ -10,3 +10,4 @@ struct TransportContext {
 static const TransportContext EMPTY_CONTEXT = {"", ""};
 
 } // Tracing
+#include <string>

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/pure.h"
 #include "envoy/http/access_log.h"
 #include "envoy/http/header_map.h"

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 #include "envoy/http/async_client.h"
 #include "envoy/http/conn_pool.h"
 #include "envoy/json/json_object.h"

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
 #include "envoy/upstream/upstream.h"
 
 namespace Upstream {

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/network/address.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/upstream/outlier_detection.h"

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/upstream/upstream.h"
 

--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
 #include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"

--- a/include/envoy/upstream/resource_manager.h
+++ b/include/envoy/upstream/resource_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/common/pure.h"
 
 namespace Upstream {

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/network/connection.h"
 #include "envoy/ssl/context.h"

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "common/access_log/access_log_manager_impl.h"
 
+#include <string>
+
 namespace AccessLog {
 
 void AccessLogManagerImpl::reopen() {

--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <unordered_map>
+
 #include "envoy/access_log/access_log.h"
 #include "envoy/api/api.h"
 

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -1,5 +1,8 @@
 #include "common/api/api_impl.h"
 
+#include <chrono>
+#include <string>
+
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/filesystem_impl.h"
 

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <string>
+
 #include "envoy/api/api.h"
 #include "envoy/filesystem/filesystem.h"
 

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -1,5 +1,8 @@
 #include "common/buffer/buffer_impl.h"
 
+#include <cstdint>
+#include <string>
+
 #include "common/common/assert.h"
 
 #include "event2/buffer.h"

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 
 #include "common/event/libevent.h"

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -1,5 +1,8 @@
 #include "common/common/base64.h"
 
+#include <cstdint>
+#include <string>
+
 #include "common/common/empty_string.h"
 
 static constexpr char CHAR_TABLE[] =

--- a/source/common/common/base64.h
+++ b/source/common/common/base64.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 
 class Base64 {

--- a/source/common/common/c_smart_ptr.h
+++ b/source/common/common/c_smart_ptr.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 /**
  * This is a helper that wraps C style API objects that need to be deleted with a smart pointer.
  */

--- a/source/common/common/empty_string.h
+++ b/source/common/common/empty_string.h
@@ -1,3 +1,5 @@
 #pragma once
 
 static const std::string EMPTY_STRING = "";
+
+#include <string>

--- a/source/common/common/enum_to_int.h
+++ b/source/common/common/enum_to_int.h
@@ -4,3 +4,5 @@
  * Convert an int based enum to an int.
  */
 template <typename T> uint32_t enumToInt(T val) { return static_cast<uint32_t>(val); }
+
+#include <cstdint>

--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -1,5 +1,11 @@
 #include "common/common/hex.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/utility.h"

--- a/source/common/common/hex.h
+++ b/source/common/common/hex.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 /**
  * Hex encoder/decoder. Produces lowercase hex digits. Can consume either lowercase or uppercase
  * digits.

--- a/source/common/common/linked_object.h
+++ b/source/common/common/linked_object.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <list>
+#include <memory>
+
 #include "common/common/assert.h"
 
 /**

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -1,5 +1,12 @@
 #include "common/common/logger.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include "envoy/thread/thread.h"
 
 namespace Logger {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/thread/thread.h"
 
 #include "common/common/macros.h"

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -2,6 +2,8 @@
 
 #include <sys/syscall.h>
 
+#include <functional>
+
 #include "common/common/assert.h"
 #include "common/common/macros.h"
 

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+#include <mutex>
+
 #include "envoy/thread/thread.h"
 
 namespace Thread {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -1,5 +1,13 @@
 #include "common/common/utility.h"
 
+#include <spdlog/spdlog.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 std::string DateFormatter::fromTime(const SystemTime& time) {
   return fromTimeT(std::chrono::system_clock::to_time_t(time));
 }

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <strings.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/common/time.h"
 
 /**

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -1,5 +1,9 @@
 #include "common/common/version.h"
 
+#include <spdlog/spdlog.h>
+
+#include <string>
+
 std::string VersionInfo::version() {
   return fmt::format("{}/{}", GIT_SHA.substr(0, 6),
 #ifdef NDEBUG

--- a/source/common/common/version.h
+++ b/source/common/common/version.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 /**
  * Wraps compiled in code versioning.
  * NOTE: The GIT_SHA is generated into version_generated.cc and is not present in the source tree.

--- a/source/common/dynamo/dynamo_filter.cc
+++ b/source/common/dynamo/dynamo_filter.cc
@@ -1,5 +1,12 @@
 #include "common/dynamo/dynamo_filter.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/dynamo/dynamo_request_parser.h"
 #include "common/dynamo/dynamo_utility.h"

--- a/source/common/dynamo/dynamo_filter.h
+++ b/source/common/dynamo/dynamo_filter.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"

--- a/source/common/dynamo/dynamo_request_parser.cc
+++ b/source/common/dynamo/dynamo_request_parser.cc
@@ -1,5 +1,9 @@
 #include "common/dynamo/dynamo_request_parser.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/utility.h"
 
 namespace Dynamo {

--- a/source/common/dynamo/dynamo_request_parser.h
+++ b/source/common/dynamo/dynamo_request_parser.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/http/header_map.h"
 
 #include "common/json/json_loader.h"

--- a/source/common/dynamo/dynamo_utility.cc
+++ b/source/common/dynamo/dynamo_utility.cc
@@ -1,5 +1,9 @@
 #include "common/dynamo/dynamo_utility.h"
 
+#include <spdlog/spdlog.h>
+
+#include <string>
+
 #include "common/stats/stats_impl.h"
 
 namespace Dynamo {

--- a/source/common/dynamo/dynamo_utility.h
+++ b/source/common/dynamo/dynamo_utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace Dynamo {
 
 class Utility {

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -1,5 +1,11 @@
 #include "common/event/dispatcher_impl.h"
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <vector>
+
 #include "envoy/network/listen_socket.h"
 #include "envoy/network/listener.h"
 

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <vector>
+
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection_handler.h"

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -1,5 +1,7 @@
 #include "common/event/file_event_impl.h"
 
+#include <cstdint>
+
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
 

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/event/file_event.h"
 
 #include "common/event/dispatcher_impl.h"

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -1,5 +1,7 @@
 #include "common/event/libevent.h"
 
+#include <signal.h>
+
 #include "common/common/assert.h"
 
 #include "event2/thread.h"

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -1,5 +1,7 @@
 #include "common/event/timer_impl.h"
 
+#include <chrono>
+
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
 

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include "envoy/event/timer.h"
 
 #include "common/event/dispatcher_impl.h"

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -2,8 +2,16 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
 
+#include <chrono>
+#include <cstdint>
+#include <fstream>
 #include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
 
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/stats/stats_macros.h"

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -1,6 +1,10 @@
 #include "common/filesystem/watcher_impl.h"
 
+#include <spdlog/spdlog.h>
 #include <sys/inotify.h>
+
+#include <cstdint>
+#include <string>
 
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/filesystem/watcher_impl.h
+++ b/source/common/filesystem/watcher_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <string>
+#include <unordered_map>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -1,5 +1,11 @@
 #include "common/filter/auth/client_ssl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/network/connection.h"
 
 #include "common/common/assert.h"

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -1,5 +1,10 @@
 #include "common/filter/ratelimit.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "common/common/empty_string.h"
 #include "common/json/config_schemas.h"
 

--- a/source/common/filter/ratelimit.h
+++ b/source/common/filter/ratelimit.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/ratelimit/ratelimit.h"

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -1,5 +1,10 @@
 #include "common/filter/tcp_proxy.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/event/timer.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -1,5 +1,9 @@
 #include "common/grpc/codec.h"
 
+#include <array>
+#include <cstdint>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 
 namespace Grpc {

--- a/source/common/grpc/codec.h
+++ b/source/common/grpc/codec.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 
 namespace Grpc {

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -1,5 +1,11 @@
 #include "common/grpc/common.h"
 
+#include <arpa/inet.h>
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/common/optional.h"
 #include "envoy/http/header_map.h"

--- a/source/common/grpc/http1_bridge_filter.cc
+++ b/source/common/grpc/http1_bridge_filter.cc
@@ -1,5 +1,9 @@
 #include "common/grpc/http1_bridge_filter.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/http/codes.h"
 
 #include "common/common/enum_to_int.h"

--- a/source/common/grpc/http1_bridge_filter.h
+++ b/source/common/grpc/http1_bridge_filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/upstream/cluster_manager.h"
 

--- a/source/common/grpc/rpc_channel_impl.cc
+++ b/source/common/grpc/rpc_channel_impl.cc
@@ -1,5 +1,8 @@
 #include "common/grpc/rpc_channel_impl.h"
 
+#include <cstdint>
+#include <string>
+
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
 #include "common/grpc/common.h"

--- a/source/common/grpc/rpc_channel_impl.h
+++ b/source/common/grpc/rpc_channel_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/grpc/rpc_channel.h"
 #include "envoy/upstream/cluster_manager.h"
 

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -1,5 +1,11 @@
 #include "common/http/access_log/access_log_formatter.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 

--- a/source/common/http/access_log/access_log_formatter.h
+++ b/source/common/http/access_log/access_log_formatter.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <string>
+#include <vector>
+
 #include "envoy/http/access_log.h"
 
 namespace Http {

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -1,5 +1,8 @@
 #include "common/http/access_log/access_log_impl.h"
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/http/header_map.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/access_log/access_log.h"
 #include "envoy/http/access_log.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+
 #include "envoy/http/access_log.h"
 
 namespace Http {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -1,5 +1,11 @@
 #include "common/http/async_client_impl.h"
 
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/http/utility.h"
 
 namespace Http {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/codec.h"

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -1,5 +1,7 @@
 #include "common/http/codec_client.h"
 
+#include <cstdint>
+
 #include "common/common/enum_to_int.h"
 #include "common/http/exception.h"
 #include "common/http/http1/codec_impl.h"

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <memory>
+
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -44,3 +44,5 @@ private:
 };
 
 } // Http
+
+#include <vector>

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -1,5 +1,10 @@
 #include "common/http/codes.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "envoy/http/header_map.h"
 #include "envoy/stats/stats.h"
 

--- a/source/common/http/codes.h
+++ b/source/common/http/codes.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
 #include "envoy/stats/stats.h"

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1,5 +1,13 @@
 #include "common/http/conn_manager_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/access_log.h"
 #include "envoy/http/codec.h"

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -1,5 +1,9 @@
 #include "common/http/conn_manager_utility.h"
 
+#include <atomic>
+#include <cstdint>
+#include <string>
+
 #include "common/common/empty_string.h"
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/http/headers.h"

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
 

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -1,5 +1,8 @@
 #include "common/http/date_provider_impl.h"
 
+#include <chrono>
+#include <string>
+
 namespace Http {
 
 DateFormatter DateProviderImplBase::date_formatter_("%a, %d %b %Y %H:%M:%S GMT");

--- a/source/common/http/date_provider_impl.h
+++ b/source/common/http/date_provider_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/thread_local/thread_local.h"
 

--- a/source/common/http/exception.h
+++ b/source/common/http/exception.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/http/header_map.h"
 

--- a/source/common/http/filter/buffer_filter.cc
+++ b/source/common/http/filter/buffer_filter.cc
@@ -1,5 +1,7 @@
 #include "common/http/filter/buffer_filter.h"
 
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"

--- a/source/common/http/filter/buffer_filter.h
+++ b/source/common/http/filter/buffer_filter.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/stats/stats_macros.h"
 

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -1,5 +1,10 @@
 #include "common/http/filter/fault_filter.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/http/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -1,5 +1,10 @@
 #include "common/http/filter/ratelimit.h"
 
+#include <spdlog/spdlog.h>
+
+#include <string>
+#include <vector>
+
 #include "envoy/http/codes.h"
 
 #include "common/common/assert.h"

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/http/filter.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/ratelimit/ratelimit.h"

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -1,5 +1,9 @@
 #include "common/http/header_map_impl.h"
 
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/utility.h"

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/http/header_map.h"
 
 #include "common/common/non_copyable.h"

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/http/header_map.h"
 
 namespace Http {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1,5 +1,10 @@
 #include "common/http/http1/codec_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -1,5 +1,8 @@
 #include "common/http/http1/conn_pool.h"
 
+#include <cstdint>
+#include <list>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/header_map.h"

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <memory>
+
 #include "envoy/common/optional.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/timer.h"

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1,5 +1,11 @@
 #include "common/http/http2/codec_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -1,5 +1,7 @@
 #include "common/http/http2/conn_pool.h"
 
+#include <cstdint>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/upstream/upstream.h"

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <memory>
+
 #include "envoy/event/timer.h"
 #include "envoy/http/conn_pool.h"
 #include "envoy/network/connection.h"

--- a/source/common/http/message_impl.cc
+++ b/source/common/http/message_impl.cc
@@ -1,5 +1,8 @@
 #include "common/http/message_impl.h"
 
+#include <cstdint>
+#include <string>
+
 namespace Http {
 
 std::string MessageImpl::bodyAsString() const {

--- a/source/common/http/message_impl.h
+++ b/source/common/http/message_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/http/header_map.h"
 #include "envoy/http/message.h"
 

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -1,5 +1,9 @@
 #include "common/http/rest_api_fetcher.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/common/enum_to_int.h"
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"

--- a/source/common/http/rest_api_fetcher.h
+++ b/source/common/http/rest_api_fetcher.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -1,5 +1,8 @@
 #include "common/http/user_agent.h"
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
 

--- a/source/common/http/user_agent.h
+++ b/source/common/http/user_agent.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/http/header_map.h"
 #include "envoy/stats/stats_macros.h"
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1,5 +1,11 @@
 #include "common/http/utility.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/http/header_map.h"
 
 #include "common/buffer/buffer_impl.h"

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1,5 +1,7 @@
 #include "common/json/config_schemas.h"
 
+#include <string>
+
 const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",

--- a/source/common/json/config_schemas.h
+++ b/source/common/json/config_schemas.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace Json {
 
 class Schema {

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -1,5 +1,12 @@
 #include "common/json/json_loader.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
 // Do not let RapidJson leak outside of this file.
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"

--- a/source/common/json/json_loader.h
+++ b/source/common/json/json_loader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/json/json_object.h"
 
 namespace Json {

--- a/source/common/json/json_validator.h
+++ b/source/common/json/json_validator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/json/json_object.h"
 
 namespace Json {

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/local_info/local_info.h"
 
 namespace LocalInfo {

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -1,5 +1,7 @@
 #include "common/memory/stats.h"
 
+#include <cstdint>
+
 #ifdef TCMALLOC
 
 #include "gperftools/malloc_extension.h"

--- a/source/common/memory/stats.h
+++ b/source/common/memory/stats.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Memory {
 
 /**

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -1,5 +1,11 @@
 #include "common/mongo/bson_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/common/hex.h"
 

--- a/source/common/mongo/bson_impl.h
+++ b/source/common/mongo/bson_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 #include "envoy/mongo/bson.h"

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -1,5 +1,13 @@
 #include "common/mongo/codec_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <sstream>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 

--- a/source/common/mongo/codec_impl.h
+++ b/source/common/mongo/codec_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "envoy/mongo/codec.h"
 
 #include "common/common/logger.h"

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -1,5 +1,11 @@
 #include "common/mongo/proxy.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/time.h"
 #include "envoy/mongo/codec.h"

--- a/source/common/mongo/utility.cc
+++ b/source/common/mongo/utility.cc
@@ -1,5 +1,7 @@
 #include "common/mongo/utility.h"
 
+#include <string>
+
 #include "envoy/common/exception.h"
 
 #include "common/json/json_loader.h"

--- a/source/common/mongo/utility.h
+++ b/source/common/mongo/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/mongo/codec.h"
 
 namespace Mongo {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,5 +1,15 @@
 #include "common/network/address_impl.h"
 
+#include <arpa/inet.h>
+#include <netinet/ip.h>
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -1,6 +1,13 @@
 #pragma once
 
+#include <netinet/ip.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/un.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
 
 #include "envoy/network/address.h"
 

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -1,5 +1,15 @@
 #include "common/network/cidr_range.h"
 
+#include <arpa/inet.h>
+#include <netinet/ip.h>
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"

--- a/source/common/network/cidr_range.h
+++ b/source/common/network/cidr_range.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/network/address.h"
 
 namespace Network {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1,5 +1,13 @@
 #include "common/network/connection_impl.h"
 
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+
 #include "envoy/common/exception.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/filter.h"

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/network/connection.h"
 
 #include "common/buffer/buffer_impl.h"

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -1,5 +1,15 @@
 #include "common/network/dns_impl.h"
 
+#include <netdb.h>
+#include <netinet/ip.h>
+#include <sys/socket.h>
+
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <netdb.h>
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
 #include "envoy/network/dns.h"

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "common/network/filter_manager_impl.h"
 
+#include <list>
+
 #include "envoy/network/connection.h"
 
 #include "common/common/assert.h"

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <list>
+#include <memory>
+
 #include "envoy/network/filter.h"
 
 #include "common/common/linked_object.h"

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -1,5 +1,11 @@
 #include "common/network/listen_socket_impl.h"
 
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <string>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <unistd.h>
+
+#include <memory>
+#include <string>
+
 #include "envoy/network/listen_socket.h"
 
 #include "common/ssl/context_impl.h"

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -1,5 +1,8 @@
 #include "common/network/listener_impl.h"
 
+#include <spdlog/spdlog.h>
+#include <sys/un.h>
+
 #include "envoy/common/exception.h"
 #include "envoy/network/connection_handler.h"
 

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -1,5 +1,11 @@
 #include "common/network/proxy_protocol.h"
 
+#include <unistd.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"

--- a/source/common/network/proxy_protocol.h
+++ b/source/common/network/proxy_protocol.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/stats_macros.h"
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -1,7 +1,17 @@
 #include "common/network/utility.h"
 
+#include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <linux/netfilter_ipv4.h>
+#include <netinet/ip.h>
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+
+#include <cstdint>
+#include <list>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "envoy/json/json_object.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"

--- a/source/common/profiler/profiler.cc
+++ b/source/common/profiler/profiler.cc
@@ -1,5 +1,7 @@
 #include "common/profiler/profiler.h"
 
+#include <string>
+
 #ifdef TCMALLOC
 
 #include "gperftools/heap-profiler.h"

--- a/source/common/profiler/profiler.h
+++ b/source/common/profiler/profiler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace Profiler {
 
 /**

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -1,5 +1,12 @@
 #include "common/ratelimit/ratelimit_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/tracing/context.h"
 
 #include "common/common/assert.h"

--- a/source/common/ratelimit/ratelimit_impl.h
+++ b/source/common/ratelimit/ratelimit_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/grpc/rpc_channel.h"
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/tracing/context.h"

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -1,5 +1,11 @@
 #include "common/redis/codec_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 

--- a/source/common/redis/codec_impl.h
+++ b/source/common/redis/codec_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <forward_list>
+#include <string>
+#include <vector>
+
 #include "envoy/redis/codec.h"
 
 #include "common/common/logger.h"

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -1,5 +1,12 @@
 #include "common/redis/command_splitter_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 
 namespace Redis {

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/redis/command_splitter.h"
 #include "envoy/redis/conn_pool.h"
 

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -1,5 +1,10 @@
 #include "common/redis/conn_pool_impl.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/json/config_schemas.h"
 

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/redis/conn_pool.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"

--- a/source/common/redis/proxy_filter.cc
+++ b/source/common/redis/proxy_filter.cc
@@ -1,5 +1,10 @@
 #include "common/redis/proxy_filter.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/json/config_schemas.h"
 

--- a/source/common/redis/proxy_filter.h
+++ b/source/common/redis/proxy_filter.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/network/filter.h"
 #include "envoy/redis/codec.h"
 #include "envoy/redis/command_splitter.h"

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1,5 +1,15 @@
 #include "common/router/config_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <regex>
+#include <string>
+#include <vector>
+
 #include "envoy/http/header_map.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1,5 +1,15 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <map>
+#include <memory>
+#include <regex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/router/router.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -1,5 +1,9 @@
 #include "common/router/config_utility.h"
 
+#include <regex>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 
 namespace Router {

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <regex>
+#include <string>
+#include <vector>
+
 #include "envoy/json/json_object.h"
 #include "envoy/upstream/resource_manager.h"
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -1,5 +1,12 @@
 #include "common/router/rds_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/json/config_schemas.h"
 #include "common/router/config_impl.h"

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <string>
+
 #include "envoy/init/init.h"
 #include "envoy/json/json_object.h"
 #include "envoy/local_info/local_info.h"

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -1,5 +1,10 @@
 #include "common/router/retry_state_impl.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/http/codes.h"

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/optional.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/codec.h"

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1,5 +1,9 @@
 #include "common/router/router.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/conn_pool.h"

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/http/codec.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -1,5 +1,10 @@
 #include "common/router/router_ratelimit.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/json/config_schemas.h"

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/router/router.h"
 #include "envoy/router/router_ratelimit.h"
 

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -1,5 +1,8 @@
 #include "common/router/shadow_writer_impl.h"
 
+#include <chrono>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/http/headers.h"
 

--- a/source/common/router/shadow_writer_impl.h
+++ b/source/common/router/shadow_writer_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <string>
+
 #include "envoy/router/shadow_writer.h"
 #include "envoy/upstream/cluster_manager.h"
 

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -1,7 +1,11 @@
 #include "common/runtime/runtime_impl.h"
 
 #include <fcntl.h>
+#include <spdlog/spdlog.h>
 #include <unistd.h>
+
+#include <cstdint>
+#include <string>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/stats.h"

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <dirent.h>
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "envoy/common/exception.h"
 #include "envoy/common/optional.h"

--- a/source/common/runtime/uuid_util.cc
+++ b/source/common/runtime/uuid_util.cc
@@ -1,5 +1,8 @@
 #include "common/runtime/uuid_util.h"
 
+#include <cstdint>
+#include <string>
+
 #include "common/common/utility.h"
 #include "common/runtime/runtime_impl.h"
 

--- a/source/common/runtime/uuid_util.h
+++ b/source/common/runtime/uuid_util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 enum class UuidTraceStatus { NoTrace, Sampled, Client, Forced };
 
 /*

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -1,5 +1,9 @@
 #include "common/ssl/connection_impl.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/hex.h"

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "common/network/connection_impl.h"
 #include "common/ssl/context_impl.h"
 

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -1,5 +1,7 @@
 #include "common/ssl/context_config_impl.h"
 
+#include <string>
+
 #include "openssl/ssl.h"
 
 namespace Ssl {

--- a/source/common/ssl/context_config_impl.h
+++ b/source/common/ssl/context_config_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "envoy/ssl/context_config.h"
 
 #include "common/json/json_loader.h"

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -1,5 +1,12 @@
 #include "common/ssl/context_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/exception.h"
 #include "envoy/runtime/runtime.h"
 

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -1,5 +1,8 @@
 #include "common/ssl/context_manager_impl.h"
 
+#include <functional>
+#include <mutex>
+
 #include "common/common/assert.h"
 #include "common/ssl/context_impl.h"
 

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <list>
+#include <mutex>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/ssl/context_manager.h"
 

--- a/source/common/ssl/openssl.cc
+++ b/source/common/ssl/openssl.cc
@@ -1,5 +1,8 @@
 #include "common/ssl/openssl.h"
 
+#include <memory>
+#include <mutex>
+
 #include "common/common/assert.h"
 
 #include "openssl/rand.h"

--- a/source/common/ssl/openssl.h
+++ b/source/common/ssl/openssl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <mutex>
+
 #include "common/common/c_smart_ptr.h"
 
 #include "openssl/ssl.h"

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -1,5 +1,10 @@
 #include "common/stats/stats_impl.h"
 
+#include <string.h>
+
+#include <chrono>
+#include <string>
+
 #include "common/common/utility.h"
 
 namespace Stats {

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 #include "envoy/common/time.h"
 #include "envoy/stats/stats.h"
 

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -1,5 +1,11 @@
 #include "common/stats/statsd.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/upstream/cluster_manager.h"

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -1,5 +1,13 @@
 #include "common/stats/thread_local_store.h"
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
 namespace Stats {
 
 ThreadLocalStoreImpl::ThreadLocalStoreImpl(RawStatDataAllocator& alloc)

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/stats/stats_impl.h"

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -1,5 +1,9 @@
 #include "common/thread_local/thread_local_impl.h"
 
+#include <atomic>
+#include <cstdint>
+#include <list>
+
 #include "envoy/event/dispatcher.h"
 
 #include "common/common/assert.h"

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <vector>
+
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/logger.h"

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -1,5 +1,9 @@
 #include "common/tracing/http_tracer_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/common/macros.h"
 #include "common/common/utility.h"

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -1,5 +1,12 @@
 #include "common/tracing/lightstep_tracer_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/common/base64.h"
 #include "common/grpc/common.h"
 #include "common/http/message_impl.h"

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -1,5 +1,11 @@
 #include "common/upstream/cds_api_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/http/headers.h"
 #include "common/json/config_schemas.h"

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/json/json_object.h"
 #include "envoy/local_info/local_info.h"

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1,5 +1,14 @@
 #include "common/upstream/cluster_manager_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/http/codes.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -1,5 +1,10 @@
 #include "common/upstream/health_checker_impl.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/codes.h"

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/event/timer.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -1,5 +1,7 @@
 #include "common/upstream/host_utility.h"
 
+#include <string>
+
 namespace Upstream {
 
 std::string HostUtility::healthFlagsToString(const Host& host) {

--- a/source/common/upstream/host_utility.h
+++ b/source/common/upstream/host_utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/upstream/upstream.h"
 
 namespace Upstream {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1,5 +1,9 @@
 #include "common/upstream/load_balancer_impl.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
 #include "envoy/upstream/upstream.h"

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/upstream.h"

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -1,5 +1,10 @@
 #include "common/upstream/logical_dns_cluster.h"
 
+#include <chrono>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string>
+
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/empty_string.h"

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -1,5 +1,13 @@
 #include "common/upstream/outlier_detection_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 
 #include "common/common/assert.h"

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/access_log/access_log.h"
 #include "envoy/event/timer.h"
 #include "envoy/runtime/runtime.h"

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/resource_manager.h"
 

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -1,5 +1,9 @@
 #include "common/upstream/ring_hash_lb.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/upstream/load_balancer_impl.h"
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/load_balancer.h"
 

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -1,5 +1,9 @@
 #include "common/upstream/sds.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/http/headers.h"
 #include "common/json/config_schemas.h"
 #include "common/network/address_impl.h"

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/local_info/local_info.h"
 
 #include "common/http/rest_api_fetcher.h"

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1,5 +1,15 @@
 #include "common/upstream/upstream_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/dns.h"

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1,5 +1,15 @@
 #pragma once
 
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/event/timer.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/dns.h"

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -1,7 +1,15 @@
 #include "exe/hot_restart.h"
 
+#include <signal.h>
+#include <spdlog/spdlog.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+
+#include <cstdint>
+#include <string>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"

--- a/source/exe/hot_restart.h
+++ b/source/exe/hot_restart.h
@@ -3,6 +3,11 @@
 #include <fcntl.h>
 #include <sys/un.h>
 
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <string>
+
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/options.h"
 

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,3 +1,8 @@
+#include <spdlog/spdlog.h>
+
+#include <iostream>
+#include <memory>
+
 #include "common/event/libevent.h"
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"

--- a/source/precompiled/BUILD
+++ b/source/precompiled/BUILD
@@ -1,10 +1,1 @@
-package(default_visibility = ["//visibility:public"])
-
-load("//bazel:envoy_build_system.bzl", "envoy_external_dep_path")
-
-cc_library(
-    name = "precompiled_includes",
-    hdrs = ["precompiled.h"],
-    include_prefix = "precompiled",
-    deps = [envoy_external_dep_path("spdlog")],
-)
+# TODO(htuch): Nuke this directory when cmake is no more.

--- a/source/server/config/http/buffer.cc
+++ b/source/server/config/http/buffer.cc
@@ -1,5 +1,9 @@
 #include "server/config/http/buffer.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/http/filter/buffer_filter.h"
 #include "common/json/config_schemas.h"
 

--- a/source/server/config/http/buffer.h
+++ b/source/server/config/http/buffer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/server/instance.h"
 
 #include "server/config/network/http_connection_manager.h"

--- a/source/server/config/http/dynamo.cc
+++ b/source/server/config/http/dynamo.cc
@@ -1,5 +1,7 @@
 #include "server/config/http/dynamo.h"
 
+#include <string>
+
 #include "common/dynamo/dynamo_filter.h"
 
 namespace Server {

--- a/source/server/config/http/dynamo.h
+++ b/source/server/config/http/dynamo.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/config/network/http_connection_manager.h"
 
 namespace Server {

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -1,5 +1,7 @@
 #include "server/config/http/fault.h"
 
+#include <string>
+
 #include "common/http/filter/fault_filter.h"
 #include "common/json/config_schemas.h"
 

--- a/source/server/config/http/fault.h
+++ b/source/server/config/http/fault.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/server/instance.h"
 
 #include "server/config/network/http_connection_manager.h"

--- a/source/server/config/http/grpc_http1_bridge.cc
+++ b/source/server/config/http/grpc_http1_bridge.cc
@@ -1,5 +1,7 @@
 #include "server/config/http/grpc_http1_bridge.h"
 
+#include <string>
+
 #include "common/grpc/http1_bridge_filter.h"
 
 namespace Server {

--- a/source/server/config/http/grpc_http1_bridge.h
+++ b/source/server/config/http/grpc_http1_bridge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/server/instance.h"
 
 #include "server/config/network/http_connection_manager.h"

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -1,5 +1,8 @@
 #include "server/config/http/ratelimit.h"
 
+#include <chrono>
+#include <string>
+
 #include "common/http/filter/ratelimit.h"
 
 namespace Server {

--- a/source/server/config/http/ratelimit.h
+++ b/source/server/config/http/ratelimit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/server/instance.h"
 
 #include "server/config/network/http_connection_manager.h"

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -1,5 +1,7 @@
 #include "server/config/http/router.h"
 
+#include <string>
+
 #include "common/json/config_schemas.h"
 #include "common/router/router.h"
 #include "common/router/shadow_writer_impl.h"

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/server/instance.h"
 
 #include "server/config/network/http_connection_manager.h"

--- a/source/server/config/network/client_ssl_auth.cc
+++ b/source/server/config/network/client_ssl_auth.cc
@@ -1,5 +1,7 @@
 #include "server/config/network/client_ssl_auth.h"
 
+#include <string>
+
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"
 

--- a/source/server/config/network/client_ssl_auth.h
+++ b/source/server/config/network/client_ssl_auth.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/configuration_impl.h"
 
 namespace Server {

--- a/source/server/config/network/echo.cc
+++ b/source/server/config/network/echo.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "envoy/network/connection.h"
 
 #include "common/filter/echo.h"

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -1,5 +1,12 @@
 #include "server/config/network/http_connection_manager.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/server/instance.h"
 

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -1,5 +1,7 @@
 #include "server/config/network/mongo_proxy.h"
 
+#include <string>
+
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"
 

--- a/source/server/config/network/mongo_proxy.h
+++ b/source/server/config/network/mongo_proxy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/configuration_impl.h"
 
 namespace Server {

--- a/source/server/config/network/ratelimit.cc
+++ b/source/server/config/network/ratelimit.cc
@@ -1,5 +1,8 @@
 #include "server/config/network/ratelimit.h"
 
+#include <chrono>
+#include <string>
+
 #include "envoy/network/connection.h"
 
 #include "common/filter/ratelimit.h"

--- a/source/server/config/network/ratelimit.h
+++ b/source/server/config/network/ratelimit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/configuration_impl.h"
 
 namespace Server {

--- a/source/server/config/network/redis_proxy.cc
+++ b/source/server/config/network/redis_proxy.cc
@@ -1,5 +1,8 @@
 #include "server/config/network/redis_proxy.h"
 
+#include <memory>
+#include <string>
+
 #include "common/redis/codec_impl.h"
 #include "common/redis/command_splitter_impl.h"
 #include "common/redis/conn_pool_impl.h"

--- a/source/server/config/network/redis_proxy.h
+++ b/source/server/config/network/redis_proxy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/configuration_impl.h"
 
 namespace Server {

--- a/source/server/config/network/tcp_proxy.cc
+++ b/source/server/config/network/tcp_proxy.cc
@@ -1,5 +1,7 @@
 #include "server/config/network/tcp_proxy.h"
 
+#include <string>
+
 #include "envoy/network/connection.h"
 #include "envoy/server/instance.h"
 

--- a/source/server/config/network/tcp_proxy.h
+++ b/source/server/config/network/tcp_proxy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "server/configuration_impl.h"
 
 namespace Server {

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -1,5 +1,13 @@
 #include "server/configuration_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/network/connection.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/instance.h"

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/configuration.h"

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -1,5 +1,7 @@
 #include "server/connection_handler_impl.h"
 
+#include <spdlog/spdlog.h>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/filter.h"

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <memory>
+
 #include "envoy/api/api.h"
 #include "envoy/common/time.h"
 #include "envoy/event/deferred_deletable.h"

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -1,5 +1,8 @@
 #include "server/drain_manager_impl.h"
 
+#include <chrono>
+#include <cstdint>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/runtime/runtime.h"

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/instance.h"
 

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -1,5 +1,10 @@
 #include "server/guarddog_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <mutex>
+
 #include "common/common/assert.h"
 
 #include "server/watchdog_impl.h"

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
 #include "envoy/server/configuration.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/server/watchdog.h"

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1,5 +1,11 @@
 #include "server/http/admin.h"
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/instance.h"

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <list>
+#include <string>
+
 #include "envoy/http/filter.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/server/admin.h"

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -1,5 +1,8 @@
 #include "server/http/health_check.h"
 
+#include <chrono>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/http/header_map.h"

--- a/source/server/http/health_check.h
+++ b/source/server/http/health_check.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -1,5 +1,12 @@
 #include "server/options_impl.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
 #include "common/common/macros.h"
 #include "common/common/version.h"
 

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "envoy/server/options.h"
 
 /**

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1,5 +1,12 @@
 #include "server/server.h"
 
+#include <signal.h>
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/signal.h"
 #include "envoy/event/timer.h"

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/common/optional.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/instance.h"

--- a/source/server/watchdog_impl.h
+++ b/source/server/watchdog_impl.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/server/watchdog.h"

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -1,5 +1,7 @@
 #include "server/worker.h"
 
+#include <chrono>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/server/configuration.h"

--- a/source/server/worker.h
+++ b/source/server/worker.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <chrono>
+#include <memory>
+
 #include "envoy/server/configuration.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/thread_local/thread_local.h"

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,7 +6,6 @@ envoy_cc_test_library(
     name = "main",
     srcs = ["main.cc"],
     external_deps = [
-        "googletest",
         "protobuf",
     ],
     deps = [

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/access_log/access_log_manager_impl.h"
 #include "common/stats/stats_impl.h"
 
@@ -5,6 +7,9 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Return;

--- a/test/common/api/api_impl_test.cc
+++ b/test/common/api/api_impl_test.cc
@@ -1,6 +1,12 @@
+#include <chrono>
+#include <fstream>
+#include <string>
+
 #include "common/api/api_impl.h"
 
 #include "test/test_common/environment.h"
+
+#include "gtest/gtest.h"
 
 namespace Api {
 

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -1,5 +1,11 @@
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/base64.h"
+
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
 
 TEST(Base64Test, EmptyBufferEncode) {
   {

--- a/test/common/common/hex_test.cc
+++ b/test/common/common/hex_test.cc
@@ -1,6 +1,11 @@
+#include <string>
+#include <vector>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/hex.h"
+
+#include "gtest/gtest.h"
 
 TEST(Hex, SimpleEncode) {
   std::vector<uint8_t> bytes = {0x01, 0x02, 0x03, 0x0a, 0x0b, 0x0c};

--- a/test/common/common/optional_test.cc
+++ b/test/common/common/optional_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/common/optional.h"
 
+#include "gtest/gtest.h"
+
 TEST(Optional, All) {
   Optional<int> optional;
   EXPECT_FALSE(optional.valid());

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -1,4 +1,11 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/utility.h"
+
+#include "gtest/gtest.h"
 
 TEST(StringUtil, atoul) {
   uint64_t out;

--- a/test/common/dynamo/dynamo_filter_test.cc
+++ b/test/common/dynamo/dynamo_filter_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/dynamo/dynamo_filter.h"
 #include "common/http/header_map_impl.h"
@@ -5,7 +8,11 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/dynamo/dynamo_request_parser_test.cc
+++ b/test/common/dynamo/dynamo_request_parser_test.cc
@@ -1,8 +1,14 @@
+#include <string>
+#include <vector>
+
 #include "common/dynamo/dynamo_request_parser.h"
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Dynamo {
 

--- a/test/common/dynamo/dynamo_utility_test.cc
+++ b/test/common/dynamo/dynamo_utility_test.cc
@@ -1,5 +1,10 @@
+#include <string>
+
 #include "common/dynamo/dynamo_utility.h"
 #include "common/stats/stats_impl.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1,6 +1,11 @@
+#include <functional>
+
 #include "common/event/dispatcher_impl.h"
 
 #include "test/mocks/common.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::InSequence;
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -1,8 +1,12 @@
+#include <cstdint>
+
 #include "envoy/event/file_event.h"
 
 #include "common/event/dispatcher_impl.h"
 
 #include "test/mocks/common.h"
+
+#include "gtest/gtest.h"
 
 namespace Event {
 

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <fstream>
+#include <string>
+
 #include "common/common/thread.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/filesystem_impl.h"
@@ -6,6 +10,9 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
 #include "test/test_common/environment.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/filesystem/watcher_impl_test.cc
+++ b/test/common/filesystem/watcher_impl_test.cc
@@ -1,8 +1,14 @@
+#include <cstdint>
+#include <fstream>
+
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/watcher_impl.h"
 
 #include "test/test_common/environment.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace Filesystem {
 

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <memory>
+#include <string>
+
 #include "common/filesystem/filesystem_impl.h"
 #include "common/filter/auth/client_ssl.h"
 #include "common/http/message_impl.h"
@@ -8,7 +12,11 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/filter/ratelimit_test.cc
+++ b/test/common/filter/ratelimit_test.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/filter/ratelimit.h"
 #include "common/stats/stats_impl.h"
@@ -6,6 +10,10 @@
 #include "test/mocks/ratelimit/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/tracing/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/filter/tcp_proxy.h"
 #include "common/network/address_impl.h"
@@ -9,6 +13,10 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -1,5 +1,14 @@
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/grpc/codec.h"
+
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
 
 #ifdef BAZEL_BRINGUP
 #include "test/proto/helloworld.pb.h"

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -1,6 +1,8 @@
 #include "common/grpc/common.h"
 #include "common/http/headers.h"
 
+#include "gtest/gtest.h"
+
 #ifdef BAZEL_BRINGUP
 #include "test/proto/helloworld.pb.h"
 #else

--- a/test/common/grpc/http1_bridge_filter_test.cc
+++ b/test/common/grpc/http1_bridge_filter_test.cc
@@ -4,7 +4,11 @@
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/grpc/rpc_channel_impl_test.cc
+++ b/test/common/grpc/rpc_channel_impl_test.cc
@@ -1,6 +1,15 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/grpc/common.h"
 #include "common/grpc/rpc_channel_impl.h"
 #include "common/http/message_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #ifdef BAZEL_BRINGUP
 #include "test/proto/helloworld.pb.h"

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -1,10 +1,19 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/utility.h"
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/http/header_map_impl.h"
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
@@ -16,7 +21,11 @@
 #include "test/mocks/filesystem/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/async_client_impl.h"
 #include "common/http/headers.h"
@@ -12,6 +16,10 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/codec_client.h"
 #include "common/http/exception.h"
@@ -10,7 +12,11 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -1,10 +1,19 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/common/empty_string.h"
 #include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 

--- a/test/common/http/common.cc
+++ b/test/common/http/common.cc
@@ -1,5 +1,7 @@
 #include "common.h"
 
+#include <string>
+
 #include "envoy/http/header_map.h"
 
 void HttpTestUtility::addDefaultHeaders(Http::HeaderMap& headers) {

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/http/conn_pool.h"
 
 #include "common/http/codec_client.h"

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1,3 +1,9 @@
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/access_log.h"
@@ -21,6 +27,10 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/tracing/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "common/http/conn_manager_utility.h"
 #include "common/http/headers.h"
 #include "common/network/address_impl.h"
@@ -8,7 +10,11 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/http/date_provider_impl_test.cc
+++ b/test/common/http/date_provider_impl_test.cc
@@ -1,8 +1,14 @@
+#include <chrono>
+
 #include "common/http/date_provider_impl.h"
 #include "common/http/header_map_impl.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 

--- a/test/common/http/filter/buffer_filter_test.cc
+++ b/test/common/http/filter/buffer_filter_test.cc
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <memory>
+
 #include "envoy/event/dispatcher.h"
 
 #include "common/http/filter/buffer_filter.h"
@@ -6,6 +9,10 @@
 
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -10,7 +15,11 @@
 #include "test/common/http/common.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/empty_string.h"
 #include "common/http/filter/ratelimit.h"
@@ -9,7 +13,11 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -1,6 +1,11 @@
+#include <string>
+
 #include "common/http/header_map_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Http {
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 
@@ -9,6 +11,10 @@
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/codec_client.h"
 #include "common/http/http1/conn_pool.h"
@@ -10,7 +13,11 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1,3 +1,6 @@
+#include <cstdint>
+#include <string>
+
 #include "common/http/exception.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/http2/codec_impl.h"
@@ -6,7 +9,11 @@
 #include "test/common/http/common.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::AtLeast;

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 #include "common/http/http2/conn_pool.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
@@ -8,6 +12,10 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -2,7 +2,10 @@
 #include "common/http/user_agent.h"
 
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Http {
 

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -1,9 +1,17 @@
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "common/http/exception.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/utility.h"
 #include "common/network/address_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Http {
 

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -1,8 +1,16 @@
+#include <spdlog/spdlog.h>
+
+#include <string>
+#include <vector>
+
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
 
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -1,4 +1,9 @@
+#include <string>
+#include <vector>
+
 #include "common/json/json_loader.h"
+
+#include "gtest/gtest.h"
 
 namespace Json {
 

--- a/test/common/mongo/bson_impl_test.cc
+++ b/test/common/mongo/bson_impl_test.cc
@@ -1,5 +1,11 @@
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/mongo/bson_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
 
 namespace Bson {
 

--- a/test/common/mongo/codec_impl_test.cc
+++ b/test/common/mongo/codec_impl_test.cc
@@ -1,6 +1,13 @@
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/mongo/bson_impl.h"
 #include "common/mongo/codec_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::Eq;
 using testing::NiceMock;

--- a/test/common/mongo/proxy_test.cc
+++ b/test/common/mongo/proxy_test.cc
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/mongo/bson_impl.h"
 #include "common/mongo/codec_impl.h"
 #include "common/mongo/proxy.h"
@@ -8,6 +13,10 @@
 #include "test/mocks/filesystem/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::AtLeast;

--- a/test/common/mongo/utility_test.cc
+++ b/test/common/mongo/utility_test.cc
@@ -1,6 +1,10 @@
+#include <string>
+
 #include "common/mongo/bson_impl.h"
 #include "common/mongo/codec_impl.h"
 #include "common/mongo/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Mongo {
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -1,6 +1,11 @@
+#include <arpa/inet.h>
 #include <fcntl.h>
+#include <netinet/ip.h>
+#include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+
+#include <string>
 
 #include "envoy/common/exception.h"
 
@@ -9,6 +14,8 @@
 
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Network {
 namespace Address {

--- a/test/common/network/cidr_range_test.cc
+++ b/test/common/network/cidr_range_test.cc
@@ -1,9 +1,15 @@
+#include <spdlog/spdlog.h>
 #include <sys/un.h>
+
+#include <iostream>
+#include <string>
 
 #include "envoy/common/exception.h"
 
 #include "common/network/address_impl.h"
 #include "common/network/cidr_range.h"
+
+#include "gtest/gtest.h"
 
 // We are adding things into the std namespace.
 // Note that this is technically undefined behavior!

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/empty_string.h"
 #include "common/event/dispatcher_impl.h"
@@ -10,6 +14,10 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Sequence;

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -1,5 +1,12 @@
+#include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <arpa/nameser_compat.h>
+
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
@@ -13,9 +20,11 @@
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
 
 #include "ares.h"
 #include "ares_dns.h"
+#include "gtest/gtest.h"
 
 namespace Network {
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/filter/ratelimit.h"
 #include "common/filter/tcp_proxy.h"
@@ -12,6 +15,10 @@
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -5,6 +5,8 @@
 
 #include "test/test_common/network_utility.h"
 
+#include "gtest/gtest.h"
+
 namespace Network {
 
 class ListenSocketImplTest : public testing::TestWithParam<Address::IpVersion> {

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -7,6 +7,9 @@
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/network_utility.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::ByRef;
 using testing::Eq;

--- a/test/common/network/proxy_protocol_test.cc
+++ b/test/common/network/proxy_protocol_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/network/listener_impl.h"
@@ -8,6 +11,10 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -1,8 +1,14 @@
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/common/exception.h"
 
 #include "common/json/json_loader.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Network {
 

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -1,9 +1,17 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/ratelimit/ratelimit_impl.h"
 
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::AtLeast;

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -1,9 +1,14 @@
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/redis/codec_impl.h"
 
 #include "test/mocks/redis/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Redis {
 

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -1,8 +1,17 @@
+#include <cstdint>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "common/redis/command_splitter_impl.h"
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/redis/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::ByRef;

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "common/network/utility.h"
 #include "common/redis/conn_pool_impl.h"
 #include "common/upstream/upstream_impl.h"
@@ -6,6 +9,10 @@
 #include "test/mocks/redis/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Eq;

--- a/test/common/redis/proxy_filter_test.cc
+++ b/test/common/redis/proxy_filter_test.cc
@@ -1,9 +1,16 @@
+#include <memory>
+#include <string>
+
 #include "common/redis/proxy_filter.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/redis/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::ByRef;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1,3 +1,9 @@
+#include <chrono>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
@@ -5,7 +11,11 @@
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::ContainerEq;

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <string>
+
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
 #include "common/router/rds_impl.h"
@@ -6,7 +9,11 @@
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "common/http/header_map_impl.h"
 #include "common/router/retry_state_impl.h"
 #include "common/upstream/resource_manager_impl.h"
@@ -5,7 +7,11 @@
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
 #include "common/router/config_impl.h"
@@ -7,7 +11,11 @@
 #include "test/mocks/ratelimit/mocks.h"
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <cstdint>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/network/utility.h"
 #include "common/router/router.h"
@@ -10,7 +14,11 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::AtLeast;

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -1,8 +1,14 @@
+#include <chrono>
+#include <string>
+
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "common/router/shadow_writer_impl.h"
 
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "common/runtime/runtime_impl.h"
 #include "common/stats/stats_impl.h"
 
@@ -6,6 +9,9 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/environment.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 using testing::Return;

--- a/test/common/runtime/uuid_util_test.cc
+++ b/test/common/runtime/uuid_util_test.cc
@@ -1,5 +1,9 @@
+#include <string>
+
 #include "common/runtime/runtime_impl.h"
 #include "common/runtime/uuid_util.h"
+
+#include "gtest/gtest.h"
 
 TEST(UUIDUtilsTest, mod) {
   uint16_t result;

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/json/json_loader.h"
@@ -14,6 +18,10 @@
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include "common/json/json_loader.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/ssl/context_impl.h"
@@ -6,6 +9,8 @@
 #include "test/common/ssl/ssl_certs_test.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/test_common/environment.h"
+
+#include "gtest/gtest.h"
 
 namespace Ssl {
 

--- a/test/common/ssl/ssl_certs_test.h
+++ b/test/common/ssl/ssl_certs_test.h
@@ -2,6 +2,8 @@
 
 #include "test/test_common/environment.h"
 
+#include "gtest/gtest.h"
+
 class SslCertsTest : public testing::Test {
 public:
   static void SetUpTestCase() {

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -1,4 +1,8 @@
+#include <chrono>
+
 #include "common/stats/stats_impl.h"
+
+#include "gtest/gtest.h"
 
 namespace Stats {
 

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <memory>
+
 #include "common/network/utility.h"
 #include "common/stats/statsd.h"
 #include "common/upstream/upstream_impl.h"
@@ -7,6 +10,9 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -1,8 +1,16 @@
+#include <chrono>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 #include "common/stats/thread_local_store.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "common/common/base64.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
@@ -14,7 +18,11 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/tracing/lightstep_tracer_impl_test.cc
+++ b/test/common/tracing/lightstep_tracer_impl_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <memory>
+#include <string>
+
 #include "common/common/base64.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
@@ -14,7 +18,11 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -1,10 +1,18 @@
+#include <chrono>
+#include <string>
+#include <vector>
+
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
 #include "common/upstream/cds_api_impl.h"
 
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "envoy/upstream/upstream.h"
 
 #include "common/network/utility.h"
@@ -13,6 +16,9 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
@@ -9,7 +14,11 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -4,6 +4,8 @@
 
 #include "test/mocks/upstream/mocks.h"
 
+#include "gtest/gtest.h"
+
 namespace Upstream {
 
 TEST(HostUtilityTest, All) {

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -1,9 +1,17 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/network/utility.h"
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 using testing::Return;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -1,3 +1,9 @@
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"
 #include "common/upstream/load_balancer_impl.h"
@@ -5,6 +11,9 @@
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 using testing::Return;

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/network/utility.h"
 #include "common/upstream/logical_dns_cluster.h"
 
@@ -7,6 +12,9 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1,3 +1,9 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/common/optional.h"
 #include "envoy/common/time.h"
 
@@ -9,6 +15,9 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/upstream/resource_manager_impl_test.cc
+++ b/test/common/upstream/resource_manager_impl_test.cc
@@ -2,6 +2,9 @@
 
 #include "test/mocks/runtime/mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::NiceMock;
 using testing::Return;
 

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -1,9 +1,15 @@
+#include <cstdint>
+#include <string>
+
 #include "common/network/utility.h"
 #include "common/upstream/ring_hash_lb.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -1,3 +1,9 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/filesystem/filesystem_impl.h"
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
@@ -8,7 +14,11 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1,3 +1,9 @@
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <string>
+#include <vector>
+
 #include "envoy/api/api.h"
 #include "envoy/http/codec.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -13,6 +19,9 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::ContainerEq;

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -1,9 +1,17 @@
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <string>
+
 #include "server/configuration_impl.h"
 
 #include "test/integration/server.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/config_test/config_test.h
+++ b/test/config_test/config_test.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 namespace ConfigTest {
 
 /**

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -2,6 +2,8 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "gtest/gtest.h"
+
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -1,5 +1,11 @@
 #include "fake_upstream.h"
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 
 #include "common/api/api_impl.h"
@@ -10,6 +16,7 @@
 #include "common/network/address_impl.h"
 #include "common/network/listen_socket_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
 FakeStream::FakeStream(FakeHttpConnection& parent, Http::StreamEncoder& encoder)

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <condition_variable>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
@@ -13,6 +20,7 @@
 
 #include "server/connection_handler_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
 class FakeHttpConnection;

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1,11 +1,16 @@
 #include "test/integration/http2_integration_test.h"
 
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/header_map_impl.h"
 
 #include "test/integration/utility.h"
 #include "test/mocks/http/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 TEST_F(Http2IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP2); }
 

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -2,6 +2,8 @@
 
 #include "test/integration/integration.h"
 
+#include "gtest/gtest.h"
+
 class Http2IntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:
   /**

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -2,7 +2,10 @@
 
 #include "common/http/header_map_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 TEST_F(Http2UpstreamIntegrationTest, RouterNotFound) {
   testRouterNotFound(Http::CodecClient::Type::HTTP2);

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -2,6 +2,8 @@
 
 #include "test/integration/integration.h"
 
+#include "gtest/gtest.h"
+
 class Http2UpstreamIntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:
   /**

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -1,5 +1,15 @@
 #include "test/integration/integration.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/header_map.h"
@@ -13,7 +23,10 @@
 #include "test/integration/utility.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 IntegrationTestServerPtr BaseIntegrationTest::test_server_;
 std::vector<std::unique_ptr<FakeUpstream>> BaseIntegrationTest::fake_upstreams_;

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/http/codec_client.h"
 #include "common/network/filter_impl.h"
 #include "common/stats/stats_impl.h"
@@ -7,6 +16,7 @@
 #include "test/integration/fake_upstream.h"
 #include "test/integration/server.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
 
 /**
  * Stream decoder wrapper used during integration testing.

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -1,7 +1,11 @@
+#include <spdlog/spdlog.h>
+
 #include "envoy/http/header_map.h"
 
 #include "test/integration/integration_test.h"
 #include "test/integration/utility.h"
+
+#include "gtest/gtest.h"
 
 TEST_F(IntegrationTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1,9 +1,14 @@
 #include "test/integration/integration_test.h"
 
+#include <string>
+
 #include "common/http/header_map_impl.h"
 
 #include "test/integration/utility.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
 
 TEST_F(IntegrationTest, Echo) {
   Buffer::OwnedImpl buffer("hello");

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -2,6 +2,8 @@
 
 #include "test/integration/integration.h"
 
+#include "gtest/gtest.h"
+
 class IntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:
   /**

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -2,6 +2,10 @@
 
 #include "common/buffer/buffer_impl.h"
 
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
+
 TEST_F(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
 

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -7,6 +7,8 @@
 #include "test/integration/integration.h"
 #include "test/integration/server.h"
 
+#include "gtest/gtest.h"
+
 class ProxyProtoIntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:
   /**

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -1,5 +1,7 @@
 #include "test/integration/server.h"
 
+#include <string>
+
 #include "envoy/http/header_map.h"
 #include "envoy/server/hot_restart.h"
 
@@ -9,6 +11,8 @@
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 #include "test/test_common/environment.h"
+
+#include "gtest/gtest.h"
 
 namespace Server {
 

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include "envoy/server/options.h"
 
 #include "common/common/assert.h"

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -1,10 +1,15 @@
 #include "ssl_integration_test.h"
 
+#include <memory>
+#include <string>
+
 #include "common/event/dispatcher_impl.h"
 #include "common/network/utility.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/ssl/context_manager_impl.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "integration.h"
 #include "utility.h"
 

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -1,8 +1,14 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "test/integration/integration.h"
 #include "test/integration/server.h"
 #include "test/mocks/runtime/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -2,6 +2,8 @@
 
 #include "common/event/dispatcher_impl.h"
 
+#include "gtest/gtest.h"
+
 TEST_F(UdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP1, 1024, 512, false);

--- a/test/integration/uds_integration_test.h
+++ b/test/integration/uds_integration_test.h
@@ -8,6 +8,8 @@
 #include "test/integration/server.h"
 #include "test/test_common/environment.h"
 
+#include "gtest/gtest.h"
+
 class UdsIntegrationTest : public BaseIntegrationTest, public testing::Test {
 public:
   /**

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -1,5 +1,12 @@
 #include "utility.h"
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
 
@@ -12,6 +19,7 @@
 #include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
 void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "envoy/api/api.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/filter.h"
 
 #include "common/http/codec_client.h"
+
+#include "test/test_common/printers.h"
 
 /**
  * A buffering response decoder used for testing.

--- a/test/mocks/access_log/mocks.cc
+++ b/test/mocks/access_log/mocks.cc
@@ -1,5 +1,8 @@
 #include "test/mocks/access_log/mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Return;
 

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/access_log/access_log.h"
 
 #include "test/mocks/filesystem/mocks.h"
+
+#include "gmock/gmock.h"
 
 namespace AccessLog {
 

--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -1,5 +1,8 @@
 #include "mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Return;
 

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "envoy/api/api.h"
 #include "envoy/event/dispatcher.h"
 
 #include "test/mocks/filesystem/mocks.h"
+
+#include "gmock/gmock.h"
 
 namespace Api {
 

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -2,7 +2,10 @@
 
 #include "common/buffer/buffer_impl.h"
 
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
 
 MATCHER_P(BufferEqual, rhs, testing::PrintToString(*rhs)) {
   return TestUtility::buffersEqual(arg, *rhs);

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -2,7 +2,7 @@
 
 #include "envoy/common/time.h"
 
-#include "test/precompiled/precompiled_test.h"
+#include "gmock/gmock.h"
 
 /**
  * This action allows us to save a reference parameter to a pointer target.

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -3,6 +3,9 @@
 #include "common/network/listen_socket_impl.h"
 #include "common/stats/stats_impl.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Invoke;
 using testing::NiceMock;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
@@ -10,6 +15,8 @@
 #include "envoy/network/dns.h"
 #include "envoy/network/listener.h"
 #include "envoy/ssl/context.h"
+
+#include "gmock/gmock.h"
 
 namespace Event {
 

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -1,5 +1,7 @@
 #include "test/mocks/filesystem/mocks.h"
 
+#include <string>
+
 namespace Filesystem {
 
 MockOsSysCalls::MockOsSysCalls() { num_writes_ = num_open_ = 0; }

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -1,8 +1,14 @@
 #pragma once
 
+#include <condition_variable>
+#include <cstdint>
+#include <string>
+
 #include "envoy/filesystem/filesystem.h"
 
 #include "common/common/thread.h"
+
+#include "gmock/gmock.h"
 
 namespace Filesystem {
 

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/grpc/rpc_channel.h"
+
+#include "gmock/gmock.h"
 
 namespace Grpc {
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -3,6 +3,9 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/dispatcher.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Invoke;
 using testing::Return;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "envoy/http/access_log.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/codec.h"
@@ -14,6 +21,9 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/upstream/host.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
 
 namespace Http {
 namespace AccessLog {

--- a/test/mocks/init/mocks.cc
+++ b/test/mocks/init/mocks.cc
@@ -1,5 +1,10 @@
 #include "mocks.h"
 
+#include <functional>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Invoke;
 

--- a/test/mocks/init/mocks.h
+++ b/test/mocks/init/mocks.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <functional>
+#include <list>
+
 #include "envoy/init/init.h"
 
 #include "test/mocks/common.h"
+
+#include "gmock/gmock.h"
 
 namespace Init {
 

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -2,6 +2,9 @@
 
 #include "common/network/address_impl.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::Return;
 using testing::ReturnRef;
 

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/local_info/local_info.h"
+
+#include "gmock/gmock.h"
 
 namespace LocalInfo {
 

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -1,9 +1,16 @@
 #include "mocks.h"
 
+#include <cstdint>
+
 #include "envoy/buffer/buffer.h"
 
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/network/connection.h"
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
@@ -7,6 +11,9 @@
 #include "common/network/proxy_protocol.h"
 
 #include "test/mocks/event/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
 
 namespace Network {
 

--- a/test/mocks/ratelimit/mocks.h
+++ b/test/mocks/ratelimit/mocks.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/tracing/context.h"
+
+#include "gmock/gmock.h"
 
 namespace RateLimit {
 

--- a/test/mocks/redis/mocks.cc
+++ b/test/mocks/redis/mocks.cc
@@ -1,6 +1,13 @@
 #include "mocks.h"
 
+#include <cstdint>
+
 #include "common/common/assert.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/mocks/redis/mocks.h
+++ b/test/mocks/redis/mocks.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/redis/command_splitter.h"
 #include "envoy/redis/conn_pool.h"
 
 #include "common/redis/codec_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
 
 namespace Redis {
 

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -1,5 +1,10 @@
 #include "mocks.h"
 
+#include <chrono>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::NiceMock;
 using testing::Return;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -1,8 +1,18 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/router/router.h"
 #include "envoy/router/router_ratelimit.h"
 #include "envoy/router/shadow_writer.h"
+
+#include "gmock/gmock.h"
 
 namespace Router {
 

--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -1,5 +1,8 @@
 #include "mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::ReturnArg;
 

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "envoy/runtime/runtime.h"
+
+#include "gmock/gmock.h"
 
 namespace Runtime {
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -1,5 +1,10 @@
 #include "mocks.h"
 
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Return;
 using testing::ReturnNew;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/server/admin.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/drain_manager.h"
@@ -22,6 +29,9 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -1,10 +1,15 @@
 #pragma once
 
+#include <functional>
+#include <string>
+
 #include "envoy/ssl/connection.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/stats/stats.h"
+
+#include "gmock/gmock.h"
 
 namespace Ssl {
 

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -1,5 +1,8 @@
 #include "mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 
 namespace Stats {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/stats/stats.h"
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/stats/stats_impl.h"
+
+#include "gmock/gmock.h"
 
 namespace Stats {
 

--- a/test/mocks/thread_local/mocks.cc
+++ b/test/mocks/thread_local/mocks.cc
@@ -1,5 +1,8 @@
 #include "mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::Invoke;
 

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <cstdint>
+#include <unordered_map>
+
 #include "envoy/thread_local/thread_local.h"
 
 #include "test/mocks/event/mocks.h"
+
+#include "gmock/gmock.h"
 
 namespace ThreadLocal {
 

--- a/test/mocks/tracing/mocks.cc
+++ b/test/mocks/tracing/mocks.cc
@@ -1,5 +1,8 @@
 #include "mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::Return;
 using testing::ReturnRef;
 

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "envoy/tracing/context.h"
 #include "envoy/tracing/http_tracer.h"
+
+#include "gmock/gmock.h"
 
 namespace Tracing {
 

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
@@ -7,6 +12,9 @@
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <list>
+#include <string>
+
 #include "envoy/upstream/upstream.h"
 
 #include "common/stats/stats_impl.h"
 
 #include "test/mocks/upstream/cluster_info.h"
+
+#include "gmock/gmock.h"
 
 namespace Upstream {
 namespace Outlier {

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -1,9 +1,15 @@
 #include "test/mocks/upstream/mocks.h"
 
+#include <chrono>
+#include <functional>
+
 #include "envoy/upstream/load_balancer.h"
 
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Invoke;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <functional>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "envoy/http/async_client.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/health_checker.h"
@@ -12,6 +18,8 @@
 #include "test/mocks/stats/mocks.h"
 
 #include "cluster_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::NiceMock;
 

--- a/test/precompiled/BUILD
+++ b/test/precompiled/BUILD
@@ -1,12 +1,1 @@
-package(default_visibility = ["//visibility:public"])
-
-load("//bazel:envoy_build_system.bzl", "envoy_cc_library")
-
-envoy_cc_library(
-    name = "precompiled_includes",
-    hdrs = ["precompiled_test.h"],
-    external_deps = ["googletest"],
-    deps = [
-        "//test/test_common:printers_includes",
-    ],
-)
+# TODO(htuch): Nuke this directory when cmake is no more.

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "server/config/http/buffer.h"
 #include "server/config/http/dynamo.h"
 #include "server/config/http/fault.h"
@@ -7,6 +9,9 @@
 #include "server/http/health_check.h"
 
 #include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "server/config/network/client_ssl_auth.h"
 #include "server/config/network/http_connection_manager.h"
 #include "server/config/network/mongo_proxy.h"
@@ -6,6 +8,9 @@
 #include "server/config/network/tcp_proxy.h"
 
 #include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/server/config/network/http_connection_manager_test.cc
+++ b/test/server/config/network/http_connection_manager_test.cc
@@ -3,6 +3,10 @@
 #include "server/config/network/http_connection_manager.h"
 
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::Return;
 

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -1,8 +1,15 @@
+#include <chrono>
+#include <list>
+#include <string>
+
 #include "server/configuration_impl.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::InSequence;
 using testing::Return;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -8,6 +8,9 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::ByRef;
 using testing::InSequence;

--- a/test/server/drain_manager_impl_test.cc
+++ b/test/server/drain_manager_impl_test.cc
@@ -1,6 +1,11 @@
+#include <chrono>
+
 #include "server/drain_manager_impl.h"
 
 #include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::Return;

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -1,3 +1,7 @@
+#include <atomic>
+#include <chrono>
+#include <memory>
+
 #include "envoy/common/time.h"
 
 #include "common/common/utility.h"
@@ -8,6 +12,9 @@
 #include "test/mocks/common.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::InSequence;
 using testing::NiceMock;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -5,7 +5,11 @@
 
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/test/server/http/health_check_test.cc
+++ b/test/server/http/health_check_test.cc
@@ -1,9 +1,16 @@
+#include <chrono>
+#include <memory>
+
 #include "common/buffer/buffer_impl.h"
 
 #include "server/http/health_check.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::_;
 using testing::DoAll;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -1,6 +1,15 @@
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "common/common/utility.h"
 
 #include "server/options_impl.h"
+
+#include "gtest/gtest.h"
 
 // Do the ugly work of turning a std::string into a char** and create an OptionsImpl. Args are
 // separated by a single space: no fancy quoting or escaping.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -7,6 +7,9 @@
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 using testing::_;
 using testing::InSequence;
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -1,5 +1,16 @@
 #include "test/test_common/environment.h"
 
+#include <spdlog/spdlog.h>
+#include <sys/un.h>
+
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "common/common/assert.h"
 
 #include "server/options_impl.h"

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "envoy/server/options.h"
 
 #include "common/json/json_loader.h"

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -1,5 +1,12 @@
 #include "test/test_common/network_utility.h"
 
+#include <netinet/ip.h>
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+
+#include <cstdint>
+#include <string>
+
 #include "common/common/assert.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/network/address.h"
 
 namespace Network {

--- a/test/test_common/network_utility_test.cc
+++ b/test/test_common/network_utility_test.cc
@@ -1,4 +1,8 @@
+#include <string>
+
 #include "test/test_common/network_utility.h"
+
+#include "gtest/gtest.h"
 
 namespace Network {
 namespace Test {

--- a/test/test_common/printers.cc
+++ b/test/test_common/printers.cc
@@ -1,4 +1,7 @@
 #include "printers.h"
+#include "test/test_common/printers.h"
+
+#include <iostream>
 
 #include "envoy/redis/codec.h"
 

--- a/test/test_common/printers.h
+++ b/test/test_common/printers.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <iostream>
+#include <memory>
+
+#include "test/test_common/printers.h"
+
 namespace Http {
 /**
  * Pretty print const HeaderMapImpl&

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -1,11 +1,24 @@
 #include "utility.h"
 
 #include <dirent.h>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "envoy/buffer/buffer.h"
 
 #include "common/common/empty_string.h"
 #include "common/network/address_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
 
 bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instance& rhs) {
   if (lhs.length() != rhs.length()) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1,9 +1,19 @@
 #pragma once
 
+#include <condition_variable>
+#include <list>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/network/address.h"
 
 #include "common/http/header_map_impl.h"
+
+#include "test/test_common/printers.h"
+
+#include "gtest/gtest.h"
 
 #define EXPECT_THROW_WITH_MESSAGE(statement, expected_exception, message)                          \
   try {                                                                                            \

--- a/test/tools/router_check/json/tool_config_schemas.cc
+++ b/test/tools/router_check/json/tool_config_schemas.cc
@@ -1,5 +1,7 @@
 #include "test/tools/router_check/json/tool_config_schemas.h"
 
+#include <string>
+
 const std::string& Json::ToolSchema::routerCheckSchema() {
   static const std::string* router_check_schema = new std::string(R"EOF(
   {

--- a/test/tools/router_check/json/tool_config_schemas.h
+++ b/test/tools/router_check/json/tool_config_schemas.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace Json {
 
 class ToolSchema {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -1,5 +1,12 @@
 #include "test/tools/router_check/router.h"
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "test/test_common/printers.h"
+
 // static
 ToolConfig ToolConfig::create(const Json::ObjectPtr& check_config) {
   Json::ObjectPtr input = check_config->getObject("input");

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "common/common/logger.h"
 #include "common/common/utility.h"
 #include "common/http/header_map_impl.h"
@@ -9,6 +12,7 @@
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 #include "test/tools/router_check/json/tool_config_schemas.h"
 

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <string>
+
 #include "test/tools/router_check/router.h"
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Since Bazel doesn't support precompiled headers (https://github.com/bazelbuild/bazel/issues/1215),
we actually suffer a slowdown rather than speedup by having all files implicitly include
precompiled.h in the Bazel build. I found ~10% performance improvement on my workstation, going from
181s to 163s for a "bazel build //test/..." from a "bazel clean" state.

This patch makes all includes now explicit. This will slowdown the cmake build, but since this is
not long for this world it seems alright. The header reordering in this patch was achieved using #793.
The addition of the missing headers in each file was done using a modified version of the tool in #793,
which substituted in headers based on simple substring matches (e.g. whenever it saw std::string in
a file, it added #include <string>). Here's the patterns I ended up using that seemed to work:

  sys_extra_includes = [
      ('std::runtime_error', 'stdexcept'),
      ('strcmp', 'string.h'),
      ('strcasecmp', 'strings.h'),
      ('std::unique_ptr', 'memory'),
      ('std::shared_ptr', 'memory'),
      ('std::unordered_set', 'unordered_set'),
      ('std::transform', 'algorithm'),
      ('std::vector', 'vector'),
      ('std::regex', 'regex'),
      ('spdlog::', 'spdlog/spdlog.h'),
      ('fmt::format', 'spdlog/spdlog.h'),
      ('std::string', 'string'),
      ('uint32_t', 'cstdint'),
      ('uint64_t', 'cstdint'),
      ('std::array', 'array'),
      ('sockaddr_un', 'sys/un.h'),
      ('sockaddr_in', 'netinet/ip.h'),
      ('std::chrono', 'chrono'),
      ('std::list', 'list'),
      ('std::multimap', 'map'),
      ('std::unordered_map', 'unordered_map'),
      ('std::stringstream', 'sstream'),
      ('std::condition_variable', 'condition_variable'),
      ('std::mutex', 'mutex'),
      (' ::close', 'unistd.h'),
      ('inet_ntop', 'arpa/inet.h'),
      ('inet_pton', 'arpa/inet.h'),
      ('htonl', 'arpa/inet.h'),
      ('setsockopt', 'sys/types.h'),
      ('setsockopt', 'sys/socket.h'),
      ('TCP_NODELAY', 'netinet/tcp.h'),
      ('SIGTERM', 'signal.h'),
      ('SIGPIPE', 'signal.h'),
      ('std::function', 'functional'),
      ('std::ifstream', 'fstream'),
      ('std::ofstream', 'fstream'),
      ('std::forward_list', 'forward_list'),
      ('std::atomic', 'atomic'),
      ('std::cerr', 'iostream'),
      ('hostent', 'netdb.h'),
      (' bind(', 'sys/types.h'),
      (' bind(', 'sys/socket.h'),
      ('std::ostream', 'iostream'),
  ]

  extra_includes = [
      ('MOCK_METHOD', 'gmock/gmock.h'),
      ('MOCK_CONST_METHOD', 'gmock/gmock.h'),
      ('MATCHER_P', 'gmock/gmock.h'),
      ('ON_CALL', 'gmock/gmock.h'),
      ('using testing::_', 'gmock/gmock.h'),
      ('testing::Test', 'gtest/gtest.h'),
      ('EXPECT_', 'gtest/gtest.h'),
      ('\nTEST(', 'gtest/gtest.h'),
      ('\nTEST_F(', 'gtest/gtest.h'),
      ('\nTEST_P(', 'gtest/gtest.h'),
      ('HeaderMapImpl', 'test/test_common/printers.h'),
      ('Buffer::', 'test/test_common/printers.h'),
      ('RespValue', 'test/test_common/printers.h'),
  ]