### PR TITLE
tracing: make default sample rate 100%

### DIFF
--- a/docs/configuration/http_conn_man/runtime.rst
+++ b/docs/configuration/http_conn_man/runtime.rst
@@ -19,5 +19,5 @@ tracing.global_enabled
 
 tracing.random_sampling
   % of requests that will be randomly traced. See :ref:`here <arch_overview_tracing>` for more
-  information. This runtime control is specified in the range 0-10000 and defaults to 0. Thus,
+  information. This runtime control is specified in the range 0-10000 and defaults to 10000. Thus,
   trace sampling can be specified in 0.01% increments.

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -56,7 +56,7 @@ void HttpTracerUtility::mutateHeaders(Http::HeaderMap& request_headers, Runtime:
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Client);
     } else if (request_headers.EnvoyForceTrace()) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Forced);
-    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", 0, result, 10000)) {
+    } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", 10000, result, 10000)) {
       UuidUtils::setTraceableUuid(x_request_id, UuidTraceStatus::Sampled);
     }
   }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -29,7 +29,7 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
   // Sampling, global on.
   {
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 0, _, 10000))
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
         .WillOnce(Return(true));
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
@@ -45,7 +45,8 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
   // Sampling must not be done on client traced.
   {
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 0, _, 10000)).Times(0);
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
+        .Times(0);
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(true));
 
@@ -60,7 +61,7 @@ TEST(HttpTracerUtilityTest, mutateHeaders) {
   // Sampling, global off.
   {
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 0, _, 10000))
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.random_sampling", 10000, _, 10000))
         .WillOnce(Return(true));
     EXPECT_CALL(runtime.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
         .WillOnce(Return(false));


### PR DESCRIPTION
It is confusing for new users that the default sample rate is 0%.
In the future, we should make this JSON configurable for those that
are not using runtime.