### PR TITLE
Http1: Handle upstream remote close to indicate response complete 

### DIFF
--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -50,11 +50,14 @@ void CodecClient::onEvent(uint32_t events) {
     connected_ = true;
   }
 
+  if (events & Network::ConnectionEvent::RemoteClose) {
+    remote_closed_ = true;
+  }
+
   // HTTP/1 can signal end of response by disconnecting. We need to handle that case.
   if (type_ == Type::HTTP1 && (events & Network::ConnectionEvent::RemoteClose) &&
       !active_requests_.empty()) {
     Buffer::OwnedImpl empty;
-    remote_close_ = true;
     onData(empty);
   }
 

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -54,6 +54,7 @@ void CodecClient::onEvent(uint32_t events) {
   if (type_ == Type::HTTP1 && (events & Network::ConnectionEvent::RemoteClose) &&
       !active_requests_.empty()) {
     Buffer::OwnedImpl empty;
+    remote_close_ = true;
     onData(empty);
   }
 

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -101,7 +101,7 @@ public:
     codec_callbacks_ = &callbacks;
   }
 
-  bool remoteClose() const { return remote_close_; }
+  bool remoteClosed() const { return remote_closed_; }
 
 protected:
   /**
@@ -184,7 +184,7 @@ private:
   Http::ConnectionCallbacks* codec_callbacks_{};
   CodecClientCallbacks* codec_client_callbacks_{};
   bool connected_{};
-  bool remote_close_{};
+  bool remote_closed_{};
 };
 
 typedef std::unique_ptr<CodecClient> CodecClientPtr;

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -101,6 +101,8 @@ public:
     codec_callbacks_ = &callbacks;
   }
 
+  bool remoteClose() const { return remote_close_; }
+
 protected:
   /**
    * Create a codec client and connect to a remote host/port.
@@ -117,6 +119,9 @@ protected:
       codec_callbacks_->onGoAway();
     }
   }
+
+  // Network::ConnectionCallbacks
+  void onEvent(uint32_t events) override;
 
   const Type type_;
   ClientConnectionPtr codec_;
@@ -175,13 +180,11 @@ private:
   void onReset(ActiveRequest& request, StreamResetReason reason);
   void onData(Buffer::Instance& data);
 
-  // Network::ConnectionCallbacks
-  void onEvent(uint32_t events) override;
-
   std::list<ActiveRequestPtr> active_requests_;
   Http::ConnectionCallbacks* codec_callbacks_{};
   CodecClientCallbacks* codec_client_callbacks_{};
   bool connected_{};
+  bool remote_close_{};
 };
 
 typedef std::unique_ptr<CodecClient> CodecClientPtr;

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -120,9 +120,6 @@ protected:
     }
   }
 
-  // Network::ConnectionCallbacks
-  void onEvent(uint32_t events) override;
-
   const Type type_;
   ClientConnectionPtr codec_;
   Network::ClientConnectionPtr connection_;
@@ -179,6 +176,9 @@ private:
   void deleteRequest(ActiveRequest& request);
   void onReset(ActiveRequest& request, StreamResetReason reason);
   void onData(Buffer::Instance& data);
+
+  // Network::ConnectionCallbacks
+  void onEvent(uint32_t events) override;
 
   std::list<ActiveRequestPtr> active_requests_;
   Http::ConnectionCallbacks* codec_callbacks_{};

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -189,6 +189,9 @@ void ConnPoolImpl::onResponseComplete(ActiveClient& client) {
     conn_log_debug("maximum requests per connection", *client.codec_client_);
     host_->cluster().stats().upstream_cx_max_requests_.inc();
     onDownstreamReset(client);
+  } else if (client.codec_client_->remoteClose()) {
+    conn_log_debug("remote close of client connection", *client.codec_client_);
+    onDownstreamReset(client);
   } else {
     processIdleClient(client);
   }
@@ -242,6 +245,7 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end
 }
 
 void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
+  std::cout << "ondecode " << std::endl;
   decode_complete_ = encode_complete_;
   parent_.parent_.onResponseComplete(parent_);
 }

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -182,15 +182,12 @@ void ConnPoolImpl::onResponseComplete(ActiveClient& client) {
   if (!client.stream_wrapper_->encode_complete_) {
     conn_log_debug("response before request complete", *client.codec_client_);
     onDownstreamReset(client);
-  } else if (client.stream_wrapper_->saw_close_header_) {
+  } else if (client.stream_wrapper_->saw_close_header_ || client.codec_client_->remoteClosed()) {
     conn_log_debug("saw upstream connection: close", *client.codec_client_);
     onDownstreamReset(client);
   } else if (client.remaining_requests_ > 0 && --client.remaining_requests_ == 0) {
     conn_log_debug("maximum requests per connection", *client.codec_client_);
     host_->cluster().stats().upstream_cx_max_requests_.inc();
-    onDownstreamReset(client);
-  } else if (client.codec_client_->remoteClose()) {
-    conn_log_debug("remote close of client connection", *client.codec_client_);
     onDownstreamReset(client);
   } else {
     processIdleClient(client);

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -245,7 +245,6 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end
 }
 
 void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
-  std::cout << "ondecode " << std::endl;
   decode_complete_ = encode_complete_;
   parent_.parent_.onResponseComplete(parent_);
 }

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -9,7 +9,7 @@
 #include "test/mocks/common.h"
 
 /**
- * A fake CodecClient that 1) allows a mock codec to be passed in and 2) Allows or a destroy
+ * A fake CodecClient that 1) allows a mock codec to be passed in and 2) Allows for a destroy
  * callback.
  */
 class CodecClientForTest : public Http::CodecClient {
@@ -30,6 +30,8 @@ public:
   }
 
   void raiseGoAway() { onGoAway(); }
+
+  void raiseOnEvent(uint32_t events) { onEvent(events); }
 
   DestroyCb destroy_cb_;
 };

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -31,8 +31,6 @@ public:
 
   void raiseGoAway() { onGoAway(); }
 
-  void raiseOnEvent(uint32_t events) { onEvent(events); }
-
   DestroyCb destroy_cb_;
 };
 

--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -32,6 +32,7 @@ envoy_cc_test(
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//test/common/http:common_lib",
+        "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -3,11 +3,13 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/http/codec_client.h"
+#include "common/http/http1/codec_impl.h"
 #include "common/http/http1/conn_pool.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
+#include "test/mocks/buffer/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
@@ -54,7 +56,7 @@ public:
   struct TestCodecClient {
     Http::MockClientConnection* codec_;
     Network::MockClientConnection* connection_;
-    CodecClient* codec_client_;
+    CodecClientForTest* codec_client_;
     Event::MockTimer* connect_timer_;
   };
 
@@ -537,6 +539,55 @@ TEST_F(Http1ConnPoolImplTest, DrainCallback) {
   r1.completeResponse(false);
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http1ConnPoolImplTest, RemoteClosePendingResponses) {
+  InSequence s;
+
+  // Request 1 should kick off a new connection.
+  NiceMock<Http::MockStreamDecoder> outer_decoder1;
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectClientCreate();
+  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder1, callbacks);
+
+  EXPECT_NE(nullptr, handle);
+
+  // Connect event will bind to request 1.
+  NiceMock<Http::MockStreamEncoder> request_encoder;
+  Http::StreamDecoder* inner_decoder;
+  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
+  EXPECT_CALL(callbacks.pool_ready_, ready());
+
+  // TBD: do we need a pending request?
+  //  NiceMock<Http::MockStreamDecoder> outer_decoder2;
+  //  ConnPoolCallbacks callbacks2;
+  //  //EXPECT_CALL(callbacks2.pool_failure_, ready());
+  //  Http::ConnectionPool::Cancellable* handle2 = conn_pool_.newStream(outer_decoder2, callbacks2);
+  EXPECT_CALL(*conn_pool_.test_clients_[0].connect_timer_, disableTimer());
+  // check why this one isn't a nullptr?
+  // EXPECT_NE(nullptr, handle2);
+  conn_pool_.test_clients_[0].connection_->raiseEvents(Network::ConnectionEvent::Connected);
+
+  callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
+
+  // Need to have another request pending.
+  // set expect_call callback2.pool_ready_, read()). Times(0);
+  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, dispatch(_))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+        // Simulate the onResponseComplete call to decodeData since dispatch is mocked out.
+        inner_decoder->decodeData(data, true);
+      }));
+
+  // We should get a reset callback when the connection disconnects.
+  EXPECT_CALL(conn_pool_, onClientDestroy());
+  Http::MockStreamCallbacks stream_callbacks;
+  EXPECT_CALL(stream_callbacks, onResetStream(StreamResetReason::ConnectionTermination));
+  request_encoder.getStream().addCallbacks(stream_callbacks);
+
+  // conn_pool_.test_clients_[0].codec_client_->raiseOnEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_clients_[0].connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
 }
 


### PR DESCRIPTION
When an upstream remote close is issued to indicate response complete and there are pending requests in the connection pool, Envoy would crash because onResponseComplete would have no way of knowing that a remote close was issued and would continue to processIdleClient. To handle this case, the codec client now sets a boolean to true when a remote close is received and the Http1 Connection Pool checks for this boolean in onResponseComplete and discards the connection instead of reusing it.