### PR TITLE
Modify Header Value Match action to pivots on expecting match

### DIFF
--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -157,7 +157,7 @@ Header Value Match
   {
     "type": "header_value_match",
     "descriptor_value" : "...",
-    "header_present" : "...",
+    "headers_present" : "...",
     "headers" : []
   }
 
@@ -165,19 +165,21 @@ Header Value Match
 descriptor_value
   *(required, string)* The value to use in the descriptor entry.
 
-header_present
-  *(optional, boolean)* Specifies if the action should be checking for the headers being present. If
-  set to true, the action will append a descriptor entry if the headers match. If set to
-  false, the action will append a descriptor entry if the headers do not match. 
+headers_present
+  *(optional, boolean)* Specifies when the action should append a descriptor based on the
+  :ref:`headers<config_http_conn_man_route_table_route_headers>` matching or not. If set to true,
+  the action will append a descriptor entry when the request does match the headers.
+  If set to false, the action will append a descriptor entry when the request does not match the
+  headers. The default value is true.
 
 :ref:`headers<config_http_conn_man_route_table_route_headers>`
   *(required, array)* Specifies a set of headers that the rate limit action should match on. The
-    action will check the request's headers against all the specified headers in the config. A match
-    will happen if all the headers in the config are present in the request with the same values (or
-    based on presence if the ``value`` field is not in the config).
+  action will check the request's headers against all the specified headers in the config. A match
+  will happen if all the headers in the config are present in the request with the same values (or
+  based on presence if the ``value`` field is not in the config).
 
-The following descriptor entry is appended to the descriptor if the request matches the headers
-specified in the action config:
+The following descriptor entry is appended to the descriptor if the headers match and
+headers_present is true or the headers do not match and headers_present is false:
 
 .. code-block:: cpp
 

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -165,9 +165,9 @@ Header Value Match
 descriptor_value
   *(required, string)* The value to use in the descriptor entry.
 
-headers_present
-  *(optional, boolean)* Specifies when the action should append a descriptor based on the
-  :ref:`headers<config_http_conn_man_route_table_route_headers>` matching. If set to true,
+expect_match
+  *(optional, boolean)* Specifies if the action should append a descriptor when it expects a match
+  to the :ref:`headers<config_http_conn_man_route_table_route_headers>`. If set to true,
   the action will append a descriptor entry when the request matches the headers. If set to false,
   the action will append a descriptor entry when the request does not match the headers. The default
   value is true.

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -166,11 +166,10 @@ descriptor_value
   *(required, string)* The value to use in the descriptor entry.
 
 expect_match
-  *(optional, boolean)* Specifies if the action should append a descriptor when it expects a match
-  to the :ref:`headers<config_http_conn_man_route_table_route_headers>`. If set to true,
-  the action will append a descriptor entry when the request matches the headers. If set to false,
-  the action will append a descriptor entry when the request does not match the headers. The default
-  value is true.
+  *(optional, boolean)* If set to true, the action will append a descriptor entry when the request
+  matches the :ref:`headers<config_http_conn_man_route_table_route_headers>`. If set to false,
+  the action will append a descriptor entry when the request does not match the
+  :ref:`headers<config_http_conn_man_route_table_route_headers>`. The default value is true.
 
 :ref:`headers<config_http_conn_man_route_table_route_headers>`
   *(required, array)* Specifies a set of headers that the rate limit action should match on. The

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -157,7 +157,7 @@ Header Value Match
   {
     "type": "header_value_match",
     "descriptor_value" : "...",
-    "headers_present" : "...",
+    "expect_match" : "...",
     "headers" : []
   }
 

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -167,10 +167,10 @@ descriptor_value
 
 headers_present
   *(optional, boolean)* Specifies when the action should append a descriptor based on the
-  :ref:`headers<config_http_conn_man_route_table_route_headers>` matching or not. If set to true,
-  the action will append a descriptor entry when the request does match the headers.
-  If set to false, the action will append a descriptor entry when the request does not match the
-  headers. The default value is true.
+  :ref:`headers<config_http_conn_man_route_table_route_headers>` matching. If set to true,
+  the action will append a descriptor entry when the request matches the headers. If set to false,
+  the action will append a descriptor entry when the request does not match the headers. The default
+  value is true.
 
 :ref:`headers<config_http_conn_man_route_table_route_headers>`
   *(required, array)* Specifies a set of headers that the rate limit action should match on. The
@@ -178,9 +178,7 @@ headers_present
   will happen if all the headers in the config are present in the request with the same values (or
   based on presence if the ``value`` field is not in the config).
 
-The following descriptor entry is appended to the descriptor if the headers match and
-headers_present is true or the headers do not match and headers_present is false:
-
+The following descriptor entry is appended to the descriptor:
 .. code-block:: cpp
 
   ("header_match", "<descriptor_value>")

--- a/docs/configuration/http_conn_man/route_config/rate_limits.rst
+++ b/docs/configuration/http_conn_man/route_config/rate_limits.rst
@@ -141,7 +141,7 @@ Generic Key
 
 
 descriptor_value
-    *(required, string)* The value to use in the descriptor entry.
+  *(required, string)* The value to use in the descriptor entry.
 
 The following descriptor entry is appended to the descriptor:
 
@@ -157,15 +157,21 @@ Header Value Match
   {
     "type": "header_value_match",
     "descriptor_value" : "...",
+    "header_present" : "...",
     "headers" : []
   }
 
 
 descriptor_value
-    *(required, string)* The value to use in the descriptor entry.
+  *(required, string)* The value to use in the descriptor entry.
+
+header_present
+  *(optional, boolean)* Specifies if the action should be checking for the headers being present. If
+  set to true, the action will append a descriptor entry if the headers match. If set to
+  false, the action will append a descriptor entry if the headers do not match. 
 
 :ref:`headers<config_http_conn_man_route_table_route_headers>`
-    *(required, array)* Specifies a set of headers that the rate limit action should match on. The
+  *(required, array)* Specifies a set of headers that the rate limit action should match on. The
     action will check the request's headers against all the specified headers in the config. A match
     will happen if all the headers in the config are present in the request with the same values (or
     based on presence if the ``value`` field is not in the config).

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -721,6 +721,7 @@ const std::string Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA(R"EOF(
             "enum" : ["header_value_match"]
           },
           "descriptor_value" : {"type" : "string"},
+          "expect_match" : {"type" : "boolean"},
           "headers" : {
             "type" : "array",
             "minItems" : 1,

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -63,7 +63,7 @@ bool GenericKeyAction::populateDescriptor(const Router::RouteEntry&,
 
 HeaderValueMatchAction::HeaderValueMatchAction(const Json::Object& action)
     : descriptor_value_(action.getString("descriptor_value")),
-      headers_present_(action.getBoolean("headers_present", true)) {
+      expect_match_(action.getBoolean("expect_match", true)) {
   std::vector<Json::ObjectPtr> config_headers = action.getObjectArray("headers");
   for (const Json::ObjectPtr& header_map : config_headers) {
     action_headers_.push_back(*header_map);
@@ -74,7 +74,7 @@ bool HeaderValueMatchAction::populateDescriptor(const Router::RouteEntry&,
                                                 ::RateLimit::Descriptor& descriptor,
                                                 const std::string&, const Http::HeaderMap& headers,
                                                 const std::string&) const {
-  if (headers_present_ == ConfigUtility::matchHeaders(headers, action_headers_)) {
+  if (expect_match_ == ConfigUtility::matchHeaders(headers, action_headers_)) {
     descriptor.entries_.push_back({"header_match", descriptor_value_});
     return true;
   } else {

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -63,7 +63,7 @@ bool GenericKeyAction::populateDescriptor(const Router::RouteEntry&,
 
 HeaderValueMatchAction::HeaderValueMatchAction(const Json::Object& action)
     : descriptor_value_(action.getString("descriptor_value")),
-      header_present_(action.getBoolean("header_present", true)) {
+      headers_present_(action.getBoolean("headers_present", true)) {
   std::vector<Json::ObjectPtr> config_headers = action.getObjectArray("headers");
   for (const Json::ObjectPtr& header_map : config_headers) {
     action_headers_.push_back(*header_map);
@@ -74,15 +74,12 @@ bool HeaderValueMatchAction::populateDescriptor(const Router::RouteEntry&,
                                                 ::RateLimit::Descriptor& descriptor,
                                                 const std::string&, const Http::HeaderMap& headers,
                                                 const std::string&) const {
-  bool headers_match = ConfigUtility::matchHeaders(headers, action_headers_);
-
-  if (headers_match && he)
-    if (ConfigUtility::matchHeaders(headers, action_headers_)) {
-      descriptor.entries_.push_back({"header_match", descriptor_value_});
-      return true;
-    } else {
-      return false;
-    }
+  if (headers_present_ == ConfigUtility::matchHeaders(headers, action_headers_)) {
+    descriptor.entries_.push_back({"header_match", descriptor_value_});
+    return true;
+  } else {
+    return false;
+  }
 }
 
 RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(const Json::Object& config)

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -97,6 +97,7 @@ public:
 
 private:
   const std::string descriptor_value_;
+  const bool header_present_;
   std::vector<Router::ConfigUtility::HeaderData> action_headers_;
 };
 

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -97,7 +97,7 @@ public:
 
 private:
   const std::string descriptor_value_;
-  const bool header_present_;
+  const bool headers_present_;
   std::vector<Router::ConfigUtility::HeaderData> action_headers_;
 };
 

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -97,7 +97,7 @@ public:
 
 private:
   const std::string descriptor_value_;
-  const bool headers_present_;
+  const bool expect_match_;
   std::vector<Router::ConfigUtility::HeaderData> action_headers_;
 };
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -559,7 +559,7 @@ TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchHeadersNotPresent) {
       {
         "type": "header_value_match",
         "descriptor_value": "fake_value",
-        "headers_present": false,
+        "expect_match": false,
         "headers": [
           {
             "name": "x-header-name",
@@ -587,7 +587,7 @@ TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchHeadersPresent) {
       {
         "type": "header_value_match",
         "descriptor_value": "fake_value",
-        "headers_present": false,
+        "expect_match": false,
         "headers": [
           {
             "name": "x-header-name",

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -546,7 +546,7 @@ TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchNoMatch) {
   )EOF";
 
   SetUpTest(json);
-  Http::TestHeaderMapImpl header{{"x-header-name", "fake_value"}};
+  Http::TestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, "");
   EXPECT_TRUE(descriptors_.empty());
@@ -573,7 +573,7 @@ TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchHeadersNotPresent) {
   )EOF";
 
   SetUpTest(json);
-  Http::TestHeaderMapImpl header{{"x-header-name", "fake_value"}};
+  Http::TestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, "");
   EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -552,6 +552,61 @@ TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchNoMatch) {
   EXPECT_TRUE(descriptors_.empty());
 }
 
+TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchHeadersNotPresent) {
+  std::string json = R"EOF(
+  {
+    "actions": [
+      {
+        "type": "header_value_match",
+        "descriptor_value": "fake_value",
+        "headers_present": false,
+        "headers": [
+          {
+            "name": "x-header-name",
+            "value": "test_value",
+            "regex": false
+          }
+        ]
+      }
+    ]
+  }
+  )EOF";
+
+  SetUpTest(json);
+  Http::TestHeaderMapImpl header{{"x-header-name", "fake_value"}};
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, "");
+  EXPECT_THAT(std::vector<::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
+              testing::ContainerEq(descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchHeadersPresent) {
+  std::string json = R"EOF(
+  {
+    "actions": [
+      {
+        "type": "header_value_match",
+        "descriptor_value": "fake_value",
+        "headers_present": false,
+        "headers": [
+          {
+            "name": "x-header-name",
+            "value": "test_value",
+            "regex": false
+          }
+        ]
+      }
+    ]
+  }
+  )EOF";
+
+  SetUpTest(json);
+  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, "");
+  EXPECT_TRUE(descriptors_.empty());
+}
+
 TEST_F(RateLimitPolicyEntryTest, CompoundActions) {
   std::string json = R"EOF(
   {


### PR DESCRIPTION
The Header Value Match action sets a descriptor entry depending on if the expected outcome of comparing request headers to the config is to match or not. 