### PR TITLE
hot restart: start parent shutdown sequence after init complete

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -186,7 +186,6 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;
   restarter_.shutdownParentAdmin(info);
-  drain_manager_->startParentShutdownSequence();
   original_start_time_ = info.original_start_time_;
   admin_.reset(new AdminImpl(initial_config.admin().accessLogPath(),
                              initial_config.admin().profilePath(), initial_config.admin().address(),
@@ -296,6 +295,7 @@ void InstanceImpl::startWorkers(TestHooks& hooks) {
   // At this point we are ready to take traffic and all listening ports are up. Notify our parent
   // if applicable that they can stop listening and drain.
   restarter_.drainParentListeners();
+  drain_manager_->startParentShutdownSequence();
   hooks.onServerInitialized();
 }
 


### PR DESCRIPTION
Previously it was possible to race with initialization.