### PR TITLE
test: use explicit openssl.cnf for generated certs.

### DIFF
--- a/test/common/ssl/gen_unittest_certs.sh
+++ b/test/common/ssl/gen_unittest_certs.sh
@@ -5,6 +5,35 @@
 set -e
 
 TEST_CERT_DIR=$TEST_TMPDIR
+export OPENSSL_CONF="$TEST_CERT_DIR"/openssl.cnf
+(cat << EOF
+[ req ]
+default_bits            = 2048
+distinguished_name      = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName                     = Country Name (2 letter code)
+countryName_default             = AU
+countryName_min                 = 2
+countryName_max                 = 2
+
+stateOrProvinceName             = State or Province Name (full name)
+stateOrProvinceName_default     = Some-State
+
+localityName                    = Locality Name (eg, city)
+
+0.organizationName              = Organization Name (eg, company)
+0.organizationName_default      = Internet Widgits Pty Ltd
+
+organizationalUnitName          = Organizational Unit Name (eg, section)
+
+commonName                      = Common Name (e.g. server FQDN or YOUR name)
+commonName_max                  = 64
+
+emailAddress                    = Email Address
+emailAddress_max                = 64
+EOF
+) > "$OPENSSL_CONF"
 
 mkdir -p $TEST_CERT_DIR
 openssl genrsa -out $TEST_CERT_DIR/unittestkey.pem 1024


### PR DESCRIPTION
Previously, openssl was picking up on whatever the default openssl.cnf path it was compiled with
pointed at, e.g. /etc/ssl/openssl.cnf. This was non-hermetic and failed in test environments in
which access to /etc was sandboxed. This patch provides an explicit minimal openssl.cnf, derived
from the /etc/ssl/openssl.cnf on my workstation.