### PR TITLE
misc: some fixes for bugs that manifest on clang builds.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -166,7 +166,7 @@ int ConnectionImpl::StreamImpl::onDataSourceSend(const uint8_t* framehd, size_t 
 void ConnectionImpl::ClientStreamImpl::submitHeaders(const std::vector<nghttp2_nv>& final_headers,
                                                      nghttp2_data_provider* provider) {
   ASSERT(stream_id_ == -1);
-  stream_id_ = nghttp2_submit_request(parent_.session_, nullptr, &final_headers[0],
+  stream_id_ = nghttp2_submit_request(parent_.session_, nullptr, &final_headers.data()[0],
                                       final_headers.size(), provider, base());
   ASSERT(stream_id_ > 0);
 }
@@ -174,7 +174,7 @@ void ConnectionImpl::ClientStreamImpl::submitHeaders(const std::vector<nghttp2_n
 void ConnectionImpl::ServerStreamImpl::submitHeaders(const std::vector<nghttp2_nv>& final_headers,
                                                      nghttp2_data_provider* provider) {
   ASSERT(stream_id_ != -1);
-  int rc = nghttp2_submit_response(parent_.session_, stream_id_, &final_headers[0],
+  int rc = nghttp2_submit_response(parent_.session_, stream_id_, &final_headers.data()[0],
                                    final_headers.size(), provider);
   ASSERT(rc == 0);
   UNREFERENCED_PARAMETER(rc);

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -84,7 +84,7 @@ void LightStepRecorder::flushSpans() {
 
 LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(lightstep::Tracer tracer,
                                                         LightStepDriver& driver)
-    : tracer_(tracer), driver_(driver) {}
+    : tracer_(new lightstep::Tracer(tracer)), driver_(driver) {}
 
 LightStepDriver::LightStepDriver(const Json::Object& config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
@@ -118,7 +118,7 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
 
 SpanPtr LightStepDriver::startSpan(Http::HeaderMap& request_headers,
                                    const std::string& operation_name, SystemTime start_time) {
-  lightstep::Tracer& tracer = tls_.getTyped<TlsLightStepTracer>(tls_slot_).tracer_;
+  lightstep::Tracer& tracer = *tls_.getTyped<TlsLightStepTracer>(tls_slot_).tracer_;
   LightStepSpanPtr active_span;
 
   if (request_headers.OtSpanContext()) {

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -67,9 +67,7 @@ private:
   struct TlsLightStepTracer : ThreadLocal::ThreadLocalObject {
     TlsLightStepTracer(lightstep::Tracer tracer, LightStepDriver& driver);
 
-    void shutdown() override {
-      tracer_.reset();
-    }
+    void shutdown() override { tracer_.reset(); }
 
     std::unique_ptr<lightstep::Tracer> tracer_;
     LightStepDriver& driver_;

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -67,9 +67,11 @@ private:
   struct TlsLightStepTracer : ThreadLocal::ThreadLocalObject {
     TlsLightStepTracer(lightstep::Tracer tracer, LightStepDriver& driver);
 
-    void shutdown() override {}
+    void shutdown() override {
+      tracer_.reset();
+    }
 
-    lightstep::Tracer tracer_;
+    std::unique_ptr<lightstep::Tracer> tracer_;
     LightStepDriver& driver_;
   };
 

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -72,5 +72,6 @@ void Worker::threadRoutine(Server::GuardDog& guard_dog) {
   handler_->closeConnections();
   tls_.shutdownThread();
   no_exit_timer_.reset();
+  watchdog.reset();
   handler_.reset();
 }

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -216,6 +216,12 @@ public:
     ares_set_servers_ports_csv(peer_->channel(), socket_->localAddress()->asString().c_str());
   }
 
+  void TearDown() override {
+    // Make sure we clean this up before dispatcher destruction.
+    listener_.reset();
+    server_.reset();
+  }
+
 protected:
   // Should the DnsResolverImpl use a zero timeout for c-ares queries?
   virtual bool zero_timeout() const { return false; }


### PR DESCRIPTION
When running internally in Google, there were some destructor ordering bugs exposed that are fixed
in this patch. In addition, fixed an issue in source/common/http/http2/codec_impl.cc where empty
headers resulted in a vector access at index 0 on an empty vector.