### PR TITLE
bazel: misc fixes

### DIFF
--- a/bazel/cc_configure.bzl
+++ b/bazel/cc_configure.bzl
@@ -783,6 +783,7 @@ cc_autoconf = repository_rule(
         "CPLUS_INCLUDE_PATH",
         "CUDA_COMPUTE_CAPABILITIES",
         "CUDA_PATH",
+        "CXX",
         "HOMEBREW_RUBY_PATH",
         "NO_WHOLE_ARCHIVE_OPTION",
         "SYSTEMROOT",

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -168,7 +168,7 @@ def envoy_cc_test(name,
     native.cc_test(
         name = name,
         copts = envoy_copts(repository),
-        linkopts = ["-pthread"],
+        linkopts = ["-pthread", "-latomic"],
         linkstatic = 1,
         malloc = tcmalloc_external_dep(repository),
         deps = [

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -168,6 +168,8 @@ def envoy_cc_test(name,
     native.cc_test(
         name = name,
         copts = envoy_copts(repository),
+        # TODO(mattklein123): It's not great that we universally link against the following libs.
+        # In particular, -latomic is not needed on all platforms. Make this more granular.
         linkopts = ["-pthread", "-latomic"],
         linkstatic = 1,
         malloc = tcmalloc_external_dep(repository),


### PR DESCRIPTION
1) We should trigger recompile when CXX changes
2) When compiling with clang++-4.0 on Ubuntu 16.04 I'm getting linking
   errors without -latomic. I'm not crazy about setting this universally
   since I'm not sure if it's available on all platforms but we can see
   how it goes.