### PR TITLE
build: force gperftools to link with pthread.

### DIFF
--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -3,5 +3,5 @@ set -e
 wget https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz
 tar xf gperftools-2.5.tar.gz
 cd gperftools-2.5
-./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers
+LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers
 make install


### PR DESCRIPTION
This seems necessary for some link combinations with libunwind and clang. I have an open thread
internally to figure out why gperftools doesn't auto-detect and why it is version dependent.