### PR TITLE
test: fix config_test to support site specific (e.g. google) import.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -210,10 +210,11 @@ def envoy_cc_test_library(name,
 # Envoy Python test binaries should be specified with this function.
 def envoy_py_test_binary(name,
                          external_deps = [],
+                         deps = [],
                          **kargs):
-    # TODO(htuch): Add support for external_deps, e.g. jinja2 for config_test.
     native.py_binary(
         name = name,
+        deps = deps + [envoy_external_dep_path(dep) for dep in external_deps],
         **kargs
     )
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -39,6 +39,7 @@ py_library(
     name = "jinja2",
     srcs = glob(["jinja2/**/*.py"]),
     visibility = ["//visibility:public"],
+    deps = ["@markupsafe_git//:markupsafe"],
 )
 """
     native.new_git_repository(
@@ -48,9 +49,30 @@ py_library(
         build_file_content = BUILD,
     )
 
+def py_markupsafe_dep():
+    BUILD = """
+py_library(
+    name = "markupsafe",
+    srcs = glob(["markupsafe/**/*.py"]),
+    visibility = ["//visibility:public"],
+)
+"""
+    native.new_git_repository(
+        name = "markupsafe_git",
+        remote = "https://github.com/pallets/markupsafe.git",
+        tag = "1.0",
+        build_file_content = BUILD,
+    )
+
 # Python dependencies. If these become non-trivial, we might be better off using a virtualenv to
 # wrap them, but for now we can treat them as first-class Bazel.
 def python_deps(skip_targets):
+    if 'markupsafe' not in skip_targets:
+        py_markupsafe_dep()
+        native.bind(
+            name = "markupsafe",
+            actual = "@markupsafe_git//:markupsafe",
+        )
     if 'jinja2' not in skip_targets:
         py_jinja2_dep()
         native.bind(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -33,6 +33,31 @@ def _repository_impl(ctxt):
     if result.return_code != 0:
         fail("External dep build failed")
 
+def py_jinja2_dep():
+    BUILD = """
+py_library(
+    name = "jinja2",
+    srcs = glob(["jinja2/**/*.py"]),
+    visibility = ["//visibility:public"],
+)
+"""
+    native.new_git_repository(
+        name = "jinja2_git",
+        remote = "https://github.com/pallets/jinja.git",
+        tag = "2.9.6",
+        build_file_content = BUILD,
+    )
+
+# Python dependencies. If these become non-trivial, we might be better off using a virtualenv to
+# wrap them, but for now we can treat them as first-class Bazel.
+def python_deps(skip_targets):
+    if 'jinja2' not in skip_targets:
+        py_jinja2_dep()
+        native.bind(
+            name = "jinja2",
+            actual = "@jinja2_git//:jinja2",
+        )
+
 def envoy_dependencies(path = "@envoy_deps//", skip_protobuf_bzl = False, skip_targets = []):
     # Used only for protobuf.bzl.
     if not skip_protobuf_bzl:
@@ -82,3 +107,5 @@ def envoy_dependencies(path = "@envoy_deps//", skip_protobuf_bzl = False, skip_t
                 name = t,
                 actual = path + ":" + t,
             )
+
+    python_deps(skip_targets)

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -1,13 +1,21 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//bazel:envoy_build_system.bzl", "envoy_py_test_binary")
+
+envoy_py_test_binary(
+    name = "configgen",
+    srcs = ["configgen.py"],
+    data = glob(["*.json"]),
+    external_deps = ["jinja2"],
+)
+
 genrule(
     name = "example_configs",
-    srcs = glob(["*.json"]) + ["//examples:configs"],
+    srcs = ["//examples:configs"],
     outs = ["example_configs.tar"],
-    cmd = "$(location configgen.sh) $(@D) $(locations //examples:configs)",
+    cmd = "$(location configgen.sh) $(location configgen) $(@D) $(locations //examples:configs)",
     tools = [
-        "configgen.py",
         "configgen.sh",
-        "requirements.txt",
+        ":configgen",
     ],
 )

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -2,11 +2,8 @@
 
 set -e
 
-# We need to use /tmp for building the venv, since the sandboxed env does not allow execution in
-# the build output directory.
 CONFIGGEN="$1"
 shift
-BUILD_DIR=/tmp/configgen
 OUT_DIR="$1"
 shift
 

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -4,19 +4,14 @@ set -e
 
 # We need to use /tmp for building the venv, since the sandboxed env does not allow execution in
 # the build output directory.
-SCRIPT_DIR=`dirname $0`
+CONFIGGEN="$1"
+shift
 BUILD_DIR=/tmp/configgen
 OUT_DIR="$1"
 shift
 
-if [ ! -d "$BUILD_DIR"/venv ]; then
-  virtualenv "$BUILD_DIR"/venv
-  "$BUILD_DIR"/venv/bin/pip install -r "$SCRIPT_DIR"/requirements.txt
-fi
-
 mkdir -p "$OUT_DIR"
-"$BUILD_DIR"/venv/bin/python "$SCRIPT_DIR"/configgen.py "$SCRIPT_DIR" "$OUT_DIR"
-cp "$SCRIPT_DIR/google_com_proxy.json" "$OUT_DIR"
+"$CONFIGGEN" "$OUT_DIR"
 cp $* "$OUT_DIR"
 
 # tar is having issues with -C for some reason so just cd into OUT_DIR.

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
-tar -xvf configs/example_configs.tar -C "$DIR"
+tar -xvf "$TEST_RUNDIR"/configs/example_configs.tar -C "$DIR"


### PR DESCRIPTION
* jinja2 external dependency via new_git_repository instead of virtualenv.

* Some rejiggering of the paths in configgen.{sh,py} to work better with
  symlinked and relative paths.