### PR TITLE
test: don't run static linking test when doing ASAN

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -4,4 +4,7 @@ sh_test(
     name = "envoy_static_test",
     srcs = ["envoy_static_test.sh"],
     data = ["//source/exe:envoy-static"],
+    # NOTE: In some environments, ASAN causes dynamic linking no matter what, so don't run this
+    # test when doing ASAN.
+    tags = ["no_asan"],
 )

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -4,3 +4,5 @@ build:asan --copt -fsanitize=address
 build:asan --linkopt -fsanitize=address
 build:asan --linkopt -ldl
 build:asan --define tcmalloc=disabled
+build:asan --build_tag_filters=-no_asan
+build:asan --test_tag_filters=-no_asan


### PR DESCRIPTION
Some environments do not static link.