### PR TITLE
External Deps: Add 'Backward' backtrace library.

### DIFF
--- a/bazel/target_recipes.bzl
+++ b/bazel/target_recipes.bzl
@@ -3,6 +3,7 @@
 # ci/build_container/build_recipes.
 TARGET_RECIPES = {
     "ares": "cares",
+    "backward": "backward",
     # TODO(htuch): Remove when cmake goes.
     "cotire": "cotire",
     "event": "libevent",

--- a/ci/build_container/build_recipes/backward.sh
+++ b/ci/build_container/build_recipes/backward.sh
@@ -1,0 +1,7 @@
+set -e
+
+git clone https://github.com/bombela/backward-cpp.git
+cd backward-cpp
+# v1.3 release
+git reset --hard cd1c4bd9e48afe812a0e996d335298c455afcd92
+cp backward.hpp $THIRDPARTY_BUILD/include

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -8,6 +8,12 @@ cc_library(
 )
 
 cc_library(
+    name = "backward",
+    hdrs = glob(["thirdparty_build/include/*.hpp"]),
+    includes = ["thirdparty_build/include"],
+)
+
+cc_library(
     name = "crypto",
     srcs = ["thirdparty_build/lib/libcrypto.a"],
     hdrs = glob(["thirdparty_build/include/openssl/**/*.h"]),

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -9,7 +9,7 @@ cc_library(
 
 cc_library(
     name = "backward",
-    hdrs = glob(["thirdparty_build/include/*.hpp"]),
+    hdrs = ["thirdparty_build/include/backward.hpp"],
     includes = ["thirdparty_build/include"],
 )
 

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -21,6 +21,7 @@ Envoy has the following requirements:
 * `lightstep-tracer-cpp <https://github.com/lightstep/lightstep-tracer-cpp/>`_ (last tested with 0.36)
 * `rapidjson <https://github.com/miloyip/rapidjson/>`_ (last tested with 1.1.0)
 * `c-ares <https://github.com/c-ares/c-ares>`_ (last tested with 1.12.0)
+* `backward <https://github.com/bombela/backward-cpp>`_ (last tested with 1.3)
 
 In order to compile and run the tests the following is required:
 


### PR DESCRIPTION
This adds github:bombela/backward-cpp as an external dependency.  It is
covered under the MIT license.

This PR is a pre-requisite for a second PR which uses this feature
within Envoy.  This PR needs to be merged first for the CI image to
include the external dependency.