### PR TITLE
style: rename Json::Factory load methods to match style guide

### DIFF
--- a/source/common/dynamo/dynamo_filter.cc
+++ b/source/common/dynamo/dynamo_filter.cc
@@ -51,7 +51,7 @@ void DynamoFilter::onDecodeComplete(const Buffer::Instance& data) {
   std::string body = buildBody(decoder_callbacks_->decodingBuffer().get(), data);
   if (!body.empty()) {
     try {
-      Json::ObjectPtr json_body = Json::Factory::LoadFromString(body);
+      Json::ObjectPtr json_body = Json::Factory::loadFromString(body);
       table_descriptor_ = RequestParser::parseTable(operation_, *json_body);
     } catch (const Json::Exception& jsonEx) {
       // Body parsing failed. This should not happen, just put a stat for that.
@@ -71,7 +71,7 @@ void DynamoFilter::onEncodeComplete(const Buffer::Instance& data) {
   std::string body = buildBody(encoder_callbacks_->encodingBuffer().get(), data);
   if (!body.empty()) {
     try {
-      Json::ObjectPtr json_body = Json::Factory::LoadFromString(body);
+      Json::ObjectPtr json_body = Json::Factory::loadFromString(body);
       chargeTablePartitionIdStats(*json_body);
 
       if (Http::CodeUtility::is4xx(status)) {

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -61,7 +61,7 @@ GlobalStats Config::generateStats(Stats::Store& store, const std::string& prefix
 
 void Config::parseResponse(const Http::Message& message) {
   AllowedPrincipalsSharedPtr new_principals(new AllowedPrincipals());
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(message.bodyAsString());
+  Json::ObjectPtr loader = Json::Factory::loadFromString(message.bodyAsString());
   for (const Json::ObjectPtr& certificate : loader->getObjectArray("certificates")) {
     new_principals->add(certificate->getString("fingerprint_sha256"));
   }

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -219,7 +219,7 @@ private:
   rapidjson::Document root_;
 };
 
-ObjectPtr Factory::LoadFromFile(const std::string& file_path) {
+ObjectPtr Factory::loadFromFile(const std::string& file_path) {
   rapidjson::Document document;
   std::ifstream file_stream(file_path);
   rapidjson::IStreamWrapper stream_wrapper(file_stream);
@@ -230,7 +230,7 @@ ObjectPtr Factory::LoadFromFile(const std::string& file_path) {
   return ObjectPtr{new ObjectImplRoot(std::move(document))};
 }
 
-ObjectPtr Factory::LoadFromString(const std::string& json) {
+ObjectPtr Factory::loadFromString(const std::string& json) {
   rapidjson::Document document;
   if (document.Parse<0>(json.c_str()).HasParseError()) {
     throw Exception(fmt::format("Error(offset {}): {}\n", document.GetErrorOffset(),

--- a/source/common/json/json_loader.h
+++ b/source/common/json/json_loader.h
@@ -9,16 +9,15 @@ namespace Json {
 
 class Factory {
 public:
-  // TODO(hennna): Cleanup function names - i.e. s/LoadFromFile/loadFromFile/.
   /*
    * Constructs a Json Object from a File.
    */
-  static ObjectPtr LoadFromFile(const std::string& file_path);
+  static ObjectPtr loadFromFile(const std::string& file_path);
 
   /*
    * Constructs a Json Object from a String.
    */
-  static ObjectPtr LoadFromString(const std::string& json);
+  static ObjectPtr loadFromString(const std::string& json);
 
   static const std::string listAsJsonString(const std::list<std::string>& items);
 };

--- a/source/common/mongo/utility.cc
+++ b/source/common/mongo/utility.cc
@@ -84,7 +84,7 @@ std::string QueryMessageInfo::parseCallingFunction(const QueryMessage& query) {
 
 std::string QueryMessageInfo::parseCallingFunctionJson(const std::string& json_string) {
   try {
-    Json::ObjectPtr json = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json = Json::Factory::loadFromString(json_string);
     return json->getString("callingFunction");
   } catch (Json::Exception&) {
     return "";

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -85,7 +85,7 @@ void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
 
 void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
   log_debug("rds: parsing response");
-  Json::ObjectPtr response_json = Json::Factory::LoadFromString(response.bodyAsString());
+  Json::ObjectPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   uint64_t new_hash = response_json->hash();
   if (new_hash != last_config_hash_ || !initialized_) {
     response_json->validateSchema(Json::Schema::ROUTE_CONFIGURATION_SCHEMA);

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -46,7 +46,7 @@ void CdsApiImpl::createRequest(Http::Message& request) {
 
 void CdsApiImpl::parseResponse(const Http::Message& response) {
   log_debug("cds: parsing response");
-  Json::ObjectPtr response_json = Json::Factory::LoadFromString(response.bodyAsString());
+  Json::ObjectPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   response_json->validateSchema(Json::Schema::CDS_SCHEMA);
   std::vector<Json::ObjectPtr> clusters = response_json->getObjectArray("clusters");
 

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -22,7 +22,7 @@ SdsClusterImpl::SdsClusterImpl(const Json::Object& config, Runtime::Loader& runt
       local_info_(local_info), service_name_(config.getString("service_name")) {}
 
 void SdsClusterImpl::parseResponse(const Http::Message& response) {
-  Json::ObjectPtr json = Json::Factory::LoadFromString(response.bodyAsString());
+  Json::ObjectPtr json = Json::Factory::loadFromString(response.bodyAsString());
   json->validateSchema(Json::Schema::SDS_SCHEMA);
   std::vector<HostSharedPtr> new_hosts;
   for (const Json::ObjectPtr& host : json->getObjectArray("hosts")) {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -179,7 +179,7 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
              restarter_.version());
 
   // Handle configuration that needs to take place prior to the main configuration load.
-  Json::ObjectPtr config_json = Json::Factory::LoadFromFile(options.configPath());
+  Json::ObjectPtr config_json = Json::Factory::loadFromFile(options.configPath());
   config_json->validateSchema(Json::Schema::TOP_LEVEL_CONFIG_SCHEMA);
   Configuration::InitialImpl initial_config(*config_json);
   log().info("admin address: {}", initial_config.admin().address()->asString());

--- a/test/common/dynamo/dynamo_request_parser_test.cc
+++ b/test/common/dynamo/dynamo_request_parser_test.cc
@@ -52,7 +52,7 @@ TEST(DynamoRequestParser, parseTableNameSingleOperation) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     // Supported operation
     for (const std::string& operation : supported_single_operations) {
@@ -64,7 +64,7 @@ TEST(DynamoRequestParser, parseTableNameSingleOperation) {
   }
 
   {
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString("{\"TableName\":\"Pets\"}");
+    Json::ObjectPtr json_data = Json::Factory::loadFromString("{\"TableName\":\"Pets\"}");
     EXPECT_EQ("Pets", RequestParser::parseTable("GetItem", *json_data).table_name);
   }
 }
@@ -74,7 +74,7 @@ TEST(DynamoRequestParser, parseErrorType) {
     EXPECT_EQ(
         "ResourceNotFoundException",
         RequestParser::parseErrorType(
-            *Json::Factory::LoadFromString(
+            *Json::Factory::loadFromString(
                 "{\"__type\":\"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException\"}")));
   }
 
@@ -82,14 +82,14 @@ TEST(DynamoRequestParser, parseErrorType) {
     EXPECT_EQ(
         "ResourceNotFoundException",
         RequestParser::parseErrorType(
-            *Json::Factory::LoadFromString(
+            *Json::Factory::loadFromString(
                 "{\"__type\":\"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException\","
                 "\"message\":\"Requested resource not found: Table: tablename not found\"}")));
   }
 
   {
     EXPECT_EQ("", RequestParser::parseErrorType(
-                      *Json::Factory::LoadFromString("{\"__type\":\"UnKnownError\"}")));
+                      *Json::Factory::loadFromString("{\"__type\":\"UnKnownError\"}")));
   }
 }
 
@@ -103,7 +103,7 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchGetItem", *json_data);
     EXPECT_EQ("", table.table_name);
@@ -119,7 +119,7 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchGetItem", *json_data);
     EXPECT_EQ("table_2", table.table_name);
@@ -136,7 +136,7 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchGetItem", *json_data);
     EXPECT_EQ("", table.table_name);
@@ -152,7 +152,7 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchWriteItem", *json_data);
     EXPECT_EQ("table_2", table.table_name);
@@ -160,22 +160,22 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
   }
 
   {
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString("{}");
+    Json::ObjectPtr json_data = Json::Factory::loadFromString("{}");
     RequestParser::TableDescriptor table =
-        RequestParser::parseTable("BatchWriteItem", *Json::Factory::LoadFromString("{}"));
+        RequestParser::parseTable("BatchWriteItem", *Json::Factory::loadFromString("{}"));
     EXPECT_EQ("", table.table_name);
     EXPECT_TRUE(table.is_single_table);
   }
 
   {
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString("{\"RequestItems\":{}}");
+    Json::ObjectPtr json_data = Json::Factory::loadFromString("{\"RequestItems\":{}}");
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchWriteItem", *json_data);
     EXPECT_EQ("", table.table_name);
     EXPECT_TRUE(table.is_single_table);
   }
 
   {
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString("{}");
+    Json::ObjectPtr json_data = Json::Factory::loadFromString("{}");
     RequestParser::TableDescriptor table = RequestParser::parseTable("BatchGetItem", *json_data);
     EXPECT_EQ("", table.table_name);
     EXPECT_TRUE(table.is_single_table);
@@ -183,20 +183,20 @@ TEST(DynamoRequestParser, parseTableNameBatchOperation) {
 }
 TEST(DynamoRequestParser, parseBatchUnProcessedKeys) {
   {
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString("{}");
+    Json::ObjectPtr json_data = Json::Factory::loadFromString("{}");
     std::vector<std::string> unprocessed_tables =
         RequestParser::parseBatchUnProcessedKeys(*json_data);
     EXPECT_EQ(0u, unprocessed_tables.size());
   }
   {
     std::vector<std::string> unprocessed_tables = RequestParser::parseBatchUnProcessedKeys(
-        *Json::Factory::LoadFromString("{\"UnprocessedKeys\":{}}"));
+        *Json::Factory::loadFromString("{\"UnprocessedKeys\":{}}"));
     EXPECT_EQ(0u, unprocessed_tables.size());
   }
 
   {
     std::vector<std::string> unprocessed_tables = RequestParser::parseBatchUnProcessedKeys(
-        *Json::Factory::LoadFromString("{\"UnprocessedKeys\":{\"table_1\" :{}}}"));
+        *Json::Factory::loadFromString("{\"UnprocessedKeys\":{\"table_1\" :{}}}"));
     EXPECT_EQ("table_1", unprocessed_tables[0]);
     EXPECT_EQ(1u, unprocessed_tables.size());
   }
@@ -210,7 +210,7 @@ TEST(DynamoRequestParser, parseBatchUnProcessedKeys) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     std::vector<std::string> unprocessed_tables =
         RequestParser::parseBatchUnProcessedKeys(*json_data);
@@ -225,17 +225,17 @@ TEST(DynamoRequestParser, parseBatchUnProcessedKeys) {
 TEST(DynamoRequestParser, parsePartitionIds) {
   {
     std::vector<RequestParser::PartitionDescriptor> partitions =
-        RequestParser::parsePartitions(*Json::Factory::LoadFromString("{}"));
+        RequestParser::parsePartitions(*Json::Factory::loadFromString("{}"));
     EXPECT_EQ(0u, partitions.size());
   }
   {
     std::vector<RequestParser::PartitionDescriptor> partitions =
-        RequestParser::parsePartitions(*Json::Factory::LoadFromString("{\"ConsumedCapacity\":{}}"));
+        RequestParser::parsePartitions(*Json::Factory::loadFromString("{\"ConsumedCapacity\":{}}"));
     EXPECT_EQ(0u, partitions.size());
   }
   {
     std::vector<RequestParser::PartitionDescriptor> partitions = RequestParser::parsePartitions(
-        *Json::Factory::LoadFromString("{\"ConsumedCapacity\":{ \"Partitions\":{}}}"));
+        *Json::Factory::loadFromString("{\"ConsumedCapacity\":{ \"Partitions\":{}}}"));
     EXPECT_EQ(0u, partitions.size());
   }
   {
@@ -249,7 +249,7 @@ TEST(DynamoRequestParser, parsePartitionIds) {
       }
     }
     )EOF";
-    Json::ObjectPtr json_data = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_data = Json::Factory::loadFromString(json_string);
 
     std::vector<RequestParser::PartitionDescriptor> partitions =
         RequestParser::parsePartitions(*json_data);

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -52,7 +52,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     EXPECT_CALL(cm_, get("vpn"));
     setupRequest();
     config_ = Config::create(*loader, tls_, cm_, dispatcher_, stats_store_, random_);
@@ -99,7 +99,7 @@ TEST_F(ClientSslAuthFilterTest, NoCluster) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_CALL(cm_, get("bad_cluster")).WillOnce(Return(nullptr));
   EXPECT_THROW(Config::create(*loader, tls_, cm_, dispatcher_, stats_store_, random_),
                EnvoyException);
@@ -115,7 +115,7 @@ TEST_F(ClientSslAuthFilterTest, BadClientSslAuthConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   EXPECT_THROW(Config::create(*json_config, tls_, cm_, dispatcher_, stats_store_, random_),
                Json::Exception);
 }

--- a/test/common/filter/ratelimit_test.cc
+++ b/test/common/filter/ratelimit_test.cc
@@ -44,7 +44,7 @@ public:
     ON_CALL(runtime_.snapshot_, featureEnabled("ratelimit.tcp_filter_enforcing", 100))
         .WillByDefault(Return(true));
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     config_.reset(new Config(*config, stats_store_, runtime_));
     client_ = new MockClient();
     filter_.reset(new Instance(config_, ClientPtr{client_}));
@@ -76,7 +76,7 @@ TEST_F(RateLimitFilterTest, BadRatelimitConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   EXPECT_THROW(Config(*json_config, stats_store_, runtime_), Json::Exception);
 }
 

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -33,7 +33,7 @@ TEST(TcpProxyConfigTest, NoRouteConfig) {
     }
     )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   EXPECT_THROW(TcpProxyConfig(*config, cluster_manager,
                               cluster_manager.thread_local_cluster_.cluster_.info_->stats_store_),
@@ -54,7 +54,7 @@ TEST(TcpProxyConfigTest, NoCluster) {
     }
     )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   EXPECT_CALL(cluster_manager, get("fake_cluster")).WillOnce(Return(nullptr));
   EXPECT_THROW(TcpProxyConfig(*config, cluster_manager,
@@ -76,7 +76,7 @@ TEST(TcpProxyConfigTest, BadTcpProxyConfig) {
    }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   EXPECT_THROW(TcpProxyConfig(*json_config, cluster_manager,
                               cluster_manager.thread_local_cluster_.cluster_.info_->stats_store_),
@@ -126,7 +126,7 @@ TEST(TcpProxyConfigTest, Routes) {
     }
     )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json);
   NiceMock<Upstream::MockClusterManager> cm_;
 
   TcpProxyConfig config_obj(*json_config, cm_,
@@ -282,7 +282,7 @@ TEST(TcpProxyConfigTest, EmptyRouteConfig) {
     }
     )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json);
   NiceMock<Upstream::MockClusterManager> cm_;
 
   TcpProxyConfig config_obj(*json_config, cm_,
@@ -308,7 +308,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     config_.reset(
         new TcpProxyConfig(*config, cluster_manager_,
                            cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_));
@@ -479,7 +479,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     config_.reset(
         new TcpProxyConfig(*config, cluster_manager_,
                            cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_));

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -96,7 +96,7 @@ TEST_F(AccessLogImplTest, LogMoreData) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_));
@@ -119,7 +119,7 @@ TEST_F(AccessLogImplTest, EnvoyUpstreamServiceTime) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_));
@@ -138,7 +138,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
     }
     )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_));
@@ -159,7 +159,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
       }
       )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_));
@@ -181,7 +181,7 @@ TEST_F(AccessLogImplTest, WithFilterMiss) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
@@ -204,7 +204,7 @@ TEST_F(AccessLogImplTest, WithFilterHit) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_)).Times(3);
@@ -226,7 +226,7 @@ TEST_F(AccessLogImplTest, RuntimeFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   // Value is taken from random generator.
@@ -258,7 +258,7 @@ TEST_F(AccessLogImplTest, PathRewrite) {
       }
       )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   EXPECT_CALL(*file_, write(_));
@@ -276,7 +276,7 @@ TEST_F(AccessLogImplTest, healthCheckTrue) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   TestHeaderMapImpl header_map{};
@@ -294,7 +294,7 @@ TEST_F(AccessLogImplTest, healthCheckFalse) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   TestHeaderMapImpl header_map{};
@@ -320,7 +320,7 @@ TEST_F(AccessLogImplTest, requestTracing) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
 
   {
@@ -353,7 +353,7 @@ TEST(AccessLogImplTestCtor, FiltersMissingInOrAndFilter) {
         "filter": {"type": "logical_or"}
       }
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
     EXPECT_THROW(InstanceImpl::fromJson(*loader, runtime, log_manager), EnvoyException);
   }
@@ -365,7 +365,7 @@ TEST(AccessLogImplTestCtor, FiltersMissingInOrAndFilter) {
         "filter": {"type": "logical_and"}
       }
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
     EXPECT_THROW(InstanceImpl::fromJson(*loader, runtime, log_manager), EnvoyException);
   }
@@ -383,7 +383,7 @@ TEST_F(AccessLogImplTest, andFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
   request_info_.response_code_.value(500);
 
@@ -414,7 +414,7 @@ TEST_F(AccessLogImplTest, orFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
   request_info_.response_code_.value(500);
 
@@ -448,7 +448,7 @@ TEST_F(AccessLogImplTest, multipleOperators) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   InstanceSharedPtr log = InstanceImpl::fromJson(*loader, runtime_, log_manager_);
   request_info_.response_code_.value(500);
 
@@ -475,7 +475,7 @@ TEST(AccessLogFilterTest, DurationWithRuntimeKey) {
     }
     )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(filter_json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(filter_json);
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectPtr filter_object = loader->getObject("filter");
@@ -507,7 +507,7 @@ TEST(AccessLogFilterTest, StatusCodeWithRuntimeKey) {
     }
     )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(filter_json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(filter_json);
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectPtr filter_object = loader->getObject("filter");

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -96,7 +96,7 @@ public:
     )EOF";
 
   void SetUpTest(const std::string json) {
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     config_.reset(new FaultFilterConfig(*config, runtime_, "", stats_));
     filter_.reset(new FaultFilter(config_));
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
@@ -125,7 +125,7 @@ TEST(FaultFilterBadConfigTest, EmptyConfig) {
   )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -141,7 +141,7 @@ TEST(FaultFilterBadConfigTest, BadAbortPercent) {
   )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -156,7 +156,7 @@ TEST(FaultFilterBadConfigTest, MissingHTTPStatus) {
   )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -173,7 +173,7 @@ TEST(FaultFilterBadConfigTest, BadDelayType) {
   )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -190,7 +190,7 @@ TEST(FaultFilterBadConfigTest, BadDelayPercent) {
   )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -207,7 +207,7 @@ TEST(FaultFilterBadConfigTest, BadDelayDuration) {
    )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }
@@ -223,7 +223,7 @@ TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
    )EOF";
 
   Stats::IsolatedStoreImpl stats;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   EXPECT_THROW(FaultFilterConfig(*config, runtime, "", stats), EnvoyException);
 }

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -43,7 +43,7 @@ public:
   }
 
   void SetUpTest(const std::string json) {
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     config_.reset(new FilterConfig(*config, local_info_, stats_store_, runtime_, cm_));
 
     client_ = new ::RateLimit::MockClient();
@@ -88,7 +88,7 @@ TEST_F(HttpRateLimitFilterTest, BadConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(filter_config);
+  Json::ObjectPtr config = Json::Factory::loadFromString(filter_config);
   EXPECT_THROW(FilterConfig(*config, local_info_, stats_store_, runtime_, cm_), Json::Exception);
 }
 

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -91,18 +91,18 @@ TEST(HttpUtility, createSslRedirectPath) {
 
 TEST(HttpUtility, parseCodecOptions) {
   {
-    Json::ObjectPtr json = Json::Factory::LoadFromString("{}");
+    Json::ObjectPtr json = Json::Factory::loadFromString("{}");
     EXPECT_EQ(0UL, Utility::parseCodecOptions(*json));
   }
 
   {
     Json::ObjectPtr json =
-        Json::Factory::LoadFromString("{\"http_codec_options\": \"no_compression\"}");
+        Json::Factory::loadFromString("{\"http_codec_options\": \"no_compression\"}");
     EXPECT_EQ(CodecOptions::NoCompression, Utility::parseCodecOptions(*json));
   }
 
   {
-    Json::ObjectPtr json = Json::Factory::LoadFromString("{\"http_codec_options\": \"foo\"}");
+    Json::ObjectPtr json = Json::Factory::loadFromString("{\"http_codec_options\": \"foo\"}");
     EXPECT_THROW(Utility::parseCodecOptions(*json), EnvoyException);
   }
 }

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -28,7 +28,7 @@ std::vector<std::string> generateTestInputs() {
 class ConfigSchemasTest : public ::testing::TestWithParam<std::string> {};
 
 TEST_P(ConfigSchemasTest, CheckValidationExpectation) {
-  ObjectPtr json = Factory::LoadFromFile(GetParam());
+  ObjectPtr json = Factory::loadFromFile(GetParam());
 
   // lookup schema in test input
   std::string schema, schema_name{json->getString("schema")};

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -8,11 +8,11 @@
 namespace Json {
 
 TEST(JsonLoaderTest, Basic) {
-  EXPECT_THROW(Factory::LoadFromFile("bad_file"), Exception);
-  EXPECT_THROW(Factory::LoadFromString("{"), Exception);
+  EXPECT_THROW(Factory::loadFromFile("bad_file"), Exception);
+  EXPECT_THROW(Factory::loadFromString("{"), Exception);
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"hello\":123}");
+    ObjectPtr json = Factory::loadFromString("{\"hello\":123}");
     EXPECT_TRUE(json->hasObject("hello"));
     EXPECT_FALSE(json->hasObject("world"));
     EXPECT_FALSE(json->empty());
@@ -23,31 +23,31 @@ TEST(JsonLoaderTest, Basic) {
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"hello\":\"123\"}");
+    ObjectPtr json = Factory::loadFromString("{\"hello\":\"123\"}");
     EXPECT_THROW(json->getInteger("hello"), Exception);
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"hello\":true}");
+    ObjectPtr json = Factory::loadFromString("{\"hello\":true}");
     EXPECT_TRUE(json->getBoolean("hello"));
     EXPECT_TRUE(json->getBoolean("hello", false));
     EXPECT_FALSE(json->getBoolean("world", false));
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"hello\": [\"a\", \"b\", 3]}");
+    ObjectPtr json = Factory::loadFromString("{\"hello\": [\"a\", \"b\", 3]}");
     EXPECT_THROW(json->getStringArray("hello"), Exception);
     EXPECT_THROW(json->getStringArray("world"), Exception);
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"hello\":123}");
+    ObjectPtr json = Factory::loadFromString("{\"hello\":123}");
     EXPECT_EQ(123, json->getInteger("hello", 456));
     EXPECT_EQ(456, json->getInteger("world", 456));
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"1\":{\"11\":\"111\"},\"2\":{\"22\":\"222\"}}");
+    ObjectPtr json = Factory::loadFromString("{\"1\":{\"11\":\"111\"},\"2\":{\"22\":\"222\"}}");
     int pos = 0;
     json->iterate([&pos](const std::string& key, const Json::Object& value) {
       EXPECT_TRUE(key == "1" || key == "2");
@@ -66,7 +66,7 @@ TEST(JsonLoaderTest, Basic) {
   }
 
   {
-    ObjectPtr json = Factory::LoadFromString("{\"1\":{\"11\":\"111\"},\"2\":{\"22\":\"222\"}}");
+    ObjectPtr json = Factory::loadFromString("{\"1\":{\"11\":\"111\"},\"2\":{\"22\":\"222\"}}");
     int pos = 0;
     json->iterate([&pos](const std::string& key, const Json::Object& value) {
       EXPECT_TRUE(key == "1" || key == "2");
@@ -94,9 +94,8 @@ TEST(JsonLoaderTest, Basic) {
     }
     )EOF";
 
-    ObjectPtr config = Factory::LoadFromString(json);
+    ObjectPtr config = Factory::loadFromString(json);
     EXPECT_EQ(2U, config->getObjectArray("descriptors")[0]->asObjectArray().size());
-
     EXPECT_EQ(1U, config->getObjectArray("descriptors")[1]->asObjectArray().size());
   }
 
@@ -107,7 +106,7 @@ TEST(JsonLoaderTest, Basic) {
     }
     )EOF";
 
-    ObjectPtr config = Factory::LoadFromString(json);
+    ObjectPtr config = Factory::loadFromString(json);
     std::vector<ObjectPtr> array = config->getObjectArray("descriptors");
     EXPECT_THROW(array[0]->asObjectArray(), Exception);
   }
@@ -118,7 +117,7 @@ TEST(JsonLoaderTest, Basic) {
     }
     )EOF";
 
-    ObjectPtr config = Factory::LoadFromString(json);
+    ObjectPtr config = Factory::loadFromString(json);
     ObjectPtr object = config->getObject("foo", true);
     EXPECT_EQ(2, object->getInteger("bar", 2));
     EXPECT_TRUE(object->empty());
@@ -128,39 +127,39 @@ TEST(JsonLoaderTest, Basic) {
 TEST(JsonLoaderTest, Integer) {
   {
     ObjectPtr json =
-        Factory::LoadFromString("{\"max\":9223372036854775807, \"min\":-9223372036854775808}");
+        Factory::loadFromString("{\"max\":9223372036854775807, \"min\":-9223372036854775808}");
     EXPECT_EQ(std::numeric_limits<int64_t>::max(), json->getInteger("max"));
     EXPECT_EQ(std::numeric_limits<int64_t>::min(), json->getInteger("min"));
   }
   {
-    ObjectPtr json_max = Factory::LoadFromString("{\"val\":9223372036854775808}");
+    ObjectPtr json_max = Factory::loadFromString("{\"val\":9223372036854775808}");
     EXPECT_THROW(json_max->getInteger("val"), Exception);
-    ObjectPtr json_min = Factory::LoadFromString("{\"val\":-9223372036854775809}");
+    ObjectPtr json_min = Factory::loadFromString("{\"val\":-9223372036854775809}");
     EXPECT_THROW(json_min->getInteger("val"), Exception);
   }
 }
 
 TEST(JsonLoaderTest, Double) {
   {
-    ObjectPtr json = Factory::LoadFromString("{\"value1\": 10.5, \"value2\": -12.3}");
+    ObjectPtr json = Factory::loadFromString("{\"value1\": 10.5, \"value2\": -12.3}");
     EXPECT_EQ(10.5, json->getDouble("value1"));
     EXPECT_EQ(-12.3, json->getDouble("value2"));
   }
   {
-    ObjectPtr json = Factory::LoadFromString("{\"foo\": 13.22}");
+    ObjectPtr json = Factory::loadFromString("{\"foo\": 13.22}");
     EXPECT_EQ(13.22, json->getDouble("foo", 0));
     EXPECT_EQ(0, json->getDouble("bar", 0));
   }
   {
-    ObjectPtr json = Factory::LoadFromString("{\"foo\": \"bar\"}");
+    ObjectPtr json = Factory::loadFromString("{\"foo\": \"bar\"}");
     EXPECT_THROW(json->getDouble("foo"), Exception);
   }
 }
 
 TEST(JsonLoaderTest, Hash) {
-  ObjectPtr json1 = Factory::LoadFromString("{\"value1\": 10.5, \"value2\": -12.3}");
-  ObjectPtr json2 = Factory::LoadFromString("{\"value2\": -12.3, \"value1\": 10.5}");
-  ObjectPtr json3 = Factory::LoadFromString("  {  \"value2\":  -12.3, \"value1\":  10.5} ");
+  ObjectPtr json1 = Factory::loadFromString("{\"value1\": 10.5, \"value2\": -12.3}");
+  ObjectPtr json2 = Factory::loadFromString("{\"value2\": -12.3, \"value1\": 10.5}");
+  ObjectPtr json3 = Factory::loadFromString("  {  \"value2\":  -12.3, \"value1\":  10.5} ");
   EXPECT_NE(json1->hash(), json2->hash());
   EXPECT_EQ(json2->hash(), json3->hash());
 }
@@ -206,7 +205,7 @@ TEST(JsonLoaderTest, Schema) {
   }
   )EOF";
 
-  ObjectPtr json = Factory::LoadFromString(json_string);
+  ObjectPtr json = Factory::loadFromString(json_string);
 
   EXPECT_THROW(json->validateSchema(invalid_json_schema), std::invalid_argument);
   EXPECT_THROW(json->validateSchema(invalid_schema), Exception);
@@ -215,7 +214,7 @@ TEST(JsonLoaderTest, Schema) {
 }
 
 TEST(JsonLoaderTest, AsString) {
-  ObjectPtr json = Factory::LoadFromString("{\"name1\": \"value1\", \"name2\": true}");
+  ObjectPtr json = Factory::loadFromString("{\"name1\": \"value1\", \"name2\": true}");
   json->iterate([&](const std::string& key, const Json::Object& value) {
     EXPECT_TRUE(key == "name1" || key == "name2");
 
@@ -231,14 +230,14 @@ TEST(JsonLoaderTest, AsString) {
 TEST(JsonLoaderTest, ListAsString) {
   {
     std::list<std::string> list = {};
-    Json::ObjectPtr json = Json::Factory::LoadFromString(Json::Factory::listAsJsonString(list));
+    Json::ObjectPtr json = Json::Factory::loadFromString(Json::Factory::listAsJsonString(list));
     std::vector<Json::ObjectPtr> output = json->asObjectArray();
     EXPECT_TRUE(output.empty());
   }
 
   {
     std::list<std::string> list = {"one"};
-    Json::ObjectPtr json = Json::Factory::LoadFromString(Json::Factory::listAsJsonString(list));
+    Json::ObjectPtr json = Json::Factory::loadFromString(Json::Factory::listAsJsonString(list));
     std::vector<Json::ObjectPtr> output = json->asObjectArray();
     EXPECT_EQ(1, output.size());
     EXPECT_EQ("one", output[0]->asString());
@@ -246,7 +245,7 @@ TEST(JsonLoaderTest, ListAsString) {
 
   {
     std::list<std::string> list = {"one", "two", "three", "four"};
-    Json::ObjectPtr json = Json::Factory::LoadFromString(Json::Factory::listAsJsonString(list));
+    Json::ObjectPtr json = Json::Factory::loadFromString(Json::Factory::listAsJsonString(list));
     std::vector<Json::ObjectPtr> output = json->asObjectArray();
     EXPECT_EQ(4, output.size());
     EXPECT_EQ("one", output[0]->asString());
@@ -257,7 +256,7 @@ TEST(JsonLoaderTest, ListAsString) {
 
   {
     std::list<std::string> list = {"127.0.0.1:46465", "127.0.0.1:52211", "127.0.0.1:58941"};
-    Json::ObjectPtr json = Json::Factory::LoadFromString(Json::Factory::listAsJsonString(list));
+    Json::ObjectPtr json = Json::Factory::loadFromString(Json::Factory::listAsJsonString(list));
     std::vector<Json::ObjectPtr> output = json->asObjectArray();
     EXPECT_EQ(3, output.size());
     EXPECT_EQ("127.0.0.1:46465", output[0]->asString());

--- a/test/common/mongo/codec_impl_test.cc
+++ b/test/common/mongo/codec_impl_test.cc
@@ -99,10 +99,10 @@ TEST_F(MongoCodecImplTest, Query) {
   query2.query(Bson::DocumentImpl::create()->addString("string2", "string2_value"));
   query2.returnFieldsSelector(Bson::DocumentImpl::create()->addDouble("double2", -2.3));
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query.toString(false)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query2.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query2.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query2.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query2.toString(false)));
 
   encoder_.encodeQuery(query);
   encoder_.encodeQuery(query2);
@@ -146,8 +146,8 @@ TEST_F(MongoCodecImplTest, Reply) {
   reply.documents().push_back(Bson::DocumentImpl::create());
   reply.documents().push_back(Bson::DocumentImpl::create());
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(reply.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(reply.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(reply.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(reply.toString(false)));
 
   encoder_.encodeReply(reply);
   EXPECT_CALL(callbacks_, decodeReply_(Pointee(Eq(reply))));
@@ -176,8 +176,8 @@ TEST_F(MongoCodecImplTest, GetMore) {
   get_more.numberToReturn(20);
   get_more.cursorId(20000);
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(get_more.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(get_more.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(get_more.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(get_more.toString(false)));
 
   encoder_.encodeGetMore(get_more);
   EXPECT_CALL(callbacks_, decodeGetMore_(Pointee(Eq(get_more))));
@@ -217,8 +217,8 @@ TEST_F(MongoCodecImplTest, Insert) {
   insert.documents().push_back(Bson::DocumentImpl::create());
   insert.documents().push_back(Bson::DocumentImpl::create());
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(insert.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(insert.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(insert.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(insert.toString(false)));
 
   encoder_.encodeInsert(insert);
   EXPECT_CALL(callbacks_, decodeInsert_(Pointee(Eq(insert))));
@@ -256,8 +256,8 @@ TEST_F(MongoCodecImplTest, KillCursors) {
   kill.numberOfCursorIds(2);
   kill.cursorIds({20000, 40000});
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(kill.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(kill.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(kill.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(kill.toString(false)));
 
   encoder_.encodeKillCursors(kill);
   EXPECT_CALL(callbacks_, decodeKillCursors_(Pointee(Eq(kill))));
@@ -326,8 +326,8 @@ TEST_F(MongoCodecImplTest, QueryToStringWithEscape) {
       R"EOF({"string_need_esc": "{\"foo\": \"bar\n\"}"}, "fields": {}})EOF",
       query.toString(true));
 
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query.toString(true)));
-  EXPECT_NO_THROW(Json::Factory::LoadFromString(query.toString(false)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query.toString(true)));
+  EXPECT_NO_THROW(Json::Factory::loadFromString(query.toString(false)));
 }
 
 } // Mongo

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -116,7 +116,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   ON_CALL(runtime.snapshot_, featureEnabled("ratelimit.tcp_filter_enforcing", 100))
       .WillByDefault(Return(true));
 
-  Json::ObjectPtr rl_config_loader = Json::Factory::LoadFromString(rl_json);
+  Json::ObjectPtr rl_config_loader = Json::Factory::loadFromString(rl_json);
 
   RateLimit::TcpFilter::ConfigSharedPtr rl_config(
       new RateLimit::TcpFilter::Config(*rl_config_loader, stats_store, runtime));
@@ -137,7 +137,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
     }
     )EOF";
 
-  Json::ObjectPtr tcp_proxy_config_loader = Json::Factory::LoadFromString(tcp_proxy_json);
+  Json::ObjectPtr tcp_proxy_config_loader = Json::Factory::loadFromString(tcp_proxy_json);
   ::Filter::TcpProxyConfigSharedPtr tcp_proxy_config(
       new ::Filter::TcpProxyConfig(*tcp_proxy_config_loader, cm, stats_store));
   manager.addReadFilter(ReadFilterSharedPtr{new ::Filter::TcpProxy(tcp_proxy_config, cm)});

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -20,7 +20,7 @@ TEST(IpListTest, Errors) {
     }
     )EOF";
 
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     EXPECT_THROW({ IpList wl(*loader, "ip_white_list"); }, EnvoyException);
   }
 
@@ -31,7 +31,7 @@ TEST(IpListTest, Errors) {
     }
     )EOF";
 
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     EXPECT_THROW({ IpList wl(*loader, "ip_white_list"); }, EnvoyException);
   }
 
@@ -42,7 +42,7 @@ TEST(IpListTest, Errors) {
     }
     )EOF";
 
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     EXPECT_THROW({ IpList wl(*loader, "ip_white_list"); }, EnvoyException);
   }
 
@@ -53,7 +53,7 @@ TEST(IpListTest, Errors) {
     }
     )EOF";
 
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     EXPECT_THROW({ IpList wl(*loader, "ip_white_list"); }, EnvoyException);
   }
 }
@@ -69,7 +69,7 @@ TEST(IpListTest, Normal) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   IpList wl(*loader, "ip_white_list");
 
   EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.0")));
@@ -100,7 +100,7 @@ TEST(IpListTest, MatchAny) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   IpList wl(*loader, "ip_white_list");
 
   EXPECT_TRUE(wl.contains(Address::Ipv4Instance("192.168.3.3")));

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -130,7 +130,7 @@ TEST(RateLimitGrpcFactoryTest, NoCluster) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   Upstream::MockClusterManager cm;
 
   EXPECT_CALL(cm, get("foo")).WillOnce(Return(nullptr));
@@ -144,7 +144,7 @@ TEST(RateLimitGrpcFactoryTest, Create) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   Upstream::MockClusterManager cm;
 
   EXPECT_CALL(cm, get("foo")).Times(AtLeast(1));

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -52,7 +52,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
     config_.reset(new ConfigImpl(*json_config));
 
     upstream_connection_ = new NiceMock<Network::MockClientConnection>();
@@ -318,7 +318,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
 
   ClientFactoryImpl factory;
   Upstream::MockHost::MockCreateConnectionData conn_info;
@@ -340,7 +340,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
     conn_pool_.reset(new InstanceImpl(cluster_name_, cm_, *this, tls_, *json_config));
   }
 

--- a/test/common/redis/proxy_filter_test.cc
+++ b/test/common/redis/proxy_filter_test.cc
@@ -34,7 +34,7 @@ TEST(RedisProxyFilterConfigTest, Normal) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Upstream::MockClusterManager> cm;
   Stats::IsolatedStoreImpl store;
   ProxyFilterConfig config(*json_config, cm, store);
@@ -50,7 +50,7 @@ TEST(RedisProxyFilterConfigTest, InvalidCluster) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Upstream::MockClusterManager> cm;
   Stats::IsolatedStoreImpl store;
   EXPECT_CALL(cm, get("fake_cluster")).WillOnce(Return(nullptr));
@@ -65,7 +65,7 @@ TEST(RedisProxyFilterConfigTest, BadRedisProxyConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<Upstream::MockClusterManager> cm;
   Stats::IsolatedStoreImpl store;
   EXPECT_THROW(ProxyFilterConfig(*json_config, cm, store), Json::Exception);
@@ -82,7 +82,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+    Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
     NiceMock<Upstream::MockClusterManager> cm;
     config_.reset(new ProxyFilterConfig(*json_config, cm, store_));
     filter_.reset(new ProxyFilter(*this, EncoderPtr{encoder_}, splitter_, config_));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -161,7 +161,7 @@ TEST(RouteMatcherTest, TestRoutes) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -442,7 +442,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -523,7 +523,7 @@ TEST(RouteMatcherTest, Priority) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -568,7 +568,7 @@ TEST(RouteMatcherTest, NoHostRewriteAndAutoRewrite) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -628,7 +628,7 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -708,7 +708,7 @@ TEST(RouterMatcherTest, HashPolicy) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -756,7 +756,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -814,7 +814,7 @@ TEST(RouteMatcherTest, ContentType) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -865,7 +865,7 @@ TEST(RouteMatcherTest, Runtime) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   Runtime::MockSnapshot snapshot;
@@ -906,7 +906,7 @@ TEST(RouteMatcherTest, ShadowClusterNotFound) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_CALL(cm, get("www2")).WillRepeatedly(Return(&cm.thread_local_cluster_));
@@ -933,7 +933,7 @@ TEST(RouteMatcherTest, ClusterNotFound) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_CALL(cm, get("www2")).WillRepeatedly(Return(nullptr));
@@ -959,7 +959,7 @@ TEST(RouteMatcherTest, ClusterNotFoundNotChecking) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_CALL(cm, get("www2")).WillRepeatedly(Return(nullptr));
@@ -1000,7 +1000,7 @@ TEST(RouteMatcherTest, Shadow) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1069,7 +1069,7 @@ TEST(RouteMatcherTest, Retry) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1150,7 +1150,7 @@ TEST(RouteMatcherTest, TestBadDefaultConfig) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
@@ -1184,7 +1184,7 @@ TEST(RouteMatcherTest, TestDuplicateDomainConfig) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
@@ -1250,7 +1250,7 @@ TEST(RouteMatcherTest, Redirect) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1322,7 +1322,7 @@ TEST(RouteMatcherTest, ExclusiveRouteEntryOrRedirectEntry) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1370,7 +1370,7 @@ TEST(RouteMatcherTest, ExclusiveWeightedClustersEntryOrRedirectEntry) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1430,7 +1430,7 @@ TEST(RouteMatcherTest, WeightedClusters) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1509,7 +1509,7 @@ TEST(RouteMatcherTest, ExclusiveWeightedClustersOrClusterConfig) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -1535,7 +1535,7 @@ TEST(RouteMatcherTest, WeightedClustersMissingClusterList) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -1562,7 +1562,7 @@ TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -1592,7 +1592,7 @@ TEST(RouteMatcherTest, WeightedClustersSumOFWeightsNotEqualToMax) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -1622,7 +1622,7 @@ TEST(RouteMatcherTest, TestWeightedClusterWithMissingWeights) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW(ConfigImpl(*loader, runtime, cm, true), EnvoyException);
@@ -1652,7 +1652,7 @@ TEST(RouteMatcherTest, TestWeightedClusterInvalidClusterName) {
 }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_CALL(cm, get("cluster1")).WillRepeatedly(Return(&cm.thread_local_cluster_));
@@ -1691,7 +1691,7 @@ TEST(BadHttpRouteConfigurationsTest, BadRouteConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
 
@@ -1719,7 +1719,7 @@ TEST(BadHttpRouteConfigurationsTest, BadVirtualHostConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
 
@@ -1745,7 +1745,7 @@ TEST(BadHttpRouteConfigurationsTest, BadRouteEntryConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
 
@@ -1771,7 +1771,7 @@ TEST(BadHttpRouteConfigurationsTest, BadRouteEntryConfigPrefixAndPath) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
 
@@ -1801,7 +1801,7 @@ TEST(RouteMatcherTest, TestOpaqueConfig) {
 }
 )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(*loader, runtime, cm, true);
@@ -1837,7 +1837,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
@@ -1872,7 +1872,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   }
   )EOF";
 
-  loader = Json::Factory::LoadFromString(json);
+  loader = Json::Factory::loadFromString(json);
   config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
   EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 
@@ -1903,7 +1903,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   }
   )EOF";
 
-  loader = Json::Factory::LoadFromString(json);
+  loader = Json::Factory::loadFromString(json);
   config_ptr.reset(new ConfigImpl(*loader, runtime, cm, true));
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -39,7 +39,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
 
     interval_timer_ = new Event::MockTimer(&dispatcher_);
     EXPECT_CALL(init_manager_, registerTarget(_));
@@ -87,7 +87,7 @@ TEST_F(RdsImplTest, RdsAndStatic) {
     }
     )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
   EXPECT_THROW(RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,
                                                local_info_, store_, "foo.", tls_, init_manager_),
                EnvoyException);
@@ -103,7 +103,7 @@ TEST_F(RdsImplTest, LocalInfoNotDefined) {
     }
     )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
   local_info_.cluster_name_ = "";
   local_info_.node_name_ = "";
   interval_timer_ = new Event::MockTimer(&dispatcher_);
@@ -122,7 +122,7 @@ TEST_F(RdsImplTest, UnknownCluster) {
     }
     )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
   ON_CALL(cm_, get("foo_cluster")).WillByDefault(Return(nullptr));
   interval_timer_ = new Event::MockTimer(&dispatcher_);
   EXPECT_THROW(RouteConfigProviderUtil::create(*config, runtime_, cm_, dispatcher_, random_,

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -30,7 +30,7 @@ TEST(BadRateLimitConfiguration, MissingActions) {
 }
 )EOF";
 
-  EXPECT_THROW(RateLimitPolicyImpl(*Json::Factory::LoadFromString(json)), EnvoyException);
+  EXPECT_THROW(RateLimitPolicyImpl(*Json::Factory::loadFromString(json)), EnvoyException);
 }
 
 TEST(BadRateLimitConfiguration, BadType) {
@@ -44,7 +44,7 @@ TEST(BadRateLimitConfiguration, BadType) {
   }
   )EOF";
 
-  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::LoadFromString(json)), EnvoyException);
+  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::loadFromString(json)), EnvoyException);
 }
 
 TEST(BadRateLimitConfiguration, ActionsMissingRequiredFields) {
@@ -58,7 +58,7 @@ TEST(BadRateLimitConfiguration, ActionsMissingRequiredFields) {
   }
   )EOF";
 
-  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::LoadFromString(json_one)), EnvoyException);
+  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::loadFromString(json_one)), EnvoyException);
 
   std::string json_two = R"EOF(
   {
@@ -71,7 +71,7 @@ TEST(BadRateLimitConfiguration, ActionsMissingRequiredFields) {
   }
   )EOF";
 
-  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::LoadFromString(json_two)), EnvoyException);
+  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::loadFromString(json_two)), EnvoyException);
 
   std::string json_three = R"EOF(
   {
@@ -84,7 +84,7 @@ TEST(BadRateLimitConfiguration, ActionsMissingRequiredFields) {
   }
   )EOF";
 
-  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::LoadFromString(json_three)),
+  EXPECT_THROW(RateLimitPolicyEntryImpl(*Json::Factory::loadFromString(json_three)),
                EnvoyException);
 }
 
@@ -96,7 +96,7 @@ static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::st
 class RateLimitConfiguration : public testing::Test {
 public:
   void SetUpTest(const std::string json) {
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     config_.reset(new ConfigImpl(*loader, runtime_, cm_, true));
   }
 
@@ -337,7 +337,7 @@ TEST_F(RateLimitConfiguration, Stages) {
 class RateLimitPolicyEntryTest : public testing::Test {
 public:
   void SetUpTest(const std::string json) {
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(json);
     rate_limit_entry_.reset(new RateLimitPolicyEntryImpl(*loader));
     descriptors_.clear();
   }

--- a/test/common/tracing/lightstep_tracer_impl_test.cc
+++ b/test/common/tracing/lightstep_tracer_impl_test.cc
@@ -59,7 +59,7 @@ public:
     std::string valid_config = R"EOF(
       {"collector_cluster": "fake_cluster"}
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(valid_config);
 
     setup(*loader, true);
   }
@@ -86,14 +86,14 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     std::string invalid_config = R"EOF(
       {"fake" : "fake"}
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(invalid_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(invalid_config);
 
     EXPECT_THROW(setup(*loader, false), EnvoyException);
   }
 
   {
     std::string empty_config = "{}";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(empty_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(empty_config);
 
     EXPECT_THROW(setup(*loader, false), EnvoyException);
   }
@@ -105,7 +105,7 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     std::string valid_config = R"EOF(
       {"collector_cluster": "fake_cluster"}
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(valid_config);
 
     EXPECT_THROW(setup(*loader, false), EnvoyException);
   }
@@ -118,7 +118,7 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     std::string valid_config = R"EOF(
       {"collector_cluster": "fake_cluster"}
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(valid_config);
 
     EXPECT_THROW(setup(*loader, false), EnvoyException);
   }
@@ -131,7 +131,7 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     std::string valid_config = R"EOF(
       {"collector_cluster": "fake_cluster"}
     )EOF";
-    Json::ObjectPtr loader = Json::Factory::LoadFromString(valid_config);
+    Json::ObjectPtr loader = Json::Factory::loadFromString(valid_config);
 
     setup(*loader, true);
   }

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -37,7 +37,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
     cds_ = CdsApiImpl::create(*config, cm_, dispatcher_, random_, local_info_, store_);
     cds_->setInitializedCb([this]() -> void { initialized_.ready(); });
 
@@ -99,7 +99,7 @@ TEST_F(CdsApiImplTest, InvalidOptions) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(config_json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(config_json);
   local_info_.cluster_name_ = "";
   local_info_.node_name_ = "";
   EXPECT_THROW(CdsApiImpl::create(*config, cm_, dispatcher_, random_, local_info_, store_),

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -102,7 +102,7 @@ TEST_F(ClusterManagerImplTest, OutlierEventLog) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_CALL(log_manager_, createAccessLog("foo"));
   create(*loader);
 }
@@ -120,7 +120,7 @@ TEST_F(ClusterManagerImplTest, NoSdsConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
@@ -137,7 +137,7 @@ TEST_F(ClusterManagerImplTest, UnknownClusterType) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
@@ -163,7 +163,7 @@ TEST_F(ClusterManagerImplTest, LocalClusterNotDefined) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
@@ -178,7 +178,7 @@ TEST_F(ClusterManagerImplTest, BadClusterManagerConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), Json::Exception);
 }
 
@@ -211,7 +211,7 @@ TEST_F(ClusterManagerImplTest, LocalClusterDefined) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
 
   EXPECT_EQ(3UL, factory_.stats_.counter("cluster_manager.cluster_added").value());
@@ -241,7 +241,7 @@ TEST_F(ClusterManagerImplTest, DuplicateCluster) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
@@ -262,7 +262,7 @@ TEST_F(ClusterManagerImplTest, UnknownHcType) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(create(*loader), EnvoyException);
 }
 
@@ -276,7 +276,7 @@ TEST_F(ClusterManagerImplTest, MaxClusterName) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW_WITH_MESSAGE(create(*loader), Json::Exception,
                             "JSON object doesn't conform to schema.\n Invalid schema: "
                             "#/properties/name.\n Invalid keyword: maxLength.\n Invalid document "
@@ -293,7 +293,7 @@ TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW_WITH_MESSAGE(create(*loader), Json::Exception,
                             "JSON object doesn't conform to schema.\n Invalid schema: "
                             "#/properties/name.\n Invalid keyword: pattern.\n Invalid document "
@@ -327,7 +327,7 @@ TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   EXPECT_CALL(factory_.dispatcher_, createClientConnection_(PointeesEq(Network::Utility::resolveUrl(
                                         "tcp://127.0.0.1:11001")))).WillOnce(Return(connection));
@@ -349,7 +349,7 @@ TEST_F(ClusterManagerImplTest, UnknownCluster) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
   EXPECT_EQ(nullptr, cluster_manager_->get("hello"));
   EXPECT_EQ(nullptr,
@@ -377,7 +377,7 @@ TEST_F(ClusterManagerImplTest, VerifyBufferLimits) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   EXPECT_CALL(*connection, setReadBufferLimit(8192));
@@ -401,7 +401,7 @@ TEST_F(ClusterManagerImplTest, ShutdownOrder) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
   const Cluster& cluster = cluster_manager_->clusters().begin()->second;
   EXPECT_EQ("cluster_1", cluster.info()->name());
@@ -457,7 +457,7 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster2));
   ON_CALL(*cluster2, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
 
   ReadyWatcher initialized;
@@ -484,7 +484,7 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
   }
   )EOF";
 
-  Json::ObjectPtr loader_api = Json::Factory::LoadFromString(json_api);
+  Json::ObjectPtr loader_api = Json::Factory::loadFromString(json_api);
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster3));
   ON_CALL(*cluster3, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   cluster_manager_->addOrUpdatePrimaryCluster(*loader_api);
@@ -495,7 +495,7 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
   }
   )EOF";
 
-  loader_api = Json::Factory::LoadFromString(json_api);
+  loader_api = Json::Factory::loadFromString(json_api);
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster4));
   ON_CALL(*cluster4, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(*cluster4, initialize());
@@ -507,7 +507,7 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
   }
   )EOF";
 
-  loader_api = Json::Factory::LoadFromString(json_api);
+  loader_api = Json::Factory::loadFromString(json_api);
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster5));
   ON_CALL(*cluster5, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
   cluster_manager_->addOrUpdatePrimaryCluster(*loader_api);
@@ -533,7 +533,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
 
   InSequence s;
@@ -547,7 +547,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   }
   )EOF";
 
-  Json::ObjectPtr loader_api = Json::Factory::LoadFromString(json_api);
+  Json::ObjectPtr loader_api = Json::Factory::loadFromString(json_api);
   MockCluster* cluster1 = new NiceMock<MockCluster>();
   EXPECT_CALL(factory_, clusterFromJson_(_, _, _, _)).WillOnce(Return(cluster1));
   EXPECT_CALL(*cluster1, initializePhase()).Times(0);
@@ -564,7 +564,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   }
   )EOF";
 
-  loader_api = Json::Factory::LoadFromString(json_api_2);
+  loader_api = Json::Factory::loadFromString(json_api_2);
   EXPECT_FALSE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
 
   // Now do it again with a different hash.
@@ -575,7 +575,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   }
   )EOF";
 
-  loader_api = Json::Factory::LoadFromString(json_api_3);
+  loader_api = Json::Factory::loadFromString(json_api_3);
   MockCluster* cluster2 = new NiceMock<MockCluster>();
   cluster2->hosts_ = {HostSharedPtr{new HostImpl(
       cluster2->info_, "", Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, "")}};
@@ -625,7 +625,7 @@ TEST_F(ClusterManagerImplTest, AddOrUpdatePrimaryClusterStaticExists) {
   ON_CALL(*cluster1, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Primary));
   EXPECT_CALL(*cluster1, initialize());
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   create(*loader);
 
   ReadyWatcher initialized;
@@ -640,7 +640,7 @@ TEST_F(ClusterManagerImplTest, AddOrUpdatePrimaryClusterStaticExists) {
   }
   )EOF";
 
-  Json::ObjectPtr loader_api = Json::Factory::LoadFromString(json_api);
+  Json::ObjectPtr loader_api = Json::Factory::loadFromString(json_api);
   EXPECT_FALSE(cluster_manager_->addOrUpdatePrimaryCluster(*loader_api));
 
   // Attempt to remove a static cluster.
@@ -663,7 +663,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   Network::DnsResolver::ResolveCb dns_callback;
   Event::MockTimer* dns_timer_ = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -72,7 +72,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     health_checker_.reset(
         new TestHttpHealthCheckerImpl(*cluster_, *config, dispatcher_, runtime_, random_));
     health_checker_->addHostCheckCompleteCb([this](HostSharedPtr host, bool changed_state)
@@ -93,7 +93,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     health_checker_.reset(
         new TestHttpHealthCheckerImpl(*cluster_, *config, dispatcher_, runtime_, random_));
     health_checker_->addHostCheckCompleteCb([this](HostSharedPtr host, bool changed_state)
@@ -516,7 +516,7 @@ TEST(TcpHealthCheckMatcher, loadJsonBytes) {
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     TcpHealthCheckMatcher::MatchSegments segments =
         TcpHealthCheckMatcher::loadJsonBytes(config->getObjectArray("bytes"));
     EXPECT_EQ(2U, segments.size());
@@ -531,7 +531,7 @@ TEST(TcpHealthCheckMatcher, loadJsonBytes) {
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     EXPECT_THROW(TcpHealthCheckMatcher::loadJsonBytes(config->getObjectArray("bytes")),
                  EnvoyException);
   }
@@ -545,7 +545,7 @@ TEST(TcpHealthCheckMatcher, loadJsonBytes) {
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     EXPECT_THROW(TcpHealthCheckMatcher::loadJsonBytes(config->getObjectArray("bytes")),
                  EnvoyException);
   }
@@ -565,7 +565,7 @@ TEST(TcpHealthCheckMatcher, match) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   TcpHealthCheckMatcher::MatchSegments segments =
       TcpHealthCheckMatcher::loadJsonBytes(config->getObjectArray("bytes"));
 
@@ -609,7 +609,7 @@ public:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     health_checker_.reset(
         new TcpHealthCheckerImpl(*cluster_, *config, dispatcher_, runtime_, random_));
   }

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -25,7 +25,7 @@ namespace Upstream {
 class LogicalDnsClusterTest : public testing::Test {
 public:
   void setup(const std::string& json) {
-    Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+    Json::ObjectPtr config = Json::Factory::loadFromString(json);
     resolve_timer_ = new Event::MockTimer(&dispatcher_);
     cluster_.reset(new LogicalDnsCluster(*config, runtime_, stats_store_, ssl_context_manager_,
                                          dns_resolver_, tls_, dispatcher_));

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -29,7 +29,7 @@ namespace Upstream {
 namespace Outlier {
 
 TEST(OutlierDetectorImplFactoryTest, NoDetector) {
-  Json::ObjectPtr loader = Json::Factory::LoadFromString("{}");
+  Json::ObjectPtr loader = Json::Factory::loadFromString("{}");
   NiceMock<MockCluster> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
@@ -44,7 +44,7 @@ TEST(OutlierDetectorImplFactoryTest, Detector) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   NiceMock<MockCluster> cluster;
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Runtime::MockLoader> runtime;
@@ -85,7 +85,7 @@ public:
   CallbackChecker checker_;
   MockMonotonicTimeSource time_source_;
   std::shared_ptr<MockEventLogger> event_logger_{new MockEventLogger()};
-  Json::ObjectPtr loader_ = Json::Factory::LoadFromString("{}");
+  Json::ObjectPtr loader_ = Json::Factory::loadFromString("{}");
 };
 
 TEST_F(OutlierDetectorImplTest, DetectorStaticConfig) {
@@ -103,7 +103,7 @@ TEST_F(OutlierDetectorImplTest, DetectorStaticConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr custom_config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr custom_config = Json::Factory::loadFromString(json);
   EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(100)));
   std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(
       cluster_, *custom_config, dispatcher_, runtime_, time_source_, event_logger_));
@@ -538,7 +538,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
                            "\"eject\", \"type\": \"5xx\", \"num_ejections\": \"0\", "
                            "\"enforced\": \"true\"}\n")).WillOnce(SaveArg<0>(&log1));
   event_logger.logEject(host, detector, EjectionType::Consecutive5xx, true);
-  Json::Factory::LoadFromString(log1);
+  Json::Factory::loadFromString(log1);
 
   std::string log2;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
@@ -547,7 +547,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
                            "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
                            "\"num_ejections\": 0}\n")).WillOnce(SaveArg<0>(&log2));
   event_logger.logUneject(host);
-  Json::Factory::LoadFromString(log2);
+  Json::Factory::loadFromString(log2);
 
   // now test with time since last action.
   time.value(time_source.currentTime() - std::chrono::seconds(30));
@@ -567,7 +567,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
                            "\"-1\", \"cluster_success_rate_ejection_threshold\": \"-1\""
                            "}\n")).WillOnce(SaveArg<0>(&log3));
   event_logger.logEject(host, detector, EjectionType::SuccessRate, false);
-  Json::Factory::LoadFromString(log3);
+  Json::Factory::loadFromString(log3);
 
   std::string log4;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
@@ -576,7 +576,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
                            "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
                            "\"num_ejections\": 0}\n")).WillOnce(SaveArg<0>(&log4));
   event_logger.logUneject(host);
-  Json::Factory::LoadFromString(log4);
+  Json::Factory::loadFromString(log4);
 }
 
 TEST(OutlierUtility, SRThreshold) {

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -44,7 +44,7 @@ protected:
     }
     )EOF";
 
-    Json::ObjectPtr config = Json::Factory::LoadFromString(raw_config);
+    Json::ObjectPtr config = Json::Factory::loadFromString(raw_config);
 
     timer_ = new Event::MockTimer(&dispatcher_);
     local_info_.zone_name_ = "us-east-1a";

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -85,7 +85,7 @@ TEST(StrictDnsClusterImplTest, ImmediateResolve) {
                              cb(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
                              return nullptr;
                            }));
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   StrictDnsClusterImpl cluster(*loader, runtime, stats, ssl_context_manager, dns_resolver,
                                dispatcher);
   cluster.setInitializedCb([&]() -> void { initialized.ready(); });
@@ -132,7 +132,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   StrictDnsClusterImpl cluster(*loader, runtime, stats, ssl_context_manager, dns_resolver,
                                dispatcher);
   EXPECT_EQ(43U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
@@ -276,7 +276,7 @@ TEST(StaticClusterImplTest, EmptyHostname) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
   EXPECT_EQ(1UL, cluster.healthyHosts().size());
   EXPECT_EQ("", cluster.hosts()[0]->hostname());
@@ -296,7 +296,7 @@ TEST(StaticClusterImplTest, RingHash) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
   EXPECT_EQ(1UL, cluster.healthyHosts().size());
   EXPECT_EQ(LoadBalancerType::RingHash, cluster.info()->lbType());
@@ -317,7 +317,7 @@ TEST(StaticClusterImplTest, OutlierDetector) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
 
   Outlier::MockDetector* detector = new Outlier::MockDetector();
@@ -358,7 +358,7 @@ TEST(StaticClusterImplTest, HealthyStat) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
 
   Outlier::MockDetector* outlier_detector = new NiceMock<Outlier::MockDetector>();
@@ -416,7 +416,7 @@ TEST(StaticClusterImplTest, UrlConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   StaticClusterImpl cluster(*config, runtime, stats, ssl_context_manager);
   EXPECT_EQ(1024U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
   EXPECT_EQ(1024U,
@@ -452,7 +452,7 @@ TEST(StaticClusterImplTest, UnsupportedLBType) {
   }
   )EOF";
 
-  Json::ObjectPtr config = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr config = Json::Factory::loadFromString(json);
   EXPECT_THROW(StaticClusterImpl(*config, runtime, stats, ssl_context_manager), EnvoyException);
 }
 
@@ -468,7 +468,7 @@ TEST(ClusterDefinitionTest, BadClusterConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
   EXPECT_THROW(loader->validateSchema(Json::Schema::CLUSTER_SCHEMA), Json::Exception);
 }
 

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -28,7 +28,7 @@ public:
     ON_CALL(server_.api_, fileReadToEnd("lightstep_access_token"))
         .WillByDefault(Return("access_token"));
 
-    Json::ObjectPtr config_json = Json::Factory::LoadFromFile(file_path);
+    Json::ObjectPtr config_json = Json::Factory::loadFromFile(file_path);
     Server::Configuration::InitialImpl initial_config(*config_json);
     Server::Configuration::MainImpl main_config(server_);
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -130,7 +130,7 @@ TEST_F(IntegrationTest, Admin) {
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
-  Json::ObjectPtr json = Json::Factory::LoadFromString(response->body());
+  Json::ObjectPtr json = Json::Factory::loadFromString(response->body());
   std::vector<Json::ObjectPtr> listener_info = json->asObjectArray();
   for (std::size_t index = 0; index < listener_info.size(); index++) {
     EXPECT_EQ(test_server_->server().getListenSocketByIndex(index)->localAddress()->asString(),

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -27,7 +27,7 @@ TEST(HttpFilterConfigTest, BufferFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   BufferFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "buffer",
@@ -45,7 +45,7 @@ TEST(HttpFilterConfigTest, BadBufferFilterConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   BufferFilterConfig factory;
   EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Decoder, "buffer", *json_config,
@@ -59,7 +59,7 @@ TEST(HttpFilterConfigTest, DynamoFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   DynamoFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(
@@ -80,7 +80,7 @@ TEST(HttpFilterConfigTest, FaultFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   FaultFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "fault",
@@ -96,7 +96,7 @@ TEST(HttpFilterConfigTest, GrpcHttp1BridgeFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   GrpcHttp1BridgeFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Both, "grpc_http1_bridge",
@@ -114,7 +114,7 @@ TEST(HttpFilterConfigTest, HealthCheckFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   HealthCheckFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Both, "health_check",
@@ -133,7 +133,7 @@ TEST(HttpFilterConfigTest, BadHealthCheckFilterConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   HealthCheckFilterConfig factory;
   EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Both, "health_check", *json_config,
@@ -148,7 +148,7 @@ TEST(HttpFilterConfigTest, RouterFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   RouterFilterConfig factory;
   HttpFilterFactoryCb cb = factory.tryCreateFilterFactory(HttpFilterType::Decoder, "router",
@@ -166,7 +166,7 @@ TEST(HttpFilterConfigTest, BadRouterFilterConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   RouterFilterConfig factory;
   EXPECT_THROW(factory.tryCreateFilterFactory(HttpFilterType::Decoder, "router", *json_config,

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -29,7 +29,7 @@ TEST(NetworkFilterConfigTest, RedisProxy) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   RedisProxyFilterConfigFactory factory;
   NetworkFilterFactoryCb cb =
@@ -47,7 +47,7 @@ TEST(NetworkFilterConfigTest, MongoProxy) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   MongoProxyFilterConfigFactory factory;
   NetworkFilterFactoryCb cb =
@@ -66,7 +66,7 @@ TEST(NetworkFilterConfigTest, BadMongoProxyConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   MongoProxyFilterConfigFactory factory;
   EXPECT_THROW(
@@ -102,7 +102,7 @@ TEST(NetworkFilterConfigTest, TcpProxy) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   TcpProxyConfigFactory factory;
   NetworkFilterFactoryCb cb =
@@ -124,7 +124,7 @@ TEST(NetworkFilterConfigTest, ClientSslAuth) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   ClientSslAuthConfigFactory factory;
   NetworkFilterFactoryCb cb = factory.tryCreateFilterFactory(
@@ -143,7 +143,7 @@ TEST(NetworkFilterConfigTest, Ratelimit) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockInstance> server;
   RateLimitConfigFactory factory;
   NetworkFilterFactoryCb cb =
@@ -176,7 +176,7 @@ TEST(NetworkFilterConfigTest, BadHttpConnectionMangerConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
   NiceMock<MockInstance> server;
   EXPECT_THROW(factory.tryCreateFilterFactory(NetworkFilterType::Read, "http_connection_manager",
@@ -219,7 +219,7 @@ TEST(NetworkFilterConfigTest, BadAccessLogConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
   NiceMock<MockInstance> server;
   EXPECT_THROW(factory.tryCreateFilterFactory(NetworkFilterType::Read, "http_connection_manager",
@@ -264,7 +264,7 @@ TEST(NetworkFilterConfigTest, BadAccessLogType) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
   NiceMock<MockInstance> server;
   EXPECT_THROW(factory.tryCreateFilterFactory(NetworkFilterType::Read, "http_connection_manager",
@@ -319,7 +319,7 @@ TEST(NetworkFilterConfigTest, BadAccessLogNestedTypes) {
   }
   )EOF";
 
-  Json::ObjectPtr json_config = Json::Factory::LoadFromString(json_string);
+  Json::ObjectPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
   NiceMock<MockInstance> server;
   EXPECT_THROW(factory.tryCreateFilterFactory(NetworkFilterType::Read, "http_connection_manager",

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -50,7 +50,7 @@ TEST(ConfigurationImplTest, DefaultStatsFlushInterval) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -72,7 +72,7 @@ TEST(ConfigurationImplTest, CustomStatsFlushInterval) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -96,7 +96,7 @@ TEST(ConfigurationImplTest, EmptyFilter) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -120,7 +120,7 @@ TEST(ConfigurationImplTest, DefaultListenerPerConnectionBufferLimit) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -145,7 +145,7 @@ TEST(ConfigurationImplTest, SetListenerPerConnectionBufferLimit) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -207,7 +207,7 @@ TEST(ConfigurationImplTest, SetUpstreamClusterPerConnectionBufferLimit) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -239,7 +239,7 @@ TEST(ConfigurationImplTest, BadListenerConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -267,7 +267,7 @@ TEST(ConfigurationImplTest, BadFilterConfig) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   MainImpl config(server);
@@ -299,7 +299,7 @@ TEST(ConfigurationImplTest, ServiceClusterNotSetWhenLSTracing) {
   }
   )EOF";
 
-  Json::ObjectPtr loader = Json::Factory::LoadFromString(json);
+  Json::ObjectPtr loader = Json::Factory::loadFromString(json);
 
   NiceMock<Server::MockInstance> server;
   server.local_info_.cluster_name_ = "";

--- a/test/server/http/health_check_test.cc
+++ b/test/server/http/health_check_test.cc
@@ -203,7 +203,7 @@ TEST_F(HealthCheckFilterCachingTest, NotHcRequest) {
 
 TEST(HealthCheckFilterConfig, failsWhenNotPassThroughButTimeoutSet) {
   Server::Configuration::HealthCheckFilterConfig healthCheckFilterConfig;
-  Json::ObjectPtr config = Json::Factory::LoadFromString(
+  Json::ObjectPtr config = Json::Factory::loadFromString(
       "{\"pass_through_mode\":false, \"cache_time_ms\":234, \"endpoint\":\"foo\"}");
   NiceMock<Server::MockInstance> serverMock;
 
@@ -216,7 +216,7 @@ TEST(HealthCheckFilterConfig, failsWhenNotPassThroughButTimeoutSet) {
 TEST(HealthCheckFilterConfig, notFailingWhenNotPassThroughAndTimeoutNotSet) {
   Server::Configuration::HealthCheckFilterConfig healthCheckFilterConfig;
   Json::ObjectPtr config =
-      Json::Factory::LoadFromString("{\"pass_through_mode\":false, \"endpoint\":\"foo\"}");
+      Json::Factory::loadFromString("{\"pass_through_mode\":false, \"endpoint\":\"foo\"}");
   NiceMock<Server::MockInstance> serverMock;
 
   healthCheckFilterConfig.tryCreateFilterFactory(Server::Configuration::HttpFilterType::Both,

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -118,7 +118,7 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
 }
 
 Json::ObjectPtr TestEnvironment::jsonLoadFromString(const std::string& json) {
-  return Json::Factory::LoadFromString(substitute(json));
+  return Json::Factory::loadFromString(substitute(json));
 }
 
 void TestEnvironment::exec(const std::vector<std::string>& args) {

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -38,7 +38,7 @@ ToolConfig::ToolConfig(std::unique_ptr<Http::TestHeaderMapImpl> headers, int ran
 // static
 RouterCheckTool RouterCheckTool::create(const std::string& router_config_json) {
   // TODO(hennna): Allow users to load a full config and extract the route configuration from it.
-  Json::ObjectPtr loader = Json::Factory::LoadFromFile(router_config_json);
+  Json::ObjectPtr loader = Json::Factory::loadFromFile(router_config_json);
   loader->validateSchema(Json::Schema::ROUTE_CONFIGURATION_SCHEMA);
 
   std::unique_ptr<NiceMock<Runtime::MockLoader>> runtime(new NiceMock<Runtime::MockLoader>());
@@ -55,7 +55,7 @@ RouterCheckTool::RouterCheckTool(std::unique_ptr<NiceMock<Runtime::MockLoader>> 
     : runtime_(std::move(runtime)), cm_(std::move(cm)), config_(std::move(config)) {}
 
 bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_json) {
-  Json::ObjectPtr loader = Json::Factory::LoadFromFile(expected_route_json);
+  Json::ObjectPtr loader = Json::Factory::loadFromFile(expected_route_json);
   loader->validateSchema(Json::ToolSchema::routerCheckSchema());
 
   bool no_failures = true;


### PR DESCRIPTION
Conform Json::Factory methods to camel case function names as specified in STYLE.md.

s/LoadFromString/loadFromString
s/LoadFromFile/loadFromFile