### PR TITLE
ci: release build with envoy standalone.

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -1,6 +1,6 @@
-# This file was imported from https://github.com/bazelbuild/bazel at d6fec93.
-
 #!/bin/bash
+
+# This file was imported from https://github.com/bazelbuild/bazel at d6fec93.
 
 # This script will be run bazel when building process starts to
 # generate key-value information that represents the status of the

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -54,7 +54,8 @@ export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS}"
 export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone \
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
   --jobs=${NUM_CPUS}"
-export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE"
+export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
+  --cache_test_results=no --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
 ln -sf /thirdparty "${ENVOY_SRCDIR}"/ci/prebuilt
 ln -sf /thirdparty_build "${ENVOY_SRCDIR}"/ci/prebuilt
@@ -66,11 +67,6 @@ then
   git clone https://github.com/htuch/envoy-consumer.git "${ENVOY_CONSUMER_SRCDIR}"
 fi
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.consumer "${ENVOY_CONSUMER_SRCDIR}"/WORKSPACE
-mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/tools
-# Hack due to https://github.com/lyft/envoy/issues/838.
-ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_CONSUMER_SRCDIR}"/tools/
-mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/bazel
-ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CONSUMER_SRCDIR}"/bazel/
 
 # This is the hash on https://github.com/htuch/envoy-consumer.git we pin to.
 (cd "${ENVOY_CONSUMER_SRCDIR}" && git checkout 94e11fa753a1e787c82cccaec642eda5e5b61ed8)
@@ -83,3 +79,15 @@ cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE "${ENVOY_BUILD_DIR}"
 # This is where we copy build deliverables to.
 export ENVOY_DELIVERY_DIR="${ENVOY_BUILD_DIR}"/source/exe
 mkdir -p "${ENVOY_DELIVERY_DIR}"
+
+# Hack due to https://github.com/lyft/envoy/issues/838 and the need to have
+# .git, tools and bazel.rc available for build linkstamping.
+ln -sf "${ENVOY_SRCDIR}"/.git "${ENVOY_BUILD_DIR}"/
+mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/tools
+mkdir -p "${ENVOY_BUILD_DIR}"/tools
+ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_CONSUMER_SRCDIR}"/tools/
+ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_BUILD_DIR}"/tools/
+mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/bazel
+mkdir -p "${ENVOY_BUILD_DIR}"/bazel
+ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CONSUMER_SRCDIR}"/bazel/
+ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_BUILD_DIR}"/bazel/

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -80,14 +80,16 @@ cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE "${ENVOY_BUILD_DIR}"
 export ENVOY_DELIVERY_DIR="${ENVOY_BUILD_DIR}"/source/exe
 mkdir -p "${ENVOY_DELIVERY_DIR}"
 
+# This is where we build for bazel.release* and bazel.dev.
+export ENVOY_CI_DIR="${ENVOY_SRCDIR}"/ci
+
 # Hack due to https://github.com/lyft/envoy/issues/838 and the need to have
-# .git, tools and bazel.rc available for build linkstamping.
-ln -sf "${ENVOY_SRCDIR}"/.git "${ENVOY_BUILD_DIR}"/
+# tools and bazel.rc available for build linkstamping.
 mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/tools
-mkdir -p "${ENVOY_BUILD_DIR}"/tools
+mkdir -p "${ENVOY_CI_DIR}"/tools
 ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_CONSUMER_SRCDIR}"/tools/
-ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_BUILD_DIR}"/tools/
+ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_CI_DIR}"/tools/
 mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/bazel
-mkdir -p "${ENVOY_BUILD_DIR}"/bazel
+mkdir -p "${ENVOY_CI_DIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CONSUMER_SRCDIR}"/bazel/
-ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_BUILD_DIR}"/bazel/
+ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CI_DIR}"/bazel/

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -93,3 +93,13 @@ mkdir -p "${ENVOY_CONSUMER_SRCDIR}"/bazel
 mkdir -p "${ENVOY_CI_DIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CONSUMER_SRCDIR}"/bazel/
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CI_DIR}"/bazel/
+
+function cleanup() {
+  # Remove build artifacts. This doesn't mess with incremental builds as these
+  # are just symlinks.
+  rm -f "${ENVOY_SRCDIR}"/bazel-*
+  rm -f "${ENVOY_CI_DIR}"/bazel-*
+  rm -rf "${ENVOY_CI_DIR}"/bazel
+  rm -rf "${ENVOY_CI_DIR}"/tools
+}
+trap cleanup EXIT

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -52,9 +52,6 @@ elif [[ "$1" == "bazel.dev" ]]; then
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   echo "bazel coverage build with tests..."
-  # Nuke any circular symlinks in source directory.
-  rm -f "${ENVOY_SRCDIR}"/bazel-*
-  rm -f "${ENVOY_CI_DIR}"/bazel-*
   export GCOVR="/thirdparty/gcovr-3.3/scripts/gcovr"
   export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"
   export TESTLOGS_DIR="${ENVOY_BUILD_DIR}/bazel-testlogs"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -23,12 +23,10 @@ if [[ "$1" == "bazel.release" ]]; then
   bazel_release_binary_build
   echo "Testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
-  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then
   echo "bazel release build..."
   bazel_release_binary_build
-  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.asan" ]]; then
   echo "bazel ASAN debug build with tests..."
@@ -51,10 +49,12 @@ elif [[ "$1" == "bazel.dev" ]]; then
     "${ENVOY_DELIVERY_DIR}"/envoy-fastbuild
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
-  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   echo "bazel coverage build with tests..."
+  # Nuke any circular symlinks in source directory.
+  rm -f "${ENVOY_SRCDIR}"/bazel-*
+  rm -f "${ENVOY_CI_DIR}"/bazel-*
   export GCOVR="/thirdparty/gcovr-3.3/scripts/gcovr"
   export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"
   export TESTLOGS_DIR="${ENVOY_BUILD_DIR}/bazel-testlogs"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,12 +9,12 @@ echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {
   echo "Building..."
-  cd "${ENVOY_BUILD_DIR}"
+  cd "${ENVOY_CI_DIR}"
   bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //source/exe:envoy-static.stripped.stamped
   # Copy the envoy-static binary somewhere that we can access outside of the
   # container for building Docker images.
   cp -f \
-    "${ENVOY_BUILD_DIR}"/bazel-genfiles/source/exe/envoy-static.stripped.stamped \
+    "${ENVOY_CI_DIR}"/bazel-genfiles/source/exe/envoy-static.stripped.stamped \
     "${ENVOY_DELIVERY_DIR}"/envoy
 }
 
@@ -23,10 +23,12 @@ if [[ "$1" == "bazel.release" ]]; then
   bazel_release_binary_build
   echo "Testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
+  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then
   echo "bazel release build..."
   bazel_release_binary_build
+  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.asan" ]]; then
   echo "bazel ASAN debug build with tests..."
@@ -39,16 +41,17 @@ elif [[ "$1" == "bazel.asan" ]]; then
 elif [[ "$1" == "bazel.dev" ]]; then
   # This doesn't go into CI but is available for developer convenience.
   echo "bazel fastbuild build with tests..."
-  cd "${ENVOY_BUILD_DIR}"
+  cd "${ENVOY_CI_DIR}"
   echo "Building..."
   bazel --batch build ${BAZEL_BUILD_OPTIONS} -c fastbuild //source/exe:envoy-static
   # Copy the envoy-static binary somewhere that we can access outside of the
   # container for developers.
   cp -f \
-    "${ENVOY_BUILD_DIR}"/bazel-bin/source/exe/envoy-static \
+    "${ENVOY_CI_DIR}"/bazel-bin/source/exe/envoy-static \
     "${ENVOY_DELIVERY_DIR}"/envoy-fastbuild
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
+  rm -f bazel-*
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   echo "bazel coverage build with tests..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -8,13 +8,13 @@ set -e
 echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {
-  cd "${ENVOY_CONSUMER_SRCDIR}"
   echo "Building..."
-  bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt @envoy//source/exe:envoy-static.stripped.stamped
+  cd "${ENVOY_BUILD_DIR}"
+  bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //source/exe:envoy-static.stripped.stamped
   # Copy the envoy-static binary somewhere that we can access outside of the
   # container for building Docker images.
   cp -f \
-    "${ENVOY_CONSUMER_SRCDIR}"/bazel-genfiles/external/envoy/source/exe/envoy-static.stripped.stamped \
+    "${ENVOY_BUILD_DIR}"/bazel-genfiles/source/exe/envoy-static.stripped.stamped \
     "${ENVOY_DELIVERY_DIR}"/envoy
 }
 
@@ -22,8 +22,7 @@ if [[ "$1" == "bazel.release" ]]; then
   echo "bazel release build with tests..."
   bazel_release_binary_build
   echo "Testing..."
-  bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt --test_output=all \
-    --cache_test_results=no @envoy//test/... //:echo2_integration_test
+  bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then
   echo "bazel release build..."
@@ -34,8 +33,8 @@ elif [[ "$1" == "bazel.asan" ]]; then
   cd "${ENVOY_CONSUMER_SRCDIR}"
   echo "Building and testing..."
   # TODO(htuch): This should switch to using clang when available.
-  bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=asan --test_output=all \
-    --cache_test_results=no @envoy//test/... //:echo2_integration_test
+  bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=asan @envoy//test/... \
+    //:echo2_integration_test
   exit 0
 elif [[ "$1" == "bazel.dev" ]]; then
   # This doesn't go into CI but is available for developer convenience.


### PR DESCRIPTION
This fixes an issue where the Envoy consumer git hash was picked up in the
release binary instead of Envoy proper.