### PR TITLE
build/test: some fixups for the google import.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,1 @@
+licenses(["notice"])  # Apache 2

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files([

--- a/ci/build_container/BUILD
+++ b/ci/build_container/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/ci/build_container/build_recipes/BUILD
+++ b/ci/build_container/build_recipes/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/include/envoy/access_log/BUILD
+++ b/include/envoy/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/api/BUILD
+++ b/include/envoy/api/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/buffer/BUILD
+++ b/include/envoy/buffer/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/filesystem/BUILD
+++ b/include/envoy/filesystem/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/grpc/BUILD
+++ b/include/envoy/grpc/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/init/BUILD
+++ b/include/envoy/init/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/json/BUILD
+++ b/include/envoy/json/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/local_info/BUILD
+++ b/include/envoy/local_info/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/mongo/BUILD
+++ b/include/envoy/mongo/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/ratelimit/BUILD
+++ b/include/envoy/ratelimit/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/redis/BUILD
+++ b/include/envoy/redis/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/runtime/BUILD
+++ b/include/envoy/runtime/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/stats/BUILD
+++ b/include/envoy/stats/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/thread/BUILD
+++ b/include/envoy/thread/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/thread_local/BUILD
+++ b/include/envoy/thread_local/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/tracing/BUILD
+++ b/include/envoy/tracing/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/access_log/BUILD
+++ b/source/common/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/buffer/BUILD
+++ b/source/common/buffer/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/dynamo/BUILD
+++ b/source/common/dynamo/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/filter/auth/BUILD
+++ b/source/common/filter/auth/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/http/access_log/BUILD
+++ b/source/common/http/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/http/filter/BUILD
+++ b/source/common/http/filter/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/local_info/BUILD
+++ b/source/common/local_info/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/profiler/BUILD
+++ b/source/common/profiler/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/ratelimit/BUILD
+++ b/source/common/ratelimit/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/redis/BUILD
+++ b/source/common/redis/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/thread_local/BUILD
+++ b/source/common/thread_local/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/server/config/network/BUILD
+++ b/source/server/config/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/api/BUILD
+++ b/test/common/api/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/dynamo/BUILD
+++ b/test/common/dynamo/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/filesystem/BUILD
+++ b/test/common/filesystem/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/filter/BUILD
+++ b/test/common/filter/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/filter/auth/BUILD
+++ b/test/common/filter/auth/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/http/access_log/BUILD
+++ b/test/common/http/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/http/filter/BUILD
+++ b/test/common/http/filter/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/json/config_schemas_test_data/BUILD
+++ b/test/common/json/config_schemas_test_data/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/common/mongo/BUILD
+++ b/test/common/mongo/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/ratelimit/BUILD
+++ b/test/common/ratelimit/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/redis/BUILD
+++ b/test/common/redis/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/runtime/BUILD
+++ b/test/common/runtime/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/ssl/test_data/BUILD
+++ b/test/common/ssl/test_data/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/tracing/BUILD
+++ b/test/common/tracing/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/config/integration/BUILD
+++ b/test/config/integration/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/config/integration/certs/BUILD
+++ b/test/config/integration/certs/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -50,7 +50,7 @@ echo "Checking that listener addresses have not changed"
 HOT_RESTART_JSON_1="${TEST_TMPDIR}"/hot_restart_1.json
 "${TEST_RUNDIR}"/tools/socket_passing.py "-o" "${UPDATED_HOT_RESTART_JSON}" "-a" "${ADMIN_ADDRESS_PATH_1}" \
   "-u" "${HOT_RESTART_JSON_1}"
-CONFIG_DIFF=$(diff -Z "${UPDATED_HOT_RESTART_JSON}" "${HOT_RESTART_JSON_1}")
+CONFIG_DIFF=$(diff "${UPDATED_HOT_RESTART_JSON}" "${HOT_RESTART_JSON_1}")
 [[ -z "${CONFIG_DIFF}" ]]
 
 ADMIN_ADDRESS_PATH_2="${TEST_TMPDIR}"/admin_2.address
@@ -66,7 +66,7 @@ echo "Checking that listener addresses have not changed"
 HOT_RESTART_JSON_2="${TEST_TMPDIR}"/hot_restart_2.json
 "${TEST_RUNDIR}"/tools/socket_passing.py "-o" "${UPDATED_HOT_RESTART_JSON}" "-a" "${ADMIN_ADDRESS_PATH_2}" \
   "-u" "${HOT_RESTART_JSON_2}"
-CONFIG_DIFF=$(diff -Z "${UPDATED_HOT_RESTART_JSON}" "${HOT_RESTART_JSON_2}")
+CONFIG_DIFF=$(diff "${UPDATED_HOT_RESTART_JSON}" "${HOT_RESTART_JSON_2}")
 [[ -z "${CONFIG_DIFF}" ]]
 
 # First server should already be gone.

--- a/test/main.cc
+++ b/test/main.cc
@@ -4,6 +4,8 @@
 // The main entry point (and the rest of this file) should have no logic in it,
 // this allows overriding by site specific versions of main.cc.
 int main(int argc, char** argv) {
-  ::setenv("TEST_RUNDIR", TestEnvironment::runfilesDirectory().c_str(), 1);
+  ::setenv("TEST_RUNDIR", (TestEnvironment::getCheckedEnvVar("TEST_SRCDIR") + "/" +
+                           TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE")).c_str(),
+           1);
   return TestRunner::RunTests(argc, argv);
 }

--- a/test/mocks/BUILD
+++ b/test/mocks/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",

--- a/test/mocks/access_log/BUILD
+++ b/test/mocks/access_log/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/api/BUILD
+++ b/test/mocks/api/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/buffer/BUILD
+++ b/test/mocks/buffer/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/event/BUILD
+++ b/test/mocks/event/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/filesystem/BUILD
+++ b/test/mocks/filesystem/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/grpc/BUILD
+++ b/test/mocks/grpc/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/init/BUILD
+++ b/test/mocks/init/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/local_info/BUILD
+++ b/test/mocks/local_info/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/ratelimit/BUILD
+++ b/test/mocks/ratelimit/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/redis/BUILD
+++ b/test/mocks/redis/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/router/BUILD
+++ b/test/mocks/router/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/runtime/BUILD
+++ b/test/mocks/runtime/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/ssl/BUILD
+++ b/test/mocks/ssl/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/stats/BUILD
+++ b/test/mocks/stats/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/thread_local/BUILD
+++ b/test/mocks/thread_local/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/tracing/BUILD
+++ b/test/mocks/tracing/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/server/config/http/BUILD
+++ b/test/server/config/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/server/config/network/BUILD
+++ b/test/server/config/network/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/server/http/BUILD
+++ b/test/server/http/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -18,13 +18,6 @@
 
 namespace {
 
-std::string getCheckedEnvVar(const std::string& var) {
-  // Bazel style temp dirs. Should be set by test runner or Bazel.
-  const char* path = ::getenv(var.c_str());
-  RELEASE_ASSERT(path != nullptr);
-  return std::string(path);
-}
-
 std::string getOrCreateUnixDomainSocketDirectory() {
   const char* path = ::getenv("TEST_UDSDIR");
   if (path != nullptr) {
@@ -44,6 +37,13 @@ char** argv_;
 
 } // namespace
 
+std::string TestEnvironment::getCheckedEnvVar(const std::string& var) {
+  // Bazel style temp dirs. Should be set by test runner or Bazel.
+  const char* path = ::getenv(var.c_str());
+  RELEASE_ASSERT(path != nullptr);
+  return std::string(path);
+}
+
 void TestEnvironment::initializeOptions(int argc, char** argv) {
   argc_ = argc;
   argv_ = argv;
@@ -60,8 +60,7 @@ const std::string& TestEnvironment::temporaryDirectory() {
 }
 
 const std::string& TestEnvironment::runfilesDirectory() {
-  static const std::string* runfiles_directory =
-      new std::string(getCheckedEnvVar("TEST_SRCDIR") + "/" + getCheckedEnvVar("TEST_WORKSPACE"));
+  static const std::string* runfiles_directory = new std::string(getCheckedEnvVar("TEST_RUNDIR"));
   return *runfiles_directory;
 }
 

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -27,6 +27,12 @@ public:
   static Server::Options& getOptions();
 
   /**
+   * Obtain the value of an environment variable, die if not available.
+   * @return std::string with the value of the environment variable.
+   */
+  static std::string getCheckedEnvVar(const std::string& var);
+
+  /**
    * Obtain a private writable temporary directory.
    * @return const std::string& with the path to the temporary directory.
    */

--- a/test/tools/router_check/BUILD
+++ b/test/tools/router_check/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",

--- a/test/tools/router_check/json/BUILD
+++ b/test/tools/router_check/json/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/test/tools/router_check/test/BUILD
+++ b/test/tools/router_check/test/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -10,6 +10,8 @@ SUFFIXES = (".cc", ".h", "BUILD")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG-FORMAT", "clang-format-3.6")
 BUILDIFIER_PATH = os.getenv("BUILDIFIER", "/usr/lib/go/bin/buildifier")
+ENVOY_BUILD_FIXER_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(sys.argv[0])), "envoy_build_fixer.py")
 HEADER_ORDER_PATH = os.path.join(
     os.path.dirname(os.path.abspath(sys.argv[0])), "header_order.py")
 
@@ -24,6 +26,9 @@ def printError(error):
 
 def checkFilePath(file_path):
   if os.path.basename(file_path) == "BUILD":
+    if os.system("%s %s | diff -q %s - > /dev/null" %
+                 (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
+      printError("envoy_build_fixer check failed for file: %s" % (file_path))
     if os.system("cat %s | %s -mode=fix | diff -q %s - > /dev/null" %
                  (file_path, BUILDIFIER_PATH, file_path)) != 0:
       printError("buildifier check failed for file: %s" % (file_path))
@@ -40,6 +45,8 @@ def checkFilePath(file_path):
 
 def fixFilePath(file_path):
   if os.path.basename(file_path) == "BUILD":
+    if os.system("%s %s %s" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
+      printError("envoy_build_fixer rewrite failed for file: %s" % (file_path))
     if os.system("%s -mode=fix %s" % (BUILDIFIER_PATH, file_path)) != 0:
       printError("buildifier rewrite failed for file: %s" % (file_path))
     return

--- a/tools/envoy_build_fixer.py
+++ b/tools/envoy_build_fixer.py
@@ -8,11 +8,12 @@ LICENSE_STRING = 'licenses(["notice"])  # Apache 2\n'
 
 def FixBuild(path):
   with open(path, 'r') as f:
-    contents = f.read()
+    outlines = [LICENSE_STRING]
+    for line in f:
+      if not line.startswith('licenses'):
+        outlines.append(line)
 
-  if not contents.startswith(LICENSE_STRING):
-    return LICENSE_STRING + contents
-  return contents
+  return ''.join(outlines)
 
 if __name__ == '__main__':
   if len(sys.argv) == 2:

--- a/tools/envoy_build_fixer.py
+++ b/tools/envoy_build_fixer.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Enforce license headers on Envoy BUILD files (maybe more later?)
+
+import sys
+
+LICENSE_STRING = 'licenses(["notice"])  # Apache 2\n'
+
+def FixBuild(path):
+  with open(path, 'r') as f:
+    contents = f.read()
+
+  if not contents.startswith(LICENSE_STRING):
+    return LICENSE_STRING + contents
+  return contents
+
+if __name__ == '__main__':
+  if len(sys.argv) == 2:
+    sys.stdout.write(FixBuild(sys.argv[1]))
+    sys.exit(0)
+  elif len(sys.argv) == 3:
+    reorderd_source = FixBuild(sys.argv[1])
+    with open(sys.argv[2], 'w') as f:
+      f.write(reorderd_source)
+    sys.exit(0)
+  print 'Usage: %s <source file path> [<destination file path>]' % sys.argv[0]
+  sys.exit(1)


### PR DESCRIPTION
* Fix TestEnvironment::runfilesDirectory() to use TEST_RUNDIR, rather
  than the other way around.

* Remove use of diff -Z in hotrestart_test, since it's not needed and
  isn't supported by all versions of diff.

* Add license directives to all files.