### PR TITLE
Begin to support Ipv6 only or Ipv4 only testing

### DIFF
--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -88,6 +88,7 @@ envoy_cc_test(
     deps = [
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
+        "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
     ],
 )
@@ -103,6 +104,7 @@ envoy_cc_test(
         "//source/common/stats:stats_lib",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
     ],
 )

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -3,6 +3,7 @@
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 
+#include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
 #include "gtest/gtest.h"
@@ -15,7 +16,7 @@ protected:
   const Address::IpVersion version_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTest,
-                        testing::Values(Address::IpVersion::v4, Address::IpVersion::v6));
+                        testing::ValuesIn(TestEnvironment::getIpTestParameters()));
 
 TEST_P(ListenSocketImplTest, BindSpecificPort) {
   // Pick a free port.

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -16,7 +16,7 @@ protected:
   const Address::IpVersion version_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpTestParameters()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(ListenSocketImplTest, BindSpecificPort) {
   // Pick a free port.

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
 #include "gmock/gmock.h"
@@ -82,7 +83,7 @@ protected:
   const Address::InstanceConstSharedPtr alt_address_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplTest,
-                        testing::Values(Address::IpVersion::v4, Address::IpVersion::v6));
+                        testing::ValuesIn(TestEnvironment::getIpTestParameters()));
 
 TEST_P(ListenerImplTest, NormalRedirect) {
   Stats::IsolatedStoreImpl stats_store;

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -83,7 +83,7 @@ protected:
   const Address::InstanceConstSharedPtr alt_address_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpTestParameters()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(ListenerImplTest, NormalRedirect) {
   Stats::IsolatedStoreImpl stats_store;

--- a/test/main.cc
+++ b/test/main.cc
@@ -5,5 +5,14 @@
 // this allows overriding by site specific versions of main.cc.
 int main(int argc, char** argv) {
   ::setenv("TEST_RUNDIR", TestEnvironment::runfilesDirectory().c_str(), 1);
+  // Select whether to test only for IPv4, IPv6, or both. The default is to
+  // test for both. Options are {"v4only", "v6only", "all"}. Set IP_TEST_TYPE
+  // to "v4only" if the system currently does not support IPv6 network
+  // operations. Similary set IP_TEST_TYPE to "v6only" if IPv4 has already been
+  // phased out of network operations. Set to "all" (or don't set) if testing both
+  // v4 and v6 addresses is desired. This feature will be rolled out to all tests
+  // in upcoming PRs but currently only applies to listen_socket_impl_test
+  // and listener_impl_test tests.
+  ::setenv("IP_TEST_TYPE", "all", 1);
   return TestRunner::RunTests(argc, argv);
 }

--- a/test/main.cc
+++ b/test/main.cc
@@ -8,13 +8,12 @@ int main(int argc, char** argv) {
                            TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE")).c_str(),
            1);
   // Select whether to test only for IPv4, IPv6, or both. The default is to
-  // test for both. Options are {"v4only", "v6only", "all"}. Set IP_TEST_TYPE
-  // to "v4only" if the system currently does not support IPv6 network
-  // operations. Similary set IP_TEST_TYPE to "v6only" if IPv4 has already been
+  // test for both. Options are {"v4only", "v6only", "all"}. Set
+  // ENVOY_IP_TEST_VERSIONS to "v4only" if the system currently does not support IPv6 network
+  // operations. Similary set ENVOY_IP_TEST_VERSIONS to "v6only" if IPv4 has already been
   // phased out of network operations. Set to "all" (or don't set) if testing both
-  // v4 and v6 addresses is desired. This feature will be rolled out to all tests
-  // in upcoming PRs but currently only applies to listen_socket_impl_test
-  // and listener_impl_test tests.
-  ::setenv("IP_TEST_TYPE", "all", 1);
+  // v4 and v6 addresses is desired. This feature is in progress and will be rolled out to all tests
+  // in upcoming PRs.
+  ::setenv("ENVOY_IP_TEST_VERSIONS", "all", 0);
   return TestRunner::RunTests(argc, argv);
 }

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test_library(
         "//include/envoy/server:options_interface",
         "//source/common/common:assert_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/network:utility_lib",
         "//source/server:options_lib",
     ],
 )

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -8,7 +8,6 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "common/common/assert.h"
 
@@ -47,6 +46,30 @@ char** argv_;
 void TestEnvironment::initializeOptions(int argc, char** argv) {
   argc_ = argc;
   argv_ = argv;
+}
+
+bool TestEnvironment::isTestIpVersionOnly(const Network::Address::IpVersion& type) {
+  const char* option = ::getenv("IP_TEST_TYPE");
+  if (option == nullptr) {
+    return false;
+  }
+  if ((type == Network::Address::IpVersion::v4 && strcmp(option, "v4only") == 0) ||
+      (type == Network::Address::IpVersion::v6 && strcmp(option, "v6only") == 0)) {
+    return true;
+  }
+  return false;
+}
+
+std::vector<Network::Address::IpVersion> TestEnvironment::getIpTestParameters() {
+  std::vector<Network::Address::IpVersion> parameters;
+  if (TestEnvironment::isTestIpVersionOnly(Network::Address::IpVersion::v6) == false) {
+    parameters.push_back(Network::Address::IpVersion::v4);
+  }
+
+  if (TestEnvironment::isTestIpVersionOnly(Network::Address::IpVersion::v4) == false) {
+    parameters.push_back(Network::Address::IpVersion::v6);
+  }
+  return parameters;
 }
 
 Server::Options& TestEnvironment::getOptions() {

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -64,11 +64,11 @@ bool TestEnvironment::shouldRunTestForIpVersion(const Network::Address::IpVersio
 
 std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest() {
   std::vector<Network::Address::IpVersion> parameters;
-  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4) == true) {
+  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4)) {
     parameters.push_back(Network::Address::IpVersion::v4);
   }
 
-  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v6) == true) {
+  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v6)) {
     parameters.push_back(Network::Address::IpVersion::v6);
   }
   return parameters;

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -22,15 +22,22 @@ public:
   static void initializeOptions(int argc, char** argv);
 
   /**
+   * Check whether testing with IP version type {v4 or v6} only is enabled via
+   * setting the environment variable ENVOY_IP_TEST_VERSIONS.
+   * @param Network::Address::IpVersion IP address version to check.
    * @return bool if testing only with IP type addresses only.
    */
-  static bool isTestIpVersionOnly(const Network::Address::IpVersion& type);
+  static bool shouldRunTestForIpVersion(const Network::Address::IpVersion& type);
 
   /**
-   * @return std::vector<Network::Address::IpVersion> vector of ip address
+   * Return a vector of IP address parameters to test. Tests can be run with
+   * only IPv4 addressing or only IPv6 addressing by setting the environmnet
+   * variable ENVOY_IP_TEST_VERSIONS to "v4only" or "v6only", respectively.
+   * The default test setting runs all tests with both IPv4 and IPv6 addresses.
+   * @return std::vector<Network::Address::IpVersion> vector of IP address
    * types to test.
    */
-  static std::vector<Network::Address::IpVersion> getIpTestParameters();
+  static std::vector<Network::Address::IpVersion> getIpVersionsForTest();
 
   /**
    * Obtain command-line options reference.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "envoy/network/address.h"
 #include "envoy/server/options.h"
 
 #include "common/json/json_loader.h"
@@ -19,6 +20,17 @@ public:
    * @param argv array of command-line args.
    */
   static void initializeOptions(int argc, char** argv);
+
+  /**
+   * @return bool if testing only with IP type addresses only.
+   */
+  static bool isTestIpVersionOnly(const Network::Address::IpVersion& type);
+
+  /**
+   * @return std::vector<Network::Address::IpVersion> vector of ip address
+   * types to test.
+   */
+  static std::vector<Network::Address::IpVersion> getIpTestParameters();
 
   /**
    * Obtain command-line options reference.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -22,7 +22,7 @@ public:
   static void initializeOptions(int argc, char** argv);
 
   /**
-   * Check whether testing with IP version type {v4 or v6} only is enabled via
+   * Check whether testing with IP version type {v4 or v6} is enabled via
    * setting the environment variable ENVOY_IP_TEST_VERSIONS.
    * @param Network::Address::IpVersion IP address version to check.
    * @return bool if testing only with IP type addresses only.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -31,7 +31,7 @@ public:
 
   /**
    * Return a vector of IP address parameters to test. Tests can be run with
-   * only IPv4 addressing or only IPv6 addressing by setting the environmnet
+   * only IPv4 addressing or only IPv6 addressing by setting the environment
    * variable ENVOY_IP_TEST_VERSIONS to "v4only" or "v6only", respectively.
    * The default test setting runs all tests with both IPv4 and IPv6 addresses.
    * @return std::vector<Network::Address::IpVersion> vector of IP address

--- a/test/test_common/network_utility_test.cc
+++ b/test/test_common/network_utility_test.cc
@@ -1,5 +1,6 @@
 #include <string>
 
+#include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
 #include "gtest/gtest.h"
@@ -14,7 +15,7 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, NetworkUtilityTest,
-                        testing::Values(Address::IpVersion::v4, Address::IpVersion::v6));
+                        testing::ValuesIn(TestEnvironment::getIpTestParameters()));
 
 // This validates Network::Test::bindFreeLoopbackPort behaves as desired, i.e. that we don't have
 // a significant risk of flakes due to re-use of a port over short time intervals. We can't drive


### PR DESCRIPTION
This PR allows testing in environments that either don't support IPv4 or IPv6 networking. The way this is achieved is by setting an environment variable (IP_TEST_TYPE) in test/main.cc to "v4only" or "v6only". We then construct parameterized gtests based on the value of IP_TEST_TYPE. 

This PR only modifies existing tests that were testing with both IPv4 and IPv6 addresses. If the approach taken in this PR is agreed upon, testing with IPv4 only and IPv6 only will be extended in subsequent PRs. 

This PR is related to #351 .