### PR TITLE
Docs: Provide more details about using GDB.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -113,8 +113,8 @@ bazel test -c dbg //test/server:backtrace_test
 --cache_test_results=no --test_output=all
 ```
 
-You will need to use either a `dbg` build type or the `--define
-debug_symbols=yes` option to get symbol information in the binaries.
+You will need to use either a `dbg` build type or the `opt` build type to get symbol
+information in the binaries.
 
 By default main.cc will install signal handlers to print backtraces at the
 location where a fatal signal occurred.  The signal handler will re-raise the
@@ -126,8 +126,11 @@ be installed.
 # Running a single Bazel test under GDB
 
 ```
-tools/bazel-test-gdb //test/common/http:async_client_impl_test
+tools/bazel-test-gdb //test/common/http:async_client_impl_test -c dbg
 ```
+
+Without the `-c dbg` Bazel option at the end of the command line the test
+binaries will not include debugging symbols and GDB will not be very useful.
 
 # Additional Envoy build and test options
 

--- a/tools/bazel-test-gdb
+++ b/tools/bazel-test-gdb
@@ -3,6 +3,11 @@
 # Run a single Bazel test target under gdb. Usage:
 #
 # tools/bazel-test-gdb //test/foo:bar --some_other --bazel_args
+#
+# The default build type ("fastbuild") does not generate debugging symbols so
+# you almost certainly want to use "-c opt" or "-c dbg" Bazel arguments to
+# trigger generation of debug symbols.  By default the "opt" build type does not
+# include symbols for tests: see bazel/envoy_build_system.bzl for details.
 
 if [[ ! "$1" =~ (@[a-zA-Z0-9_-]+)?//.*:[a-zA-Z0-9_-]+ ]]
 then


### PR DESCRIPTION
The GDB wrapper script is not particular useful unless run with the
"dbg" build type so there are debug symbols for tests.  Update the
example command line and and comments to document this.