### PR TITLE
http: make StaticLookupTable a ConstSingleton.

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -160,6 +160,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:non_copyable",
+        "//source/common/common:singleton",
         "//source/common/common:utility_lib",
     ],
 )

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -6,6 +6,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
+#include "common/common/singleton.h"
 #include "common/common/utility.h"
 
 namespace Http {
@@ -197,8 +198,6 @@ void HeaderMapImpl::HeaderEntryImpl::value(const HeaderEntry& header) {
     return {&h.inline_headers_.name##_, &Headers::get().name};                                     \
   });
 
-const HeaderMapImpl::StaticLookupTable HeaderMapImpl::static_lookup_table_;
-
 HeaderMapImpl::StaticLookupTable::StaticLookupTable() {
   ALL_INLINE_HEADERS(INLINE_HEADER_STATIC_MAP_ENTRY)
 
@@ -279,7 +278,7 @@ bool HeaderMapImpl::operator==(const HeaderMapImpl& rhs) const {
 }
 
 void HeaderMapImpl::insertByKey(HeaderString&& key, HeaderString&& value) {
-  StaticLookupEntry::EntryCb cb = static_lookup_table_.find(key.c_str());
+  StaticLookupEntry::EntryCb cb = ConstSingleton<StaticLookupTable>::get().find(key.c_str());
   if (cb) {
     // TODO(mattklein123): Currently, for all of the inline headers, we don't support appending. The
     // only inline header where we should be converting multiple headers into a comma delimited
@@ -350,7 +349,7 @@ void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
 }
 
 void HeaderMapImpl::remove(const LowerCaseString& key) {
-  StaticLookupEntry::EntryCb cb = static_lookup_table_.find(key.get().c_str());
+  StaticLookupEntry::EntryCb cb = ConstSingleton<StaticLookupTable>::get().find(key.get().c_str());
   if (cb) {
     StaticLookupResponse static_lookup_response = cb(*this);
     removeInline(static_lookup_response.entry_);

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -106,8 +106,6 @@ protected:
     StaticLookupEntry root_;
   };
 
-  static const StaticLookupTable static_lookup_table_;
-
   struct AllInlineHeaders {
     ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_STRUCT)
   };


### PR DESCRIPTION
This seems to fix the ASAN failure in the Google import. There are still
a lot of other static initialization order fiasco violations that ASAN
isn't picking up of the "static const std::string" variety, will save
those for a future PR.