### PR TITLE
build: add backtrace tags to backtrace-related libs/tests.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -64,6 +64,7 @@ def envoy_cc_library(name,
                      tcmalloc_dep = None,
                      repository = "",
                      linkstamp = None,
+                     tags = [],
                      deps = []):
     if tcmalloc_dep:
         deps += tcmalloc_external_deps(repository)
@@ -73,6 +74,7 @@ def envoy_cc_library(name,
         hdrs = hdrs,
         copts = envoy_copts(repository) + copts,
         visibility = visibility,
+        tags = tags,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//include/envoy/common:base_includes",
             envoy_external_dep_path('spdlog'),

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -80,6 +80,7 @@ envoy_cc_library(
     name = "sigaction_lib",
     srcs = ["signal_action.cc"],
     hdrs = ["signal_action.h"],
+    tags = ["backtrace"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:non_copyable",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "backtrace_lib",
     hdrs = ["backtrace.h"],
     external_deps = ["backward"],
+    tags = ["backtrace"],
     deps = ["//source/common/common:logger_lib"],
 )
 

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -20,5 +20,6 @@ sh_test(
 envoy_cc_test(
     name = "signals_test",
     srcs = ["signals_test.cc"],
+    tags = ["backtrace"],
     deps = ["//source/exe:sigaction_lib"],
 )

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -11,6 +11,7 @@ envoy_package()
 envoy_cc_test(
     name = "backtrace_test",
     srcs = ["backtrace_test.cc"],
+    tags = ["backtrace"],
     deps = ["//source/server:backtrace_lib"],
 )
 


### PR DESCRIPTION
This makes it easier to exclude from the build during site specific
import (e.g. Google).