### PR TITLE
hotrestart: fix msan errors.

### DIFF
--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -23,7 +23,7 @@ namespace Server {
 
 // Increment this whenever there is a shared memory / RPC change that will prevent a hot restart
 // from working. Operations code can then cope with this and do a full restart.
-const uint64_t SharedMemory::VERSION = 7;
+const uint64_t SharedMemory::VERSION = 8;
 
 SharedMemory& SharedMemory::initialize(Options& options) {
   int flags = O_RDWR;

--- a/source/exe/hot_restart.h
+++ b/source/exe/hot_restart.h
@@ -143,33 +143,33 @@ private:
 
     RpcMessageType type_;
     uint64_t length_;
-  };
+  } __attribute__((packed));
 
   struct RpcGetListenSocketRequest : public RpcBase {
     RpcGetListenSocketRequest() : RpcBase(RpcMessageType::GetListenSocketRequest, sizeof(*this)) {}
 
-    char address_[256];
-  };
+    char address_[256]{0};
+  } __attribute__((packed));
 
   struct RpcGetListenSocketReply : public RpcBase {
     RpcGetListenSocketReply() : RpcBase(RpcMessageType::GetListenSocketReply, sizeof(*this)) {}
 
-    int fd_;
-  };
+    int fd_{0};
+  } __attribute__((packed));
 
   struct RpcShutdownAdminReply : public RpcBase {
     RpcShutdownAdminReply() : RpcBase(RpcMessageType::ShutdownAdminReply, sizeof(*this)) {}
 
-    uint64_t original_start_time_;
-  };
+    uint64_t original_start_time_{0};
+  } __attribute__((packed));
 
   struct RpcGetStatsReply : public RpcBase {
     RpcGetStatsReply() : RpcBase(RpcMessageType::GetStatsReply, sizeof(*this)) {}
 
-    uint64_t memory_allocated_;
-    uint64_t num_connections_;
-    uint64_t unused_[16];
-  };
+    uint64_t memory_allocated_{0};
+    uint64_t num_connections_{0};
+    uint64_t unused_[16]{0};
+  } __attribute__((packed));
 
   template <class rpc_class, RpcMessageType rpc_type> rpc_class* receiveTypedRpc() {
     RpcBase* base_message = receiveRpc(true);


### PR DESCRIPTION
Clang msan triggered on the RPC structs, since they were unpacked and
uninitialized values (the padding between member variables) were passed
into the sendMessage() iovec and were being copied into the kernel.

The fix is to pack the structs and have them zeroed by default (mostly
defensive, this wasn't the original error).