### PR TITLE
ssl_integration_test: fix tsan errors.

### DIFF
--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -179,7 +179,6 @@ public:
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
-  Stats::IsolatedStoreImpl stats_store_;
 
 protected:
   void testRouterRedirect(Http::CodecClient::Type type);

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -113,7 +113,8 @@ ClientContextPtr SslIntegrationTest::createClientSslContext(bool alpn, bool san)
   }
   Json::ObjectPtr loader = TestEnvironment::jsonLoadFromString(target);
   ContextConfigImpl cfg(*loader);
-  return context_manager_->createSslClientContext(test_server_->store(), cfg);
+  static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
+  return context_manager_->createSslClientContext(*client_stats_store, cfg);
 }
 
 Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool alpn, bool san) {


### PR DESCRIPTION
Don't share the stats store between Envoy server and clients, instead
have them share a locked stats store.