### PR TITLE
docs: fixing example config generator instructions

### DIFF
--- a/docs/install/ref_configs.rst
+++ b/docs/install/ref_configs.rst
@@ -33,7 +33,7 @@ To generate the example configurations run the following from the root of the re
 .. code-block:: console
 
   mkdir -p generated/configs
-  configs/configgen.sh generated/configs
+  python ./configs/configgen.py generated/configs
 
 The previous command will produce three fully expanded configurations using some variables
 defined inside of `configgen.py`. See the comments inside of `configgen.py` for detailed

--- a/docs/install/ref_configs.rst
+++ b/docs/install/ref_configs.rst
@@ -33,7 +33,8 @@ To generate the example configurations run the following from the root of the re
 .. code-block:: console
 
   mkdir -p generated/configs
-  python ./configs/configgen.py generated/configs
+  bazel build //configs:example_configs
+  tar xvf $PWD/bazel-genfiles/configs/example_configs.tar -C generated/configs
 
 The previous command will produce three fully expanded configurations using some variables
 defined inside of `configgen.py`. See the comments inside of `configgen.py` for detailed


### PR DESCRIPTION
configgen.sh doesn't seem to execute configgen.py so a documentation update seemed appropriate