### PR TITLE
Add backtrace-on-fatal behavior for tests.

### DIFF
--- a/source/exe/signal_action.h
+++ b/source/exe/signal_action.h
@@ -85,7 +85,7 @@ private:
    * The object will contain an array of struct sigactions with the same number
    * of elements that are in this array.
    */
-  static const constexpr int FATAL_SIGS[] = {SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV};
+  static constexpr int FATAL_SIGS[] = {SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV};
   /**
    * Return the memory size we actually map including two guard pages.
    */

--- a/test/BUILD
+++ b/test/BUILD
@@ -20,8 +20,10 @@ envoy_cc_test_library(
     deps = [
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
-        "//source/exe:sigaction_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:printers_lib",
-    ],
+    ] + select({
+        "//bazel:disable_signal_trace": [],
+        "//conditions:default": ["//source/exe:sigaction_lib"],
+    }),
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test_library(
     deps = [
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
+        "//source/exe:sigaction_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:printers_lib",
     ],

--- a/test/main.cc
+++ b/test/main.cc
@@ -1,9 +1,18 @@
 #include "test/test_common/environment.h"
 #include "test/test_runner.h"
 
+#ifdef ENVOY_HANDLE_SIGNALS
+#include "exe/signal_action.h"
+#endif
+
 // The main entry point (and the rest of this file) should have no logic in it,
 // this allows overriding by site specific versions of main.cc.
 int main(int argc, char** argv) {
+#ifdef ENVOY_HANDLE_SIGNALS
+  // Enabled by default. Control with "bazel --define=signal_trace=disabled"
+  SignalAction handle_sigs;
+#endif
+
   ::setenv("TEST_RUNDIR", (TestEnvironment::getCheckedEnvVar("TEST_SRCDIR") + "/" +
                            TestEnvironment::getCheckedEnvVar("TEST_WORKSPACE")).c_str(),
            1);


### PR DESCRIPTION
Instantiate SignalAction at the top level of test/main.cc so fatal
signals occurring in tests will result in logged backtrace.  Use
--run_under=`pwd`/tools/stack_decode.py to decode symbols for quick
debugging.  As with exe/main.cc the feature can be disabled with
--define=signal_trace=disabled.

In the process of testing this the need for restoration of the previous
signal handler was seen, particularly in the case where SignalAction was
explicitly instantiated at a tighter scope inside a test.  SignalAction
is modified to restore the prior signal handler and signal handling
stack upon destruction. A new test verifies this functionality.