### PR TITLE
Fail nice and hard if old GCC encountered.

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -32,6 +32,11 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "compiler_requirements_lib",
+    hdrs = ["compiler_requirements.h"],
+)
+
+envoy_cc_library(
     name = "empty_string",
     hdrs = ["empty_string.h"],
 )

--- a/source/common/common/compiler_requirements.h
+++ b/source/common/common/compiler_requirements.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <regex>
+
+#if __cplusplus < 201103L ||                                                                       \
+    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
+     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
+#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
+#endif

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
     name = "envoy_main_lib",
     srcs = ["main.cc"],
     deps = [
+        "//source/common/common:compiler_requirements_lib",
         ":envoy_common_lib",
         ":hot_restart_lib",
     ] + select({

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <regex>
 
 #include "common/event/libevent.h"
 #include "common/local_info/local_info_impl.h"
@@ -19,6 +20,12 @@
 
 #include "ares.h"
 #include "spdlog/spdlog.h"
+
+#if __cplusplus < 201103L ||                                                                       \
+    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
+     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
+#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
+#endif
 
 namespace Server {
 

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <memory>
-#include <regex>
 
+#include "common/common/compiler_requirements.h"
 #include "common/event/libevent.h"
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"
@@ -20,12 +20,6 @@
 
 #include "ares.h"
 #include "spdlog/spdlog.h"
-
-#if __cplusplus < 201103L ||                                                                       \
-    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
-     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
-#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
-#endif
 
 namespace Server {
 

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test_library(
     deps = [
         "//include/envoy/server:options_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:compiler_requirements_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/network:utility_lib",
         "//source/server:options_lib",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -16,7 +16,6 @@
 
 #include "spdlog/spdlog.h"
 
-#include <regex>
 #if __cplusplus < 201103L ||                               \
     (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&    \
         (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && \

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -11,16 +11,11 @@
 #include <vector>
 
 #include "common/common/assert.h"
+#include "common/common/compiler_requirements.h"
 
 #include "server/options_impl.h"
 
 #include "spdlog/spdlog.h"
-
-#if __cplusplus < 201103L ||                                                                       \
-    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
-     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
-#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
-#endif
 
 namespace {
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -16,10 +16,9 @@
 
 #include "spdlog/spdlog.h"
 
-#if __cplusplus < 201103L ||                               \
-    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&    \
-        (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && \
-         !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
+#if __cplusplus < 201103L ||                                                                       \
+    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
+     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
 #error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
 #endif
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -16,6 +16,14 @@
 
 #include "spdlog/spdlog.h"
 
+#include <regex>
+#if __cplusplus < 201103L ||                               \
+    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&    \
+        (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && \
+         !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
+#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
+#endif
+
 namespace {
 
 std::string getOrCreateUnixDomainSocketDirectory() {


### PR DESCRIPTION
If GCC prior to 4.9 was used to compile the result was a mysterious
runtime failure of 14 different tests that rely on the use of
std::regex but are otherwise unremarkable.  This is because GCC 4.8 and
below have a silently incomplete and buggy std::regex implementation. It
compiles, but it doesn't actually do the right thing at runtime (!!).

To prevent a repeat of the confusion this caused #error out if GCC that
doesn't support regex properly is used to compile
test/test_common/environment.cc.