### PR TITLE
http: fix filter iteration when adding body

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -486,7 +486,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilte
         headers, end_stream && continue_data_entry == decoder_filters_.end());
     stream_log_trace("decode headers called: filter={} status={}", *this,
                      static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-    if (!(*entry)->commonHandleAfterHeadersCallback(status)) {
+    if (!(*entry)->commonHandleAfterHeadersCallback(status) &&
+        std::next(entry) != decoder_filters_.end()) {
+      // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
+      // processing since we need to handle the case where a terminal filter wants to buffer, but
+      // a previous filter has added body.
       return;
     }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -860,11 +860,12 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyInline) {
 
   EXPECT_CALL(*decoder_filter2, decodeHeaders(_, false))
       .WillOnce(InvokeWithoutArgs(
-          [&]() -> Http::FilterHeadersStatus { return Http::FilterHeadersStatus::Continue; }));
+          [&]() -> Http::FilterHeadersStatus { return Http::FilterHeadersStatus::StopIteration; }));
 
   EXPECT_CALL(*decoder_filter2, decodeData(_, true))
-      .WillOnce(InvokeWithoutArgs(
-          [&]() -> Http::FilterDataStatus { return Http::FilterDataStatus::Continue; }));
+      .WillOnce(InvokeWithoutArgs([&]() -> Http::FilterDataStatus {
+        return Http::FilterDataStatus::StopIterationAndBuffer;
+      }));
 
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");


### PR DESCRIPTION
Previously, if an intermediate filter added a body during header
iteration, but a terminal filter stopped iteration, the body
would never get dispatched. This commit fixes that case.

Fixes https://github.com/lyft/envoy/issues/624