### PR TITLE
build: prebuilt fixups

### DIFF
--- a/ci/build_container/Makefile
+++ b/ci/build_container/Makefile
@@ -8,6 +8,10 @@ RECIPES := build_recipes
 CC ?= gcc
 CXX ?= g++
 
+# Common compiler flags
+CXXFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2 -DNDEBUG"
+CFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2 -DNDEBUG"
+
 # If $(BUILD_DISTINCT) is set in the make environment, the artifacts are built and installed in
 # distinct directories under $(THIRDPARTY_BUILD) and $(THIRDPARTY_SRC). They end up looking like
 # $(THIRDPARTY_BUILD)/protobuf.dep/include, etc. instead of all being under
@@ -35,6 +39,8 @@ build-recipe = cd $(THIRDPARTY_SRC) && \
 	   THIRDPARTY_BUILD=$(THIRDPARTY_BUILD)/$(DISTINCT_PATH) \
 	   CC=$(CC) \
 	   CXX=$(CXX) \
+	   CFLAGS=$(CFLAGS) \
+	   CXXFLAGS=$(CXXFLAGS) \
 	   $(1) \
 	   time bash $(CURDIR)/recipe_wrapper.sh $(realpath $<) 2>&1) > $@.log) || (cat $@.log; exit 1)) && \
 	$(build-complete)

--- a/ci/build_container/Makefile
+++ b/ci/build_container/Makefile
@@ -9,8 +9,9 @@ CC ?= gcc
 CXX ?= g++
 
 # Common compiler flags
-CXXFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2 -DNDEBUG"
-CFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2 -DNDEBUG"
+CXXFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2"
+CFLAGS ?= "-ggdb3 -fno-omit-frame-pointer -O2"
+CPPFLAGS ?= "-DNDEBUG"
 
 # If $(BUILD_DISTINCT) is set in the make environment, the artifacts are built and installed in
 # distinct directories under $(THIRDPARTY_BUILD) and $(THIRDPARTY_SRC). They end up looking like
@@ -41,6 +42,7 @@ build-recipe = cd $(THIRDPARTY_SRC) && \
 	   CXX=$(CXX) \
 	   CFLAGS=$(CFLAGS) \
 	   CXXFLAGS=$(CXXFLAGS) \
+	   CPPFLAGS=$(CPPFLAGS) \
 	   $(1) \
 	   time bash $(CURDIR)/recipe_wrapper.sh $(realpath $<) 2>&1) > $@.log) || (cat $@.log; exit 1)) && \
 	$(build-complete)

--- a/ci/build_container/build_recipes/boringssl.sh
+++ b/ci/build_container/build_recipes/boringssl.sh
@@ -7,8 +7,10 @@ COMMIT=be2ee342d3781ddb954f91f8a7e660c6f59e87e5
 git clone https://boringssl.googlesource.com/boringssl
 cd boringssl
 git reset --hard $COMMIT
-cmake .
-make
+cmake -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS}" \
+  -DCMAKE_C_FLAGS:STRING="${CFLAGS}" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+make VERBOSE=1
 cp -r include/* $THIRDPARTY_BUILD/include
 cp ssl/libssl.a $THIRDPARTY_BUILD/lib
 cp crypto/libcrypto.a $THIRDPARTY_BUILD/lib

--- a/ci/build_container/build_recipes/boringssl.sh
+++ b/ci/build_container/build_recipes/boringssl.sh
@@ -7,8 +7,8 @@ COMMIT=be2ee342d3781ddb954f91f8a7e660c6f59e87e5
 git clone https://boringssl.googlesource.com/boringssl
 cd boringssl
 git reset --hard $COMMIT
-cmake -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS}" \
-  -DCMAKE_C_FLAGS:STRING="${CFLAGS}" \
+cmake -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS} ${CPPFLAGS}" \
+  -DCMAKE_C_FLAGS:STRING="${CFLAGS} ${CPPFLAGS}" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 make VERBOSE=1
 cp -r include/* $THIRDPARTY_BUILD/include

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -8,5 +8,6 @@ wget -O c-ares-$VERSION.tar.gz https://github.com/c-ares/c-ares/archive/$VERSION
 tar xf c-ares-$VERSION.tar.gz
 cd c-ares-$VERSION
 ./buildconf
-./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-lib-only
-make install
+./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-lib-only \
+  --enable-debug --enable-optimize
+make V=1 install

--- a/ci/build_container/build_recipes/googletest.sh
+++ b/ci/build_container/build_recipes/googletest.sh
@@ -7,5 +7,8 @@ VERSION=release-1.8.0
 wget -O googletest-$VERSION.tar.gz https://github.com/google/googletest/archive/$VERSION.tar.gz
 tar xf googletest-$VERSION.tar.gz
 cd googletest-$VERSION
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$THIRDPARTY_BUILD .
-make install
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$THIRDPARTY_BUILD \
+  -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS} ${CPPFLAGS}" \
+  -DCMAKE_C_FLAGS:STRING="${CFLAGS} ${CPPFLAGS}" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+make VERBOSE=1 install

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -8,4 +8,4 @@ wget -O gperftools-$VERSION.tar.gz https://github.com/gperftools/gperftools/rele
 tar xf gperftools-$VERSION.tar.gz
 cd gperftools-$VERSION
 LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers
-make install
+make V=1 install

--- a/ci/build_container/build_recipes/http-parser.sh
+++ b/ci/build_container/build_recipes/http-parser.sh
@@ -7,7 +7,7 @@ VERSION=2.7.0
 wget -O http-parser-$VERSION.tar.gz https://github.com/nodejs/http-parser/archive/v$VERSION.tar.gz
 tar xf http-parser-$VERSION.tar.gz
 cd http-parser-$VERSION
-$CC -O2 -c http_parser.c -o http_parser.o
+$CC $CFLAGS -c http_parser.c -o http_parser.o
 ar rcs libhttp_parser.a http_parser.o
 cp libhttp_parser.a $THIRDPARTY_BUILD/lib
 cp http_parser.h $THIRDPARTY_BUILD/include

--- a/ci/build_container/build_recipes/http-parser.sh
+++ b/ci/build_container/build_recipes/http-parser.sh
@@ -7,7 +7,7 @@ VERSION=2.7.0
 wget -O http-parser-$VERSION.tar.gz https://github.com/nodejs/http-parser/archive/v$VERSION.tar.gz
 tar xf http-parser-$VERSION.tar.gz
 cd http-parser-$VERSION
-$CC $CFLAGS -c http_parser.c -o http_parser.o
+$CC $CFLAGS $CPPFLAGS -c http_parser.c -o http_parser.o
 ar rcs libhttp_parser.a http_parser.o
 cp libhttp_parser.a $THIRDPARTY_BUILD/lib
 cp http_parser.h $THIRDPARTY_BUILD/include

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -8,4 +8,4 @@ wget -O libevent-$VERSION.tar.gz https://github.com/libevent/libevent/releases/d
 tar xf libevent-$VERSION.tar.gz
 cd libevent-$VERSION
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --disable-libevent-regress --disable-openssl
-make install
+make V=1 install

--- a/ci/build_container/build_recipes/lightstep.sh
+++ b/ci/build_container/build_recipes/lightstep.sh
@@ -11,4 +11,4 @@ cd lightstep-tracer-cpp-$VERSION
 [ -z "$PROTOBUF_BUILD" ] && PROTOBUF_BUILD="$THIRDPARTY_BUILD"
 ./configure --disable-grpc --prefix=$THIRDPARTY_BUILD --enable-shared=no \
 	    protobuf_CFLAGS="-I$PROTOBUF_BUILD/include" protobuf_LIBS="-L$PROTOBUF_BUILD/lib -lprotobuf" PROTOC=$PROTOBUF_BUILD/bin/protoc
-make install
+make V=1 install

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -8,4 +8,4 @@ wget -O nghttp2-$VERSION.tar.gz https://github.com/nghttp2/nghttp2/releases/down
 tar xf nghttp2-$VERSION.tar.gz
 cd nghttp2-$VERSION
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-lib-only
-make install
+make V=1 install

--- a/ci/build_container/build_recipes/protobuf.sh
+++ b/ci/build_container/build_recipes/protobuf.sh
@@ -9,4 +9,4 @@ tar xf protobuf-$VERSION.tar.gz
 rsync -av protobuf-$VERSION/* $THIRDPARTY_SRC/protobuf
 cd protobuf-$VERSION
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no
-make install
+make V=1 install


### PR DESCRIPTION
1) Don't omit frame pointers
2) Compile symbols
3) Compile optimized version of boringssl (oops)

Fixes https://github.com/lyft/envoy/issues/898