### PR TITLE
sanitize: various fixes for issues raised by clang asan/ubsan.

### DIFF
--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -29,11 +29,13 @@ bool fileExists(const std::string& path) {
 }
 
 bool directoryExists(const std::string& path) {
-  DIR* dir = opendir(path.c_str());
-  bool dirExists = nullptr != dir;
-  closedir(dir);
+  DIR* const dir = opendir(path.c_str());
+  const bool dir_exists = nullptr != dir;
+  if (dir_exists) {
+    closedir(dir);
+  }
 
-  return dirExists;
+  return dir_exists;
 }
 
 std::string fileReadToEnd(const std::string& path) {

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -209,17 +209,13 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
         throw ProtocolError("expected new line");
       }
 
-      if (pending_integer_.negative_) {
-        pending_integer_.integer_ *= -1;
-      }
-
       log_trace("parse slice: IntegerLF: {}", pending_integer_.integer_);
       remaining--;
       buffer++;
 
       PendingValue& current_value = pending_value_stack_.front();
       if (current_value.value_->type() == RespType::Array) {
-        if (pending_integer_.integer_ < 0) {
+        if (pending_integer_.negative_) {
           // Null array. Convert to null.
           current_value.value_->type(RespType::Null);
           state_ = State::ValueComplete;
@@ -232,11 +228,16 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
           state_ = State::ValueStart;
         }
       } else if (current_value.value_->type() == RespType::Integer) {
-        current_value.value_->asInteger() = pending_integer_.integer_;
+        if (pending_integer_.integer_ == 0 || !pending_integer_.negative_) {
+          current_value.value_->asInteger() = pending_integer_.integer_;
+        } else {
+          current_value.value_->asInteger() =
+              static_cast<int64_t>(pending_integer_.integer_ - 1) * -1 - 1;
+        }
         state_ = State::ValueComplete;
       } else {
         ASSERT(current_value.value_->type() == RespType::BulkString);
-        if (pending_integer_.integer_ >= 0) {
+        if (!pending_integer_.negative_) {
           // TODO(mattklein123): reserve and define max length since we don't stream currently.
           state_ = State::BulkStringBody;
         } else {
@@ -250,7 +251,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::BulkStringBody: {
-      ASSERT(pending_integer_.integer_ >= 0);
+      ASSERT(!pending_integer_.negative_);
       uint64_t length_to_copy =
           std::min(static_cast<uint64_t>(pending_integer_.integer_), remaining);
       pending_value_stack_.front().value_->asString().append(buffer, length_to_copy);
@@ -396,7 +397,7 @@ void EncoderImpl::encodeInteger(int64_t integer, Buffer::Instance& out) {
     current += StringUtil::itoa(current, 31, integer);
   } else {
     *current++ = '-';
-    current += StringUtil::itoa(current, 30, integer * -1);
+    current += StringUtil::itoa(current, 30, static_cast<uint64_t>((integer + 1) * -1) + 1ULL);
   }
 
   *current++ = '\r';

--- a/source/common/redis/codec_impl.h
+++ b/source/common/redis/codec_impl.h
@@ -43,7 +43,7 @@ private:
       negative_ = false;
     }
 
-    int64_t integer_;
+    uint64_t integer_;
     bool negative_;
   };
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -202,8 +202,7 @@ const std::vector<HostSharedPtr>& LoadBalancerBase::tryChooseLocalZoneHosts() {
 const std::vector<HostSharedPtr>& LoadBalancerBase::hostsToUse() {
   ASSERT(host_set_.healthyHosts().size() <= host_set_.hosts().size());
 
-  if (host_set_.hosts().empty() ||
-      LoadBalancerUtility::isGlobalPanic(host_set_, stats_, runtime_)) {
+  if (LoadBalancerUtility::isGlobalPanic(host_set_, stats_, runtime_)) {
     return host_set_.hosts();
   }
 
@@ -215,8 +214,7 @@ const std::vector<HostSharedPtr>& LoadBalancerBase::hostsToUse() {
     return host_set_.healthyHosts();
   }
 
-  if (local_host_set_->hosts().empty() ||
-      LoadBalancerUtility::isGlobalPanic(*local_host_set_, stats_, runtime_)) {
+  if (LoadBalancerUtility::isGlobalPanic(*local_host_set_, stats_, runtime_)) {
     stats_.lb_local_cluster_not_ok_.inc();
     return host_set_.healthyHosts();
   }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -125,7 +125,9 @@ bool LoadBalancerUtility::isGlobalPanic(const HostSet& host_set, ClusterStats& s
                                         Runtime::Loader& runtime) {
   uint64_t global_panic_threshold =
       std::min<uint64_t>(100, runtime.snapshot().getInteger(RuntimePanicThreshold, 50));
-  double healthy_percent = 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
+  double healthy_percent = host_set.hosts().size() == 0
+                               ? 0
+                               : 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
 
   // If the % of healthy hosts in the cluster is less than our panic threshold, we use all hosts.
   if (healthy_percent < global_panic_threshold) {

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -73,7 +73,18 @@ TEST_F(RedisEncoderDecoderImplTest, Integer) {
   EXPECT_EQ(0UL, buffer_.length());
 }
 
-TEST_F(RedisEncoderDecoderImplTest, NegativeInteger) {
+TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerSmall) {
+  RespValue value;
+  value.type(RespType::Integer);
+  value.asInteger() = -1;
+  encoder_.encode(value, buffer_);
+  EXPECT_EQ(":-1\r\n", TestUtility::bufferToString(buffer_));
+  decoder_.decode(buffer_);
+  EXPECT_EQ(value, *decoded_values_[0]);
+  EXPECT_EQ(0UL, buffer_.length());
+}
+
+TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerLarge) {
   RespValue value;
   value.type(RespType::Integer);
   value.asInteger() = std::numeric_limits<int64_t>::min();

--- a/test/common/runtime/uuid_util_test.cc
+++ b/test/common/runtime/uuid_util_test.cc
@@ -41,12 +41,15 @@ TEST(UUIDUtilsTest, checkDistribution) {
   const int required_percentage = 11;
   int total_samples = 0;
   int interesting_samples = 0;
+  // For some reason, ASAN/UBSAN seems to run very slowly unless this is defined outside the loop
+  // condition.
+  const int iters = 500000;
 
-  for (int i = 0; i < 500000; ++i) {
+  for (int i = 0; i < iters; ++i) {
     std::string uuid = random.uuid();
 
     uint16_t value;
-    UuidUtils::uuidModBy(uuid, value, mod);
+    ASSERT_TRUE(UuidUtils::uuidModBy(uuid, value, mod));
 
     if (value < required_percentage) {
       interesting_samples++;

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -360,6 +360,7 @@ TEST_F(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
   HostListsSharedPtr local_hosts_per_zone(new std::vector<std::vector<HostSharedPtr>>({{}, {}}));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 50))
+      .WillOnce(Return(50))
       .WillOnce(Return(50));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
       .WillOnce(Return(true));

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -26,6 +26,7 @@ ClientContextPtr SslIntegrationTest::client_ssl_ctx_san_;
 ClientContextPtr SslIntegrationTest::client_ssl_ctx_alpn_san_;
 
 void SslIntegrationTest::SetUpTestCase() {
+  runtime_.reset(new NiceMock<Runtime::MockLoader>());
   context_manager_.reset(new ContextManagerImpl(*runtime_));
   upstream_ssl_ctx_ = createUpstreamSslContext();
   fake_upstreams_.emplace_back(
@@ -52,6 +53,7 @@ void SslIntegrationTest::TearDownTestCase() {
   client_ssl_ctx_san_.reset();
   client_ssl_ctx_alpn_san_.reset();
   context_manager_.reset();
+  runtime_.reset();
 }
 
 ServerContextPtr SslIntegrationTest::createUpstreamSslContext() {


### PR DESCRIPTION
* nullptr and closedir in source/common/filesystem/filesystem_impl.cc.

* int64_t negative overflow in source/common/redis/codec_impl.cc.

* Divide-by-zero in source/common/upstream/load_balancer_impl.cc.

* UBSAN performance rejigger in test/common/runtime/uuid_util_test.cc.

* unique_ptr nullptr reference in test/integration/ssl_integration_test.cc.