### PR TITLE
Fix segfault caused by modifying list within iteration.

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -95,7 +95,12 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
     if (!started_secondary_initialize_) {
       log().info("cm init: initializing secondary clusters");
       started_secondary_initialize_ = true;
-      for (Cluster* cluster : secondary_init_clusters_) {
+      // Cluster::initialize() method can modify the list of secondary_init_clusters_ to remove
+      // the item currently being initialized, so we eschew range-based-for and do this complicated
+      // dance to increment the iterator before calling initialize.
+      for (auto iter = secondary_init_clusters_.begin(); iter != secondary_init_clusters_.end();) {
+        Cluster* cluster = *iter;
+        ++iter;
         cluster->initialize();
       }
     }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -839,31 +839,23 @@ TEST(ClusterManagerInitHelper, AddSecondaryAfterSecondaryInit) {
 }
 
 TEST(ClusterManagerInitHelper, RemoveClusterWithinInitLoop) {
-  InSequence s;
-  ClusterManagerInitHelper init_helper;
-
   // Tests the scenario encountered in Issue 903: The cluster was removed from
   // the secondary init list while traversing the list.
+
+  InSequence s;
+  ClusterManagerInitHelper init_helper;
   NiceMock<MockCluster> cluster;
-  // Fake that we are in the secondary InitializePhase for this test.
   ON_CALL(cluster, initializePhase()).WillByDefault(Return(Cluster::InitializePhase::Secondary));
-  // We expect that initialize() should be called first upon addCluster.  In the
-  // bug scenario this initialize was not able to complete right away because of
-  // DNS lookup, so the initializedCb containing the call to removeCluster was not called
-  // yet.  The same scenario is simulated here by taking no action upon
-  // initialize().
-  EXPECT_CALL(cluster, initialize());
   init_helper.addCluster(cluster);
 
-  // Short circuit by making initialize immediately call
-  // init_helper.removeCluster().  In the real bug scenario actual initialization
-  // happens followed by a call to addCluster(), which calls removeCluster()
-  // because initialization is complete.
-  ON_CALL(cluster, initialize())
-      .WillByDefault(Invoke([&]() -> void { init_helper.removeCluster(cluster); }));
+  // Set up the scenario seen in Issue 903 where initialize() ultimately results
+  // in the removeCluster() call. In the real bug this was a long and complex call
+  // chain.
+  EXPECT_CALL(cluster, initialize())
+      .WillOnce(Invoke([&]() -> void { init_helper.removeCluster(cluster); }));
 
   // Now call onStaticLoadComplete which will exercise maybeFinishInitialize()
-  // In the real bug scenario this was reached once DNS lookup attempt finished.
+  // which calls initialize() on the members of the secondary init list.
   init_helper.onStaticLoadComplete();
 }
 


### PR DESCRIPTION
A segfault arose when iterating over the list of
secondary_init_clusters_ and calling initialize().  The call to
initialize may result in the initialized item being removed from the
secondary_init_clusters_ list while walking through the list.  The
initialized item can only remove itself, not any other item in the
list.  However, this resulted in chasing an invalidated iterator when
trying to go to the next element in the list.

To fix this the loop is modified so that the iterator is advanced to the
next item (or end() if no more items) before calling
Cluster::initialize().

A test is included which exercises this scenario

Fixes #903