### PR TITLE
statsd: add connection overlow handling

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -47,9 +47,8 @@ public:
   virtual ClusterInfoMap clusters() PURE;
 
   /**
-   * @return ClusterInfoConstSharedPtr the thread local cluster with the given name or nullptr if it
-   *does not
-   * exist. This is thread safe.
+   * @return ThreadLocalCluster* the thread local cluster with the given name or nullptr if it
+   * does not exist. This is thread safe.
    *
    * NOTE: The pointer returned by this function is ONLY safe to use in the context of the owning
    * call (or if the caller knows that the cluster is fully static and will never be deleted). In

--- a/source/common/http/filter/buffer_filter.h
+++ b/source/common/http/filter/buffer_filter.h
@@ -22,7 +22,7 @@ namespace Http {
 // clang-format on
 
 /**
- * Wrapper struct for connection manager stats. @see stats_macros.h
+ * Wrapper struct for buffer filter stats. @see stats_macros.h
  */
 struct BufferFilterStats {
   ALL_BUFFER_FILTER_STATS(GENERATE_COUNTER_STRUCT)

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -62,7 +62,8 @@ private:
 class TcpStatsdSink : public Sink {
 public:
   TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
-                ThreadLocal::Instance& tls, Upstream::ClusterManager& cluster_manager);
+                ThreadLocal::Instance& tls, Upstream::ClusterManager& cluster_manager,
+                Stats::Scope& scope);
 
   // Stats::Sink
   void flushCounter(const std::string& name, uint64_t delta) override {
@@ -104,11 +105,14 @@ private:
     bool shutdown_{};
   };
 
+  static constexpr uint32_t MaxBufferedStatsBytes = (1024 * 1024 * 16);
+
   const LocalInfo::LocalInfo& local_info_;
-  std::string cluster_name_;
+  Upstream::ClusterInfoConstSharedPtr cluster_info_;
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;
   Upstream::ClusterManager& cluster_manager_;
+  Stats::Counter& cx_overflow_stat_;
 };
 
 } // Statsd

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -105,6 +105,7 @@ private:
     bool shutdown_{};
   };
 
+  // Somewhat arbitrary 16MiB limit for buffered stats.
   static constexpr uint32_t MaxBufferedStatsBytes = (1024 * 1024 * 16);
 
   const LocalInfo::LocalInfo& local_info_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -330,7 +330,7 @@ void InstanceImpl::initializeStatSinks() {
     log().info("statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
     stat_sinks_.emplace_back(
         new Stats::Statsd::TcpStatsdSink(local_info_, config_->statsdTcpClusterName().value(),
-                                         thread_local_, config_->clusterManager()));
+                                         thread_local_, config_->clusterManager(), stats_store_));
     stats_store_.addSink(*stat_sinks_.back());
   }
 }

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -40,6 +40,7 @@ public:
         Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
 
     EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+    EXPECT_CALL(*connection_, setBufferStats(_));
     EXPECT_CALL(*connection_, connect());
   }
 

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::InSequence;
 using testing::NiceMock;
 using testing::Return;
 
@@ -24,48 +25,79 @@ namespace Statsd {
 class TcpStatsdSinkTest : public testing::Test {
 public:
   TcpStatsdSinkTest() {
-    EXPECT_CALL(cluster_manager_, get("statsd"));
-    sink_.reset(new TcpStatsdSink(local_info_, "statsd", tls_, cluster_manager_));
+    EXPECT_CALL(cluster_manager_, get("fake_cluster"));
+    sink_.reset(
+        new TcpStatsdSink(local_info_, "fake_cluster", tls_, cluster_manager_,
+                          cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_));
+  }
+
+  void expectCreateConnection() {
+    connection_ = new NiceMock<Network::MockClientConnection>();
+    Upstream::MockHost::MockCreateConnectionData conn_info;
+    conn_info.connection_ = connection_;
+    conn_info.host_.reset(new Upstream::HostImpl(
+        Upstream::ClusterInfoConstSharedPtr{new Upstream::MockClusterInfo}, "",
+        Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
+
+    EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+    EXPECT_CALL(*connection_, connect());
   }
 
   NiceMock<ThreadLocal::MockInstance> tls_;
   Upstream::MockClusterManager cluster_manager_;
   std::unique_ptr<TcpStatsdSink> sink_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  Network::MockClientConnection* connection_{};
 };
 
 TEST_F(TcpStatsdSinkTest, All) {
-  Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
-  Upstream::MockHost::MockCreateConnectionData conn_info;
-  conn_info.connection_ = connection;
-  conn_info.host_.reset(
-      new Upstream::HostImpl(Upstream::ClusterInfoConstSharedPtr{new Upstream::MockClusterInfo}, "",
-                             Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
+  InSequence s;
 
-  EXPECT_CALL(cluster_manager_, tcpConnForCluster_("statsd")).WillOnce(Return(conn_info));
-  EXPECT_CALL(*connection, connect());
-
-  EXPECT_CALL(*connection, write(BufferStringEqual("envoy.test_counter:1|c\n")));
+  expectCreateConnection();
+  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
   sink_->flushCounter("test_counter", 1);
 
-  EXPECT_CALL(*connection, write(BufferStringEqual("envoy.test_gauge:2|g\n")));
+  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_gauge:2|g\n")));
   sink_->flushGauge("test_gauge", 2);
 
   // Test a disconnect. We should connect again.
-  connection->raiseEvents(Network::ConnectionEvent::RemoteClose);
+  connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
 
-  connection = new NiceMock<Network::MockClientConnection>();
-  conn_info.connection_ = connection;
-  EXPECT_CALL(cluster_manager_, tcpConnForCluster_("statsd")).WillOnce(Return(conn_info));
-  EXPECT_CALL(*connection, connect());
-
-  EXPECT_CALL(*connection, write(BufferStringEqual("envoy.test_timer:5|ms\n")));
+  expectCreateConnection();
+  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_timer:5|ms\n")));
   sink_->onTimespanComplete("test_timer", std::chrono::milliseconds(5));
 
-  EXPECT_CALL(*connection, write(BufferStringEqual("envoy.histogram_test_timer:15|ms\n")));
+  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.histogram_test_timer:15|ms\n")));
   sink_->onHistogramComplete("histogram_test_timer", 15);
 
-  EXPECT_CALL(*connection, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  tls_.shutdownThread();
+}
+
+TEST_F(TcpStatsdSinkTest, Overflow) {
+  InSequence s;
+
+  // Synthetically set buffer above high watermark. Make sure we don't write anything.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
+      1024 * 1024 * 17);
+  sink_->flushCounter("test_counter", 1);
+
+  // Lower and make sure we write.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
+      1024 * 1024 * 15);
+  expectCreateConnection();
+  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
+  sink_->flushCounter("test_counter", 1);
+
+  // Raise and make sure we don't write and kill connection.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
+      1024 * 1024 * 17);
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  sink_->flushCounter("test_counter", 1);
+
+  EXPECT_EQ(2UL, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                     .counter("statsd.cx_overflow")
+                     .value());
   tls_.shutdownThread();
 }
 


### PR DESCRIPTION
We have seen a production issue where the local statsd relay
stops responding without breaking the connection. Eventually this
leads to an OOM condition. This commit adds a safeguard around the
maximum amount of memory that can be buffered before we give up.
In that case we increment a stat that can at least be viewed locally.

Fixes https://github.com/lyft/envoy/issues/897