### PR TITLE
test/network: turn dual bind off and parameterize ipv6 tests

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -85,8 +85,16 @@ example, for extremely verbose test debugging:
 bazel test --test_output=streamed //test/common/http:async_client_impl_test --test_arg="-l trace"
 ```
 
-Bazel will by default cache successful test results. To force it to rerun tests:
+By default, testing exercises both IPv4 and IPv6 address connections. In IPv4 or IPv6 only
+environments, set the environment variable ENVOY_IP_TEST_VERSIONS to "v4only" or
+"v6only", respectively.
 
+```
+bazel test //test/... --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+bazel test //test/... --test_env=ENVOY_IP_TEST_VERSIONS=v6only
+```
+
+Bazel will by default cache successful test results. To force it to rerun tests:
 
 ```
 bazel test //test/common/http:async_client_impl_test --cache_test_results=no

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -81,7 +81,6 @@ fi
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-# TODO(hennna): Point to updated hash.
 (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git checkout 9f006f6be519007e9be3b29ad531b8e8be5a18d6)
 
 # Also setup some space for building Envoy standalone.

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -185,7 +185,12 @@ int Ipv6Instance::connect(int fd) const {
 }
 
 int Ipv6Instance::socket(SocketType type) const {
-  return ::socket(AF_INET6, flagsFromSocketType(type), 0);
+  const int fd = ::socket(AF_INET6, flagsFromSocketType(type), 0);
+  RELEASE_ASSERT(fd != -1);
+  // Setting IPV6_V6ONLY resticts the IPv6 socket to IPv6 connections only.
+  const int v6only = 1;
+  RELEASE_ASSERT(::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != -1);
+  return fd;
 }
 
 PipeInstance::PipeInstance(const sockaddr_un* address) : InstanceBase(Type::Pipe) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -87,12 +87,8 @@ const std::string Utility::TCP_SCHEME = "tcp://";
 const std::string Utility::UNIX_SCHEME = "unix://";
 
 Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
-  // TODO(mattklein123): IPv6 support.
-  // TODO(mattklein123): We still support the legacy tcp:// and unix:// names. We should
-  // support/parse ip:// and pipe:// as better names.
   if (url.find(TCP_SCHEME) == 0) {
-    return Address::InstanceConstSharedPtr{
-        new Address::Ipv4Instance(hostFromTcpUrl(url), portFromTcpUrl(url))};
+    return Address::parseInternetAddressAndPort(url.substr(TCP_SCHEME.size()));
   } else if (url.find(UNIX_SCHEME) == 0) {
     return Address::InstanceConstSharedPtr{
         new Address::PipeInstance(url.substr(UNIX_SCHEME.size()))};

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     srcs = ["address_impl_test.cc"],
     deps = [
         "//source/common/network:address_lib",
+        "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
     ],
@@ -42,6 +43,8 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
     ],
 )
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -12,6 +12,7 @@
 #include "common/common/utility.h"
 #include "common/network/address_impl.h"
 
+#include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"
 
@@ -40,11 +41,21 @@ void testSocketBindAndConnect(const std::string& addr_port_str) {
   if (addr_port->ip()->port() == 0) {
     addr_port = Network::Test::findOrCheckFreePort(addr_port, SocketType::Stream);
   }
+  ASSERT_NE(addr_port, nullptr);
+  ASSERT_NE(addr_port->ip(), nullptr);
 
   // Create a socket on which we'll listen for connections from clients.
   const int listen_fd = addr_port->socket(SocketType::Stream);
   ASSERT_GE(listen_fd, 0) << addr_port->asString();
   ScopedFdCloser closer1(listen_fd);
+
+  // Check that IPv6 sockets accept IPv6 connections only.
+  if (addr_port->ip()->ipv6() != nullptr) {
+    int v6only = 0;
+    socklen_t size_int = sizeof(v6only);
+    ASSERT_GE(::getsockopt(listen_fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &size_int), 0);
+    EXPECT_EQ(v6only, 1);
+  }
 
   // Bind the socket to the desired address and port.
   int rc = addr_port->bind(listen_fd);
@@ -72,6 +83,16 @@ void testSocketBindAndConnect(const std::string& addr_port_str) {
   ASSERT_EQ(rc, 0) << addr_port->asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
 }
 } // namespace
+
+class AddressImplSocketTest : public testing::TestWithParam<IpVersion> {};
+INSTANTIATE_TEST_CASE_P(IpVersions, AddressImplSocketTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(AddressImplSocketTest, SocketBindAndConnect) {
+  // Test listening on and connecting to an unused port with an IP loopback address.
+  testSocketBindAndConnect(
+      fmt::format("{}:0", Network::Test::getLoopbackAddressUrlString(GetParam())));
+}
 
 TEST(Ipv4InstanceTest, SocketAddress) {
   sockaddr_in addr4;
@@ -128,11 +149,6 @@ TEST(Ipv4InstanceTest, BadAddress) {
   EXPECT_EQ(parseInternetAddress("1.2.3.4.5"), nullptr);
   EXPECT_EQ(parseInternetAddress("1.2.3.256"), nullptr);
   EXPECT_EQ(parseInternetAddress("foo"), nullptr);
-}
-
-TEST(Ipv4InstanceTest, SocketBindAndConnect) {
-  // Test listening on and connecting to an unused port on the IPv4 loopback address.
-  testSocketBindAndConnect("127.0.0.1:0");
 }
 
 TEST(Ipv4InstanceTest, ParseInternetAddressAndPort) {
@@ -208,11 +224,6 @@ TEST(Ipv6InstanceTest, BadAddress) {
   EXPECT_EQ(parseInternetAddress("0:0:0:0"), nullptr);
   EXPECT_EQ(parseInternetAddress("fffff::"), nullptr);
   EXPECT_EQ(parseInternetAddress("/foo"), nullptr);
-}
-
-TEST(Ipv6InstanceTest, SocketBindAndConnect) {
-  // Test listening on and connecting to an unused port on the IPv6 loopback address.
-  testSocketBindAndConnect("[::1]:0");
 }
 
 TEST(Ipv6InstanceTest, ParseInternetAddressAndPort) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -147,7 +147,6 @@ public:
 
     Stats::IsolatedStoreImpl stats_store;
     Event::DispatcherImpl dispatcher;
-
     Network::TcpListenSocket socket(Network::Test::getAnyAddress(GetParam()), true);
     Network::MockListenerCallbacks listener_callbacks;
     Network::MockConnectionHandler connection_handler;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -14,6 +14,8 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
@@ -138,14 +140,15 @@ TEST(ConnectionImplTest, BufferStats) {
   dispatcher.run(Event::Dispatcher::RunType::Block);
 }
 
-class ReadBufferLimitTest : public testing::Test {
+class ReadBufferLimitTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size) {
     const uint32_t buffer_size = 256 * 1024;
 
     Stats::IsolatedStoreImpl stats_store;
     Event::DispatcherImpl dispatcher;
-    Network::TcpListenSocket socket(Network::Utility::getIpv6AnyAddress(), true);
+
+    Network::TcpListenSocket socket(Network::Test::getAnyAddress(GetParam()), true);
     Network::MockListenerCallbacks listener_callbacks;
     Network::MockConnectionHandler connection_handler;
     Network::ListenerPtr listener =
@@ -198,9 +201,12 @@ public:
   }
 };
 
-TEST_F(ReadBufferLimitTest, NoLimit) { readBufferLimitTest(0, 256 * 1024); }
+INSTANTIATE_TEST_CASE_P(IpVersions, ReadBufferLimitTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-TEST_F(ReadBufferLimitTest, SomeLimit) { readBufferLimitTest(32 * 1024, 32 * 1024); }
+TEST_P(ReadBufferLimitTest, NoLimit) { readBufferLimitTest(0, 256 * 1024); }
+
+TEST_P(ReadBufferLimitTest, SomeLimit) { readBufferLimitTest(32 * 1024, 32 * 1024); }
 
 TEST(TcpClientConnectionImplTest, BadConnectNotConnRefused) {
   Event::DispatcherImpl dispatcher;

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -124,7 +124,27 @@ TEST(NetworkUtility, Url) {
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo"), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:bar"), EnvoyException);
   EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
+}
+
+TEST(NetworkUtility, resolveUrl) {
   EXPECT_THROW(Utility::resolveUrl("foo"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("abc://foo"), EnvoyException);
+  EXPECT_EQ("", Utility::resolveUrl("unix://")->asString());
+  EXPECT_EQ("foo", Utility::resolveUrl("unix://foo")->asString());
+  EXPECT_EQ("tmp", Utility::resolveUrl("unix://tmp")->asString());
+  EXPECT_EQ("tmp/server", Utility::resolveUrl("unix://tmp/server")->asString());
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://192.168.3.3"));
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://192.168.3.3.3:0"));
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://192.168.3:0"));
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://[::1]"));
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://[:::1]:1"));
+  EXPECT_EQ(nullptr, Utility::resolveUrl("tcp://foo:0"));
+  EXPECT_EQ("1.2.3.4:1234", Utility::resolveUrl("tcp://1.2.3.4:1234")->asString());
+  EXPECT_EQ("0.0.0.0:0", Utility::resolveUrl("tcp://0.0.0.0:0")->asString());
+  EXPECT_EQ("[::1]:1", Utility::resolveUrl("tcp://[::1]:1")->asString());
+  EXPECT_EQ("[1::2:3]:4", Utility::resolveUrl("tcp://[1::2:3]:4")->asString());
+  EXPECT_EQ("[a::1]:0", Utility::resolveUrl("tcp://[a::1]:0")->asString());
+  EXPECT_EQ("[a:b:c:d::]:0", Utility::resolveUrl("tcp://[a:b:c:d::]:0")->asString());
 }
 
 TEST(NetworkUtility, getLocalAddress) { EXPECT_NE(nullptr, Utility::getLocalAddress()); }

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -19,6 +19,7 @@ envoy_cc_test_library(
     srcs = ["environment.cc"],
     hdrs = ["environment.h"],
     deps = [
+        ":network_utility_lib",
         "//include/envoy/server:options_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:compiler_requirements_lib",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -71,12 +71,12 @@ std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest()
   for (auto version : {Network::Address::IpVersion::v4, Network::Address::IpVersion::v6}) {
     if (TestEnvironment::shouldRunTestForIpVersion(version)) {
       parameters.push_back(version);
-      if (Network::Test::supportsIpVersion(version) == false) {
+      if (!Network::Test::supportsIpVersion(version)) {
         Logger::Registry::getLog(Logger::Id::testing)
-            .warn(fmt::format("Parameterized testing with IP{} addresses may not be supported."
-                              " If testing fails, set enviroment variable ENVOY_IP_TEST_VERSIONS "
-                              "in test/main.cc",
-                              Network::Test::addressVersionAsString(version)));
+            .warn(
+                fmt::format("Testing with IP{} addresses may not be supported on this machine. If "
+                            "testing fails, set the environment variable ENVOY_IP_TEST_VERSIONS.",
+                            Network::Test::addressVersionAsString(version)));
       }
     }
   }

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -80,6 +80,13 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port
   return instance;
 }
 
+const std::string getLoopbackAddressUrlString(const Address::IpVersion version) {
+  if (version == Address::IpVersion::v6) {
+    return std::string("[::1]");
+  }
+  return std::string("127.0.0.1");
+}
+
 Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion version) {
   if (version == Address::IpVersion::v4) {
     // Pick a random address in 127.0.0.0/8.
@@ -97,6 +104,13 @@ Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion versio
     // There is only one IPv6 loopback address.
     return Network::Utility::getIpv6LoopbackAddress();
   }
+}
+
+Address::InstanceConstSharedPtr getAnyAddress(Address::IpVersion version) {
+  if (version == Address::IpVersion::v4) {
+    return Network::Utility::getIpv4AnyAddress();
+  }
+  return Network::Utility::getIpv6AnyAddress();
 }
 
 std::pair<Address::InstanceConstSharedPtr, int> bindFreeLoopbackPort(Address::IpVersion version,

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -129,10 +129,10 @@ bool supportsIpVersion(const Address::IpVersion version) {
   }
   if (0 != addr->bind(fd)) {
     // Socket bind failed.
-    ::close(fd);
+    RELEASE_ASSERT(::close(fd) == 0);
     return false;
   }
-  ::close(fd);
+  RELEASE_ASSERT(::close(fd) == 0);
   return true;
 }
 

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -33,12 +33,26 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port
                                                     Address::SocketType type);
 
 /**
+ * Get a URL ready IP loopback address as a string.
+ * @param version IP address version of loopback address.
+ * @return std::string URL ready loopback address as a string.
+ */
+const std::string getLoopbackAddressUrlString(const Address::IpVersion version);
+
+/**
  * Returns a loopback address for the specified IP version. For IPv6 this is always the same,
  * but for IPv4 it is anywhere in the range 127.0.0.0/8.
  * @param version the IP version of the loopback address.
  * @returns a loopback address for the specified IP version.
  */
 Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion version);
+
+/**
+ * Returns the any address for the specified IP version.
+ * @param version the IP version of the any address.
+ * @returns the any address for the specified IP version.
+ */
+Address::InstanceConstSharedPtr getAnyAddress(Address::IpVersion version);
 
 /**
  * Bind a socket to a free port on a loopback address, and return the socket's fd and bound address.

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -40,6 +40,13 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port
 const std::string getLoopbackAddressUrlString(const Address::IpVersion version);
 
 /**
+ * Return a string version of enum IpVersion version.
+ * @param version IP address version.
+ * @return std::string string version of IpVersion.
+ */
+const std::string addressVersionAsString(const Address::IpVersion version);
+
+/**
  * Returns a loopback address for the specified IP version. For IPv6 this is always the same,
  * but for IPv4 it is anywhere in the range 127.0.0.0/8.
  * @param version the IP version of the loopback address.
@@ -52,7 +59,16 @@ Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion versio
  * @param version the IP version of the any address.
  * @returns the any address for the specified IP version.
  */
-Address::InstanceConstSharedPtr getAnyAddress(Address::IpVersion version);
+Address::InstanceConstSharedPtr getAnyAddress(const Address::IpVersion version);
+
+/**
+ * This function tries to create a socket of type IpVersion version and bind to it. If
+ * successful this function returns true. If either socket creation or socket
+ * bind fail, this function returns false.
+ * @param version the IP verson to test.
+ * @return bool whether IpVersion addresses are "supported".
+ */
+bool supportsIpVersion(const Address::IpVersion version);
 
 /**
  * Bind a socket to a free port on a loopback address, and return the socket's fd and bound address.


### PR DESCRIPTION
This PR turns off dual bind for IPv6 sockets. Turning dual bind off causes some test/common/network/.. tests to fail in Ipv4 only enviroments. In addition, a segfault path in address_impl_test.cc is exercised. This PR addresses those issues.

In Ipv4 only environments, users need to set the environment variable ENVOY_IP_TEST_VERSIONS to "v4only" to omit tests that bind or connect using Ipv6 addresses. This can be done:

1. bazel test --test_env=ENVOY_IP_TEST_VERSIONS=v4only ...
2. In main/test.cc https://github.com/lyft/envoy/blob/master/test/main.cc#L31