### PR TITLE
ci: copy coverage report out of the container.

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -62,7 +62,7 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.dev` &mdash; build Envoy static binary and run tests under `-c fastbuild` with gcc-4.9.
 * `bazel.release` &mdash; build Envoy static binary and run tests under `-c opt` with gcc-4.9.
 * `bazel.release.server_only` &mdash; build Envoy static binary under `-c opt` with gcc-4.9.
-* `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc-4.9, generating coverage information in `<SOURCE_DIR>/generated/coverage/coverage.html`.
+* `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc-4.9, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
 * `bazel.tsan` &mdash; build and run tests under `-c dbg --config=clang-tsan` with clang-5.0.
 * `check_format`&mdash; run `clang-format` 3.6 and `buildifier` on entire source tree.
 * `fix_format`&mdash; run and enforce `clang-format` 3.6 and `buildifier` on entire source tree.

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -93,6 +93,10 @@ cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE "${ENVOY_BUILD_DIR}"
 export ENVOY_DELIVERY_DIR="${ENVOY_BUILD_DIR}"/source/exe
 mkdir -p "${ENVOY_DELIVERY_DIR}"
 
+# This is where we copy the coverage report to.
+export ENVOY_COVERAGE_DIR="${ENVOY_BUILD_DIR}"/generated/coverage
+mkdir -p "${ENVOY_COVERAGE_DIR}"
+
 # This is where we build for bazel.release* and bazel.dev.
 export ENVOY_CI_DIR="${ENVOY_SRCDIR}"/ci
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -101,6 +101,7 @@ elif [[ "$1" == "bazel.coverage" ]]; then
   cd "${ENVOY_BUILD_DIR}"
   export BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} -c dbg"
   SRCDIR="${GCOVR_DIR}" "${ENVOY_SRCDIR}"/test/run_envoy_bazel_coverage.sh
+  rsync -av "${ENVOY_BUILD_DIR}"/bazel-envoy/generated/coverage/ "${ENVOY_COVERAGE_DIR}"
   exit 0
 elif [[ "$1" == "fix_format" ]]; then
   echo "fix_format..."


### PR DESCRIPTION
Previously, the coverage report was available at
/build/envoy/bazel-envoy/generated/coverage/coverage.html inside the container, but the symlinks
were broken when accessing outside the container (e.g. from ci/coverage_publish.sh).

With this patch, the coverage report is now available at
"${ENVOY_BUILD_DIR}"/envoy/generated/coverage from the Travis scripts that wrap the container
execution (or to humans).