### PR TITLE
ci: fix bazel.debug toolchain issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - TEST_TYPE=bazel.asan
   - TEST_TYPE=bazel.tsan
   - TEST_TYPE=bazel.coverage
-  - TEST_TYPE=bazel.debug
   - TEST_TYPE=check_format
   - TEST_TYPE=docs
   - TEST_TYPE=build_image

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TEST_TYPE=bazel.asan
   - TEST_TYPE=bazel.tsan
   - TEST_TYPE=bazel.coverage
+  - TEST_TYPE=bazel.debug
   - TEST_TYPE=check_format
   - TEST_TYPE=docs
   - TEST_TYPE=build_image

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -42,6 +42,7 @@ elif [[ "$1" == "bazel.release.server_only" ]]; then
   bazel_release_binary_build
   exit 0
 elif [[ "$1" == "bazel.debug" ]]; then
+  setup_gcc_toolchain
   echo "bazel debug build with tests..."
   bazel_debug_binary_build
   echo "Testing..."


### PR DESCRIPTION
This was breaking the debug build.

Also, add to Travis CI, since this is a build target that folks rely on.