### PR TITLE
add the missing setup_gcc_toolchain

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -49,6 +49,7 @@ elif [[ "$1" == "bazel.debug" ]]; then
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg //test/...
   exit 0
 elif [[ "$1" == "bazel.debug.server_only" ]]; then
+  setup_gcc_toolchain
   echo "bazel debug build..."
   bazel_debug_binary_build
   exit 0


### PR DESCRIPTION
Patch up the missing `setup_gcc_toolchain` addition from @htuch's previous PR #937 