### PR TITLE
Fix parseCookieValue utility with bad inputs.

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -80,7 +80,8 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
       for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
-        if (first_non_space == std::string::npos || equals_index == std::string::npos || equals_index < first_non_space) {
+        if (first_non_space == std::string::npos || equals_index == std::string::npos ||
+            equals_index < first_non_space) {
             break;
         }
         std::string k = s.substr(first_non_space, equals_index - first_non_space);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -83,7 +83,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         // Find the key part of the cookie (i.e. the name of the cookie).
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
-        if (first_non_space == std::string::npos || equals_index == std::string::npos) {
+        if (equals_index == std::string::npos) {
           // The cookie is malformed if it does not have an `=`. Continue
           // checking other cookies in this header.
           continue;

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -80,6 +80,9 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
       for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
+        if (first_non_space == std::string::npos || equals_index == std::string::npos || equals_index < first_non_space) {
+            break;
+        }
         std::string k = s.substr(first_non_space, equals_index - first_non_space);
         State* state = static_cast<State*>(context);
         if (k == state->key_) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -80,8 +80,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
       for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
-        if (first_non_space == std::string::npos || equals_index == std::string::npos ||
-            equals_index < first_non_space) {
+        if (first_non_space == std::string::npos || equals_index == std::string::npos) {
             break;
         }
         std::string k = s.substr(first_non_space, equals_index - first_non_space);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -80,7 +80,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
     if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
       // Split the cookie header into individual cookies.
       for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
-        // Find the key part of the cookie (i.e. the name of the cookie)
+        // Find the key part of the cookie (i.e. the name of the cookie).
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
         if (first_non_space == std::string::npos || equals_index == std::string::npos) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -81,7 +81,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
         if (first_non_space == std::string::npos || equals_index == std::string::npos) {
-            break;
+          break;
         }
         std::string k = s.substr(first_non_space, equals_index - first_non_space);
         State* state = static_cast<State*>(context);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -76,15 +76,21 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
   state.key_ = key;
 
   headers.iterate([](const HeaderEntry& header, void* context) -> void {
+    // Find the cookie headers in the request (typically, there's only one).
     if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
+      // Split the cookie header into individual cookies.
       for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
+        // Find the key part of the cookie (i.e. the name of the cookie)
         size_t first_non_space = s.find_first_not_of(" ");
         size_t equals_index = s.find('=');
         if (first_non_space == std::string::npos || equals_index == std::string::npos) {
-          break;
+          // The cookie is malformed if it does not have an `=`. Continue
+          // checking other cookies in this header.
+          continue;
         }
         std::string k = s.substr(first_non_space, equals_index - first_non_space);
         State* state = static_cast<State*>(context);
+        // If the key matches, parse the value from the rest of the cookie string.
         if (k == state->key_) {
           std::string v = s.substr(equals_index + 1, s.size() - 1);
 

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -125,11 +125,10 @@ TEST(HttpUtility, TestParseCookie) {
 }
 
 TEST(HttpUtility, TestParseCookieBadValues) {
-  TestHeaderMapImpl headers{
-      {"cookie", "token1=abc123; = "},
-      {"cookie", "token2=abc123;   "},
-      {"cookie", "; token3=abc123;"},
-      {"cookie", "=; token4=\"abc123\""}};
+  TestHeaderMapImpl headers{{"cookie", "token1=abc123; = "},
+                            {"cookie", "token2=abc123;   "},
+                            {"cookie", "; token3=abc123;"},
+                            {"cookie", "=; token4=\"abc123\""}};
 
   EXPECT_EQ(Utility::parseCookieValue(headers, "token1"), "abc123");
   EXPECT_EQ(Utility::parseCookieValue(headers, "token2"), "abc123");

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -124,6 +124,19 @@ TEST(HttpUtility, TestParseCookie) {
   EXPECT_EQ(value, "abc123");
 }
 
+TEST(HttpUtility, TestParseCookieBadValues) {
+  TestHeaderMapImpl headers{
+      {"cookie", "token1=abc123; = "}
+      {"cookie", "token2=abc123;   "}
+      {"cookie", "; token3=abc123;"}
+      {"cookie", "=; token4=\"abc123\""}};
+
+  EXPECT_EQ(Utility::parseCookieValue(headers, "token1"), "abc123");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "token2"), "abc123");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "token3"), "abc123");
+  EXPECT_EQ(Utility::parseCookieValue(headers, "token4"), "abc123");
+}
+
 TEST(HttpUtility, TestParseCookieWithQuotes) {
   TestHeaderMapImpl headers{
       {"someheader", "10.0.0.1"},

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -126,9 +126,9 @@ TEST(HttpUtility, TestParseCookie) {
 
 TEST(HttpUtility, TestParseCookieBadValues) {
   TestHeaderMapImpl headers{
-      {"cookie", "token1=abc123; = "}
-      {"cookie", "token2=abc123;   "}
-      {"cookie", "; token3=abc123;"}
+      {"cookie", "token1=abc123; = "},
+      {"cookie", "token2=abc123;   "},
+      {"cookie", "; token3=abc123;"},
       {"cookie", "=; token4=\"abc123\""}};
 
   EXPECT_EQ(Utility::parseCookieValue(headers, "token1"), "abc123");


### PR DESCRIPTION

**Backtrace:**
```
#0  0x00007fa4f434bc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#0  0x00007fa4f434bc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007fa4f434f028 in __GI_abort () at abort.c:89
#2  0x000000000079a0ad in __gnu_cxx::__verbose_terminate_handler() ()
#3  0x0000000000766166 in __cxxabiv1::__terminate(void (*)()) ()
#4  0x00000000007661a1 in std::terminate() ()
#5  0x0000000000767348 in __cxa_throw ()
#6  0x0000000000797921 in std::__throw_out_of_range_fmt(char const*, ...) ()
#7  0x000000000062b105 in _M_check (__s=0x7bb32e "basic_string::substr", __pos=18446744073709551615, this=0x24ff1e70) at /usr/include/c++/4.9/bits/basic_string.h:324
#8  substr (__n=0, __pos=18446744073709551615, this=0x24ff1e70) at /usr/include/c++/4.9/bits/basic_string.h:2226
#9  operator() (__closure=0x0, context=0x7fa4f28af210, header=...) at external/envoy/source/common/http/utility.cc:89
#10 Http::Utility::<lambda(const Http::HeaderEntry&, void*)>::_FUN(const Http::HeaderEntry &, void *) () at external/envoy/source/common/http/utility.cc:104
#11 0x000000000062c212 in Http::HeaderMapImpl::iterate (this=0x255ecc60, cb=0x62ad40 <Http::Utility::<lambda(const Http::HeaderEntry&, void*)>::_FUN(const Http::HeaderEntry &, void *)>, context=0x7fa4f28af210) at external/envoy/source/common/http/header_map_impl.cc:347
#12 0x000000000062a543 in Http::Utility::parseCookieValue (headers=..., key=...) at external/envoy/source/common/http/utility.cc:104
```