### PR TITLE
test: deflake integration tests with TSAN.

### DIFF
--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -813,6 +813,9 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
   IntegrationCodecClientPtr codec_client;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
   FakeRawConnectionPtr fake_upstream_connection;
+  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
+  // https://github.com/lyft/envoy/issues/944
+  const std::string upstream_write_data("bad protocol data!");
   executeActions(
       {[&]() -> void {
         codec_client = makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1);
@@ -827,7 +830,7 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
        // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
        // be fixed.
        [&]() -> void { fake_upstream_connection->waitForData(187); },
-       [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
+       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
        [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
        [&]() -> void { codec_client->waitForDisconnect(); }});
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -132,12 +132,15 @@ TEST_F(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
+  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
+  // https://github.com/lyft/envoy/issues/944
+  const std::string upstream_write_data("world");
   executeActions(
       {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write("world"); },
+       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
        [&]() -> void { fake_upstream_connection->close(); },
        [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
        [&]() -> void { tcp_client->waitForDisconnect(); }});
@@ -148,12 +151,15 @@ TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
 TEST_F(IntegrationTest, TcpProxyDownstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
+  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
+  // https://github.com/lyft/envoy/issues/944
+  const std::string upstream_write_data("world");
   executeActions(
       {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write("world"); },
+       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
        [&]() -> void { tcp_client->waitForData("world"); },
        [&]() -> void { tcp_client->write("hello"); }, [&]() -> void { tcp_client->close(); },
        [&]() -> void { fake_upstream_connection->waitForData(10); },


### PR DESCRIPTION
See https://github.com/lyft/envoy/issues/944. I don't think we properly understand the root cause
yet, but this at least unblocks CI.