### PR TITLE
ci: Move to GCC 5.4 (Xenial default) for prebuilts

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -29,10 +29,12 @@ go get github.com/bazelbuild/buildifier/buildifier
 # GCC for everything.
 export CC=gcc
 export CXX=g++
-if [[ "$(${CXX} --version)" != "hello" ]]; then
-  echo "Unexpected compiler version: $(${CXX} --version)"
+CXX_VERSION="$(${CXX} --version | grep ^g++)"
+if [[ "${CXX_VERSION}" != "g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609" ]]; then
+  echo "Unexpected compiler version: ${CXX_VERSION}"
   exit 1
 fi
+
 
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -29,7 +29,10 @@ go get github.com/bazelbuild/buildifier/buildifier
 # GCC for everything.
 export CC=gcc
 export CXX=g++
-g++ --version
+if [[ "$(${CXX} --version)" != "hello" ]]; then
+  echo "Unexpected compiler version: $(${CXX} --version)"
+  exit 1
+fi
 
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -9,9 +9,6 @@ apt-get install -y wget software-properties-common make cmake git python python-
 apt-get install -y golang
 # For debugging.
 apt-get install -y gdb strace
-add-apt-repository -y ppa:ubuntu-toolchain-r/test
-apt-get update
-apt-get install -y g++-4.9
 # clang head (currently 5.0)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main"
@@ -31,10 +28,6 @@ pip install virtualenv
 # buildifier
 export GOPATH=/usr/lib/go
 go get github.com/bazelbuild/buildifier/buildifier
-
-# GCC 4.9 for everything.
-export CC=gcc-4.9
-export CXX=g++-4.9
 
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -5,10 +5,7 @@ set -e
 # Setup basic requirements and install them.
 apt-get update
 apt-get install -y wget software-properties-common make cmake git python python-pip \
-  clang-format-3.6 bc libtool automake zip time
-apt-get install -y golang
-# For debugging.
-apt-get install -y gdb strace
+  clang-format-3.6 bc libtool automake zip time golang g++ gdb strace
 # clang head (currently 5.0)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main"

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -26,6 +26,11 @@ pip install virtualenv
 export GOPATH=/usr/lib/go
 go get github.com/bazelbuild/buildifier/buildifier
 
+# GCC for everything.
+export CC=gcc
+export CXX=g++
+g++ --version
+
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty
 export THIRDPARTY_BUILD=/thirdparty_build

--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -35,7 +35,6 @@ if [[ "${CXX_VERSION}" != "g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609" ]
   exit 1
 fi
 
-
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty
 export THIRDPARTY_BUILD=/thirdparty_build


### PR DESCRIPTION
This is part 1 of a change to switch us over to a GCC 5.4 so that
we get a thread safe std::string implementation. Will follow up
with another commit with CI and doc changes.