### PR TITLE
ci: switch to GCC 5.4 compiler

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -55,6 +55,12 @@ appropriate, an arbitrary compiler toolchain and standard library location can b
 slight caveat is that (at the time of writing), Bazel expects the binutils in `$(dirname $CC)` to be
 unprefixed, e.g. `as` instead of `x86_64-linux-gnu-as`.
 
+## Supported compiler versions
+
+Though Envoy has been run in production compiled with GCC 4.9 extensively, we now strongly
+recommend GCC >= 5 due to known issues with std::string thread safety. Clang >= 4.0 is also known
+to work.
+
 # Testing Envoy with Bazel
 
 All the Envoy tests can be built and run with:

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -168,7 +168,7 @@ bazel build -c opt //source/exe:envoy-static
 
 ## Sanitizers
 
-To build and run tests with the gcc-4.9 compiler's [address sanitizer
+To build and run tests with the gcc compiler's [address sanitizer
 (ASAN)](https://github.com/google/sanitizers/wiki/AddressSanitizer) and
 [undefined behavior
 (UBSAN)](https://developers.redhat.com/blog/2014/10/16/gcc-undefined-behavior-sanitizer-ubsan) sanitizer enabled:

--- a/ci/README.md
+++ b/ci/README.md
@@ -18,6 +18,11 @@ one with an Envoy binary with debug (`lyft/envoy-alpine-debug`) symbols and one 
 Both images are pushed with two different tags: `<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
 master commit at which the binary was compiled, and `latest` corresponds to a binary built from the latest tip of master that passed tests.
 
+# Build image base and compiler versions
+
+The current build image is based on Ubuntu 16.04 (Xenial) which uses the GCC 5.4 compiler. We also
+install and use the clang-5.0 compiler for some sanitizing runs.
+
 # Building and running tests as a developer
 
 An example basic invocation to build a developer version of the Envoy static binary (using the Bazel `fastbuild` type) is:

--- a/ci/README.md
+++ b/ci/README.md
@@ -59,10 +59,10 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.asan` &mdash; build and run tests under `-c dbg --config=clang-asan` with clang-5.0.
 * `bazel.debug` &mdash; build Envoy static binary and run tests under `-c dbg`.
 * `bazel.debug.server_only` &mdash; build Envoy static binary under `-c dbg`.
-* `bazel.dev` &mdash; build Envoy static binary and run tests under `-c fastbuild` with gcc-4.9.
-* `bazel.release` &mdash; build Envoy static binary and run tests under `-c opt` with gcc-4.9.
-* `bazel.release.server_only` &mdash; build Envoy static binary under `-c opt` with gcc-4.9.
-* `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc-4.9, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
+* `bazel.dev` &mdash; build Envoy static binary and run tests under `-c fastbuild` with gcc.
+* `bazel.release` &mdash; build Envoy static binary and run tests under `-c opt` with gcc.
+* `bazel.release.server_only` &mdash; build Envoy static binary under `-c opt` with gcc.
+* `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
 * `bazel.tsan` &mdash; build and run tests under `-c dbg --config=clang-tsan` with clang-5.0.
 * `check_format`&mdash; run `clang-format` 3.6 and `buildifier` on entire source tree.
 * `fix_format`&mdash; run and enforce `clang-format` 3.6 and `buildifier` on entire source tree.

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -12,17 +12,14 @@ NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 export ENVOY_SRCDIR=/source
 
 function setup_gcc_toolchain() {
-  export CC=gcc-4.9
-  export CXX=g++-4.9
+  export CC=gcc
+  export CXX=g++
   echo "$CC/$CXX toolchain configured"
 }
 
 function setup_clang_toolchain() {
   export CC=clang-5.0
   export CXX=clang++-5.0
-  # Ensure clang doesn't use a C++ ABI incompatible with the prebuilts.
-  export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --copt=-D_GLIBCXX_USE_CXX11_ABI=0"
-  export BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} --copt=-D_GLIBCXX_USE_CXX11_ABI=0"
   echo "$CC/$CXX toolchain configured"
 }
 

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=22c55f8ec756c5ddeb26c3424e128a91aec23116
+ENVOY_BUILD_SHA=fc747b3c2fd49b1260484572071fe4194cd6824d
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -813,9 +813,6 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
   IntegrationCodecClientPtr codec_client;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
   FakeRawConnectionPtr fake_upstream_connection;
-  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
-  // https://github.com/lyft/envoy/issues/944
-  const std::string upstream_write_data("bad protocol data!");
   executeActions(
       {[&]() -> void {
         codec_client = makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1);
@@ -830,7 +827,7 @@ void BaseIntegrationTest::testUpstreamProtocolError() {
        // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
        // be fixed.
        [&]() -> void { fake_upstream_connection->waitForData(187); },
-       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
+       [&]() -> void { fake_upstream_connection->write("bad protocol data!"); },
        [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
        [&]() -> void { codec_client->waitForDisconnect(); }});
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -132,15 +132,12 @@ TEST_F(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
-  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
-  // https://github.com/lyft/envoy/issues/944
-  const std::string upstream_write_data("world");
   executeActions(
       {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
+       [&]() -> void { fake_upstream_connection->write("world"); },
        [&]() -> void { fake_upstream_connection->close(); },
        [&]() -> void { fake_upstream_connection->waitForDisconnect(); },
        [&]() -> void { tcp_client->waitForDisconnect(); }});
@@ -151,15 +148,12 @@ TEST_F(IntegrationTest, TcpProxyUpstreamDisconnect) {
 TEST_F(IntegrationTest, TcpProxyDownstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
-  // TSAN seems to get upset if we destroy this in a closure below, so keep it alive.
-  // https://github.com/lyft/envoy/issues/944
-  const std::string upstream_write_data("world");
   executeActions(
       {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },
-       [&]() -> void { fake_upstream_connection->write(upstream_write_data); },
+       [&]() -> void { fake_upstream_connection->write("world"); },
        [&]() -> void { tcp_client->waitForData("world"); },
        [&]() -> void { tcp_client->write("hello"); }, [&]() -> void { tcp_client->close(); },
        [&]() -> void { fake_upstream_connection->waitForData(10); },

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,7 +2,7 @@
 
 build --workspace_status_command=bazel/get_workspace_status
 
-# Basic ASAN/UBSAN that works for gcc-4.9
+# Basic ASAN/UBSAN that works for gcc
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 build:asan --linkopt -ldl


### PR DESCRIPTION
We are moving to GCC > 5 because std::string in GCC < 5 is not
thread safe and we were seeing issues on TSAN builds.

Fixes https://github.com/lyft/envoy/issues/944