### PR TITLE
build: fix listener_lib dep issue, remove some vestigal test/mocks de…

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -58,7 +58,7 @@ envoy_cc_library(
         "//include/envoy/network:listener_interface",
         "//source/common/common:linked_object",
         "//source/common/common:non_copyable",
-        "//source/common/event:dispatcher_includes",
+        "//source/common/event:dispatcher_lib",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:listener_lib",
     ],

--- a/test/mocks/event/BUILD
+++ b/test/mocks/event/BUILD
@@ -23,7 +23,5 @@ envoy_cc_mock(
         "//include/envoy/network:dns_interface",
         "//include/envoy/network:listener_interface",
         "//include/envoy/ssl:context_interface",
-        "//source/common/network:listen_socket_lib",
-        "//source/common/stats:stats_lib",
     ],
 )

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -1,8 +1,5 @@
 #include "mocks.h"
 
-#include "common/network/listen_socket_impl.h"
-#include "common/stats/stats_impl.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -23,7 +23,6 @@ envoy_cc_mock(
         "//include/envoy/ssl:connection_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//source/common/http:conn_manager_lib",
-        "//source/common/http:header_map_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/router:router_mocks",
         "//test/mocks/tracing:tracing_mocks",

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -15,7 +15,6 @@
 #include "envoy/ssl/connection.h"
 
 #include "common/http/conn_manager_impl.h"
-#include "common/http/header_map_impl.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -18,7 +18,6 @@ envoy_cc_mock(
         "//include/envoy/network:drain_decision_interface",
         "//include/envoy/network:filter_interface",
         "//source/common/network:address_lib",
-        "//source/common/network:listener_lib",
         "//source/common/network:utility_lib",
         "//test/mocks/event:event_mocks",
     ],

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -8,8 +8,6 @@
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 
-#include "common/network/proxy_protocol.h"
-
 #include "test/mocks/event/mocks.h"
 #include "test/test_common/printers.h"
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -21,7 +21,6 @@ envoy_cc_mock(
         "//include/envoy/ssl:context_manager_interface",
         "//source/common/ssl:context_lib",
         "//source/common/stats:stats_lib",
-        "//source/common/tracing:http_tracer_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -14,7 +14,6 @@
 
 #include "common/ssl/context_manager_impl.h"
 #include "common/stats/stats_impl.h"
-#include "common/tracing/http_tracer_impl.h"
 
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/api/mocks.h"

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -14,7 +14,6 @@ envoy_cc_mock(
     deps = [
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
-        "//source/common/stats:stats_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/stats:stats_mocks",
     ],
@@ -41,7 +40,6 @@ envoy_cc_mock(
         "//include/envoy/upstream:load_balancer_interface",
         "//include/envoy/upstream:upstream_interface",
         "//source/common/network:utility_lib",
-        "//source/common/stats:stats_lib",
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//test/mocks/http:http_mocks",

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -8,8 +8,6 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
-#include "common/stats/stats_impl.h"
-
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -11,8 +11,6 @@
 #include "envoy/upstream/health_checker.h"
 #include "envoy/upstream/upstream.h"
 
-#include "common/stats/stats_impl.h"
-
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"


### PR DESCRIPTION
…pendencies.

We had an issue with GCC 5.4 ASAN where source/server/BUILD had a dependency on listener_lib, but
not dispatcher_lib (which is also required). At the same time, cleaned up some unnnecessary
implementation deps that had crept into test/mocks.