### PR TITLE
test: parameterize some network tests

### DIFF
--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -26,5 +26,6 @@ envoy_cc_test(
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",
         "//test/mocks:common_lib",
+        "//test/test_common:environment_lib",
     ],
 )

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -5,6 +5,7 @@
 #include "common/event/dispatcher_impl.h"
 
 #include "test/mocks/common.h"
+#include "test/test_common/environment.h"
 
 #include "gtest/gtest.h"
 
@@ -29,8 +30,18 @@ protected:
   int fds_[2];
 };
 
-TEST_F(FileEventImplTest, Activate) {
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
+class FileEventImplActivateTest : public testing::TestWithParam<Network::Address::IpVersion> {};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, FileEventImplActivateTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(FileEventImplActivateTest, Activate) {
+  int fd;
+  if (GetParam() == Network::Address::IpVersion::v4) {
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+  } else {
+    fd = socket(AF_INET6, SOCK_STREAM, 0);
+  }
   ASSERT_NE(-1, fd);
 
   DispatcherImpl dispatcher;

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test(
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
     ],
 )
 

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
@@ -31,7 +32,8 @@ namespace Ssl {
 namespace {
 
 void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_json,
-              const std::string& expected_digest, const std::string& expected_uri) {
+              const std::string& expected_digest, const std::string& expected_uri,
+              const Network::Address::IpVersion version) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
 
@@ -41,7 +43,7 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
 
   Event::DispatcherImpl dispatcher;
-  Network::TcpListenSocket socket(Network::Utility::getCanonicalIpv4LoopbackAddress(), true);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
@@ -80,9 +82,13 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
 
 } // namespace
 
-class SslConnectionImplTest : public SslCertsTest {};
+class SslConnectionImplTest : public SslCertsTest,
+                              public testing::WithParamInterface<Network::Address::IpVersion> {};
 
-TEST_F(SslConnectionImplTest, GetCertDigest) {
+INSTANTIATE_TEST_CASE_P(IpVersions, SslConnectionImplTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(SslConnectionImplTest, GetCertDigest) {
   std::string client_ctx_json = R"EOF(
   {
     "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/no_san_cert.pem",
@@ -99,10 +105,10 @@ TEST_F(SslConnectionImplTest, GetCertDigest) {
   )EOF";
 
   testUtil(client_ctx_json, server_ctx_json,
-           "9d51ffbe193020e88ac2eb9072315e2e8bb3dac589041995b2af80ec7cb86de2", "");
+           "9d51ffbe193020e88ac2eb9072315e2e8bb3dac589041995b2af80ec7cb86de2", "", GetParam());
 }
 
-TEST_F(SslConnectionImplTest, GetUriWithUriSan) {
+TEST_P(SslConnectionImplTest, GetUriWithUriSan) {
   std::string client_ctx_json = R"EOF(
   {
     "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/san_uri_cert.pem",
@@ -119,10 +125,10 @@ TEST_F(SslConnectionImplTest, GetUriWithUriSan) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "istio:account1.foo.cluster.local");
+  testUtil(client_ctx_json, server_ctx_json, "", "istio:account1.foo.cluster.local", GetParam());
 }
 
-TEST_F(SslConnectionImplTest, GetNoUriWithDnsSan) {
+TEST_P(SslConnectionImplTest, GetNoUriWithDnsSan) {
   std::string client_ctx_json = R"EOF(
   {
     "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem",
@@ -139,10 +145,10 @@ TEST_F(SslConnectionImplTest, GetNoUriWithDnsSan) {
   )EOF";
 
   // The SAN field only has DNS, expect "" for uriSanPeerCertificate().
-  testUtil(client_ctx_json, server_ctx_json, "", "");
+  testUtil(client_ctx_json, server_ctx_json, "", "", GetParam());
 }
 
-TEST_F(SslConnectionImplTest, NoCert) {
+TEST_P(SslConnectionImplTest, NoCert) {
   std::string client_ctx_json = R"EOF(
   {
     "cert_chain_file": "",
@@ -157,10 +163,10 @@ TEST_F(SslConnectionImplTest, NoCert) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "");
+  testUtil(client_ctx_json, server_ctx_json, "", "", GetParam());
 }
 
-TEST_F(SslConnectionImplTest, ClientAuthBadVerification) {
+TEST_P(SslConnectionImplTest, ClientAuthBadVerification) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
 
@@ -179,7 +185,7 @@ TEST_F(SslConnectionImplTest, ClientAuthBadVerification) {
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
 
   Event::DispatcherImpl dispatcher;
-  Network::TcpListenSocket socket(Network::Utility::getCanonicalIpv4LoopbackAddress(), true);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
@@ -217,7 +223,7 @@ TEST_F(SslConnectionImplTest, ClientAuthBadVerification) {
   dispatcher.run(Event::Dispatcher::RunType::Block);
 }
 
-TEST_F(SslConnectionImplTest, SslError) {
+TEST_P(SslConnectionImplTest, SslError) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
 
@@ -236,7 +242,7 @@ TEST_F(SslConnectionImplTest, SslError) {
   ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
 
   Event::DispatcherImpl dispatcher;
-  Network::TcpListenSocket socket(Network::Utility::getCanonicalIpv4LoopbackAddress(), true);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
@@ -268,13 +274,14 @@ TEST_F(SslConnectionImplTest, SslError) {
   EXPECT_EQ(1UL, stats_store.counter("ssl.connection_error").value());
 }
 
-class SslReadBufferLimitTest : public SslCertsTest {
+class SslReadBufferLimitTest : public SslCertsTest,
+                               public testing::WithParamInterface<Network::Address::IpVersion> {
 public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size,
                            uint32_t write_size, uint32_t num_writes, bool reserve_write_space) {
     Stats::IsolatedStoreImpl stats_store;
     Event::DispatcherImpl dispatcher;
-    Network::TcpListenSocket socket(Network::Utility::getCanonicalIpv4LoopbackAddress(), true);
+    Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), true);
     Network::MockListenerCallbacks listener_callbacks;
     Network::MockConnectionHandler connection_handler;
 
@@ -367,17 +374,20 @@ public:
   }
 };
 
-TEST_F(SslReadBufferLimitTest, NoLimit) {
+INSTANTIATE_TEST_CASE_P(IpVersions, SslReadBufferLimitTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(SslReadBufferLimitTest, NoLimit) {
   readBufferLimitTest(0, 256 * 1024, 256 * 1024, 1, false);
 }
 
-TEST_F(SslReadBufferLimitTest, NoLimitReserveSpace) { readBufferLimitTest(0, 512, 512, 1, true); }
+TEST_P(SslReadBufferLimitTest, NoLimitReserveSpace) { readBufferLimitTest(0, 512, 512, 1, true); }
 
-TEST_F(SslReadBufferLimitTest, NoLimitSmallWrites) {
+TEST_P(SslReadBufferLimitTest, NoLimitSmallWrites) {
   readBufferLimitTest(0, 256 * 1024, 1, 256 * 1024, false);
 }
 
-TEST_F(SslReadBufferLimitTest, SomeLimit) {
+TEST_P(SslReadBufferLimitTest, SomeLimit) {
   readBufferLimitTest(32 * 1024, 32 * 1024, 256 * 1024, 1, false);
 }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -19,13 +19,13 @@ using testing::NiceMock;
 
 namespace Server {
 
-class AdminFilterTest : public testing::Test {
+class AdminFilterTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   // TODO(mattklein123): Switch to mocks and do not bind to a real port.
   AdminFilterTest()
       : admin_("/dev/null", TestEnvironment::temporaryPath("envoy.prof"),
                TestEnvironment::temporaryPath("admin.address"),
-               Network::Utility::resolveUrl("tcp://127.0.0.1:0"), server_),
+               Network::Test::getCanonicalLoopbackAddress(GetParam()), server_),
         filter_(admin_), request_headers_{{":path", "/"}} {
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
@@ -37,19 +37,22 @@ public:
   Http::TestHeaderMapImpl request_headers_;
 };
 
-TEST_F(AdminFilterTest, HeaderOnly) {
+INSTANTIATE_TEST_CASE_P(IpVersions, AdminFilterTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(AdminFilterTest, HeaderOnly) {
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   filter_.decodeHeaders(request_headers_, true);
 }
 
-TEST_F(AdminFilterTest, Body) {
+TEST_P(AdminFilterTest, Body) {
   filter_.decodeHeaders(request_headers_, false);
   Buffer::OwnedImpl data("hello");
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   filter_.decodeData(data, true);
 }
 
-TEST_F(AdminFilterTest, Trailers) {
+TEST_P(AdminFilterTest, Trailers) {
   filter_.decodeHeaders(request_headers_, false);
   Buffer::OwnedImpl data("hello");
   filter_.decodeData(data, false);
@@ -57,13 +60,13 @@ TEST_F(AdminFilterTest, Trailers) {
   filter_.decodeTrailers(request_headers_);
 }
 
-class AdminInstanceTest : public testing::Test {
+class AdminInstanceTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   AdminInstanceTest()
       : address_out_path_(TestEnvironment::temporaryPath("admin.address")),
         cpu_profile_path_(TestEnvironment::temporaryPath("envoy.prof")),
         admin_("/dev/null", cpu_profile_path_, address_out_path_,
-               Network::Test::getSomeLoopbackAddress(Network::Address::IpVersion::v4), server_) {}
+               Network::Test::getCanonicalLoopbackAddress(GetParam()), server_) {}
 
   std::string address_out_path_;
   std::string cpu_profile_path_;
@@ -71,12 +74,14 @@ public:
   AdminImpl admin_;
 };
 
+INSTANTIATE_TEST_CASE_P(IpVersions, AdminInstanceTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 // Can only get code coverage of AdminImpl::handlerCpuProfiler stopProfiler with
 // a real profiler linked in (successful call to startProfiler). startProfiler
 // requies tcmalloc.
 #ifdef TCMALLOC
 
-TEST_F(AdminInstanceTest, AdminProfiler) {
+TEST_P(AdminInstanceTest, AdminProfiler) {
   Buffer::OwnedImpl data;
   admin_.runCallback("/cpuprofiler?enable=y", data);
   EXPECT_TRUE(Profiler::Cpu::profilerEnabled());
@@ -86,27 +91,27 @@ TEST_F(AdminInstanceTest, AdminProfiler) {
 
 #endif
 
-TEST_F(AdminInstanceTest, AdminBadProfiler) {
+TEST_P(AdminInstanceTest, AdminBadProfiler) {
   Buffer::OwnedImpl data;
   AdminImpl admin_bad_profile_path(
       "/dev/null", TestEnvironment::temporaryPath("some/unlikely/bad/path.prof"), "",
-      Network::Test::getSomeLoopbackAddress(Network::Address::IpVersion::v4), server_);
+      Network::Test::getCanonicalLoopbackAddress(GetParam()), server_);
   admin_bad_profile_path.runCallback("/cpuprofiler?enable=y", data);
   EXPECT_FALSE(Profiler::Cpu::profilerEnabled());
 }
 
-TEST_F(AdminInstanceTest, WriteAddressToFile) {
+TEST_P(AdminInstanceTest, WriteAddressToFile) {
   std::ifstream address_file(address_out_path_);
   std::string address_from_file;
   std::getline(address_file, address_from_file);
   EXPECT_EQ(admin_.socket().localAddress()->asString(), address_from_file);
 }
 
-TEST_F(AdminInstanceTest, AdminBadAddressOutPath) {
+TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
   std::string bad_path = TestEnvironment::temporaryPath("some/unlikely/bad/path/admin.address");
-  AdminImpl admin_bad_address_out_path(
-      "/dev/null", cpu_profile_path_, bad_path,
-      Network::Test::getSomeLoopbackAddress(Network::Address::IpVersion::v4), server_);
+  AdminImpl admin_bad_address_out_path("/dev/null", cpu_profile_path_, bad_path,
+                                       Network::Test::getCanonicalLoopbackAddress(GetParam()),
+                                       server_);
   EXPECT_FALSE(std::ifstream(bad_path));
 }
 } // namespace Server

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -113,6 +113,13 @@ Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion versio
   }
 }
 
+Address::InstanceConstSharedPtr getCanonicalLoopbackAddress(Address::IpVersion version) {
+  if (version == Address::IpVersion::v4) {
+    return Network::Utility::getCanonicalIpv4LoopbackAddress();
+  }
+  return Network::Utility::getIpv6LoopbackAddress();
+}
+
 Address::InstanceConstSharedPtr getAnyAddress(const Address::IpVersion version) {
   if (version == Address::IpVersion::v4) {
     return Network::Utility::getIpv4AnyAddress();
@@ -121,7 +128,7 @@ Address::InstanceConstSharedPtr getAnyAddress(const Address::IpVersion version) 
 }
 
 bool supportsIpVersion(const Address::IpVersion version) {
-  Address::InstanceConstSharedPtr addr = getSomeLoopbackAddress(version);
+  Address::InstanceConstSharedPtr addr = getCanonicalLoopbackAddress(version);
   const int fd = addr->socket(Address::SocketType::Stream);
   if (fd < 0) {
     // Socket creation failed.

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -55,6 +55,13 @@ const std::string addressVersionAsString(const Address::IpVersion version);
 Address::InstanceConstSharedPtr getSomeLoopbackAddress(Address::IpVersion version);
 
 /**
+ * Returns a loopback address for the specified IP version (127.0.0.1 for IPv4 and ::1 for IPv6).
+ * @param version the IP version of the loopback address.
+ * @returns a loopback address for the specified IP version.
+ */
+Address::InstanceConstSharedPtr getCanonicalLoopbackAddress(const Address::IpVersion version);
+
+/**
  * Returns the any address for the specified IP version.
  * @param version the IP version of the any address.
  * @returns the any address for the specified IP version.


### PR DESCRIPTION
Parameterize ipv6 testing for:

- test/common/event/file_event_impl_test

- test/common/network/listener_impl_test.cc

- test/common/ssl/connection_impl_test.cc

- test/server/http/admin_test.cc