### PR TITLE
fixed misspelling of `use_original_dst`

### DIFF
--- a/docs/configuration/listeners/listeners.rst
+++ b/docs/configuration/listeners/listeners.rst
@@ -36,7 +36,7 @@ address
 
 bind_to_port
   *(optional, boolean)* Whether the listener should bind to the port. A listener that doesn't bind
-  can only receive connections redirected from other listeners that set use_origin_dst parameter to
+  can only receive connections redirected from other listeners that set use_original_dst parameter to
   true. Default is true.
 
 use_proxy_proto


### PR DESCRIPTION
correcting this as it just tripped me up...