### PR TITLE
Hack to allow conditionally compiling out lightstep

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -31,3 +31,11 @@ config_setting(
     name = "disable_signal_trace",
     values = {"define": "signal_trace=disabled"},
 )
+
+# TODO(tschroed): This allows linking against Google code, but is very hacky.
+# https://github.com/lyft/envoy/issues/967 to do it properly, at which point
+# this can be deleted.
+config_setting(
+    name = "disable_lightstep_tracing",
+    values = {"define": "lightstep_tracing=disabled"},
+)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -32,10 +32,7 @@ config_setting(
     values = {"define": "signal_trace=disabled"},
 )
 
-# TODO(tschroed): This allows linking against Google code, but is very hacky.
-# https://github.com/lyft/envoy/issues/967 to do it properly, at which point
-# this can be deleted.
 config_setting(
-    name = "disable_lightstep_tracing",
+    name = "disable_lightstep",
     values = {"define": "lightstep_tracing=disabled"},
 )

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -12,12 +12,16 @@ envoy_cc_library(
     name = "http_tracer_lib",
     srcs = [
         "http_tracer_impl.cc",
-        "lightstep_tracer_impl.cc",
-    ],
+    ] + select({
+        "//third_party/envoy/src/bazel:disable_lightstep_tracing": [],
+        "//conditions:default": ["lightstep_tracer_impl.cc"],
+    }),
     hdrs = [
         "http_tracer_impl.h",
-        "lightstep_tracer_impl.h",
-    ],
+    ] + select({
+        "//third_party/envoy/src/bazel:disable_lightstep_tracing": [],
+        "//conditions:default": ["lightstep_tracer_impl.h"],
+    }),
     external_deps = ["lightstep"],
     deps = [
         "//include/envoy/local_info:local_info_interface",

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -10,22 +10,9 @@ envoy_package()
 
 envoy_cc_library(
     name = "http_tracer_lib",
-    srcs = [
-        "http_tracer_impl.cc",
-    ] + select({
-        "//bazel:disable_lightstep": [],
-        "//conditions:default": ["lightstep_tracer_impl.cc"],
-    }),
-    hdrs = [
-        "http_tracer_impl.h",
-    ] + select({
-        "//bazel:disable_lightstep": [],
-        "//conditions:default": ["lightstep_tracer_impl.h"],
-    }),
-    deps = select({
-        "//bazel:disable_lightstep": [],
-        "//conditions:default": [":lightstep_external_lib"],
-    }) + [
+    srcs = ["http_tracer_impl.cc"],
+    hdrs = ["http_tracer_impl.h"],
+    deps = [
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/thread_local:thread_local_interface",
@@ -47,6 +34,9 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "lightstep_external_lib",
+    name = "lightstep_tracer_lib",
+    srcs = ["lightstep_tracer_impl.cc"],
+    hdrs = ["lightstep_tracer_impl.h"],
     external_deps = ["lightstep"],
+    deps = [":http_tracer_lib"],
 )

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -13,13 +13,13 @@ envoy_cc_library(
     srcs = [
         "http_tracer_impl.cc",
     ] + select({
-        "//third_party/envoy/src/bazel:disable_lightstep_tracing": [],
+        "//bazel:disable_lightstep_tracing": [],
         "//conditions:default": ["lightstep_tracer_impl.cc"],
     }),
     hdrs = [
         "http_tracer_impl.h",
     ] + select({
-        "//third_party/envoy/src/bazel:disable_lightstep_tracing": [],
+        "//bazel:disable_lightstep_tracing": [],
         "//conditions:default": ["lightstep_tracer_impl.h"],
     }),
     external_deps = ["lightstep"],

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -13,17 +13,19 @@ envoy_cc_library(
     srcs = [
         "http_tracer_impl.cc",
     ] + select({
-        "//bazel:disable_lightstep_tracing": [],
+        "//bazel:disable_lightstep": [],
         "//conditions:default": ["lightstep_tracer_impl.cc"],
     }),
     hdrs = [
         "http_tracer_impl.h",
     ] + select({
-        "//bazel:disable_lightstep_tracing": [],
+        "//bazel:disable_lightstep": [],
         "//conditions:default": ["lightstep_tracer_impl.h"],
     }),
-    external_deps = ["lightstep"],
-    deps = [
+    deps = select({
+        "//bazel:disable_lightstep": [],
+        "//conditions:default": [":lightstep_external_lib"],
+    }) + [
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/thread_local:thread_local_interface",
@@ -42,4 +44,9 @@ envoy_cc_library(
         "//source/common/json:json_loader_lib",
         "//source/common/runtime:uuid_util_lib",
     ],
+)
+
+envoy_cc_library(
+    name = "lightstep_external_lib",
+    external_deps = ["lightstep"],
 )

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -27,7 +27,10 @@ envoy_cc_library(
         "//bazel:disable_lightstep": ["-DDISABLE_LIGHTSTEP_TRACING"],
         "//conditions:default": [],
     }),
-    deps = [
+    deps = select({
+        "//bazel:disable_lightstep": [],
+        "//conditions:default": ["//source/common/tracing:lightstep_tracer_lib"],
+        }) + [
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
@@ -43,7 +46,6 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/ratelimit:ratelimit_lib",
         "//source/common/ssl:context_config_lib",
-        "//source/common/tracing:http_tracer_lib",
         "//source/common/tracing/zipkin:zipkin_lib",
         "//source/common/upstream:cluster_manager_lib",
     ],

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -21,7 +21,7 @@ envoy_cc_library(
     srcs = ["configuration_impl.cc"],
     hdrs = ["configuration_impl.h"],
     copts = select({
-        "//third_party/envoy/src/bazel:disable_lightstep_tracing": ["-DDISABLE_LIGHTSTEP_TRACING"],
+        "//bazel:disable_lightstep_tracing": ["-DDISABLE_LIGHTSTEP_TRACING"],
         "//conditions:default": [],
     }),
     deps = [

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -20,6 +20,10 @@ envoy_cc_library(
     name = "configuration_lib",
     srcs = ["configuration_impl.cc"],
     hdrs = ["configuration_impl.h"],
+    copts = select({
+        "//third_party/envoy/src/bazel:disable_lightstep_tracing": ["-DDISABLE_LIGHTSTEP_TRACING"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:connection_interface",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -21,7 +21,10 @@ envoy_cc_library(
     srcs = ["configuration_impl.cc"],
     hdrs = ["configuration_impl.h"],
     copts = select({
-        "//bazel:disable_lightstep_tracing": ["-DDISABLE_LIGHTSTEP_TRACING"],
+        # TODO(tschroed): This allows linking against Google code, but is very hacky.
+        # https://github.com/lyft/envoy/issues/967 to do it properly, at which point
+        # the -D can be removed.
+        "//bazel:disable_lightstep": ["-DDISABLE_LIGHTSTEP_TRACING"],
         "//conditions:default": [],
     }),
     deps = [

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -17,6 +17,7 @@
 #include "common/ratelimit/ratelimit_impl.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/tracing/http_tracer_impl.h"
+
 #ifndef DISABLE_LIGHTSTEP_TRACING
 #include "common/tracing/lightstep_tracer_impl.h"
 #endif // DISABLE_LIGHTSTEP_TRACING

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -19,7 +19,7 @@
 #include "common/tracing/http_tracer_impl.h"
 #ifndef DISABLE_LIGHTSTEP_TRACING
 #include "common/tracing/lightstep_tracer_impl.h"
-+#endif // DISABLE_LIGHTSTEP_TRACING
+#endif // DISABLE_LIGHTSTEP_TRACING
 #include "common/tracing/zipkin/zipkin_tracer_impl.h"
 #include "common/upstream/cluster_manager_impl.h"
 
@@ -137,10 +137,9 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
     http_tracer_.reset(
         new Tracing::HttpTracerImpl(std::move(lightstep_driver), server_.localInfo()));
   } else {
-  if (type == "zipkin" ) {
 #else
   {
-#ifndef DISABLE_LIGHTSTEP_TRACING
+#endif // DISABLE_LIGHTSTEP_TRACING
     ASSERT(type == "zipkin");
 
     Tracing::DriverPtr zipkin_driver(

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -17,7 +17,9 @@
 #include "common/ratelimit/ratelimit_impl.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/tracing/http_tracer_impl.h"
+#ifndef DISABLE_LIGHTSTEP_TRACING
 #include "common/tracing/lightstep_tracer_impl.h"
++#endif // DISABLE_LIGHTSTEP_TRACING
 #include "common/tracing/zipkin/zipkin_tracer_impl.h"
 #include "common/upstream/cluster_manager_impl.h"
 
@@ -117,6 +119,7 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
 
   ::Runtime::RandomGenerator& rand = server_.random();
 
+#ifndef DISABLE_LIGHTSTEP_TRACING
   if (type == "lightstep") {
     Json::ObjectPtr lightstep_config = driver->getObject("config");
 
@@ -134,6 +137,10 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
     http_tracer_.reset(
         new Tracing::HttpTracerImpl(std::move(lightstep_driver), server_.localInfo()));
   } else {
+  if (type == "zipkin" ) {
+#else
+  {
+#ifndef DISABLE_LIGHTSTEP_TRACING
     ASSERT(type == "zipkin");
 
     Tracing::DriverPtr zipkin_driver(

--- a/test/common/tracing/BUILD
+++ b/test/common/tracing/BUILD
@@ -21,7 +21,7 @@ envoy_cc_test(
         "//source/common/http:message_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/runtime:uuid_util_lib",
-        "//source/common/tracing:http_tracer_lib",
+        "//source/common/tracing:lightstep_tracer_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/runtime:runtime_mocks",


### PR DESCRIPTION
Compiling in lightstep also brings in the opensource version of protobuf. Unfortunately, this introduces link time conflicts with (nearly) the same library in Google when bringing in Google dependencies.

We're working on that but it's going to take some time. Issue 967 tracks implementation of a generalized registry which provides a more elegant solution.