### PR TITLE
Remove MAX_STREAMS check on client side connection pool. (#963)

### DIFF
--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -66,7 +66,6 @@ protected:
 
   void checkForDrained();
   virtual CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) PURE;
-  virtual uint64_t maxConcurrentStreams() PURE;
   virtual uint32_t maxTotalStreams() PURE;
   void movePrimaryClientToDraining();
   void onConnectionEvent(ActiveClient& client, uint32_t events);
@@ -93,7 +92,6 @@ public:
 
 private:
   CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;
-  uint64_t maxConcurrentStreams() override;
   uint32_t maxTotalStreams() override;
 
   // All streams are 2^31. Client streams are half that, minus stream 0. Just to be on the safe

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -43,10 +43,8 @@ public:
 
   MOCK_METHOD1(createCodecClient_, CodecClient*(Upstream::Host::CreateConnectionData& data));
 
-  uint64_t maxConcurrentStreams() override { return max_concurrent_streams_; }
   uint32_t maxTotalStreams() override { return max_streams_; }
 
-  uint64_t max_concurrent_streams_{std::numeric_limits<uint64_t>::max()};
   uint32_t max_streams_{std::numeric_limits<uint32_t>::max()};
 };
 
@@ -354,26 +352,6 @@ TEST_F(Http2ConnPoolImplTest, ConnectTimeout) {
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_connect_fail_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_cx_connect_timeout_.value());
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_pending_failure_eject_.value());
-}
-
-TEST_F(Http2ConnPoolImplTest, MaxRequests) {
-  InSequence s;
-  pool_.max_concurrent_streams_ = 1;
-
-  expectClientCreate();
-  ActiveTestRequest r1(*this, 0);
-  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
-  r1.callbacks_.outer_encoder_->encodeHeaders(HeaderMapImpl{}, true);
-  expectClientConnect(0);
-
-  ConnPoolCallbacks callbacks;
-  Http::MockStreamDecoder decoder;
-  EXPECT_CALL(callbacks.pool_failure_, ready());
-  EXPECT_EQ(nullptr, pool_.newStream(decoder, callbacks));
-
-  test_clients_[0].connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
-  EXPECT_CALL(*this, onClientDestroy());
-  dispatcher_.clearDeferredDeleteList();
 }
 
 TEST_F(Http2ConnPoolImplTest, MaxGlobalRequests) {


### PR DESCRIPTION
The reason for this is that we already have protection via circuit breakers.
There is no point in having additional protection (other than potentially
for push, which we don't support currently, and can deal with later). If we
overflow the other side, the code will correctly handle the REFUSED_STREAM
reset that happens.