### PR TITLE
Fix flaky FakeHttpConnection::waitForDisconnect

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -174,7 +174,7 @@ void FakeConnectionBase::onEvent(uint32_t events) {
 
 void FakeConnectionBase::waitForDisconnect() {
   std::unique_lock<std::mutex> lock(lock_);
-  if (!disconnected_) {
+  while (!disconnected_) {
     connection_event_.wait(lock);
   }
 


### PR DESCRIPTION
I see some flakiness (about 15 failure out of 100 runs) on transcoding integration tests
https://github.com/istio/proxy/blob/master/src/envoy/transcoding/integration_test.cc#L261

```
[2017-05-19 01:58:17.947][5][critical] Backtrace (most recent call first) from thread 0:
  #1 ?? ??:0
  #2 ?? ??:0
  #3
  #4 Envoy::FakeConnectionBase::waitForDisconnect() at fake_upstream.cc:181 (discriminator 5)
  #5 void Envoy::(anonymous namespace)::TranscodingIntegrationTest::testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(Envoy::Http::HeaderMap&&, std::__cxx11::basic_string<char, std::ch$r_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_t$aits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_t$aits<char>, std::allocator<char> > > > const&, google::protobuf::util::Status const&, Envoy::Http::HeaderMap&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at integration_test.cc:158
  #6 Envoy::(anonymous namespace)::TranscodingIntegrationTest_InvalidJson_Test::TestBody() at integration_test.cc:290 (discriminator 18)
```