### PR TITLE
bazel: remove automatic run under for stack decoder

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -35,6 +35,3 @@ build:clang-msan --copt -fsanitize=memory
 build:clang-msan --linkopt -fsanitize=memory
 build:clang-msan --define tcmalloc=disabled
 build:clang-msan --copt -fsanitize-memory-track-origins=2
-
-# Symbolize stack trace for tests.
-test --run_under=//tools:stack_decode.py


### PR DESCRIPTION
This is causing various issues. Devs can put it in a local .bazelrc.