### PR TITLE
network/config: Add IPv6 DNS support

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -17,7 +17,7 @@
   includes both const and non-const references.
 * Function names using camel case starting with a lower case letter (e.g., "doFoo()").
 * Struct/Class member variables have a '\_' postfix (e.g., "int foo\_;").
-* Enum values using all CAPS (e.g., `EXTERNAL_ONLY`).
+* Enum values using PascalCase (e.g., `RoundRobin`).
 * 100 columns is the line limit.
 * Use your GitHub name in TODO comments, e.g. `TODO(foobar): blah`.
 * Smart pointers are type aliased:

--- a/STYLE.md
+++ b/STYLE.md
@@ -17,7 +17,7 @@
   includes both const and non-const references.
 * Function names using camel case starting with a lower case letter (e.g., "doFoo()").
 * Struct/Class member variables have a '\_' postfix (e.g., "int foo\_;").
-* Enum values using all CAPS (e.g., "EXTERNAL_ONLY").
+* Enum values using all CAPS (e.g., `EXTERNAL_ONLY`).
 * 100 columns is the line limit.
 * Use your GitHub name in TODO comments, e.g. `TODO(foobar): blah`.
 * Smart pointers are type aliased:

--- a/STYLE.md
+++ b/STYLE.md
@@ -17,6 +17,7 @@
   includes both const and non-const references.
 * Function names using camel case starting with a lower case letter (e.g., "doFoo()").
 * Struct/Class member variables have a '\_' postfix (e.g., "int foo\_;").
+* Enum values using all CAPS (e.g., "EXTERNAL_ONLY").
 * 100 columns is the line limit.
 * Use your GitHub name in TODO comments, e.g. `TODO(foobar): blah`.
 * Smart pointers are type aliased:

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -20,7 +20,7 @@ Cluster
     "features": "...",
     "http_codec_options": "...",
     "dns_refresh_rate_ms": "...",
-    "dns_lookup_ip_version": "...",
+    "dns_lookup_family": "...",
     "outlier_detection": "..."
   }
 
@@ -145,15 +145,15 @@ dns_refresh_rate_ms
   the value defaults to 5000. For cluster types other than *strict_dns* and *logical_dns* this setting is
   ignored.
 
-.. _config_cluster_manager_cluster_dns_lookup_ip_version:
+.. _config_cluster_manager_cluster_dns_lookup_family:
 
-dns_loopkup_ip_version
-  *(optional, string)* The DNS IP address version lookup policy. The options are *v4_only*, *v6_only*,
-  and *auto*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
+dns_lookup_family
+  *(optional, string)* The DNS IP address resolution policy. The options are *v4_only*, *v6_only*,
+  and *fallback*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
   the DNS resolver will only perform a lookup for addresses in the IPv4 family. If *v6_only* is selected,
-  the DNS resolver will only perform a lookup for addresses in the IPv6 family. If *auto* is specified,
-  the DNS resolver will first perform a lookup for addresses in the IPv4 family and fallback to a lookup for
-  addresses in the IPv6 family. For cluster types other than *strict_dns* and *logical_dns*, this setting
+  the DNS resolver will only perform a lookup for addresses in the IPv6 family. If *fallback* is specified,
+  the DNS resolver will first perform a lookup for addresses in the IPv6 family and fallback to a lookup for
+  addresses in the IPv4 family. For cluster types other than *strict_dns* and *logical_dns*, this setting
   is ignored.
 
 .. _config_cluster_manager_cluster_outlier_detection:

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -20,6 +20,7 @@ Cluster
     "features": "...",
     "http_codec_options": "...",
     "dns_refresh_rate_ms": "...",
+    "dns_lookup_ip_version": "...",
     "outlier_detection": "..."
   }
 
@@ -143,6 +144,17 @@ dns_refresh_rate_ms
   or *logical_dns*, this value is used as the cluster's dns refresh rate. If this setting is not specified,
   the value defaults to 5000. For cluster types other than *strict_dns* and *logical_dns* this setting is
   ignored.
+
+.. _config_cluster_manager_cluster_dns_refresh_rate_ms:
+
+dns_loopkup_ip_version
+  *(optional, string)* The dns IP address version lookup policy. The options are *v4_only*, *v6_only*,
+  and *auto*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
+  the dns resolver will only perform a lookup for addresses in the IPv4 family. If *v6_only* is selected,
+  the dns resolver will only perform a lookup for addresses in the IPv6 family. If *auto* is specified,
+  the dns resolver will first perform a lookup for addresses in the IPv4 family and fallback to a lookup for
+  addresses in the IPv6 family. For cluster types other than *strict_dns* and *logical_dns*, this setting
+  is ignored.
 
 .. _config_cluster_manager_cluster_outlier_detection:
 

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -145,14 +145,14 @@ dns_refresh_rate_ms
   the value defaults to 5000. For cluster types other than *strict_dns* and *logical_dns* this setting is
   ignored.
 
-.. _config_cluster_manager_cluster_dns_refresh_rate_ms:
+.. _config_cluster_manager_cluster_dns_lookup_ip_version:
 
 dns_loopkup_ip_version
-  *(optional, string)* The dns IP address version lookup policy. The options are *v4_only*, *v6_only*,
+  *(optional, string)* The DNS IP address version lookup policy. The options are *v4_only*, *v6_only*,
   and *auto*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
-  the dns resolver will only perform a lookup for addresses in the IPv4 family. If *v6_only* is selected,
-  the dns resolver will only perform a lookup for addresses in the IPv6 family. If *auto* is specified,
-  the dns resolver will first perform a lookup for addresses in the IPv4 family and fallback to a lookup for
+  the DNS resolver will only perform a lookup for addresses in the IPv4 family. If *v6_only* is selected,
+  the DNS resolver will only perform a lookup for addresses in the IPv6 family. If *auto* is specified,
+  the DNS resolver will first perform a lookup for addresses in the IPv4 family and fallback to a lookup for
   addresses in the IPv6 family. For cluster types other than *strict_dns* and *logical_dns*, this setting
   is ignored.
 

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -21,7 +21,7 @@ Cluster
     "http_codec_options": "...",
     "dns_refresh_rate_ms": "...",
     "dns_lookup_family": "...",
-    "outlier_detection": "..."
+    "outlier_detection": "{...}"
   }
 
 .. _config_cluster_manager_cluster_name:

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -149,9 +149,9 @@ dns_refresh_rate_ms
 
 dns_lookup_family
   *(optional, string)* The DNS IP address resolution policy. The options are *v4_only*, *v6_only*,
-  and *fallback*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
+  and *auto*. If this setting is not specified, the value defaults to *v4_only*. When *v4_only* is selected,
   the DNS resolver will only perform a lookup for addresses in the IPv4 family. If *v6_only* is selected,
-  the DNS resolver will only perform a lookup for addresses in the IPv6 family. If *fallback* is specified,
+  the DNS resolver will only perform a lookup for addresses in the IPv6 family. If *auto* is specified,
   the DNS resolver will first perform a lookup for addresses in the IPv6 family and fallback to a lookup for
   addresses in the IPv4 family. For cluster types other than *strict_dns* and *logical_dns*, this setting
   is ignored.

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -24,7 +24,7 @@ public:
   virtual void cancel() PURE;
 };
 
-enum class DnsLookupFamily { v4_only, v6_only, fallback };
+enum class DnsLookupFamily { V4_ONLY, V6_ONLY, AUTO };
 
 /**
  * An asynchronous DNS resolver.
@@ -48,8 +48,7 @@ public:
    * @return if non-null, a handle that can be used to cancel the resolution.
    *         This is only valid until the invocation of callback or ~DnsResolver().
    */
-  virtual ActiveDnsQuery* resolve(const std::string& dns_name,
-                                  const DnsLookupFamily& dns_lookup_family,
+  virtual ActiveDnsQuery* resolve(const std::string& dns_name, DnsLookupFamily dns_lookup_family,
                                   ResolveCb callback) PURE;
 };
 

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -41,11 +41,14 @@ public:
   /**
    * Initiate an async DNS resolution.
    * @param dns_name supplies the DNS name to lookup.
+   * @param dns_lookup_ip_version the DNS IP version lookup policy.
    * @param callback supplies the callback to invoke when the resolution is complete.
    * @return if non-null, a handle that can be used to cancel the resolution.
    *         This is only valid until the invocation of callback or ~DnsResolver().
    */
-  virtual ActiveDnsQuery* resolve(const std::string& dns_name, ResolveCb callback) PURE;
+  virtual ActiveDnsQuery* resolve(const std::string& dns_name,
+                                  const std::string& dns_lookup_ip_version,
+                                  ResolveCb callback) PURE;
 };
 
 typedef std::unique_ptr<DnsResolver> DnsResolverPtr;

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -24,7 +24,7 @@ public:
   virtual void cancel() PURE;
 };
 
-enum class DnsLookupFamily { V4_ONLY, V6_ONLY, AUTO };
+enum class DnsLookupFamily { V4Only, V6Only, Auto };
 
 /**
  * An asynchronous DNS resolver.

--- a/include/envoy/network/dns.h
+++ b/include/envoy/network/dns.h
@@ -24,6 +24,8 @@ public:
   virtual void cancel() PURE;
 };
 
+enum class DnsLookupFamily { v4_only, v6_only, fallback };
+
 /**
  * An asynchronous DNS resolver.
  */
@@ -41,13 +43,13 @@ public:
   /**
    * Initiate an async DNS resolution.
    * @param dns_name supplies the DNS name to lookup.
-   * @param dns_lookup_ip_version the DNS IP version lookup policy.
+   * @param dns_lookup_family the DNS IP version lookup policy.
    * @param callback supplies the callback to invoke when the resolution is complete.
    * @return if non-null, a handle that can be used to cancel the resolution.
    *         This is only valid until the invocation of callback or ~DnsResolver().
    */
   virtual ActiveDnsQuery* resolve(const std::string& dns_name,
-                                  const std::string& dns_lookup_ip_version,
+                                  const DnsLookupFamily& dns_lookup_family,
                                   ResolveCb callback) PURE;
 };
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1210,6 +1210,10 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
         "minimum" : 0,
         "exclusiveMinimum" : true
       },
+      "dns_lookup_ip_version" : {
+        "type" : "string",
+        "enum" : ["v4_only", "v6_only", "auto"]
+      },
       "outlier_detection" : {
         "type" : "object",
         "properties" : {

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1210,7 +1210,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
         "minimum" : 0,
         "exclusiveMinimum" : true
       },
-      "dns_lookup_ip_version" : {
+      "dns_lookup_family" : {
         "type" : "string",
         "enum" : ["v4_only", "v6_only", "auto"]
       },

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -52,25 +52,41 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
     delete this;
     return;
   }
-  std::list<Address::InstanceConstSharedPtr> address_list;
-  completed_ = true;
-  if (status == ARES_SUCCESS) {
-    ASSERT(hostent->h_addrtype == AF_INET);
-    for (int i = 0; hostent->h_addr_list[i] != nullptr; ++i) {
-      ASSERT(hostent->h_length == sizeof(in_addr));
-      sockaddr_in address;
-      memset(&address, 0, sizeof(address));
-      // TODO(mattklein123): IPv6 support.
-      address.sin_family = AF_INET;
-      address.sin_port = 0;
-      address.sin_addr = *reinterpret_cast<in_addr*>(hostent->h_addr_list[i]);
-      address_list.emplace_back(new Address::Ipv4Instance(&address));
-    }
+  if (status == ARES_SUCCESS || !fallback_if_failed) {
+    completed_ = true;
   }
-  if (!cancelled_) {
+
+  std::list<Address::InstanceConstSharedPtr> address_list;
+  if (status == ARES_SUCCESS) {
+    if (hostent->h_addrtype == AF_INET) {
+      for (int i = 0; hostent->h_addr_list[i] != nullptr; ++i) {
+        ASSERT(hostent->h_length == sizeof(in_addr));
+        sockaddr_in address;
+        memset(&address, 0, sizeof(address));
+        address.sin_family = AF_INET;
+        address.sin_port = 0;
+        address.sin_addr = *reinterpret_cast<in_addr*>(hostent->h_addr_list[i]);
+        address_list.emplace_back(new Address::Ipv4Instance(&address));
+      }
+    } else if (hostent->h_addrtype == AF_INET6) {
+      for (int i = 0; hostent->h_addr_list[i] != nullptr; ++i) {
+        ASSERT(hostent->h_length == sizeof(in6_addr));
+        sockaddr_in6 address;
+        memset(&address, 0, sizeof(address));
+        address.sin6_family = AF_INET6;
+        address.sin6_port = 0;
+        address.sin6_addr = *reinterpret_cast<in6_addr*>(hostent->h_addr_list[i]);
+        address_list.emplace_back(new Address::Ipv6Instance(address));
+      }
+    }
+  } else if (fallback_if_failed) {
+    fallback_if_failed = false;
+    getHostByName(AF_INET6);
+  }
+  if (!cancelled_ && completed_) {
     callback_(std::move(address_list));
   }
-  if (owned_) {
+  if (owned_ && completed_) {
     delete this;
   }
 }
@@ -115,17 +131,26 @@ void DnsResolverImpl::onAresSocketStateChange(int fd, int read, int write) {
                           (write ? Event::FileReadyType::Write : 0));
 }
 
-ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name, ResolveCb callback) {
+ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
+                                         const std::string& dns_lookup_ip_version,
+                                         ResolveCb callback) {
   std::unique_ptr<PendingResolution> pending_resolution(new PendingResolution());
   pending_resolution->callback_ = callback;
+  pending_resolution->channel_ = channel_;
+  pending_resolution->dns_name_ = dns_name;
+  if (dns_lookup_ip_version == "auto") {
+    pending_resolution->fallback_if_failed = true;
+  }
 
-  ares_gethostbyname(channel_, dns_name.c_str(),
-                     AF_INET, [](void* arg, int status, int timeouts, hostent* hostent) {
-                       static_cast<PendingResolution*>(arg)->onAresHostCallback(status, hostent);
-                       UNREFERENCED_PARAMETER(timeouts);
-                     }, pending_resolution.get());
+  if (dns_lookup_ip_version == "v6_only") {
+    pending_resolution->getHostByName(AF_INET6);
+  } else {
+    pending_resolution->getHostByName(AF_INET);
+  }
 
   if (pending_resolution->completed_) {
+    // Resolution does not need asynchronous behavior or network events. For
+    // example, localhost lookup.
     return nullptr;
   } else {
     // The PendingResolution will self-delete when the request completes
@@ -133,6 +158,14 @@ ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name, ResolveCb 
     pending_resolution->owned_ = true;
     return pending_resolution.release();
   }
+}
+
+void DnsResolverImpl::PendingResolution::getHostByName(int family) {
+  ares_gethostbyname(channel_, dns_name_.c_str(),
+                     family, [](void* arg, int status, int timeouts, hostent* hostent) {
+                       static_cast<PendingResolution*>(arg)->onAresHostCallback(status, hostent);
+                       UNREFERENCED_PARAMETER(timeouts);
+                     }, this);
 }
 
 } // Network

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -81,7 +81,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
     }
   } else if (fallback_if_failed) {
     fallback_if_failed = false;
-    getHostByName(AF_INET6);
+    getHostByName(AF_INET);
   }
   if (!cancelled_ && completed_) {
     callback_(std::move(address_list));
@@ -132,20 +132,20 @@ void DnsResolverImpl::onAresSocketStateChange(int fd, int read, int write) {
 }
 
 ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
-                                         const std::string& dns_lookup_ip_version,
+                                         const DnsLookupFamily& dns_lookup_family,
                                          ResolveCb callback) {
   std::unique_ptr<PendingResolution> pending_resolution(new PendingResolution());
   pending_resolution->callback_ = callback;
   pending_resolution->channel_ = channel_;
   pending_resolution->dns_name_ = dns_name;
-  if (dns_lookup_ip_version == "auto") {
+  if (dns_lookup_family == DnsLookupFamily::fallback) {
     pending_resolution->fallback_if_failed = true;
   }
 
-  if (dns_lookup_ip_version == "v6_only") {
-    pending_resolution->getHostByName(AF_INET6);
-  } else {
+  if (dns_lookup_family == DnsLookupFamily::v4_only) {
     pending_resolution->getHostByName(AF_INET);
+  } else {
+    pending_resolution->getHostByName(AF_INET6);
   }
 
   if (pending_resolution->completed_) {

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -147,11 +147,11 @@ ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
   // resolution.
   std::unique_ptr<PendingResolution> pending_resolution(
       new PendingResolution(callback, channel_, dns_name));
-  if (dns_lookup_family == DnsLookupFamily::AUTO) {
+  if (dns_lookup_family == DnsLookupFamily::Auto) {
     pending_resolution->fallback_if_failed_ = true;
   }
 
-  if (dns_lookup_family == DnsLookupFamily::V4_ONLY) {
+  if (dns_lookup_family == DnsLookupFamily::V4Only) {
     pending_resolution->getHostByName(AF_INET);
   } else {
     pending_resolution->getHostByName(AF_INET6);

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -52,7 +52,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
     delete this;
     return;
   }
-  if (status == ARES_SUCCESS || !fallback_if_failed) {
+  if (status == ARES_SUCCESS || !fallback_if_failed_) {
     completed_ = true;
   }
 
@@ -91,11 +91,12 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, hostent*
     }
   }
 
-  if (status != ARES_SUCCESS && fallback_if_failed) {
-    fallback_if_failed = false;
+  if (status != ARES_SUCCESS && fallback_if_failed_) {
+    fallback_if_failed_ = false;
     getHostByName(AF_INET);
     // Note: Nothing can follow this call to getHostByName due to deletion of this
     // object upon synchronous resolution.
+    return;
   }
 }
 
@@ -147,7 +148,7 @@ ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
   std::unique_ptr<PendingResolution> pending_resolution(
       new PendingResolution(callback, channel_, dns_name));
   if (dns_lookup_family == DnsLookupFamily::AUTO) {
-    pending_resolution->fallback_if_failed = true;
+    pending_resolution->fallback_if_failed_ = true;
   }
 
   if (dns_lookup_family == DnsLookupFamily::V4_ONLY) {

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -29,7 +29,7 @@ public:
   ~DnsResolverImpl() override;
 
   // Network::DnsResolver
-  ActiveDnsQuery* resolve(const std::string& dns_name, const std::string& dns_lookup_ip_version,
+  ActiveDnsQuery* resolve(const std::string& dns_name, const DnsLookupFamily& dns_lookup_family,
                           ResolveCb callback) override;
 
 private:
@@ -54,7 +54,7 @@ private:
     bool completed_ = false;
     // Was the query cancelled via cancel()?
     bool cancelled_ = false;
-    // If dns_lookup_ip_version is "auto", fallback to v6 address if v4
+    // If dns_lookup_family is "fallback", fallback to v4 address if v6
     // resolution failed.
     bool fallback_if_failed = false;
     ares_channel channel_;

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -29,24 +29,34 @@ public:
   ~DnsResolverImpl() override;
 
   // Network::DnsResolver
-  ActiveDnsQuery* resolve(const std::string& dns_name, const DnsLookupFamily& dns_lookup_family,
+  ActiveDnsQuery* resolve(const std::string& dns_name, DnsLookupFamily dns_lookup_family,
                           ResolveCb callback) override;
 
 private:
   friend class DnsResolverImplPeer;
   struct PendingResolution : public ActiveDnsQuery {
     // Network::ActiveDnsQuery
+    PendingResolution(ResolveCb callback, ares_channel channel, const std::string& dns_name)
+        : callback_(callback), channel_(channel), dns_name_(dns_name) {}
+
     void cancel() override {
       // c-ares only supports channel-wide cancellation, so we just allow the
       // network events to continue but don't invoke the callback on completion.
       cancelled_ = true;
     }
 
-    // c-ares ares_gethostbyname() query callback.
+    /* c-ares ares_gethostbyname() query callback.
+     * @param status return status of call to ares_gethostbyname.
+     * @param hostent structure that stores information about a given host.
+     */
     void onAresHostCallback(int status, hostent* hostent);
+    /* wrapper function of call to ares_gethostbyname.
+     * @param family currently AF_INET and AF_INET6 are supported.
+     */
+    void getHostByName(int family);
 
     // Caller supplied callback to invoke on query completion or error.
-    ResolveCb callback_;
+    const ResolveCb callback_;
     // Does the object own itself? Resource reclamation occurs via self-deleting
     // on query completion or error.
     bool owned_ = false;
@@ -57,10 +67,8 @@ private:
     // If dns_lookup_family is "fallback", fallback to v4 address if v6
     // resolution failed.
     bool fallback_if_failed = false;
-    ares_channel channel_;
-    std::string dns_name_;
-
-    void getHostByName(int family);
+    const ares_channel channel_;
+    const std::string dns_name_;
   };
 
   // Callback for events on sockets tracked in events_.

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -66,7 +66,7 @@ private:
     bool cancelled_ = false;
     // If dns_lookup_family is "fallback", fallback to v4 address if v6
     // resolution failed.
-    bool fallback_if_failed = false;
+    bool fallback_if_failed_ = false;
     const ares_channel channel_;
     const std::string dns_name_;
   };

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -29,7 +29,8 @@ public:
   ~DnsResolverImpl() override;
 
   // Network::DnsResolver
-  ActiveDnsQuery* resolve(const std::string& dns_name, ResolveCb callback) override;
+  ActiveDnsQuery* resolve(const std::string& dns_name, const std::string& dns_lookup_ip_version,
+                          ResolveCb callback) override;
 
 private:
   friend class DnsResolverImplPeer;
@@ -53,6 +54,13 @@ private:
     bool completed_ = false;
     // Was the query cancelled via cancel()?
     bool cancelled_ = false;
+    // If dns_lookup_ip_version is "auto", fallback to v6 address if v4
+    // resolution failed.
+    bool fallback_if_failed = false;
+    ares_channel channel_;
+    std::string dns_name_;
+
+    void getHostByName(int family);
   };
 
   // Callback for events on sockets tracked in events_.

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -45,12 +45,14 @@ private:
       cancelled_ = true;
     }
 
-    /* c-ares ares_gethostbyname() query callback.
+    /**
+     * c-ares ares_gethostbyname() query callback.
      * @param status return status of call to ares_gethostbyname.
      * @param hostent structure that stores information about a given host.
      */
     void onAresHostCallback(int status, hostent* hostent);
-    /* wrapper function of call to ares_gethostbyname.
+    /**
+     * wrapper function of call to ares_gethostbyname.
      * @param family currently AF_INET and AF_INET6 are supported.
      */
     void getHostByName(int family);

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -299,8 +299,8 @@ Address::InstanceConstSharedPtr Utility::getIpv6AnyAddress() {
   return any;
 }
 
-Address::InstanceConstSharedPtr Utility::getAddressUpdatePort(const Address::Instance& address,
-                                                              uint32_t port) {
+Address::InstanceConstSharedPtr Utility::getAddressWithPort(const Address::Instance& address,
+                                                            uint32_t port) {
   switch (address.ip()->version()) {
   case Network::Address::IpVersion::v4:
     return std::make_shared<Address::Ipv4Instance>(address.ip()->addressAsString(), port);

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -299,6 +299,17 @@ Address::InstanceConstSharedPtr Utility::getIpv6AnyAddress() {
   return any;
 }
 
+Address::InstanceConstSharedPtr Utility::getAddressUpdatePort(const Address::Instance& address,
+                                                              uint32_t port) {
+  switch (address.ip()->version()) {
+  case Network::Address::IpVersion::v4:
+    return std::make_shared<Address::Ipv4Instance>(address.ip()->addressAsString(), port);
+  case Network::Address::IpVersion::v6:
+    return std::make_shared<Address::Ipv6Instance>(address.ip()->addressAsString(), port);
+  }
+  NOT_REACHED;
+}
+
 Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
   sockaddr_storage orig_addr;
   socklen_t addr_len = sizeof(sockaddr_storage);

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -151,8 +151,8 @@ public:
    * @param port to update.
    * @return Address::InstanceConstSharedPtr a new address instance with updated port.
    */
-  static Address::InstanceConstSharedPtr getAddressUpdatePort(const Address::Instance& address,
-                                                              uint32_t port);
+  static Address::InstanceConstSharedPtr getAddressWithPort(const Address::Instance& address,
+                                                            uint32_t port);
 
   /**
    * Retrieve the original destination address from an accepted fd.

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -147,6 +147,14 @@ public:
   static Address::InstanceConstSharedPtr getIpv6AnyAddress();
 
   /**
+   * @param address IP address instance.
+   * @param port to update.
+   * @return Address::InstanceConstSharedPtr a new address instance with updated port.
+   */
+  static Address::InstanceConstSharedPtr getAddressUpdatePort(const Address::Instance& address,
+                                                              uint32_t port);
+
+  /**
    * Retrieve the original destination address from an accepted fd.
    * The address (IP and port) may be not local and the port may differ from
    * the listener port if the packets were redirected using iptables

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -27,12 +27,12 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
 
   std::string dns_lookup_family = config.getString("dns_lookup_family", "v4_only");
   if (dns_lookup_family == "v6_only") {
-    dns_lookup_family_ = Network::DnsLookupFamily::V6_ONLY;
+    dns_lookup_family_ = Network::DnsLookupFamily::V6Only;
   } else if (dns_lookup_family == "auto") {
-    dns_lookup_family_ = Network::DnsLookupFamily::AUTO;
+    dns_lookup_family_ = Network::DnsLookupFamily::Auto;
   } else {
     ASSERT(dns_lookup_family == "v4_only");
-    dns_lookup_family_ = Network::DnsLookupFamily::V4_ONLY;
+    dns_lookup_family_ = Network::DnsLookupFamily::V4Only;
   }
   dns_url_ = hosts_json[0]->getString("url");
   hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -25,14 +25,14 @@ LogicalDnsCluster::LogicalDnsCluster(const Json::Object& config, Runtime::Loader
     throw EnvoyException("logical_dns clusters must have a single host");
   }
 
-  // Resolve string to enum.
   std::string dns_lookup_family = config.getString("dns_lookup_family", "v4_only");
   if (dns_lookup_family == "v6_only") {
-    dns_lookup_family_ = Network::DnsLookupFamily::v6_only;
-  } else if (dns_lookup_family == "fallback") {
-    dns_lookup_family_ = Network::DnsLookupFamily::fallback;
+    dns_lookup_family_ = Network::DnsLookupFamily::V6_ONLY;
+  } else if (dns_lookup_family == "auto") {
+    dns_lookup_family_ = Network::DnsLookupFamily::AUTO;
   } else {
-    dns_lookup_family_ = Network::DnsLookupFamily::v4_only;
+    ASSERT(dns_lookup_family == "v4_only");
+    dns_lookup_family_ = Network::DnsLookupFamily::V4_ONLY;
   }
   dns_url_ = hosts_json[0]->getString("url");
   hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
@@ -70,14 +70,17 @@ void LogicalDnsCluster::startResolve() {
           // TODO(mattklein123): Move port handling into the DNS interface.
           Network::Address::IpVersion version = address_list.front()->ip()->version();
           Network::Address::InstanceConstSharedPtr new_address;
-          if (version == Network::Address::IpVersion::v4) {
+          switch (version) {
+          case Network::Address::IpVersion::v4:
             new_address.reset(
                 new Network::Address::Ipv4Instance(address_list.front()->ip()->addressAsString(),
                                                    Network::Utility::portFromTcpUrl(dns_url_)));
-          } else {
+            break;
+          case Network::Address::IpVersion::v6:
             new_address.reset(
                 new Network::Address::Ipv6Instance(address_list.front()->ip()->addressAsString(),
                                                    Network::Utility::portFromTcpUrl(dns_url_)));
+            break;
           }
           if (!current_resolved_address_ || !(*new_address == *current_resolved_address_)) {
             current_resolved_address_ = new_address;
@@ -93,12 +96,15 @@ void LogicalDnsCluster::startResolve() {
             // to show the friendly DNS name in that output, but currently there is no way to
             // express a DNS name inside of an Address::Instance. For now this is OK but we might
             // want to do better again later.
-            if (version == Network::Address::IpVersion::v4) {
+            switch (version) {
+            case Network::Address::IpVersion::v4:
               logical_host_.reset(
                   new LogicalHost(info_, hostname_, Network::Utility::getIpv4AnyAddress(), *this));
-            } else {
+              break;
+            case Network::Address::IpVersion::v6:
               logical_host_.reset(
                   new LogicalHost(info_, hostname_, Network::Utility::getIpv6AnyAddress(), *this));
+              break;
             }
             HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
             new_hosts->emplace_back(logical_host_);

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -70,8 +70,8 @@ void LogicalDnsCluster::startResolve() {
           // TODO(mattklein123): Move port handling into the DNS interface.
           ASSERT(address_list.front() != nullptr);
           Network::Address::InstanceConstSharedPtr new_address =
-              Network::Utility::getAddressUpdatePort(*address_list.front(),
-                                                     Network::Utility::portFromTcpUrl(dns_url_));
+              Network::Utility::getAddressWithPort(*address_list.front(),
+                                                   Network::Utility::portFromTcpUrl(dns_url_));
           if (!current_resolved_address_ || !(*new_address == *current_resolved_address_)) {
             current_resolved_address_ = new_address;
             // Capture URL to avoid a race with another update.

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -88,6 +88,7 @@ private:
 
   Network::DnsResolver& dns_resolver_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
+  const std::string dns_lookup_ip_version_;
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;
   std::function<void()> initialize_callback_;

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -88,7 +88,7 @@ private:
 
   Network::DnsResolver& dns_resolver_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
-  const std::string dns_lookup_ip_version_;
+  Network::DnsLookupFamily dns_lookup_family_;
   ThreadLocal::Instance& tls_;
   uint32_t tls_slot_;
   std::function<void()> initialize_callback_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -372,12 +372,12 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(const Json::Object& config, Runtime::
                                        config.getInteger("dns_refresh_rate_ms", 5000))) {
   std::string dns_lookup_family = config.getString("dns_lookup_family", "v4_only");
   if (dns_lookup_family == "v6_only") {
-    dns_lookup_family_ = Network::DnsLookupFamily::V6_ONLY;
+    dns_lookup_family_ = Network::DnsLookupFamily::V6Only;
   } else if (dns_lookup_family == "auto") {
-    dns_lookup_family_ = Network::DnsLookupFamily::AUTO;
+    dns_lookup_family_ = Network::DnsLookupFamily::Auto;
   } else {
     ASSERT(dns_lookup_family == "v4_only");
-    dns_lookup_family_ = Network::DnsLookupFamily::V4_ONLY;
+    dns_lookup_family_ = Network::DnsLookupFamily::V4Only;
   }
 
   for (Json::ObjectSharedPtr host : config.getObjectArray("hosts")) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -379,9 +379,6 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(const Json::Object& config, Runtime::
   } else {
     dns_lookup_family_ = Network::DnsLookupFamily::v4_only;
   }
-  //} else {
-  //  throw EnvoyException(fmt::format("unknown dns_lookup_family option {}", dns_lookup_family));
-  //}
 
   for (Json::ObjectSharedPtr host : config.getObjectArray("hosts")) {
     resolve_targets_.emplace_back(new ResolveTarget(*this, dispatcher, host->getString("url")));

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -435,9 +435,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.
           ASSERT(address != nullptr);
-          new_hosts.emplace_back(
-              new HostImpl(parent_.info_, dns_address_,
-                           Network::Utility::getAddressUpdatePort(*address, port_), false, 1, ""));
+          new_hosts.emplace_back(new HostImpl(parent_.info_, dns_address_,
+                                              Network::Utility::getAddressWithPort(*address, port_),
+                                              false, 1, ""));
         }
 
         std::vector<HostSharedPtr> hosts_added;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -434,22 +434,10 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           // TODO(mattklein123): Currently the DNS interface does not consider port. We need to make
           // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.
-          switch (address->ip()->version()) {
-          case Network::Address::IpVersion::v4:
-            new_hosts.emplace_back(new HostImpl(
-                parent_.info_, dns_address_,
-                Network::Address::InstanceConstSharedPtr{
-                    new Network::Address::Ipv4Instance(address->ip()->addressAsString(), port_)},
-                false, 1, ""));
-            break;
-          case Network::Address::IpVersion::v6:
-            new_hosts.emplace_back(new HostImpl(
-                parent_.info_, dns_address_,
-                Network::Address::InstanceConstSharedPtr{
-                    new Network::Address::Ipv6Instance(address->ip()->addressAsString(), port_)},
-                false, 1, ""));
-            break;
-          }
+          ASSERT(address != nullptr);
+          new_hosts.emplace_back(
+              new HostImpl(parent_.info_, dns_address_,
+                           Network::Utility::getAddressUpdatePort(*address, port_), false, 1, ""));
         }
 
         std::vector<HostSharedPtr> hosts_added;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -350,7 +350,7 @@ private:
   Network::DnsResolver& dns_resolver_;
   std::list<ResolveTargetPtr> resolve_targets_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
-  const std::string dns_lookup_ip_version_;
+  Network::DnsLookupFamily dns_lookup_family_;
 };
 
 } // Upstream

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -350,6 +350,7 @@ private:
   Network::DnsResolver& dns_resolver_;
   std::list<ResolveTargetPtr> resolve_targets_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
+  const std::string dns_lookup_ip_version_;
 };
 
 } // Upstream

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -63,6 +63,8 @@ envoy_cc_test(
         "//source/common/network:listen_socket_lib",
         "//source/common/stats:stats_lib",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
     ],
 )
 

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -300,7 +300,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplTest,
 // destruction.
 TEST_P(DnsImplTest, DestructPending) {
   EXPECT_NE(nullptr,
-            resolver_->resolve("", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  FAIL();
                                  UNREFERENCED_PARAMETER(results);
@@ -316,7 +316,7 @@ TEST_P(DnsImplTest, DestructPending) {
 TEST_P(DnsImplTest, LocalLookup) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -326,7 +326,7 @@ TEST_P(DnsImplTest, LocalLookup) {
   EXPECT_TRUE(address_list.empty());
 
   if (GetParam() == Address::IpVersion::v4) {
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V4_ONLY,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V4Only,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_TRUE(hasAddress(address_list, "127.0.0.1"));
@@ -334,13 +334,13 @@ TEST_P(DnsImplTest, LocalLookup) {
   }
 
   if (GetParam() == Address::IpVersion::v6) {
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::AUTO,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::Auto,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_FALSE(hasAddress(address_list, "127.0.0.1"));
     EXPECT_TRUE(hasAddress(address_list, "::1"));
 
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V6_ONLY,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V6Only,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_TRUE(hasAddress(address_list, "::1"));
@@ -352,7 +352,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   server_->addHosts("some.good.domain", {"1::2"}, AAAA);
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -362,7 +362,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   EXPECT_TRUE(hasAddress(address_list, "1::2"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -372,7 +372,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   EXPECT_FALSE(hasAddress(address_list, "1::2"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -386,7 +386,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   server_->addHosts("some.good.domain", {"1.2.3.4"}, A);
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -396,7 +396,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   EXPECT_TRUE(hasAddress(address_list, "1.2.3.4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -406,7 +406,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   EXPECT_TRUE(hasAddress(address_list, "1.2.3.4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -422,7 +422,7 @@ TEST_P(DnsImplTest, RemoteAsyncLookup) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.bad.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.bad.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -432,7 +432,7 @@ TEST_P(DnsImplTest, RemoteAsyncLookup) {
   EXPECT_TRUE(address_list.empty());
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -447,7 +447,7 @@ TEST_P(DnsImplTest, MultiARecordLookup) {
   server_->addHosts("some.good.domain", {"201.134.56.7", "123.4.5.6", "6.5.4.3"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -464,7 +464,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   server_->addHosts("some.good.domain", {"1::2", "1::2:3", "1::2:3:4"}, AAAA);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -476,7 +476,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   EXPECT_TRUE(hasAddress(address_list, "6.5.4.3"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -488,7 +488,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   EXPECT_TRUE(hasAddress(address_list, "1::2:3:4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -505,12 +505,12 @@ TEST_P(DnsImplTest, Cancel) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
 
   ActiveDnsQuery* query =
-      resolver_->resolve("some.domain", DnsLookupFamily::AUTO,
+      resolver_->resolve("some.domain", DnsLookupFamily::Auto,
                          [](std::list<Address::InstanceConstSharedPtr> && ) -> void { FAIL(); });
 
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::Auto,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -537,7 +537,7 @@ TEST_P(DnsImplZeroTimeoutTest, Timeout) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4Only,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -300,7 +300,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplTest,
 // destruction.
 TEST_P(DnsImplTest, DestructPending) {
   EXPECT_NE(nullptr,
-            resolver_->resolve("", DnsLookupFamily::v4_only,
+            resolver_->resolve("", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  FAIL();
                                  UNREFERENCED_PARAMETER(results);
@@ -316,7 +316,7 @@ TEST_P(DnsImplTest, DestructPending) {
 TEST_P(DnsImplTest, LocalLookup) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("", DnsLookupFamily::v4_only,
+            resolver_->resolve("", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -326,7 +326,7 @@ TEST_P(DnsImplTest, LocalLookup) {
   EXPECT_TRUE(address_list.empty());
 
   if (GetParam() == Address::IpVersion::v4) {
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::v4_only,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V4_ONLY,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_TRUE(hasAddress(address_list, "127.0.0.1"));
@@ -334,13 +334,13 @@ TEST_P(DnsImplTest, LocalLookup) {
   }
 
   if (GetParam() == Address::IpVersion::v6) {
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::fallback,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::AUTO,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_FALSE(hasAddress(address_list, "127.0.0.1"));
     EXPECT_TRUE(hasAddress(address_list, "::1"));
 
-    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::v6_only,
+    EXPECT_EQ(nullptr, resolver_->resolve("localhost", DnsLookupFamily::V6_ONLY,
                                           [&](std::list<Address::InstanceConstSharedPtr>&& results)
                                               -> void { address_list = results; }));
     EXPECT_TRUE(hasAddress(address_list, "::1"));
@@ -352,7 +352,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   server_->addHosts("some.good.domain", {"1::2"}, AAAA);
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -362,7 +362,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   EXPECT_TRUE(hasAddress(address_list, "1::2"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v4_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -372,7 +372,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersionV6) {
   EXPECT_FALSE(hasAddress(address_list, "1::2"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v6_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -386,7 +386,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   std::list<Address::InstanceConstSharedPtr> address_list;
   server_->addHosts("some.good.domain", {"1.2.3.4"}, A);
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -396,7 +396,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   EXPECT_TRUE(hasAddress(address_list, "1.2.3.4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v4_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -406,7 +406,7 @@ TEST_P(DnsImplTest, DnsIpAddressVersion) {
   EXPECT_TRUE(hasAddress(address_list, "1.2.3.4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v6_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -422,7 +422,7 @@ TEST_P(DnsImplTest, RemoteAsyncLookup) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.bad.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.bad.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -432,7 +432,7 @@ TEST_P(DnsImplTest, RemoteAsyncLookup) {
   EXPECT_TRUE(address_list.empty());
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -447,7 +447,7 @@ TEST_P(DnsImplTest, MultiARecordLookup) {
   server_->addHosts("some.good.domain", {"201.134.56.7", "123.4.5.6", "6.5.4.3"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v4_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -464,7 +464,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   server_->addHosts("some.good.domain", {"1::2", "1::2:3", "1::2:3:4"}, AAAA);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v4_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -476,7 +476,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   EXPECT_TRUE(hasAddress(address_list, "6.5.4.3"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -488,7 +488,7 @@ TEST_P(DnsImplTest, MultiARecordLookupWithV6) {
   EXPECT_TRUE(hasAddress(address_list, "1::2:3:4"));
 
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v6_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V6_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -505,12 +505,12 @@ TEST_P(DnsImplTest, Cancel) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
 
   ActiveDnsQuery* query =
-      resolver_->resolve("some.domain", DnsLookupFamily::fallback,
+      resolver_->resolve("some.domain", DnsLookupFamily::AUTO,
                          [](std::list<Address::InstanceConstSharedPtr> && ) -> void { FAIL(); });
 
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::fallback,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::AUTO,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();
@@ -528,12 +528,16 @@ protected:
   bool zero_timeout() const override { return true; }
 };
 
+// Parameterize the DNS test server socket address.
+INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplZeroTimeoutTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
 // Validate that timeouts result in an empty callback.
 TEST_P(DnsImplZeroTimeoutTest, Timeout) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,
-            resolver_->resolve("some.good.domain", DnsLookupFamily::v4_only,
+            resolver_->resolve("some.good.domain", DnsLookupFamily::V4_ONLY,
                                [&](std::list<Address::InstanceConstSharedPtr>&& results) -> void {
                                  address_list = results;
                                  dispatcher_.exit();

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -461,8 +461,9 @@ TEST_P(DnsImplTest, MultiARecordLookup) {
 TEST_P(DnsImplTest, Cancel) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, A);
 
-  ActiveDnsQuery* query = resolver_->resolve(
-      "some.domain", "auto", [](std::list<Address::InstanceConstSharedPtr> && ) -> void { FAIL(); });
+  ActiveDnsQuery* query =
+      resolver_->resolve("some.domain", "auto",
+                         [](std::list<Address::InstanceConstSharedPtr> && ) -> void { FAIL(); });
 
   std::list<Address::InstanceConstSharedPtr> address_list;
   EXPECT_NE(nullptr,

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -93,13 +93,13 @@ private:
         // name.
         long name_len;
         // Get host name from query and use the name to lookup a record
-        // in a host maap. If the query type is of type A, then perform the lookup in
+        // in a host map. If the query type is of type A, then perform the lookup in
         // the hosts_A_ host map. If the query type is of type AAAA, then perform the
         // lookup in the hosts_AAAA_ host map.
         char* name;
         ASSERT_EQ(ARES_SUCCESS, ares_expand_name(question, request, size_, &name, &name_len));
         const std::list<std::string>* ips = nullptr;
-        // Query type. We only expect for resources of type A or AAAA.
+        // We only expect resources of type A or AAAA.
         const int q_type = DNS_QUESTION_TYPE(question + name_len);
         ASSERT_TRUE(q_type == T_A || q_type == T_AAAA);
         if (q_type == T_A) {
@@ -198,7 +198,7 @@ public:
     queries_.emplace_back(query);
   }
 
-  void addHosts(const std::string& hostname, const IpList& ip, const record_type type) {
+  void addHosts(const std::string& hostname, const IpList& ip, const record_type& type) {
     if (type == A) {
       hosts_A_[hostname] = ip;
     } else if (type == AAAA) {
@@ -290,7 +290,7 @@ static bool hasAddress(const std::list<Address::InstanceConstSharedPtr>& results
   return false;
 }
 
-// Parameterized test dns server socket address.
+// Parameterize the DNS test server socket address.
 INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -669,8 +669,8 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   Network::DnsResolver::ResolveCb dns_callback;
   Event::MockTimer* dns_timer_ = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
   Network::MockActiveDnsQuery active_dns_query;
-  EXPECT_CALL(factory_.dns_resolver_, resolve(_, _))
-      .WillRepeatedly(DoAll(SaveArg<1>(&dns_callback), Return(&active_dns_query)));
+  EXPECT_CALL(factory_.dns_resolver_, resolve(_, _, _))
+      .WillRepeatedly(DoAll(SaveArg<2>(&dns_callback), Return(&active_dns_query)));
   create(*loader);
 
   // Test for no hosts returning the correct values before we have hosts.

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -60,9 +60,10 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
 };
 
-typedef std::tuple<std::string, Network::DnsLookupFamily, std::list<std::string>> DnsConfigTuple;
-std::vector<DnsConfigTuple> generateParamVector() {
-  std::vector<DnsConfigTuple> dns_config;
+typedef std::tuple<std::string, Network::DnsLookupFamily, std::list<std::string>>
+    LogicalDnsConfigTuple;
+std::vector<LogicalDnsConfigTuple> generateLogicalDnsParams() {
+  std::vector<LogicalDnsConfigTuple> dns_config;
   {
     std::string family_json("");
     Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
@@ -91,9 +92,10 @@ std::vector<DnsConfigTuple> generateParamVector() {
 }
 
 class LogicalDnsParamTest : public LogicalDnsClusterTest,
-                            public testing::WithParamInterface<DnsConfigTuple> {};
+                            public testing::WithParamInterface<LogicalDnsConfigTuple> {};
 
-INSTANTIATE_TEST_CASE_P(DnsParam, LogicalDnsParamTest, testing::ValuesIn(generateParamVector()));
+INSTANTIATE_TEST_CASE_P(DnsParam, LogicalDnsParamTest,
+                        testing::ValuesIn(generateLogicalDnsParams()));
 
 // Validate that if the DNS resolves immediately, during the LogicalDnsCluster
 // constructor, we have the expected host state and initialization callback

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -66,25 +66,25 @@ std::vector<LogicalDnsConfigTuple> generateLogicalDnsParams() {
   std::vector<LogicalDnsConfigTuple> dns_config;
   {
     std::string family_json("");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4Only);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "v4_only",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4Only);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "v6_only",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V6_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V6Only);
     std::list<std::string> dns_response{"::1", "::2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "auto",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::AUTO);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::Auto);
     std::list<std::string> dns_response{"::1"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
@@ -155,7 +155,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   }
   )EOF";
 
-  expectResolve(Network::DnsLookupFamily::V4_ONLY);
+  expectResolve(Network::DnsLookupFamily::V4Only);
   setup(json);
 
   EXPECT_CALL(membership_updated_, ready());
@@ -176,7 +176,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   logical_host->createConnection(dispatcher_);
   logical_host->outlierDetector().putHttpResponseCode(200);
 
-  expectResolve(Network::DnsLookupFamily::V4_ONLY);
+  expectResolve(Network::DnsLookupFamily::V4Only);
   resolve_timer_->callback_();
 
   // Should not cause any changes.
@@ -196,7 +196,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_EQ("foo.bar.com", data.host_description_->hostname());
   data.host_description_->outlierDetector().putHttpResponseCode(200);
 
-  expectResolve(Network::DnsLookupFamily::V4_ONLY);
+  expectResolve(Network::DnsLookupFamily::V4Only);
   resolve_timer_->callback_();
 
   // Should cause a change.
@@ -209,7 +209,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   logical_host->createConnection(dispatcher_);
 
-  expectResolve(Network::DnsLookupFamily::V4_ONLY);
+  expectResolve(Network::DnsLookupFamily::V4Only);
   resolve_timer_->callback_();
 
   // Empty should not cause any change.
@@ -224,7 +224,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
 
   // Make sure we cancel.
   EXPECT_CALL(active_dns_query_, cancel());
-  expectResolve(Network::DnsLookupFamily::V4_ONLY);
+  expectResolve(Network::DnsLookupFamily::V4Only);
   resolve_timer_->callback_();
 
   tls_.shutdownThread();

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -73,21 +73,6 @@ TEST_F(LogicalDnsClusterTest, BadConfig) {
   EXPECT_THROW(setup(json), EnvoyException);
 }
 
-TEST_F(LogicalDnsClusterTest, BadDnsConfig) {
-  std::string json = R"EOF(
-  {
-    "name": "name",
-    "connect_timeout_ms": 250,
-    "type": "logical_dns",
-    "lb_type": "round_robin",
-    "hosts": [{"url": "tcp://foo.bar.com:443"}],
-    "dns_lookup_family": "foo"
-  }
-  )EOF";
-
-  EXPECT_DEATH(setup(json), "dns_lookup_family == \"v4_only\"");
-}
-
 // Validate that if the DNS resolves immediately, during the LogicalDnsCluster
 // constructor, we have the expected host state and initialization callback
 // invocation.

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -37,9 +37,9 @@ public:
     cluster_->setInitializedCb([&]() -> void { initialized_.ready(); });
   }
 
-  void expectResolve(const Network::DnsLookupFamily& dns_lookup_family) {
+  void expectResolve(Network::DnsLookupFamily dns_lookup_family) {
     EXPECT_CALL(dns_resolver_, resolve("foo.bar.com", dns_lookup_family, _))
-        .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
+        .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
                              Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
           dns_callback_ = cb;
           return &active_dns_query_;
@@ -114,7 +114,7 @@ TEST_P(LogicalDnsParamTest, ImmediateResolve) {
 
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(dns_resolver_, resolve("foo.bar.com", std::get<1>(GetParam()), _))
-      .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
+      .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
                            Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
         EXPECT_CALL(*resolve_timer_, enableTimer(_));
         cb(TestUtility::makeDnsResponse(std::get<2>(GetParam())));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -68,25 +68,25 @@ std::vector<StrictDnsConfigTuple> generateStrictDnsParams() {
   std::vector<StrictDnsConfigTuple> dns_config;
   {
     std::string family_json("");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4Only);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "v4_only",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V4Only);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "v6_only",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::V6_ONLY);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::V6Only);
     std::list<std::string> dns_response{"::1", "::2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }
   {
     std::string family_json(R"EOF("dns_lookup_family": "auto",)EOF");
-    Network::DnsLookupFamily family(Network::DnsLookupFamily::AUTO);
+    Network::DnsLookupFamily family(Network::DnsLookupFamily::Auto);
     std::list<std::string> dns_response{"127.0.0.1", "127.0.0.2"};
     dns_config.push_back(std::make_tuple(family_json, family, dns_response));
   }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -80,7 +80,7 @@ TEST(StrictDnsClusterImplTest, ImmediateResolve) {
   )EOF";
 
   EXPECT_CALL(initialized, ready());
-  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::v4_only, _))
+  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::V4_ONLY, _))
       .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
                            Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
         cb(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
@@ -114,7 +114,7 @@ TEST(StrictDnsClusterImplTest, ImmediateResolveV6Only) {
   )EOF";
 
   EXPECT_CALL(initialized, ready());
-  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::v6_only, _))
+  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::V6_ONLY, _))
       .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
                            Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
         cb(TestUtility::makeDnsResponse({"::1", "::2"}));
@@ -143,12 +143,12 @@ TEST(StrictDnsClusterImplTest, ImmediateResolveFallback) {
     "type": "strict_dns",
     "lb_type": "round_robin",
     "hosts": [{"url": "tcp://foo.bar.com:443"}],
-    "dns_lookup_family" : "fallback"
+    "dns_lookup_family" : "auto"
   }
   )EOF";
 
   EXPECT_CALL(initialized, ready());
-  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::fallback, _))
+  EXPECT_CALL(dns_resolver, resolve("foo.bar.com", Network::DnsLookupFamily::AUTO, _))
       .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
                            Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
         cb(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -49,7 +49,7 @@ struct ResolverData {
 
   void expectResolve(Network::MockDnsResolver& dns_resolver) {
     EXPECT_CALL(dns_resolver, resolve(_, _, _))
-        .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
+        .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
                              Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
           dns_callback_ = cb;
           return &active_dns_query_;
@@ -118,7 +118,7 @@ TEST_P(StrictDnsParamTest, ImmediateResolve) {
   )EOF";
   EXPECT_CALL(initialized, ready());
   EXPECT_CALL(dns_resolver, resolve("foo.bar.com", std::get<1>(GetParam()), _))
-      .WillOnce(Invoke([&](const std::string&, const Network::DnsLookupFamily&,
+      .WillOnce(Invoke([&](const std::string&, Network::DnsLookupFamily,
                            Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
         cb(TestUtility::makeDnsResponse(std::get<2>(GetParam())));
         return nullptr;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -62,9 +62,10 @@ struct ResolverData {
   Network::MockActiveDnsQuery active_dns_query_;
 };
 
-typedef std::tuple<std::string, Network::DnsLookupFamily, std::list<std::string>> DnsConfigTuple;
-std::vector<DnsConfigTuple> generateParamVector() {
-  std::vector<DnsConfigTuple> dns_config;
+typedef std::tuple<std::string, Network::DnsLookupFamily, std::list<std::string>>
+    StrictDnsConfigTuple;
+std::vector<StrictDnsConfigTuple> generateStrictDnsParams() {
+  std::vector<StrictDnsConfigTuple> dns_config;
   {
     std::string family_json("");
     Network::DnsLookupFamily family(Network::DnsLookupFamily::V4_ONLY);
@@ -92,9 +93,9 @@ std::vector<DnsConfigTuple> generateParamVector() {
   return dns_config;
 }
 
-class StrictDnsParamTest : public testing::TestWithParam<DnsConfigTuple> {};
+class StrictDnsParamTest : public testing::TestWithParam<StrictDnsConfigTuple> {};
 
-INSTANTIATE_TEST_CASE_P(DnsParam, StrictDnsParamTest, testing::ValuesIn(generateParamVector()));
+INSTANTIATE_TEST_CASE_P(DnsParam, StrictDnsParamTest, testing::ValuesIn(generateStrictDnsParams()));
 
 TEST_P(StrictDnsParamTest, ImmediateResolve) {
   Stats::IsolatedStoreImpl stats;

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -76,7 +76,7 @@ MockActiveDnsQuery::MockActiveDnsQuery() {}
 MockActiveDnsQuery::~MockActiveDnsQuery() {}
 
 MockDnsResolver::MockDnsResolver() {
-  ON_CALL(*this, resolve(_, _)).WillByDefault(Return(&active_query_));
+  ON_CALL(*this, resolve(_, _, _)).WillByDefault(Return(&active_query_));
 }
 
 MockDnsResolver::~MockDnsResolver() {}

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -117,9 +117,8 @@ public:
   ~MockDnsResolver();
 
   // Network::DnsResolver
-  MOCK_METHOD3(resolve,
-               ActiveDnsQuery*(const std::string& dns_name,
-                               const DnsLookupFamily& dns_lookup_family, ResolveCb callback));
+  MOCK_METHOD3(resolve, ActiveDnsQuery*(const std::string& dns_name,
+                                        DnsLookupFamily dns_lookup_family, ResolveCb callback));
 
   testing::NiceMock<MockActiveDnsQuery> active_query_;
 };

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -117,7 +117,9 @@ public:
   ~MockDnsResolver();
 
   // Network::DnsResolver
-  MOCK_METHOD2(resolve, ActiveDnsQuery*(const std::string& dns_name, ResolveCb callback));
+  MOCK_METHOD3(resolve,
+               ActiveDnsQuery*(const std::string& dns_name,
+                               const std::string& dns_lookup_ip_version, ResolveCb callback));
 
   testing::NiceMock<MockActiveDnsQuery> active_query_;
 };

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -119,7 +119,7 @@ public:
   // Network::DnsResolver
   MOCK_METHOD3(resolve,
                ActiveDnsQuery*(const std::string& dns_name,
-                               const std::string& dns_lookup_ip_version, ResolveCb callback));
+                               const DnsLookupFamily& dns_lookup_family, ResolveCb callback));
 
   testing::NiceMock<MockActiveDnsQuery> active_query_;
 };

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -63,5 +63,6 @@ envoy_cc_test_library(
         "//source/common/common:empty_string",
         "//source/common/http:header_map_lib",
         "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
     ],
 )

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -14,6 +14,7 @@
 
 #include "common/common/empty_string.h"
 #include "common/network/address_impl.h"
+#include "common/network/utility.h"
 
 #include "test/test_common/printers.h"
 
@@ -65,7 +66,7 @@ std::list<Network::Address::InstanceConstSharedPtr>
 TestUtility::makeDnsResponse(const std::list<std::string>& addresses) {
   std::list<Network::Address::InstanceConstSharedPtr> ret;
   for (auto address : addresses) {
-    ret.emplace_back(new Network::Address::Ipv4Instance(address));
+    ret.emplace_back(Network::Utility::parseInternetAddress(address));
   }
   return ret;
 }


### PR DESCRIPTION
This PR adds IPv6 DNS support and adds a cluster config parameter "dns_lookup_ip_version" that specifies the DNS lookup IP address policy. The default policy if no parameter is specified is "v4_only".

Modifications were made to upstream_cluster and logical_dns_cluster to pass this parameter on when calling DnsResolver resolve. Modifications were made to dns_impl to add v6 support and also a fallback option when v4 dns lookup fails.

Fixes #978 .