### PR TITLE
coverage: some safeguards to avoid clang silent failure.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -216,7 +216,8 @@ https://github.com/bazelbuild/bazel/issues/2805.
 
 To generate coverage results, make sure you have
 [`gcovr`](https://github.com/gcovr/gcovr) 3.3 in your `PATH` (or set `GCOVR` to
-point at it). Then run:
+point at it) and are using a GCC toolchain (clang does not work currently, see
+https://github.com/lyft/envoy/issues/1000). Then run:
 
 ```
 test/run_envoy_bazel_coverage.sh

--- a/test/coverage/gcc_only_test.cc
+++ b/test/coverage/gcc_only_test.cc
@@ -1,0 +1,12 @@
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+TEST(GccOnly, CompilerCheck) {
+#if defined(__clang__) or not defined(__GNUC__)
+  // clang is incompatible with gcov.
+  FAIL() << "GCC is required for coverage runs";
+#endif
+}
+
+} // Envoy

--- a/test/coverage/gen_build.sh
+++ b/test/coverage/gen_build.sh
@@ -41,9 +41,17 @@ load(
 envoy_package()
 
 envoy_cc_test(
+    name = "gcc_only_test",
+    srcs = ["gcc_only_test.cc"],
+    tags = ["manual"],
+    coverage = False,
+)
+
+envoy_cc_test(
     name = "coverage_tests",
     repository = "${REPOSITORY}",
     deps = [
+        ":gcc_only_test_lib", # gcov requires gcc
 EOF
   for t in ${TARGETS}
   do


### PR DESCRIPTION
clang isn't compatible with gcov (see #858). We plan to switch to lcov in the future (see #1000).
For now, just make sure we fail visibly and document.