### PR TITLE
docs: fix BUILD_DIR path

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR=$(dirname "$0")
-BUILD_DIR=build/docs
+BUILD_DIR=build_docs
 [[ -z "${DOCS_OUTPUT_DIR}" ]] && DOCS_OUTPUT_DIR=generated/docs
 
 rm -rf "${DOCS_OUTPUT_DIR}"


### PR DESCRIPTION
@rshriram @ccaraman @htuch 

the previous `build/docs` path collides with the BUILD filename on Darwin. This has not been a problem for CI because it uses linux.