### PR TITLE
Supports proto subtypes for gRPC-Web.

### DIFF
--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -17,7 +17,7 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (content_type != nullptr &&
       (Http::Headers::get().ContentTypeValues.GrpcWebText == content_type->value().c_str() ||
-       Http::Headers::get().ContentTypeValues.GrpcWebText_Proto == content_type->value().c_str())) {
+       Http::Headers::get().ContentTypeValues.GrpcWebTextProto == content_type->value().c_str())) {
     // Checks whether gRPC-Web client is sending base64 encoded request.
     is_text_request_ = true;
   }
@@ -26,7 +26,7 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
   const Http::HeaderEntry* accept = headers.get(Http::Headers::get().Accept);
   if (accept != nullptr &&
       (Http::Headers::get().ContentTypeValues.GrpcWebText == accept->value().c_str() ||
-       Http::Headers::get().ContentTypeValues.GrpcWebText_Proto == accept->value().c_str())) {
+       Http::Headers::get().ContentTypeValues.GrpcWebTextProto == accept->value().c_str())) {
     // Checks whether gRPC-Web client is asking for base64 encoded response.
     is_text_response_ = true;
   }
@@ -66,9 +66,9 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
 // Implements StreamEncoderFilter.
 Http::FilterHeadersStatus GrpcWebFilter::encodeHeaders(Http::HeaderMap& headers, bool) {
   if (is_text_response_) {
-    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWebText_Proto);
+    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWebTextProto);
   } else {
-    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWeb_Proto);
+    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWebProto);
   }
   return Http::FilterHeadersStatus::Continue;
 }

--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -16,7 +16,8 @@ const uint8_t GrpcWebFilter::GRPC_WEB_TRAILER = 0b10000000;
 Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (content_type != nullptr &&
-      Http::Headers::get().ContentTypeValues.GrpcWebText == content_type->value().c_str()) {
+      (Http::Headers::get().ContentTypeValues.GrpcWebText == content_type->value().c_str() ||
+       Http::Headers::get().ContentTypeValues.GrpcWebText_Proto == content_type->value().c_str())) {
     // Checks whether gRPC-Web client is sending base64 encoded request.
     is_text_request_ = true;
   }
@@ -24,7 +25,8 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
 
   const Http::HeaderEntry* accept = headers.get(Http::Headers::get().Accept);
   if (accept != nullptr &&
-      Http::Headers::get().ContentTypeValues.GrpcWebText == accept->value().c_str()) {
+      (Http::Headers::get().ContentTypeValues.GrpcWebText == accept->value().c_str() ||
+       Http::Headers::get().ContentTypeValues.GrpcWebText_Proto == accept->value().c_str())) {
     // Checks whether gRPC-Web client is asking for base64 encoded response.
     is_text_response_ = true;
   }
@@ -64,9 +66,9 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
 // Implements StreamEncoderFilter.
 Http::FilterHeadersStatus GrpcWebFilter::encodeHeaders(Http::HeaderMap& headers, bool) {
   if (is_text_response_) {
-    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWebText);
+    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWebText_Proto);
   } else {
-    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWeb);
+    headers.insertContentType().value(Http::Headers::get().ContentTypeValues.GrpcWeb_Proto);
   }
   return Http::FilterHeadersStatus::Continue;
 }

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -76,7 +76,9 @@ public:
     const std::string Text{"text/plain"};
     const std::string Grpc{"application/grpc"};
     const std::string GrpcWeb{"application/grpc-web"};
+    const std::string GrpcWeb_Proto{"application/grpc-web+proto"};
     const std::string GrpcWebText{"application/grpc-web-text"};
+    const std::string GrpcWebText_Proto{"application/grpc-web-text+proto"};
   } ContentTypeValues;
 
   struct {

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -76,9 +76,9 @@ public:
     const std::string Text{"text/plain"};
     const std::string Grpc{"application/grpc"};
     const std::string GrpcWeb{"application/grpc-web"};
-    const std::string GrpcWeb_Proto{"application/grpc-web+proto"};
+    const std::string GrpcWebProto{"application/grpc-web+proto"};
     const std::string GrpcWebText{"application/grpc-web-text"};
-    const std::string GrpcWebText_Proto{"application/grpc-web-text+proto"};
+    const std::string GrpcWebTextProto{"application/grpc-web-text+proto"};
   } ContentTypeValues;
 
   struct {

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -37,16 +37,16 @@ public:
 
   ~GrpcWebFilterTest() override {}
 
-  const std::string& request_content_type() { return std::get<0>(GetParam()); }
+  const std::string& request_content_type() const { return std::get<0>(GetParam()); }
 
-  const std::string& request_accept() { return std::get<1>(GetParam()); }
+  const std::string& request_accept() const { return std::get<1>(GetParam()); }
 
-  bool is_text_request() {
+  bool isTextRequest() const {
     return request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWebText ||
            request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWebTextProto;
   }
 
-  bool is_binary_request() {
+  bool isBinaryRequest() const {
     return request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWeb ||
            request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWebProto;
   }

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -51,12 +51,12 @@ public:
            request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWebProto;
   }
 
-  bool accept_text_response() {
+  bool accept_text_response() const {
     return request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebText ||
            request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebTextProto;
   }
 
-  bool accept_binary_response() {
+  bool accept_binary_response() const {
     return request_accept() == Http::Headers::get().ContentTypeValues.GrpcWeb ||
            request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebProto;
   }

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -93,11 +93,11 @@ TEST_P(GrpcWebFilterTest, Unary) {
             request_headers.GrpcAcceptEncoding()->value().c_str());
 
   // Tests request data.
-  if (is_binary_request()) {
+  if (isBinaryRequest()) {
     Buffer::OwnedImpl request_buffer(MESSAGE, MESSAGE_SIZE);
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(request_buffer, true));
     EXPECT_EQ(std::string(MESSAGE, MESSAGE_SIZE), TestUtility::bufferToString(request_buffer));
-  } else if (is_text_request()) {
+  } else if (isTextRequest()) {
     Buffer::OwnedImpl request_buffer(B64_MESSAGE, B64_MESSAGE_SIZE);
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(request_buffer, true));
     EXPECT_EQ(std::string(TEXT_MESSAGE, TEXT_MESSAGE_SIZE),

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -39,6 +39,37 @@ public:
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
 };
 
+TEST_F(GrpcWebFilterTest, SupportedContentTypes) {
+  Http::TestHeaderMapImpl request_headers;
+  // Check "content-type:application/grpc-web" is supported.
+  request_headers.addViaCopy(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.GrpcWeb);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
+            request_headers.ContentType()->value().c_str());
+
+  // Check "content-type:application/grpc-web+proto" is supported.
+  request_headers.addViaCopy(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.GrpcWeb_Proto);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
+            request_headers.ContentType()->value().c_str());
+
+  // Check "content-type:application/grpc-web-text" is supported.
+  request_headers.addViaCopy(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.GrpcWebText);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
+            request_headers.ContentType()->value().c_str());
+
+  // Check "content-type:application/grpc-web-text+proto" is supported.
+  request_headers.addViaCopy(Http::Headers::get().ContentType,
+                             Http::Headers::get().ContentTypeValues.GrpcWebText_Proto);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
+            request_headers.ContentType()->value().c_str());
+}
+
 TEST_F(GrpcWebFilterTest, BinaryUnary) {
   // Tests request headers.
   Http::TestHeaderMapImpl request_headers;
@@ -69,7 +100,7 @@ TEST_F(GrpcWebFilterTest, BinaryUnary) {
   response_headers.addViaCopy(Http::Headers::get().Status, "200");
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ("200", response_headers.get_(Http::Headers::get().Status.get()));
-  EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWeb,
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWeb_Proto,
             response_headers.ContentType()->value().c_str());
 
   // Tests response data.
@@ -124,7 +155,7 @@ TEST_F(GrpcWebFilterTest, TextUnary) {
                               Http::Headers::get().ContentTypeValues.Grpc);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ("200", response_headers.get_(Http::Headers::get().Status.get()));
-  EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWebText,
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWebText_Proto,
             response_headers.ContentType()->value().c_str());
 
   // Tests response data.


### PR DESCRIPTION
Supports proto subtypes for gRPC-Web.
Includes: application/grpc-web+proto and application/grpc-web-text+proto.
TODO(fengli): Adds json and thrift once the spec is finalized.