### PR TITLE
config/stats: add udp statds address as config option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ maximize the chances of your PR being merged.
   deprecation window. We make no guarantees about code or deployments that rely on undocumented
   behavior.
 * All deprecations/breaking changes will be clearly listed in the release notes.
+* See [DEPRECATED.md](DEPRECATED.md)
 
 # Release cadence
 

--- a/DEPERECATED.md
+++ b/DEPERECATED.md
@@ -1,3 +1,0 @@
-# DEPRECATED (will be removed in 1.4.0).
-* Config option `statsd_local_udp_port` has been deprecated and replaced with
-`statsd_udp_ip_address`.

--- a/DEPERECATED.md
+++ b/DEPERECATED.md
@@ -1,0 +1,3 @@
+# DEPRECATED starting from 1.3.0
+* Config option `statsd_local_udp_port` has been deprecated and replaced with
+`statsd_udp_ip_address`.

--- a/DEPERECATED.md
+++ b/DEPERECATED.md
@@ -1,3 +1,3 @@
-# DEPRECATED starting from 1.3.0
+# DEPRECATED (will be removed in 1.4.0).
 * Config option `statsd_local_udp_port` has been deprecated and replaced with
 `statsd_udp_ip_address`.

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,10 @@
+# DEPRECATED
+
+As of release 1.3.0, Envoy will follow a
+[Breaking Change Policy](https://github.com/lyft/envoy/blob/master//CONTRIBUTING.md#breaking-change-policy).
+
+The following features have been DEPRECATED and will be removed in the specified release cycle.
+
+* Version 1.4.0
+  * Config option `statsd_local_udp_port` has been deprecated and has been replaced with
+  `statsd_udp_ip_address`.

--- a/docs/configuration/overview/overview.rst
+++ b/docs/configuration/overview/overview.rst
@@ -15,7 +15,7 @@ specify miscellaneous configuration.
     "admin": "{...}",
     "cluster_manager": "{...}",
     "flags_path": "...",
-    "statsd_local_udp_port": "...",
+    "statsd_udp_ip_address": "...",
     "statsd_tcp_cluster_name": "...",
     "stats_flush_interval_ms": "...",
     "watchdog_miss_timeout_ms": "...",
@@ -45,9 +45,11 @@ flags_path
   *(optional, string)* The file system path to search for :ref:`startup flag files
   <operations_file_system_flags>`.
 
-statsd_local_udp_port
-  *(optional, integer)* The UDP port of a locally running statsd compliant listener. If specified,
-  :ref:`statistics <arch_overview_statistics>` will be flushed to this port.
+statsd_udp_ip_address
+  *(optional, string)* The UDP address of a running statsd compliant listener. If specified,
+  :ref:`statistics <arch_overview_statistics>` will be flushed to this address. IPv4 addresses should
+  have format host:port (ex: 127.0.0.1:855). IPv6 addresses should have URL format [host]:port
+  (ex: [::1]:855). Note: statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0.
 
 statsd_tcp_cluster_name
   *(optional, string)* The name of a cluster manager cluster that is running a TCP statsd compliant

--- a/docs/configuration/overview/overview.rst
+++ b/docs/configuration/overview/overview.rst
@@ -15,6 +15,7 @@ specify miscellaneous configuration.
     "admin": "{...}",
     "cluster_manager": "{...}",
     "flags_path": "...",
+    "statsd_local_udp_port": "...",
     "statsd_udp_ip_address": "...",
     "statsd_tcp_cluster_name": "...",
     "stats_flush_interval_ms": "...",
@@ -45,11 +46,15 @@ flags_path
   *(optional, string)* The file system path to search for :ref:`startup flag files
   <operations_file_system_flags>`.
 
+statsd_local_udp_port (Warning: DEPRECATED and will be removed in 1.4.0)
+  *(optional, integer)* The UDP port of a locally running statsd compliant listener. If specified,
+  :ref:`statistics <arch_overview_statistics>` will be flushed to this port.
+
 statsd_udp_ip_address
   *(optional, string)* The UDP address of a running statsd compliant listener. If specified,
   :ref:`statistics <arch_overview_statistics>` will be flushed to this address. IPv4 addresses should
   have format host:port (ex: 127.0.0.1:855). IPv6 addresses should have URL format [host]:port
-  (ex: [::1]:855). Note: statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0.
+  (ex: [::1]:855).
 
 statsd_tcp_cluster_name
   *(optional, string)* The name of a cluster manager cluster that is running a TCP statsd compliant

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -130,14 +130,14 @@ public:
    */
   virtual Optional<std::string> statsdTcpClusterName() PURE;
 
-  // TODO(hennna): Deprecate in release: 1.4.0.
+  // TODO(hennna): DEPRECATED - will be removed in 1.4.0.
   /**
    * @return Optional<uint32_t> the optional local UDP statsd port to write to.
    */
   virtual Optional<uint32_t> statsdUdpPort() PURE;
 
   /**
-   * @return Optional<uint32_t> the optional UDP statsd address to write to.
+   * @return Optional<std::string> the optional UDP statsd address to write to.
    */
   virtual Optional<std::string> statsdUdpIpAddress() PURE;
 

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -130,10 +130,16 @@ public:
    */
   virtual Optional<std::string> statsdTcpClusterName() PURE;
 
+  // TODO(hennna): Deprecate in release: 1.4.0.
   /**
    * @return Optional<uint32_t> the optional local UDP statsd port to write to.
    */
   virtual Optional<uint32_t> statsdUdpPort() PURE;
+
+  /**
+   * @return Optional<uint32_t> the optional UDP statsd address to write to.
+   */
+  virtual Optional<std::string> statsdUdpIpAddress() PURE;
 
   /**
    * @return std::chrono::milliseconds the time interval between flushing to configured stat sinks.

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1014,6 +1014,7 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
       "cluster_manager" : {"type" : "object"},
       "flags_path" : {"type" : "string"},
       "statsd_local_udp_port" : {"type" : "integer"},
+      "statsd_udp_ip_address" : {"type" : "string"},
       "statsd_tcp_cluster_name" : {"type" : "string"},
       "stats_flush_interval_ms" : {"type" : "integer"},
       "tracing" : {

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -37,13 +37,11 @@ private:
 };
 
 /**
- * Implementation of Sink that writes to a local UDP statsd port.
+ * Implementation of Sink that writes to a UDP statsd address.
  */
 class UdpStatsdSink : public Sink {
 public:
-  // TODO(hennna): Deprecate in release 1.4.0.
-  UdpStatsdSink(ThreadLocal::Instance& tls, const uint32_t port);
-  UdpStatsdSink(ThreadLocal::Instance& tls, const std::string& ip_address);
+  UdpStatsdSink(ThreadLocal::Instance& tls, Network::Address::InstanceConstSharedPtr address);
 
   // Stats::Sink
   void flushCounter(const std::string& name, uint64_t delta) override;

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -27,13 +27,13 @@ public:
   void writeTimer(const std::string& name, const std::chrono::milliseconds& ms);
   void shutdown() override;
   // Called in unit test to validate address.
-  int getFdForTests() { return fd_; };
+  int getFdForTests() const { return fd_; };
 
 private:
   void send(const std::string& message);
 
   int fd_;
-  bool shutdown_ = false;
+  bool shutdown_{};
 };
 
 /**
@@ -56,7 +56,7 @@ public:
 
 private:
   ThreadLocal::Instance& tls_;
-  uint32_t tls_slot_;
+  const uint32_t tls_slot_;
   Network::Address::InstanceConstSharedPtr server_address_;
 };
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -138,6 +138,7 @@ envoy_cc_library(
         "//source/common/common:version_lib",
         "//source/common/json:config_schemas_lib",
         "//source/common/memory:stats_lib",
+        "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/ssl:context_lib",

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -56,7 +56,7 @@ void MainImpl::initialize(const Json::Object& json) {
         Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
   }
 
-  // TODO(hennna): Deprecate statsd_local_udp_port in release 1.4.0.
+  // TODO(hennna): DEPRECATED - statsd_local_udp_port will be removed in 1.4.0.
   if (json.hasObject("statsd_local_udp_port")) {
     statsd_udp_port_.value(json.getInteger("statsd_local_udp_port"));
   }

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -56,6 +56,11 @@ void MainImpl::initialize(const Json::Object& json) {
         Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
   }
 
+  if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {
+    throw EnvoyException("statsd_local_udp_port and statsd_udp_ip_address "
+                         "are mutually exclusive.");
+  }
+
   // TODO(hennna): DEPRECATED - statsd_local_udp_port will be removed in 1.4.0.
   if (json.hasObject("statsd_local_udp_port")) {
     statsd_udp_port_.value(json.getInteger("statsd_local_udp_port"));

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -56,8 +56,13 @@ void MainImpl::initialize(const Json::Object& json) {
         Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
   }
 
+  // TODO(hennna): Deprecate statsd_local_udp_port in release 1.4.0.
   if (json.hasObject("statsd_local_udp_port")) {
     statsd_udp_port_.value(json.getInteger("statsd_local_udp_port"));
+  }
+
+  if (json.hasObject("statsd_udp_ip_address")) {
+    statsd_udp_ip_address_.value(json.getString("statsd_udp_ip_address"));
   }
 
   if (json.hasObject("statsd_tcp_cluster_name")) {

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -177,7 +177,7 @@ public:
   const std::list<ListenerPtr>& listeners() override;
   RateLimit::ClientFactory& rateLimitClientFactory() override { return *ratelimit_client_factory_; }
   Optional<std::string> statsdTcpClusterName() override { return statsd_tcp_cluster_name_; }
-  // TODO(hennna): Deprecate statsdUdpPort in release 1.4.0
+  // TODO(hennna): DEPRECATED - statsdUdpPort() will be removed in 1.4.0
   Optional<uint32_t> statsdUdpPort() override { return statsd_udp_port_; }
   Optional<std::string> statsdUdpIpAddress() override { return statsd_udp_ip_address_; }
   std::chrono::milliseconds statsFlushInterval() override { return stats_flush_interval_; }

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -177,7 +177,9 @@ public:
   const std::list<ListenerPtr>& listeners() override;
   RateLimit::ClientFactory& rateLimitClientFactory() override { return *ratelimit_client_factory_; }
   Optional<std::string> statsdTcpClusterName() override { return statsd_tcp_cluster_name_; }
+  // TODO(hennna): Deprecate statsdUdpPort in release 1.4.0
   Optional<uint32_t> statsdUdpPort() override { return statsd_udp_port_; }
+  Optional<std::string> statsdUdpIpAddress() override { return statsd_udp_ip_address_; }
   std::chrono::milliseconds statsFlushInterval() override { return stats_flush_interval_; }
   std::chrono::milliseconds wdMissTimeout() const override { return watchdog_miss_timeout_; }
   std::chrono::milliseconds wdMegaMissTimeout() const override {
@@ -263,6 +265,7 @@ private:
   std::list<Server::Configuration::ListenerPtr> listeners_;
   Optional<std::string> statsd_tcp_cluster_name_;
   Optional<uint32_t> statsd_udp_port_;
+  Optional<std::string> statsd_udp_ip_address_;
   RateLimit::ClientFactoryPtr ratelimit_client_factory_;
   std::chrono::milliseconds stats_flush_interval_;
   std::chrono::milliseconds watchdog_miss_timeout_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -317,9 +317,18 @@ Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
 }
 
 void InstanceImpl::initializeStatSinks() {
-  if (config_->statsdUdpPort().valid()) {
+  // TODO(hennna): Deprecate statsdUdpPort in release 1.4.0.
+  if (config_->statsdUdpIpAddress().valid()) {
+    log().info("statsd UDP ip address: {}", config_->statsdUdpIpAddress().value());
+    stat_sinks_.emplace_back(
+        new Stats::Statsd::UdpStatsdSink(thread_local_, config_->statsdUdpIpAddress().value()));
+    stats_store_.addSink(*stat_sinks_.back());
+  } else if (config_->statsdUdpPort().valid()) {
+    log().warn("statsd_local_udp_port has been DEPRECATED. Consider setting statsd_udp_ip_address "
+               "instead.");
     log().info("statsd UDP port: {}", config_->statsdUdpPort().value());
-    stat_sinks_.emplace_back(new Stats::Statsd::UdpStatsdSink(config_->statsdUdpPort().value()));
+    stat_sinks_.emplace_back(
+        new Stats::Statsd::UdpStatsdSink(thread_local_, config_->statsdUdpPort().value()));
     stats_store_.addSink(*stat_sinks_.back());
   }
 

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -32,6 +32,18 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "udp_statsd_test",
+    srcs = ["udp_statsd_test.cc"],
+    deps = [
+        "//source/common/network:address_lib",
+        "//source/common/stats:statsd_lib",
+        "//test/mocks/thread_local:thread_local_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "thread_local_store_test",
     srcs = ["thread_local_store_test.cc"],
     deps = [

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test(
     srcs = ["udp_statsd_test.cc"],
     deps = [
         "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
         "//source/common/stats:statsd_lib",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:environment_lib",

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -25,10 +25,10 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   NiceMock<ThreadLocal::MockInstance> tls_;
   UdpStatsdSink sink(tls_, Network::Test::getCanonicalLoopbackAddress(GetParam()));
   int fd = sink.getFdForTests();
-  sink.flushCounter("test_counter", 1);
   EXPECT_NE(fd, -1);
 
   // Check that fd has not changed.
+  sink.flushCounter("test_counter", 1);
   sink.flushGauge("test_gauge", 1);
   sink.onTimespanComplete("test_counter", std::chrono::milliseconds(5));
   EXPECT_EQ(fd, sink.getFdForTests());

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -25,8 +25,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkTest,
 
 TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   NiceMock<ThreadLocal::MockInstance> tls_;
-  UdpStatsdSink sink(tls_,
-                     fmt::format("{}:0", Network::Test::getLoopbackAddressUrlString(GetParam())));
+  UdpStatsdSink sink(tls_, Network::Test::getCanonicalLoopbackAddress(GetParam()));
   // Creates and connects to socket.
   sink.flushCounter("test_counter", 1);
   int fd = sink.getFdForTests();
@@ -51,26 +50,6 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
                          ->addressAsString());
   }
   tls_.shutdownThread();
-}
-
-// Regression Test
-TEST(UdpStatsdSinkTest, InitWithPort) {
-  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4)) {
-    NiceMock<ThreadLocal::MockInstance> tls_;
-    UdpStatsdSink sink(tls_, 0);
-    // Creates and connects to socket.
-    sink.flushCounter("test_counter", 1);
-    int fd = sink.getFdForTests();
-    EXPECT_NE(fd, -1);
-    struct sockaddr_storage sockaddress;
-    socklen_t sock_len = sizeof(sockaddress);
-
-    EXPECT_EQ(0, getsockname(fd, reinterpret_cast<struct sockaddr*>(&sockaddress), &sock_len));
-    EXPECT_EQ("127.0.0.1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in))
-                               ->ip()
-                               ->addressAsString());
-    tls_.shutdownThread();
-  }
 }
 
 } // Statsd

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -1,5 +1,3 @@
-#include <sys/socket.h>
-
 #include <chrono>
 
 #include "common/network/address_impl.h"
@@ -36,18 +34,10 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   sink.onTimespanComplete("test_counter", std::chrono::milliseconds(5));
   EXPECT_EQ(fd, sink.getFdForTests());
 
-  struct sockaddr_storage sockaddress;
-  socklen_t sock_len = sizeof(sockaddress);
-  EXPECT_EQ(0, getsockname(fd, reinterpret_cast<struct sockaddr*>(&sockaddress), &sock_len));
-
   if (GetParam() == Network::Address::IpVersion::v4) {
-    EXPECT_EQ("127.0.0.1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in))
-                               ->ip()
-                               ->addressAsString());
+    EXPECT_EQ("127.0.0.1", Network::Address::addressFromFd(fd)->ip()->addressAsString());
   } else {
-    EXPECT_EQ("::1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in6))
-                         ->ip()
-                         ->addressAsString());
+    EXPECT_EQ("::1", Network::Address::addressFromFd(fd)->ip()->addressAsString());
   }
   tls_.shutdownThread();
 }

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -24,9 +24,8 @@ INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkTest,
 TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   NiceMock<ThreadLocal::MockInstance> tls_;
   UdpStatsdSink sink(tls_, Network::Test::getCanonicalLoopbackAddress(GetParam()));
-  // Creates and connects to socket.
-  sink.flushCounter("test_counter", 1);
   int fd = sink.getFdForTests();
+  sink.flushCounter("test_counter", 1);
   EXPECT_NE(fd, -1);
 
   // Check that fd has not changed.

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -1,0 +1,78 @@
+#include <sys/socket.h>
+
+#include <chrono>
+
+#include "common/network/address_impl.h"
+#include "common/stats/statsd.h"
+
+#include "test/mocks/thread_local/mocks.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "spdlog/spdlog.h"
+
+namespace Envoy {
+using testing::NiceMock;
+
+namespace Stats {
+namespace Statsd {
+
+class UdpStatsdSinkTest : public testing::TestWithParam<Network::Address::IpVersion> {};
+INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  UdpStatsdSink sink(tls_,
+                     fmt::format("{}:0", Network::Test::getLoopbackAddressUrlString(GetParam())));
+  // Creates and connects to socket.
+  sink.flushCounter("test_counter", 1);
+  int fd = sink.getFdForTests();
+  EXPECT_NE(fd, -1);
+
+  // Check that fd has not changed.
+  sink.flushGauge("test_gauge", 1);
+  sink.onTimespanComplete("test_counter", std::chrono::milliseconds(5));
+  EXPECT_EQ(fd, sink.getFdForTests());
+
+  struct sockaddr_storage sockaddress;
+  socklen_t sock_len = sizeof(sockaddress);
+  EXPECT_EQ(0, getsockname(fd, reinterpret_cast<struct sockaddr*>(&sockaddress), &sock_len));
+
+  if (GetParam() == Network::Address::IpVersion::v4) {
+    EXPECT_EQ("127.0.0.1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in))
+                               ->ip()
+                               ->addressAsString());
+  } else {
+    EXPECT_EQ("::1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in6))
+                         ->ip()
+                         ->addressAsString());
+  }
+  tls_.shutdownThread();
+}
+
+// Regression Test
+TEST(UdpStatsdSinkTest, InitWithPort) {
+  if (TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4)) {
+    NiceMock<ThreadLocal::MockInstance> tls_;
+    UdpStatsdSink sink(tls_, 0);
+    // Creates and connects to socket.
+    sink.flushCounter("test_counter", 1);
+    int fd = sink.getFdForTests();
+    EXPECT_NE(fd, -1);
+    struct sockaddr_storage sockaddress;
+    socklen_t sock_len = sizeof(sockaddress);
+
+    EXPECT_EQ(0, getsockname(fd, reinterpret_cast<struct sockaddr*>(&sockaddress), &sock_len));
+    EXPECT_EQ("127.0.0.1", Network::Address::addressFromSockAddr(sockaddress, sizeof(sockaddr_in))
+                               ->ip()
+                               ->addressAsString());
+    tls_.shutdownThread();
+  }
+}
+
+} // Statsd
+} // Stats
+} // Envoy

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -232,7 +232,7 @@
 
   "admin": { "access_log_path": "/dev/null", "profile_path": "{{ test_tmpdir }}/envoy.prof", "address": "tcp://127.0.0.1:0" },
   "flags_path": "/invalid_flags",
-  "statsd_local_udp_port": 8125,
+  "statsd_udp_ip_address": "127.0.0.1:0",
   "statsd_tcp_cluster_name": "statsd",
   "tracing": {
     "http": {

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -232,7 +232,7 @@
 
   "admin": { "access_log_path": "/dev/null", "profile_path": "{{ test_tmpdir }}/envoy.prof", "address": "tcp://127.0.0.1:0" },
   "flags_path": "/invalid_flags",
-  "statsd_udp_ip_address": "127.0.0.1:0",
+  "statsd_udp_ip_address": "127.0.0.1:8125",
   "statsd_tcp_cluster_name": "statsd",
   "tracing": {
     "http": {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -167,6 +167,7 @@ public:
   MOCK_METHOD0(rateLimitClientFactory, RateLimit::ClientFactory&());
   MOCK_METHOD0(statsdTcpClusterName, Optional<std::string>());
   MOCK_METHOD0(statsdUdpPort, Optional<uint32_t>());
+  MOCK_METHOD0(statsdUdpIpAddress, Optional<std::string>());
   MOCK_METHOD0(statsFlushInterval, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdMissTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdMegaMissTimeout, std::chrono::milliseconds());


### PR DESCRIPTION
This PR allows the statds UDP server address to be set as a JSON config parameter. 

To allow for unit testing, the udp statds writer_ has been changed from a static thread_local object to being derived from the ThreadLocal object class.

In this PR, `statsd_local_udp_port` has been DEPRECATED and replaced with `statsd_udp_ip_address`.

Fixes  #948 . Fixes part of #979 .