### PR TITLE
config: update check tool bazel target

### DIFF
--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -9,14 +9,14 @@ load(
 
 envoy_package()
 
-envoy_cc_binary(
-    name = "config_load_check_tool",
-    testonly = 1,
-    deps = [":config_load_check_lib"],
-)
-
 envoy_cc_test_library(
     name = "config_load_check_lib",
     srcs = ["config_load_check.cc"],
     deps = ["//test/config_test:config_test_lib"],
+)
+
+envoy_cc_binary(
+    name = "config_load_check_tool",
+    testonly = 1,
+    deps = [":config_load_check_lib"],
 )

--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 
@@ -11,6 +12,11 @@ envoy_package()
 envoy_cc_binary(
     name = "config_load_check_tool",
     testonly = 1,
+    deps = [":config_load_check_lib"],
+)
+
+envoy_cc_test_library(
+    name = "config_load_check_lib",
     srcs = ["config_load_check.cc"],
     deps = ["//test/config_test:config_test_lib"],
 )


### PR DESCRIPTION
@lyft/network-team @htuch this change creates a cc_test_lib to be consumable by the binary rule here, and other consumers that want to recompile with private filters.