### PR TITLE
build: avoid explicit time dependency.

### DIFF
--- a/ci/build_container/Makefile
+++ b/ci/build_container/Makefile
@@ -44,7 +44,7 @@ build-recipe = cd $(THIRDPARTY_SRC) && \
 	   CXXFLAGS=$(CXXFLAGS) \
 	   CPPFLAGS=$(CPPFLAGS) \
 	   $(1) \
-	   time bash $(CURDIR)/recipe_wrapper.sh $(realpath $<) 2>&1) > $@.log) || (cat $@.log; exit 1)) && \
+	   bash -c "time $(CURDIR)/recipe_wrapper.sh $(realpath $<)" 2>&1) > $@.log) || (cat $@.log; exit 1)) && \
 	$(build-complete)
 
 $(THIRDPARTY_DEPS)/%.dep: $(RECIPES)/%.sh


### PR DESCRIPTION
Not all environments have a standalone time binary. This will gracefully fallback to the bash time
utility if not available.