### PR TITLE
cleanup: Fix clang-tidy for performance-for-range-copy

### DIFF
--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -63,7 +63,7 @@ GlobalStats Config::generateStats(Stats::Store& store, const std::string& prefix
 void Config::parseResponse(const Http::Message& message) {
   AllowedPrincipalsSharedPtr new_principals(new AllowedPrincipals());
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(message.bodyAsString());
-  for (const Json::ObjectSharedPtr certificate : loader->getObjectArray("certificates")) {
+  for (const Json::ObjectSharedPtr& certificate : loader->getObjectArray("certificates")) {
     new_principals->add(certificate->getString("fingerprint_sha256"));
   }
 

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -18,9 +18,9 @@ Config::Config(const Json::Object& config, Stats::Store& stats_store, Runtime::L
 
   config.validateSchema(Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA);
 
-  for (const Json::ObjectSharedPtr descriptor : config.getObjectArray("descriptors")) {
+  for (const Json::ObjectSharedPtr& descriptor : config.getObjectArray("descriptors")) {
     Descriptor new_descriptor;
-    for (const Json::ObjectSharedPtr entry : descriptor->asObjectArray()) {
+    for (const Json::ObjectSharedPtr& entry : descriptor->asObjectArray()) {
       new_descriptor.entries_.push_back({entry->getString("key"), entry->getString("value")});
     }
     descriptors_.push_back(new_descriptor);

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -47,7 +47,7 @@ TcpProxyConfig::TcpProxyConfig(const Json::Object& config,
     : stats_(generateStats(config.getString("stat_prefix"), stats_store)) {
   config.validateSchema(Json::Schema::TCP_PROXY_NETWORK_FILTER_SCHEMA);
 
-  for (const Json::ObjectSharedPtr route_desc :
+  for (const Json::ObjectSharedPtr& route_desc :
        config.getObject("route_config")->getObjectArray("routes")) {
     routes_.emplace_back(Route(*route_desc));
 

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -109,7 +109,7 @@ bool RuntimeFilter::evaluate(const RequestInfo&, const HeaderMap& request_header
 }
 
 OperatorFilter::OperatorFilter(const Json::Object& json, Runtime::Loader& runtime) {
-  for (Json::ObjectSharedPtr filter : json.getObjectArray("filters")) {
+  for (const Json::ObjectSharedPtr& filter : json.getObjectArray("filters")) {
     filters_.emplace_back(FilterImpl::fromJson(*filter, runtime));
   }
 }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -328,7 +328,7 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
 
 ConnectionManagerImpl::ActiveStream::~ActiveStream() {
   connection_manager_.stats_.named_.downstream_rq_active_.dec();
-  for (AccessLog::InstanceSharedPtr access_log : connection_manager_.config_.accessLogs()) {
+  for (const AccessLog::InstanceSharedPtr& access_log : connection_manager_.config_.accessLogs()) {
     access_log->log(request_headers_.get(), response_headers_.get(), request_info_);
   }
   for (const auto& log_handler : access_log_handlers_) {

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -52,7 +52,7 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
 
   if (json_config.hasObject("headers")) {
     std::vector<Json::ObjectSharedPtr> config_headers = json_config.getObjectArray("headers");
-    for (const Json::ObjectSharedPtr header_map : config_headers) {
+    for (const Json::ObjectSharedPtr& header_map : config_headers) {
       fault_filter_headers_.push_back(*header_map);
     }
   }

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -51,7 +51,7 @@ void ConnPoolImpl::checkForDrained() {
       ready_clients_.front()->codec_client_->close();
     }
 
-    for (DrainedCb cb : drained_callbacks_) {
+    for (const DrainedCb& cb : drained_callbacks_) {
       cb();
     }
   }

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -58,7 +58,7 @@ void ConnPoolImpl::checkForDrained() {
 
   if (drained) {
     log_debug("invoking drained callbacks");
-    for (DrainedCb cb : drained_callbacks_) {
+    for (const DrainedCb& cb : drained_callbacks_) {
       cb();
     }
   }

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -194,7 +194,7 @@ InstanceImpl::ThreadLocalPool::ThreadLocalPool(InstanceImpl& parent, Event::Disp
 
 void InstanceImpl::ThreadLocalPool::onHostsRemoved(
     const std::vector<Upstream::HostSharedPtr>& hosts_removed) {
-  for (auto host : hosts_removed) {
+  for (const auto& host : hosts_removed) {
     auto it = client_map_.find(host);
     if (it != client_map_.end()) {
       // We don't currently support any type of draining for redis connections. If a host is gone,

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -120,7 +120,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
     const std::string runtime_key_prefix =
         weighted_clusters_json->getString("runtime_key_prefix", EMPTY_STRING);
 
-    for (const Json::ObjectSharedPtr cluster : cluster_list) {
+    for (const Json::ObjectSharedPtr& cluster : cluster_list) {
       const std::string cluster_name = cluster->getString("name");
       std::unique_ptr<WeightedClusterEntry> cluster_entry(
           new WeightedClusterEntry(this, runtime_key_prefix + "." + cluster_name, loader_,
@@ -137,7 +137,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
 
   if (route.hasObject("headers")) {
     std::vector<Json::ObjectSharedPtr> config_headers = route.getObjectArray("headers");
-    for (const Json::ObjectSharedPtr header_map : config_headers) {
+    for (const Json::ObjectSharedPtr& header_map : config_headers) {
       config_headers_.push_back(*header_map);
     }
   }
@@ -147,7 +147,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
   }
 
   if (route.hasObject("request_headers_to_add")) {
-    for (const Json::ObjectSharedPtr header : route.getObjectArray("request_headers_to_add")) {
+    for (const Json::ObjectSharedPtr& header : route.getObjectArray("request_headers_to_add")) {
       request_headers_to_add_.push_back(
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
@@ -417,14 +417,14 @@ VirtualHostImpl::VirtualHostImpl(const Json::Object& virtual_host,
   }
 
   if (virtual_host.hasObject("request_headers_to_add")) {
-    for (const Json::ObjectSharedPtr header :
+    for (const Json::ObjectSharedPtr& header :
          virtual_host.getObjectArray("request_headers_to_add")) {
       request_headers_to_add_.push_back(
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
   }
 
-  for (const Json::ObjectSharedPtr route : virtual_host.getObjectArray("routes")) {
+  for (const Json::ObjectSharedPtr& route : virtual_host.getObjectArray("routes")) {
     bool has_prefix = route->hasObject("prefix");
     bool has_path = route->hasObject("path");
     if (!(has_prefix ^ has_path)) {
@@ -450,7 +450,7 @@ VirtualHostImpl::VirtualHostImpl(const Json::Object& virtual_host,
   }
 
   if (virtual_host.hasObject("virtual_clusters")) {
-    for (const Json::ObjectSharedPtr virtual_cluster :
+    for (const Json::ObjectSharedPtr& virtual_cluster :
          virtual_host.getObjectArray("virtual_clusters")) {
       virtual_clusters_.push_back(VirtualClusterEntry(*virtual_cluster));
     }
@@ -503,7 +503,7 @@ RouteMatcher::RouteMatcher(const Json::Object& json_config, const ConfigImpl& gl
 
   json_config.validateSchema(Json::Schema::ROUTE_CONFIGURATION_SCHEMA);
 
-  for (const Json::ObjectSharedPtr virtual_host_config :
+  for (const Json::ObjectSharedPtr& virtual_host_config :
        json_config.getObjectArray("virtual_hosts")) {
     VirtualHostSharedPtr virtual_host(new VirtualHostImpl(*virtual_host_config, global_route_config,
                                                           runtime, cm, validate_clusters));
@@ -608,26 +608,26 @@ ConfigImpl::ConfigImpl(const Json::Object& config, Runtime::Loader& runtime,
   route_matcher_.reset(new RouteMatcher(config, *this, runtime, cm, validate_clusters));
 
   if (config.hasObject("internal_only_headers")) {
-    for (std::string header : config.getStringArray("internal_only_headers")) {
+    for (const std::string& header : config.getStringArray("internal_only_headers")) {
       internal_only_headers_.push_back(Http::LowerCaseString(header));
     }
   }
 
   if (config.hasObject("response_headers_to_add")) {
-    for (const Json::ObjectSharedPtr header : config.getObjectArray("response_headers_to_add")) {
+    for (const Json::ObjectSharedPtr& header : config.getObjectArray("response_headers_to_add")) {
       response_headers_to_add_.push_back(
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
   }
 
   if (config.hasObject("response_headers_to_remove")) {
-    for (std::string header : config.getStringArray("response_headers_to_remove")) {
+    for (const std::string& header : config.getStringArray("response_headers_to_remove")) {
       response_headers_to_remove_.push_back(Http::LowerCaseString(header));
     }
   }
 
   if (config.hasObject("request_headers_to_add")) {
-    for (const Json::ObjectSharedPtr header : config.getObjectArray("request_headers_to_add")) {
+    for (const Json::ObjectSharedPtr& header : config.getObjectArray("request_headers_to_add")) {
       request_headers_to_add_.push_back(
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -66,7 +66,7 @@ HeaderValueMatchAction::HeaderValueMatchAction(const Json::Object& action)
     : descriptor_value_(action.getString("descriptor_value")),
       expect_match_(action.getBoolean("expect_match", true)) {
   std::vector<Json::ObjectSharedPtr> config_headers = action.getObjectArray("headers");
-  for (const Json::ObjectSharedPtr header_map : config_headers) {
+  for (const Json::ObjectSharedPtr& header_map : config_headers) {
     action_headers_.push_back(*header_map);
   }
 }
@@ -87,7 +87,7 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(const Json::Object& config)
     : Json::Validator(config, Json::Schema::HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA),
       disable_key_(config.getString("disable_key", "")),
       stage_(static_cast<uint64_t>(config.getInteger("stage", 0))) {
-  for (const Json::ObjectSharedPtr action : config.getObjectArray("actions")) {
+  for (const Json::ObjectSharedPtr& action : config.getObjectArray("actions")) {
     std::string type = action->getString("type");
     if (type == "source_cluster") {
       actions_.emplace_back(new SourceClusterAction());
@@ -130,7 +130,7 @@ void RateLimitPolicyEntryImpl::populateDescriptors(const Router::RouteEntry& rou
 RateLimitPolicyImpl::RateLimitPolicyImpl(const Json::Object& config)
     : rate_limit_entries_reference_(RateLimitPolicyImpl::MAX_STAGE_NUMBER + 1) {
   if (config.hasObject("rate_limits")) {
-    for (const Json::ObjectSharedPtr rate_limit : config.getObjectArray("rate_limits")) {
+    for (const Json::ObjectSharedPtr& rate_limit : config.getObjectArray("rate_limits")) {
       std::unique_ptr<RateLimitPolicyEntry> rate_limit_policy_entry(
           new RateLimitPolicyEntryImpl(*rate_limit));
       uint64_t stage = rate_limit_policy_entry->stage();

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -189,7 +189,7 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config, ClusterManage
   cds_api_ = factory_.createCds(config, *this);
   init_helper_.setCds(cds_api_.get());
 
-  for (const Json::ObjectSharedPtr cluster : config.getObjectArray("clusters")) {
+  for (const Json::ObjectSharedPtr& cluster : config.getObjectArray("clusters")) {
     loadCluster(*cluster, false);
   }
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -354,7 +354,7 @@ TcpHealthCheckMatcher::MatchSegments
 TcpHealthCheckMatcher::loadJsonBytes(const std::vector<Json::ObjectSharedPtr>& byte_array) {
   MatchSegments result;
 
-  for (const Json::ObjectSharedPtr entry : byte_array) {
+  for (const Json::ObjectSharedPtr& entry : byte_array) {
     std::string hex_string = entry->getString("binary");
     result.push_back(Hex::decode(hex_string));
   }

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -113,17 +113,17 @@ DetectorImpl::create(const Cluster& cluster, const Json::Object& json_config,
 }
 
 void DetectorImpl::initialize(const Cluster& cluster) {
-  for (HostSharedPtr host : cluster.hosts()) {
+  for (const HostSharedPtr& host : cluster.hosts()) {
     addHostSink(host);
   }
 
   cluster.addMemberUpdateCb([this](const std::vector<HostSharedPtr>& hosts_added,
                                    const std::vector<HostSharedPtr>& hosts_removed) -> void {
-    for (HostSharedPtr host : hosts_added) {
+    for (const HostSharedPtr& host : hosts_added) {
       addHostSink(host);
     }
 
-    for (HostSharedPtr host : hosts_removed) {
+    for (const HostSharedPtr& host : hosts_removed) {
       ASSERT(host_sinks_.count(host) == 1);
       if (host->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
         ASSERT(stats_.ejections_active_.value() > 0);
@@ -352,7 +352,7 @@ void DetectorImpl::onIntervalTimer() {
 }
 
 void DetectorImpl::runCallbacks(HostSharedPtr host) {
-  for (ChangeStateCb cb : callbacks_) {
+  for (const ChangeStateCb& cb : callbacks_) {
     cb(host);
   }
 }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -103,7 +103,7 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
 
   log_trace("ring hash: min_ring_size={} hashes_per_host={}", min_ring_size, hashes_per_host);
   ring_.reserve(hosts.size() * hashes_per_host);
-  for (auto host : hosts) {
+  for (const auto& host : hosts) {
     for (uint64_t i = 0; i < hashes_per_host; i++) {
       std::string hash_key(host->address()->asString() + "_" + std::to_string(i));
       uint64_t hash = std::hash<std::string>()(hash_key);

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -26,7 +26,7 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
   Json::ObjectSharedPtr json = Json::Factory::loadFromString(response.bodyAsString());
   json->validateSchema(Json::Schema::SDS_SCHEMA);
   std::vector<HostSharedPtr> new_hosts;
-  for (const Json::ObjectSharedPtr host : json->getObjectArray("hosts")) {
+  for (const Json::ObjectSharedPtr& host : json->getObjectArray("hosts")) {
     bool canary = false;
     uint32_t weight = 1;
     std::string zone = "";
@@ -54,7 +54,7 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
     if (!local_info_.zoneName().empty()) {
       std::map<std::string, std::vector<HostSharedPtr>> hosts_per_zone;
 
-      for (HostSharedPtr host : *current_hosts_copy) {
+      for (const HostSharedPtr& host : *current_hosts_copy) {
         hosts_per_zone[host->zone()].push_back(host);
       }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -270,7 +270,7 @@ StaticClusterImpl::StaticClusterImpl(const Json::Object& config, Runtime::Loader
     : ClusterImplBase(config, runtime, stats, ssl_context_manager) {
   std::vector<Json::ObjectSharedPtr> hosts_json = config.getObjectArray("hosts");
   HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
-  for (Json::ObjectSharedPtr host : hosts_json) {
+  for (const Json::ObjectSharedPtr& host : hosts_json) {
     new_hosts->emplace_back(HostSharedPtr{new HostImpl(
         info_, "", Network::Utility::resolveUrl(host->getString("url")), false, 1, "")});
   }
@@ -293,7 +293,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostSharedP
   // SDS implementation could do the same thing.
   std::unordered_set<std::string> host_addresses;
   std::vector<HostSharedPtr> final_hosts;
-  for (HostSharedPtr host : new_hosts) {
+  for (const HostSharedPtr& host : new_hosts) {
     if (host_addresses.count(host->address()->asString())) {
       continue;
     }
@@ -380,7 +380,7 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(const Json::Object& config, Runtime::
     dns_lookup_family_ = Network::DnsLookupFamily::V4Only;
   }
 
-  for (Json::ObjectSharedPtr host : config.getObjectArray("hosts")) {
+  for (const Json::ObjectSharedPtr& host : config.getObjectArray("hosts")) {
     resolve_targets_.emplace_back(new ResolveTarget(*this, dispatcher, host->getString("url")));
   }
   // We have to first construct resolve_targets_ before invoking startResolve(),
@@ -430,7 +430,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         parent_.info_->stats().update_success_.inc();
 
         std::vector<HostSharedPtr> new_hosts;
-        for (Network::Address::InstanceConstSharedPtr address : address_list) {
+        for (const Network::Address::InstanceConstSharedPtr& address : address_list) {
           // TODO(mattklein123): Currently the DNS interface does not consider port. We need to make
           // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -124,7 +124,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
   }
 
   if (config.hasObject("access_log")) {
-    for (Json::ObjectSharedPtr access_log : config.getObjectArray("access_log")) {
+    for (const Json::ObjectSharedPtr& access_log : config.getObjectArray("access_log")) {
       Http::AccessLog::InstanceSharedPtr current_access_log =
           Http::AccessLog::InstanceImpl::fromJson(*access_log, server.runtime(),
                                                   server.accessLogManager());

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -39,7 +39,7 @@ void GuardDogImpl::threadRoutine() {
     const auto now = time_source_.currentTime();
     bool seen_one_multi_timeout(false);
     std::lock_guard<std::mutex> guard(wd_lock_);
-    for (auto watched_dog : watched_dogs_) {
+    for (const auto& watched_dog : watched_dogs_) {
       const auto delta = now - watched_dog->lastTouchTime();
       if (delta > miss_timeout_) {
         watchdog_miss_counter_.inc();

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -148,11 +148,11 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
 
     for (auto& host : cluster.second.get().hosts()) {
       std::map<std::string, uint64_t> all_stats;
-      for (Stats::CounterSharedPtr counter : host->counters()) {
+      for (const Stats::CounterSharedPtr& counter : host->counters()) {
         all_stats[counter->name()] = counter->value();
       }
 
-      for (Stats::GaugeSharedPtr gauge : host->gauges()) {
+      for (const Stats::GaugeSharedPtr& gauge : host->gauges()) {
         all_stats[gauge->name()] = gauge->value();
       }
 
@@ -244,7 +244,7 @@ Http::Code AdminImpl::handlerLogging(const std::string& url, Buffer::Instance& r
 }
 
 Http::Code AdminImpl::handlerResetCounters(const std::string&, Buffer::Instance& response) {
-  for (Stats::CounterSharedPtr counter : server_.stats().counters()) {
+  for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     counter->reset();
   }
 
@@ -266,11 +266,11 @@ Http::Code AdminImpl::handlerStats(const std::string&, Buffer::Instance& respons
   // We currently don't support timers locally (only via statsd) so just group all the counters
   // and gauges together, alpha sort them, and spit them out.
   std::map<std::string, uint64_t> all_stats;
-  for (Stats::CounterSharedPtr counter : server_.stats().counters()) {
+  for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     all_stats.emplace(counter->name(), counter->value());
   }
 
-  for (Stats::GaugeSharedPtr gauge : server_.stats().gauges()) {
+  for (const Stats::GaugeSharedPtr& gauge : server_.stats().gauges()) {
     all_stats.emplace(gauge->name(), gauge->value());
   }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -123,7 +123,7 @@ void InstanceImpl::flushStats() {
   server_stats_.days_until_first_cert_expiring_.set(
       sslContextManager().daysUntilFirstCertExpires());
 
-  for (Stats::CounterSharedPtr counter : stats_store_.counters()) {
+  for (const Stats::CounterSharedPtr& counter : stats_store_.counters()) {
     uint64_t delta = counter->latch();
     if (counter->used()) {
       for (const auto& sink : stat_sinks_) {
@@ -132,7 +132,7 @@ void InstanceImpl::flushStats() {
     }
   }
 
-  for (Stats::GaugeSharedPtr gauge : stats_store_.gauges()) {
+  for (const Stats::GaugeSharedPtr& gauge : stats_store_.gauges()) {
     if (gauge->used()) {
       for (const auto& sink : stat_sinks_) {
         sink->flushGauge(gauge->name(), gauge->value());

--- a/test/common/filter/ratelimit_test.cc
+++ b/test/common/filter/ratelimit_test.cc
@@ -53,7 +53,7 @@ public:
   }
 
   ~RateLimitFilterTest() {
-    for (Stats::GaugeSharedPtr gauge : stats_store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : stats_store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
   }

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -108,7 +108,7 @@ public:
 
   ~Http1ConnPoolImplTest() {
     // Make sure all gauges are 0.
-    for (Stats::GaugeSharedPtr gauge : cluster_->stats_store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : cluster_->stats_store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
   }

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -61,7 +61,7 @@ public:
 
   ~Http2ConnPoolImplTest() {
     // Make sure all gauges are 0.
-    for (Stats::GaugeSharedPtr gauge : cluster_->stats_store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : cluster_->stats_store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
   }

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -153,7 +153,7 @@ private:
         write_buffer_.add(&response_size_n, sizeof(response_size_n));
         write_buffer_.add(response_base, response_base_len);
         if (ips != nullptr) {
-          for (auto it : *ips) {
+          for (const auto& it : *ips) {
             write_buffer_.add(question, name_len);
             write_buffer_.add(response_rr_fixed, RRFIXEDSZ);
             if (q_type == T_A) {
@@ -282,7 +282,7 @@ protected:
 
 static bool hasAddress(const std::list<Address::InstanceConstSharedPtr>& results,
                        const std::string& address) {
-  for (auto result : results) {
+  for (const auto& result : results) {
     if (result->ip()->addressAsString() == address) {
       return true;
     }

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -38,10 +38,10 @@ public:
     client_.reset();
 
     // Make sure all gauges are 0.
-    for (Stats::GaugeSharedPtr gauge : host_->cluster_.stats_store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : host_->cluster_.stats_store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
-    for (Stats::GaugeSharedPtr gauge : host_->stats_store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : host_->stats_store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
   }

--- a/test/common/redis/proxy_filter_test.cc
+++ b/test/common/redis/proxy_filter_test.cc
@@ -95,7 +95,7 @@ public:
 
   ~RedisProxyFilterTest() {
     filter_.reset();
-    for (Stats::GaugeSharedPtr gauge : store_.gauges()) {
+    for (const Stats::GaugeSharedPtr& gauge : store_.gauges()) {
       EXPECT_EQ(0U, gauge->value());
     }
   }

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -66,7 +66,7 @@ protected:
 
   uint64_t numHealthy() {
     uint64_t healthy = 0;
-    for (HostSharedPtr host : cluster_->hosts()) {
+    for (const HostSharedPtr& host : cluster_->hosts()) {
       if (host->healthy()) {
         healthy++;
       }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -277,7 +277,7 @@ uint32_t BaseIntegrationTest::lookupPort(const std::string& key) {
 
 void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>& port_names) {
   int index = 0;
-  for (auto it : port_names) {
+  for (const auto& it : port_names) {
     Network::ListenSocket* listen_socket = test_server_->server().getListenSocketByIndex(index++);
     RELEASE_ASSERT(listen_socket != nullptr);
     registerPort(it, listen_socket->localAddress()->ip()->port());

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -155,7 +155,7 @@ public:
    * Integration tests are composed of a sequence of actions which are run via this routine.
    */
   void executeActions(std::list<std::function<void()>> actions) {
-    for (std::function<void()> action : actions) {
+    for (const std::function<void()>& action : actions) {
       action();
     }
   }

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -47,7 +47,7 @@ public:
   ~MockDetector();
 
   void runCallbacks(HostSharedPtr host) {
-    for (ChangeStateCb cb : callbacks_) {
+    for (const ChangeStateCb& cb : callbacks_) {
       cb(host);
     }
   }

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -31,7 +31,7 @@ public:
 
   void runCallbacks(const std::vector<HostSharedPtr> added,
                     const std::vector<HostSharedPtr> removed) {
-    for (MemberUpdateCb cb : callbacks_) {
+    for (const MemberUpdateCb& cb : callbacks_) {
       cb(added, removed);
     }
   }
@@ -122,7 +122,7 @@ public:
   MOCK_METHOD0(start, void());
 
   void runCallbacks(Upstream::HostSharedPtr host, bool changed_state) {
-    for (auto callback : callbacks_) {
+    for (const auto& callback : callbacks_) {
       callback(host, changed_state);
     }
   }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -65,7 +65,7 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
 std::list<Network::Address::InstanceConstSharedPtr>
 TestUtility::makeDnsResponse(const std::list<std::string>& addresses) {
   std::list<Network::Address::InstanceConstSharedPtr> ret;
-  for (auto address : addresses) {
+  for (const auto& address : addresses) {
     ret.emplace_back(Network::Utility::parseInternetAddress(address));
   }
   return ret;

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -25,7 +25,7 @@ ToolConfig ToolConfig::create(const Json::ObjectSharedPtr check_config) {
   }
 
   if (input->hasObject("additional_headers")) {
-    for (const Json::ObjectSharedPtr header_config : input->getObjectArray("additional_headers")) {
+    for (const Json::ObjectSharedPtr& header_config : input->getObjectArray("additional_headers")) {
       headers->addViaCopy(header_config->getString("field"), header_config->getString("value"));
     }
   }
@@ -60,7 +60,7 @@ bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_jso
   loader->validateSchema(Json::ToolSchema::routerCheckSchema());
 
   bool no_failures = true;
-  for (const Json::ObjectSharedPtr check_config : loader->asObjectArray()) {
+  for (const Json::ObjectSharedPtr& check_config : loader->asObjectArray()) {
     ToolConfig tool_config = ToolConfig::create(check_config);
     tool_config.route_ = config_->route(*tool_config.headers_, tool_config.random_value_);
 
@@ -102,7 +102,7 @@ bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_jso
     }
 
     if (validate->hasObject("header_fields")) {
-      for (const Json::ObjectSharedPtr header_field : validate->getObjectArray("header_fields")) {
+      for (const Json::ObjectSharedPtr& header_field : validate->getObjectArray("header_fields")) {
         if (!compareHeaderField(tool_config, header_field->getString("field"),
                                 header_field->getString("value"))) {
           no_failures = false;


### PR DESCRIPTION
Use const references for `for` loop variables wherever safe. See
http://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html
for details.