### PR TITLE
fix examples/grpc-bridge/script/bootstrap

### DIFF
--- a/docs/install/sandboxes/grpc_bridge.rst
+++ b/docs/install/sandboxes/grpc_bridge.rst
@@ -22,9 +22,11 @@ Building the Go service
 To build the Go gRPC service run::
 
   $ pwd
-  ~/src/envoy/examples/grpc-bridge
+  envoy/examples/grpc-bridge
   $ script/bootstrap
   $ script/build
+
+Note: ``build`` requires that your Envoy codebase (or a working copy thereof) is in ``$GOPATH/src/github.com/lyft/envoy``.
 
 Docker compose
 ~~~~~~~~~~~~~~
@@ -33,7 +35,7 @@ To run the docker compose file, and set up both the Python and the gRPC containe
 run::
 
   $ pwd
-  ~/src/envoy/examples/grpc-bridge
+  envoy/examples/grpc-bridge
   $ docker-compose up --build
 
 Sending requests to the Key/Value store
@@ -42,7 +44,7 @@ Sending requests to the Key/Value store
 To use the Python service and send gRPC requests::
 
   $ pwd
-  ~/src/envoy/examples/grpc-bridge
+  envoy/examples/grpc-bridge
   # set a key
   $ docker-compose exec python /client/client.py set foo bar
   setf foo to bar
@@ -50,3 +52,17 @@ To use the Python service and send gRPC requests::
   # get a key
   $ docker-compose exec python /client/client.py get foo
   bar
+
+  # modify an existing key
+  $ docker-compose exec python /client/client.py set foo baz
+  setf foo to baz
+
+  # get the modified key
+  $ docker-compose exec python /client/client.py get foo
+  baz
+
+In the running docker-compose container, you should see the gRPC service printing a record of its activity:
+
+  grpc_1    | 2017/05/30 12:05:09 set: foo = bar
+  grpc_1    | 2017/05/30 12:05:12 get: foo
+  grpc_1    | 2017/05/30 12:05:18 set: foo = baz


### PR DESCRIPTION
looks like the bootstrap is missing a dependency. also, not sure why the grpc logs in the docker-compose lag behind the actual requests by 1, but couldn't figure out a quick fix so left out of scope.

```
$ script/build
service/main.go:11:2: cannot find package "github.com/lyft/envoy/examples/grpc-bridge/service/gen2" in any of:
	/usr/local/Cellar/go/1.7.4_2/libexec/src/github.com/lyft/envoy/examples/grpc-bridge/service/gen2 (from $GOROOT)
	[$GOPATH]/src/github.com/lyft/envoy/examples/grpc-bridge/service/gen2 (from $GOPATH)
```