### PR TITLE
network: proxy protocol v6 support

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -96,8 +96,8 @@ std::vector<std::string> StringUtil::split(const std::string& source, char split
   return StringUtil::split(source, std::string{split});
 }
 
-std::vector<std::string> StringUtil::splitKeep(const std::string& source, const std::string& split,
-                                               bool keep_empty_string) {
+std::vector<std::string> StringUtil::split(const std::string& source, const std::string& split,
+                                           bool keep_empty_string) {
   std::vector<std::string> ret;
   size_t last_index = 0;
   size_t next_index;
@@ -121,10 +121,6 @@ std::vector<std::string> StringUtil::splitKeep(const std::string& source, const 
   } while (next_index != source.size());
 
   return ret;
-}
-
-std::vector<std::string> StringUtil::split(const std::string& source, const std::string& split) {
-  return splitKeep(source, split, false);
 }
 
 std::string StringUtil::subspan(const std::string& source, size_t start, size_t end) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -96,7 +96,8 @@ std::vector<std::string> StringUtil::split(const std::string& source, char split
   return StringUtil::split(source, std::string{split});
 }
 
-std::vector<std::string> StringUtil::split(const std::string& source, const std::string& split) {
+std::vector<std::string> StringUtil::splitKeep(const std::string& source, const std::string& split,
+                                               bool keep_empty_string) {
   std::vector<std::string> ret;
   size_t last_index = 0;
   size_t next_index;
@@ -112,7 +113,7 @@ std::vector<std::string> StringUtil::split(const std::string& source, const std:
       next_index = source.size();
     }
 
-    if (next_index != last_index) {
+    if (next_index != last_index || keep_empty_string) {
       ret.emplace_back(subspan(source, last_index, next_index));
     }
 
@@ -120,6 +121,10 @@ std::vector<std::string> StringUtil::split(const std::string& source, const std:
   } while (next_index != source.size());
 
   return ret;
+}
+
+std::vector<std::string> StringUtil::split(const std::string& source, const std::string& split) {
+  return splitKeep(source, split, false);
 }
 
 std::string StringUtil::subspan(const std::string& source, size_t start, size_t end) {

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -123,8 +123,8 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the string to split on.
-   * @param keep_empty_string result contains empty strings if the string starts or
-   * ends with 'split', or if instances of 'split' are adjacent.
+   * @param keep_empty_string result contains empty strings if the string starts or ends with
+   * 'split', or if instances of 'split' are adjacent.
    * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
   static std::vector<std::string> split(const std::string& source, const std::string& split,

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -123,6 +123,17 @@ public:
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the char to split on.
+   * @param keep_empty_string result contains empty strings if the string starts or
+   * ends with 'split', or if instances of 'split' are adjacent.
+   * @return vector of strings computed after splitting `source` around all instances of `split`.
+   */
+  static std::vector<std::string> splitKeep(const std::string& source, const std::string& split,
+                                            bool keep_empty_string);
+
+  /**
+   * Split a string.
+   * @param source supplies the string to split.
+   * @param split supplies the char to split on.
    * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
   static std::vector<std::string> split(const std::string& source, char split);

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -122,13 +122,13 @@ public:
   /**
    * Split a string.
    * @param source supplies the string to split.
-   * @param split supplies the char to split on.
+   * @param split supplies the string to split on.
    * @param keep_empty_string result contains empty strings if the string starts or
    * ends with 'split', or if instances of 'split' are adjacent.
    * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
-  static std::vector<std::string> splitKeep(const std::string& source, const std::string& split,
-                                            bool keep_empty_string);
+  static std::vector<std::string> split(const std::string& source, const std::string& split,
+                                        bool keep_empty_string = false);
 
   /**
    * Split a string.
@@ -137,14 +137,6 @@ public:
    * @return vector of strings computed after splitting `source` around all instances of `split`.
    */
   static std::vector<std::string> split(const std::string& source, char split);
-
-  /**
-   * Split a string.
-   * @param source supplies the string to split.
-   * @param split supplies the string to split on.
-   * @return vector of strings computed after splitting `source` around all instances of `split`.
-   */
-  static std::vector<std::string> split(const std::string& source, const std::string& split);
 
   /**
    * Version of substr() that operates on a start and end index instead of a start index and a

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -122,6 +122,7 @@ envoy_cc_library(
         "//include/envoy/stats:stats_macros",
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",
+        "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/event:libevent_lib",
         "//source/common/ssl:connection_lib",

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -88,10 +88,11 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
     throw EnvoyException("failed to read proxy protocol");
   }
 
-  uint64_t remote_port, destination_port;
+  uint32_t remote_port, destination_port;
   try {
-    remote_port = std::stoull(line_parts[4]);
-    destination_port = std::stoull(line_parts[5]);
+    remote_port = std::stoul(line_parts[4]);
+    destination_port = std::stoul(line_parts[5]);
+    // Check that TCP port value is in range [0, 65535].
     if (remote_port > 65535 || destination_port > 65535) {
       throw std::out_of_range("failed to read proxy protocol");
     }

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -91,13 +91,17 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   uint64_t remote_port, destination_port;
   try {
-    remote_port = std::stol(line_parts[4], nullptr);
-    destination_port = std::stol(line_parts[5], nullptr);
+    remote_port = std::stol(line_parts[4]);
+    destination_port = std::stol(line_parts[5]);
   } catch (const std::invalid_argument& ia) {
     throw EnvoyException(ia.what());
+  } catch (const std::out_of_range& ex) {
+    throw EnvoyException(ex.what());
   }
-  UNREFERENCED_PARAMETER(remote_port);
-  UNREFERENCED_PARAMETER(destination_port);
+  if (long(remote_port) < 0 || long(destination_port) < 0) {
+    // Negative port input value.
+    throw EnvoyException("failed to read proxy protocol");
+  }
 
   ListenerImpl& listener = listener_;
   int fd = fd_;

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -12,14 +12,13 @@
 #include "envoy/stats/stats.h"
 
 #include "common/common/empty_string.h"
+#include "common/common/utility.h"
 #include "common/network/address_impl.h"
 #include "common/network/listener_impl.h"
 #include "common/network/utility.h"
 
 namespace Envoy {
 namespace Network {
-
-const std::string ProxyProtocol::ActiveConnection::PROXY_TCP4 = "PROXY TCP4 ";
 
 ProxyProtocol::ProxyProtocol(Stats::Scope& scope)
     : stats_{ALL_PROXY_PROTOCOL_STATS(POOL_COUNTER(scope))} {}
@@ -61,17 +60,44 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
     return;
   }
 
-  if (proxy_line.find(PROXY_TCP4) != 0) {
+  // Parse proxy protocol line with format: PROXY TCP4/TCP6 SOURCE_ADDRESS DESTINATION_ADDRESS
+  // SOURCE_PORT DESTINATION_PORT.
+  auto line_parts = StringUtil::splitKeep(proxy_line, " ", true);
+
+  if (line_parts.size() != 6 || line_parts[0] != "PROXY") {
     throw EnvoyException("failed to read proxy protocol");
   }
 
-  size_t index = proxy_line.find(" ", PROXY_TCP4.size());
-  if (index == std::string::npos) {
+  Address::IpVersion protocol_version;
+  if (line_parts[1] == "TCP4") {
+    protocol_version = Address::IpVersion::v4;
+  } else if (line_parts[1] == "TCP6") {
+    protocol_version = Address::IpVersion::v6;
+  } else {
     throw EnvoyException("failed to read proxy protocol");
   }
 
-  size_t addr_len = index - PROXY_TCP4.size();
-  std::string remote_address = proxy_line.substr(PROXY_TCP4.size(), addr_len);
+  // Error check the source and destination fields. Currently the source port, destination address,
+  // and destination port fields are ignored. Remote address refers to the source address.
+  Address::InstanceConstSharedPtr remote_address = Utility::parseInternetAddress(line_parts[2]);
+  Address::InstanceConstSharedPtr destination_address =
+      Utility::parseInternetAddress(line_parts[3]);
+  auto remote_version = remote_address->ip()->version();
+  auto destination_version = destination_address->ip()->version();
+  if (remote_version != protocol_version || destination_version != protocol_version ||
+      remote_version != destination_version) {
+    throw EnvoyException("failed to read proxy protocol");
+  }
+
+  uint64_t remote_port, destination_port;
+  try {
+    remote_port = std::stol(line_parts[4], nullptr);
+    destination_port = std::stol(line_parts[5], nullptr);
+  } catch (const std::invalid_argument& ia) {
+    throw EnvoyException(ia.what());
+  }
+  UNREFERENCED_PARAMETER(remote_port);
+  UNREFERENCED_PARAMETER(destination_port);
 
   ListenerImpl& listener = listener_;
   int fd = fd_;
@@ -80,11 +106,7 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
   removeFromList(parent_.connections_);
 
   // TODO(mattklein123): Parse the remote port instead of passing zero.
-  // TODO(mattklein123): IPv6 support.
-  listener.newConnection(fd,
-                         Network::Address::InstanceConstSharedPtr{
-                             new Network::Address::Ipv4Instance(remote_address, 0)},
-                         listener.socket().localAddress());
+  listener.newConnection(fd, remote_address, listener.socket().localAddress());
 }
 
 void ProxyProtocol::ActiveConnection::close() {

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -62,7 +62,7 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   // Parse proxy protocol line with format: PROXY TCP4/TCP6 SOURCE_ADDRESS DESTINATION_ADDRESS
   // SOURCE_PORT DESTINATION_PORT.
-  auto line_parts = StringUtil::splitKeep(proxy_line, " ", true);
+  auto line_parts = StringUtil::split(proxy_line, " ", true);
 
   if (line_parts.size() != 6 || line_parts[0] != "PROXY") {
     throw EnvoyException("failed to read proxy protocol");
@@ -84,8 +84,7 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
       Utility::parseInternetAddress(line_parts[3]);
   auto remote_version = remote_address->ip()->version();
   auto destination_version = destination_address->ip()->version();
-  if (remote_version != protocol_version || destination_version != protocol_version ||
-      remote_version != destination_version) {
+  if (remote_version != protocol_version || destination_version != protocol_version) {
     throw EnvoyException("failed to read proxy protocol");
   }
 

--- a/source/common/network/proxy_protocol.h
+++ b/source/common/network/proxy_protocol.h
@@ -42,8 +42,7 @@ public:
     ~ActiveConnection();
 
   private:
-    static const size_t MAX_PROXY_PROTO_LEN = 56;
-    static const std::string PROXY_TCP4;
+    static const size_t MAX_PROXY_PROTO_LEN = 108;
 
     void onRead();
     void onReadWorker();

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -80,8 +80,9 @@ public:
   static uint32_t portFromTcpUrl(const std::string& url);
 
   /*
-  * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. Throw
-  * an exception if unable to parse the address. The address must not include a port number.
+  * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address
+  * must not include a port number.
+  * throws EnvoyException if unable to parse the address.
   * @param ip_address string to be parsed as an internet address.
   * @return pointer to the Instance, or nullptr if unable to parse the address.
   */
@@ -89,7 +90,7 @@ public:
 
   /*
   * Parse an internet host address (IPv4 or IPv6) AND port, and create an Instance from it.
-  * @throws an exception if unable to parse the address.
+  * throws EnvoyException if unable to parse the address.
   * @param ip_addr string to be parsed as an internet address and port. Examples:
   *        - "1.2.3.4:80"
   *        - "[1234:5678::9]:443"

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -79,18 +79,17 @@ public:
    */
   static uint32_t portFromTcpUrl(const std::string& url);
 
-  /*
-  * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address
-  * must not include a port number.
-  * throws EnvoyException if unable to parse the address.
+  /**
+  * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address must
+  * not include a port number. Throws EnvoyException if unable to parse the address.
   * @param ip_address string to be parsed as an internet address.
   * @return pointer to the Instance, or nullptr if unable to parse the address.
   */
   static Address::InstanceConstSharedPtr parseInternetAddress(const std::string& ip_address);
 
-  /*
-  * Parse an internet host address (IPv4 or IPv6) AND port, and create an Instance from it.
-  * throws EnvoyException if unable to parse the address.
+  /**
+  * Parse an internet host address (IPv4 or IPv6) AND port, and create an Instance from it. Throws
+  * EnvoyException if unable to parse the address.
   * @param ip_addr string to be parsed as an internet address and port. Examples:
   *        - "1.2.3.4:80"
   *        - "[1234:5678::9]:443"

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -5,9 +5,12 @@
 
 #include "common/common/utility.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
+using testing::ContainerEq;
+
 TEST(StringUtil, atoul) {
   uint64_t out;
   EXPECT_FALSE(StringUtil::atoul("123b", out));
@@ -116,48 +119,20 @@ TEST(StringUtil, split) {
   EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello, ", ", "));
   EXPECT_EQ(std::vector<std::string>{}, StringUtil::split(",,", ","));
   EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello", ""));
-  {
-    std::vector<std::string> expected{"hello", "world"};
-    std::vector<std::string> result = StringUtil::split("hello world", " ");
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
-  {
-    std::vector<std::string> expected{"hello", "world"};
-    std::vector<std::string> result = StringUtil::split("hello   world", " ");
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
-  {
-    std::vector<std::string> result = StringUtil::split("  hello world", " ", true);
-    std::vector<std::string> expected{"", "", "hello", "world"};
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
-  {
-    std::vector<std::string> result = StringUtil::split("hello world ", " ", true);
-    std::vector<std::string> expected{"hello", "world", ""};
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
-  {
-    std::vector<std::string> result = StringUtil::split("hello world", " ", true);
-    std::vector<std::string> expected{"hello", "world"};
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
-  {
-    std::vector<std::string> result = StringUtil::split("hello   world", " ", true);
-    std::vector<std::string> expected{"hello", "", "", "world"};
-    for (size_t i = 0; i < expected.size(); ++i) {
-      EXPECT_EQ(expected[i], result[i]);
-    }
-  }
+
+  EXPECT_THAT(std::vector<std::string>({"hello", "world"}),
+              ContainerEq(StringUtil::split("hello world", " ")));
+  EXPECT_THAT(std::vector<std::string>({"hello", "world"}),
+              ContainerEq(StringUtil::split("hello   world", " ")));
+
+  EXPECT_THAT(std::vector<std::string>({"", "", "hello", "world"}),
+              ContainerEq(StringUtil::split("  hello world", " ", true)));
+  EXPECT_THAT(std::vector<std::string>({"hello", "world", ""}),
+              ContainerEq(StringUtil::split("hello world ", " ", true)));
+  EXPECT_THAT(std::vector<std::string>({"hello", "world"}),
+              ContainerEq(StringUtil::split("hello world", " ", true)));
+  EXPECT_THAT(std::vector<std::string>({"hello", "", "", "world"}),
+              ContainerEq(StringUtil::split("hello   world", " ", true)));
 }
 
 TEST(StringUtil, endsWith) {

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -130,19 +130,30 @@ TEST(StringUtil, split) {
       EXPECT_EQ(expected[i], result[i]);
     }
   }
-}
-
-TEST(StringUtil, splitKeep) {
   {
-    std::vector<std::string> expected{"hello", "world"};
-    std::vector<std::string> result = StringUtil::splitKeep("hello world", " ", true);
+    std::vector<std::string> result = StringUtil::split("  hello world", " ", true);
+    std::vector<std::string> expected{"", "", "hello", "world"};
     for (size_t i = 0; i < expected.size(); ++i) {
       EXPECT_EQ(expected[i], result[i]);
     }
   }
   {
+    std::vector<std::string> result = StringUtil::split("hello world ", " ", true);
+    std::vector<std::string> expected{"hello", "world", ""};
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
+  {
+    std::vector<std::string> result = StringUtil::split("hello world", " ", true);
+    std::vector<std::string> expected{"hello", "world"};
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
+  {
+    std::vector<std::string> result = StringUtil::split("hello   world", " ", true);
     std::vector<std::string> expected{"hello", "", "", "world"};
-    std::vector<std::string> result = StringUtil::splitKeep("hello   world", " ", true);
     for (size_t i = 0; i < expected.size(); ++i) {
       EXPECT_EQ(expected[i], result[i]);
     }

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -116,6 +116,37 @@ TEST(StringUtil, split) {
   EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello, ", ", "));
   EXPECT_EQ(std::vector<std::string>{}, StringUtil::split(",,", ","));
   EXPECT_EQ(std::vector<std::string>{"hello"}, StringUtil::split("hello", ""));
+  {
+    std::vector<std::string> expected{"hello", "world"};
+    std::vector<std::string> result = StringUtil::split("hello world", " ");
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
+  {
+    std::vector<std::string> expected{"hello", "world"};
+    std::vector<std::string> result = StringUtil::split("hello   world", " ");
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
+}
+
+TEST(StringUtil, splitKeep) {
+  {
+    std::vector<std::string> expected{"hello", "world"};
+    std::vector<std::string> result = StringUtil::splitKeep("hello world", " ", true);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
+  {
+    std::vector<std::string> expected{"hello", "", "", "world"};
+    std::vector<std::string> result = StringUtil::splitKeep("hello   world", " ", true);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(expected[i], result[i]);
+    }
+  }
 }
 
 TEST(StringUtil, endsWith) {

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -130,6 +130,7 @@ envoy_cc_test(
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
     ],
 )

--- a/test/common/network/proxy_protocol_test.cc
+++ b/test/common/network/proxy_protocol_test.cc
@@ -180,13 +180,6 @@ TEST_P(ProxyProtocolTest, NegativePort) {
 }
 
 TEST_P(ProxyProtocolTest, PortOutOfRange) {
-  write("PROXY TCP6 1:2:3::4 5:6::7:8 1000000000000000000000 1234\r\nmore data");
-  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
-  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));
-  dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
-}
-
-TEST_P(ProxyProtocolTest, PortTooLarge) {
   write("PROXY TCP6 1:2:3::4 5:6::7:8 66776 1234\r\nmore data");
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));

--- a/test/common/network/proxy_protocol_test.cc
+++ b/test/common/network/proxy_protocol_test.cc
@@ -166,14 +166,28 @@ TEST_P(ProxyProtocolTest, NotEnoughFields) {
 }
 
 TEST_P(ProxyProtocolTest, BadPort) {
-  write("PROXY TCP6 1:2:3::4 5:6::7:8 66776 abc\r\nmore data\r\n");
+  write("PROXY TCP6 1:2:3::4 5:6::7:8 66776 abc\r\nmore data");
+  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
+  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));
+  dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+}
+
+TEST_P(ProxyProtocolTest, NegativePort) {
+  write("PROXY TCP6 1:2:3::4 5:6::7:8 -66776 1234\r\nmore data");
+  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
+  EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));
+  dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+}
+
+TEST_P(ProxyProtocolTest, PortOutOfRange) {
+  write("PROXY TCP6 1:2:3::4 5:6::7:8 1000000000000000000000 1234\r\nmore data");
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));
   dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
 }
 
 TEST_P(ProxyProtocolTest, BadAddress) {
-  write("PROXY TCP6 1::2:3::4 5:6::7:8 66776 1234\r\nmore data\r\n");
+  write("PROXY TCP6 1::2:3::4 5:6::7:8 66776 1234\r\nmore data");
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::Connected));
   EXPECT_CALL(connection_callbacks_, onEvent(ConnectionEvent::RemoteClose));
   dispatcher_.run(Event::Dispatcher::RunType::NonBlock);

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -10,7 +10,7 @@ namespace Envoy {
 TEST_F(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
 
-  Buffer::OwnedImpl buf("PROXY TCP4 1.2.3.4 255.255.255.255 66776 1234\r\n");
+  Buffer::OwnedImpl buf("PROXY TCP4 1.2.3.4 255.255.255.255 65535 1234\r\n");
   conn->write(buf);
 
   testRouterRequestAndResponseWithBody(std::move(conn), Http::CodecClient::Type::HTTP1, 1024, 512,


### PR DESCRIPTION
This PR adds IPv6 proxy protocol support.

A string utility function splitKeep was added that allows a return vector that includes empty string elements.

Extra error checking was added to the proxy protocol parsing.