### PR TITLE
test: integration test and admin integration test parameterization

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -77,7 +77,7 @@ then
 fi
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 514219e07663f0ebdfa9bf1586007f2f16401c47)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 48f83f5c697e61863b085e353cbdf77c4bba6d2a)
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -75,10 +75,10 @@ if [[ ! -a "${ENVOY_FILTER_EXAMPLE_SRCDIR}" ]]
 then
   git clone https://github.com/lyft/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
 fi
-cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout e90e73c222fec574ab50b9e72880a9c8885f4f96)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 514219e07663f0ebdfa9bf1586007f2f16401c47)
+cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.
 export ENVOY_BUILD_DIR="${BUILD_DIR}"/envoy

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -94,7 +94,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -193,7 +193,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
       { "type": "read", "name":
         "tcp_proxy",
@@ -211,7 +211,7 @@
     ]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -230,9 +230,11 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "profile_path": "{{ test_tmpdir }}/envoy.prof", "address": "tcp://127.0.0.1:0" },
+  "admin": { "access_log_path": "/dev/null",
+	     "profile_path": "{{ test_tmpdir }}/envoy.prof",
+	     "address": "tcp://{{ ip_loopback_address }}:0" },
   "flags_path": "/invalid_flags",
-  "statsd_udp_ip_address": "127.0.0.1:8125",
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
   "statsd_tcp_cluster_name": "statsd",
   "tracing": {
     "http": {
@@ -259,7 +261,7 @@
         "connect_timeout_ms": 5000,
         "type": "static",
         "lb_type": "round_robin",
-        "hosts": [{"url": "tcp://127.0.0.1:12000"}]
+        "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
       }
     },
     "clusters": [
@@ -268,20 +270,21 @@
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://127.0.0.1:12000"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
     },
     {
       "name": "cluster_1",
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://127.0.0.1:{{ upstream_0 }}"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
     },
     {
       "name": "cluster_2",
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:{{ upstream_1 }}"}]
     },
     {
@@ -289,6 +292,7 @@
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:10009"}]
     },
     {
@@ -297,6 +301,7 @@
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:10010"}]
     }]
   }

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -66,7 +66,7 @@ envoy_cc_test(
     name = "integration_admin_test",
     srcs = [
         "integration_admin_test.cc",
-        "integration_test.h",
+        "integration_admin_test.h",
     ],
     data = [
         "//test/config/integration:server.json",

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -9,11 +9,11 @@ public:
     * Initializer for an individual test.
     */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(GetParam(), 0, FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(GetParam(), 0, FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/echo_server.json", GetParam(), {"echo"});
+    createTestServer("test/config/integration/echo_server.json", {"echo"}, GetParam());
   }
 
   /**
@@ -31,12 +31,12 @@ INSTANTIATE_TEST_CASE_P(IpVersions, EchoIntegrationTest,
 TEST_P(EchoIntegrationTest, Hello) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
-  RawConnectionDriver connection(lookupPort("echo"), GetParam(), buffer,
-                                 [&](Network::ClientConnection&, const Buffer::Instance& data)
-                                     -> void {
-                                       response.append(TestUtility::bufferToString(data));
-                                       connection.close();
-                                     });
+  RawConnectionDriver connection(
+      lookupPort("echo"),
+      buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        connection.close();
+      }, GetParam());
 
   connection.run();
   EXPECT_EQ("hello", response);

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -5,6 +5,7 @@ namespace Envoy {
 class EchoIntegrationTest : public BaseIntegrationTest,
                             public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  EchoIntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
     * Initializer for an individual test.
     */
@@ -13,7 +14,7 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/echo_server.json", {"echo"}, GetParam());
+    createTestServer("test/config/integration/echo_server.json", {"echo"});
   }
 
   /**

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -199,30 +199,18 @@ FakeUpstream::FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type
   log().info("starting fake server on unix domain socket {}", uds_path);
 }
 
-// TODO(henna): Deprecate when IPv6 test support is finished.
-static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port) {
-  auto addr =
-      Network::Address::InstanceConstSharedPtr{new Network::Address::Ipv4Instance("0.0.0.0", port)};
-  return Network::ListenSocketPtr{new Network::TcpListenSocket(addr, true)};
-}
-
-static Network::ListenSocketPtr makeTcpListenSocket(const Network::Address::IpVersion version,
-                                                    uint32_t port) {
+static Network::ListenSocketPtr
+makeTcpListenSocket(uint32_t port,
+                    Network::Address::IpVersion version = Network::Address::IpVersion::v4) {
   return Network::ListenSocketPtr{new Network::TcpListenSocket(
       Network::Utility::parseInternetAddressAndPort(
           fmt::format("{}:{}", Network::Test::getAnyAddressUrlString(version), port)),
       true)};
 }
 
-// TODO(henna): Deprecate when IPv6 test support is finished.
-FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type)
-    : FakeUpstream(nullptr, makeTcpListenSocket(port), type) {
-  log().info("starting fake server on port {}", this->localAddress()->ip()->port());
-}
-
-FakeUpstream::FakeUpstream(Network::Address::IpVersion version, uint32_t port,
-                           FakeHttpConnection::Type type)
-    : FakeUpstream(nullptr, makeTcpListenSocket(version, port), type) {
+FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
+                           Network::Address::IpVersion version)
+    : FakeUpstream(nullptr, makeTcpListenSocket(port, version), type) {
   log().info("starting fake server on port {}. Address version is {}",
              this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -200,9 +200,8 @@ typedef std::unique_ptr<FakeRawConnection> FakeRawConnectionPtr;
 class FakeUpstream : Logger::Loggable<Logger::Id::testing>, public Network::FilterChainFactory {
 public:
   FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type type);
-  FakeUpstream(uint32_t port, FakeHttpConnection::Type type);
-  FakeUpstream(const Network::Address::IpVersion version, uint32_t port,
-               FakeHttpConnection::Type type);
+  FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
+               Network::Address::IpVersion version = Network::Address::IpVersion::v4);
   FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port, FakeHttpConnection::Type type);
   ~FakeUpstream();
 

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -13,6 +13,7 @@ cat "${TEST_RUNDIR}"/test/config/integration/server.json |
   sed -e "s#{{ upstream_. }}#0#g" | \
   sed -e "s#{{ test_rundir }}#$TEST_RUNDIR#" | \
   sed -e "s#{{ ip_loopback_address }}#127.0.0.1#" | \
+  sed -e "s#{{ dns_lookup_family }}#v4_only#" | \
   cat > "${HOT_RESTART_JSON}"
 
 # Now start the real server, hot restart it twice, and shut it all down as a basic hot restart

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -151,7 +151,7 @@ class BaseIntegrationTest : Logger::Loggable<Logger::Id::testing> {
 public:
   BaseIntegrationTest();
   ~BaseIntegrationTest();
-
+  BaseIntegrationTest(Network::Address::IpVersion version);
   /**
    * Integration tests are composed of a sequence of actions which are run via this routine.
    */
@@ -161,73 +161,50 @@ public:
     }
   }
 
-  Network::ClientConnectionPtr
-  makeClientConnection(uint32_t port,
-                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  Network::ClientConnectionPtr makeClientConnection(uint32_t port);
 
-  IntegrationCodecClientPtr
-  makeHttpConnection(uint32_t port, Http::CodecClient::Type type,
-                     Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  IntegrationCodecClientPtr
-  makeHttpConnection(Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-                     Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  IntegrationTcpClientPtr
-  makeTcpConnection(uint32_t port,
-                    Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  IntegrationCodecClientPtr makeHttpConnection(uint32_t port, Http::CodecClient::Type type);
+  IntegrationCodecClientPtr makeHttpConnection(Network::ClientConnectionPtr&& conn,
+                                               Http::CodecClient::Type type);
+  IntegrationTcpClientPtr makeTcpConnection(uint32_t port);
 
   // Test-wide port map.
   void registerPort(const std::string& key, uint32_t port);
   uint32_t lookupPort(const std::string& key);
 
   void registerTestServerPorts(const std::vector<std::string>& port_names);
-  void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names,
-                        Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
 
 protected:
-  void testRouterRedirect(Http::CodecClient::Type type,
-                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterNotFound(Http::CodecClient::Type type,
-                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void
-  testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type,
-                             Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterRequestAndResponseWithBody(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type, uint64_t request_size,
-      uint64_t response_size, bool big_header,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterHeaderOnlyRequestAndResponse(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterUpstreamDisconnectBeforeRequestComplete(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterUpstreamDisconnectBeforeResponseComplete(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterDownstreamDisconnectBeforeRequestComplete(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterDownstreamDisconnectBeforeResponseComplete(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRouterUpstreamResponseBeforeRequestComplete(
-      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
-      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testTwoRequests(Http::CodecClient::Type type,
-                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testBadHttpRequest(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testHttp10Request(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testNoHost(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void
-  testUpstreamProtocolError(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testBadPath(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testDrainClose(Http::CodecClient::Type type,
-                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  void testRetry(Http::CodecClient::Type type,
-                 Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterRedirect(Http::CodecClient::Type type);
+  void testRouterNotFound(Http::CodecClient::Type type);
+  void testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type);
+  void testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
+                                            Http::CodecClient::Type type, uint64_t request_size,
+                                            uint64_t response_size, bool big_header);
+  void testRouterHeaderOnlyRequestAndResponse(Network::ClientConnectionPtr&& conn,
+                                              Http::CodecClient::Type type);
+  void testRouterUpstreamDisconnectBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
+                                                         Http::CodecClient::Type type);
+  void testRouterUpstreamDisconnectBeforeResponseComplete(Network::ClientConnectionPtr&& conn,
+                                                          Http::CodecClient::Type type);
+  void testRouterDownstreamDisconnectBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
+                                                           Http::CodecClient::Type type);
+  void testRouterDownstreamDisconnectBeforeResponseComplete(Network::ClientConnectionPtr&& conn,
+                                                            Http::CodecClient::Type type);
+  void testRouterUpstreamResponseBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
+                                                       Http::CodecClient::Type type);
+  void testTwoRequests(Http::CodecClient::Type type);
+  void testBadHttpRequest();
+  void testHttp10Request();
+  void testNoHost();
+  void testUpstreamProtocolError();
+  void testBadPath();
+  void testDrainClose(Http::CodecClient::Type type);
+  void testRetry(Http::CodecClient::Type type);
 
   // HTTP/2 client tests.
   void testDownstreamResetBeforeResponseComplete();
@@ -237,5 +214,6 @@ protected:
   spdlog::level::level_enum default_log_level_;
   IntegrationTestServerPtr test_server_;
   TestEnvironment::PortMap port_map_;
+  Network::Address::IpVersion version_;
 };
 } // Envoy

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -112,7 +112,8 @@ typedef std::unique_ptr<IntegrationCodecClient> IntegrationCodecClientPtr;
  */
 class IntegrationTcpClient {
 public:
-  IntegrationTcpClient(Event::Dispatcher& dispatcher, uint32_t port);
+  IntegrationTcpClient(Event::Dispatcher& dispatcher, uint32_t port,
+                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   void close();
   const std::string& data() { return data_; }
@@ -160,53 +161,73 @@ public:
     }
   }
 
-  Network::ClientConnectionPtr makeClientConnection(uint32_t port);
+  Network::ClientConnectionPtr
+  makeClientConnection(uint32_t port,
+                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
-  IntegrationCodecClientPtr makeHttpConnection(uint32_t port, Http::CodecClient::Type type);
-  IntegrationCodecClientPtr makeHttpConnection(Network::ClientConnectionPtr&& conn,
-                                               Http::CodecClient::Type type);
-  IntegrationTcpClientPtr makeTcpConnection(uint32_t port);
+  IntegrationCodecClientPtr
+  makeHttpConnection(uint32_t port, Http::CodecClient::Type type,
+                     Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  IntegrationCodecClientPtr
+  makeHttpConnection(Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+                     Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  IntegrationTcpClientPtr
+  makeTcpConnection(uint32_t port,
+                    Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   // Test-wide port map.
   void registerPort(const std::string& key, uint32_t port);
   uint32_t lookupPort(const std::string& key);
 
   void registerTestServerPorts(const std::vector<std::string>& port_names);
-  // TODO(hennna): Deprecate when IPv6 test support is finished.
-  void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);
-  void createTestServer(const std::string& json_path, const Network::Address::IpVersion version,
-                        const std::vector<std::string>& port_names);
+  void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names,
+                        Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
 
 protected:
-  void testRouterRedirect(Http::CodecClient::Type type);
-  void testRouterNotFound(Http::CodecClient::Type type);
-  void testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type);
-  void testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
-                                            Http::CodecClient::Type type, uint64_t request_size,
-                                            uint64_t response_size, bool big_header);
-  void testRouterHeaderOnlyRequestAndResponse(Network::ClientConnectionPtr&& conn,
-                                              Http::CodecClient::Type type);
-  void testRouterUpstreamDisconnectBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
-                                                         Http::CodecClient::Type type);
-  void testRouterUpstreamDisconnectBeforeResponseComplete(Network::ClientConnectionPtr&& conn,
-                                                          Http::CodecClient::Type type);
-  void testRouterDownstreamDisconnectBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
-                                                           Http::CodecClient::Type type);
-  void testRouterDownstreamDisconnectBeforeResponseComplete(Network::ClientConnectionPtr&& conn,
-                                                            Http::CodecClient::Type type);
-  void testRouterUpstreamResponseBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
-                                                       Http::CodecClient::Type type);
-  void testTwoRequests(Http::CodecClient::Type type);
-  void testBadHttpRequest();
-  void testHttp10Request();
-  void testNoHost();
-  void testUpstreamProtocolError();
-  void testBadPath();
-  void testDrainClose(Http::CodecClient::Type type);
-  void testRetry(Http::CodecClient::Type type);
+  void testRouterRedirect(Http::CodecClient::Type type,
+                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterNotFound(Http::CodecClient::Type type,
+                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void
+  testRouterNotFoundWithBody(uint32_t port, Http::CodecClient::Type type,
+                             Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterRequestAndResponseWithBody(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type, uint64_t request_size,
+      uint64_t response_size, bool big_header,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterHeaderOnlyRequestAndResponse(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterUpstreamDisconnectBeforeRequestComplete(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterUpstreamDisconnectBeforeResponseComplete(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterDownstreamDisconnectBeforeRequestComplete(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterDownstreamDisconnectBeforeResponseComplete(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRouterUpstreamResponseBeforeRequestComplete(
+      Network::ClientConnectionPtr&& conn, Http::CodecClient::Type type,
+      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testTwoRequests(Http::CodecClient::Type type,
+                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testBadHttpRequest(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testHttp10Request(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testNoHost(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void
+  testUpstreamProtocolError(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testBadPath(Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testDrainClose(Http::CodecClient::Type type,
+                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  void testRetry(Http::CodecClient::Type type,
+                 Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   // HTTP/2 client tests.
   void testDownstreamResetBeforeResponseComplete();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -1,67 +1,73 @@
+#include "test/integration/integration_admin_test.h"
+
 #include "envoy/http/header_map.h"
 
 #include "common/json/json_loader.h"
 
-#include "test/integration/integration_test.h"
 #include "test/integration/utility.h"
 
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {
-TEST_F(IntegrationTest, HealthCheck) {
+
+INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationAdminTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(IntegrationAdminTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/healthcheck", "", Http::CodecClient::Type::HTTP1);
+      lookupPort("http"), "GET", "/healthcheck", "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/fail", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/ok", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http_buffer"), "GET", "/healthcheck",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
-TEST_F(IntegrationTest, AdminLogging) {
+TEST_P(IntegrationAdminTest, AdminLogging) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/logging", "", Http::CodecClient::Type::HTTP1);
+      lookupPort("admin"), "GET", "/logging", "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad level
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?level=blah",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad logger
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?blah=info",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // This is going to stomp over custom log levels that are set on the command line.
-  response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/logging?level=warning", "", Http::CodecClient::Type::HTTP1);
+  response =
+      IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?level=warning", "",
+                                         Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -69,7 +75,7 @@ TEST_F(IntegrationTest, AdminLogging) {
   }
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?assert=trace",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
@@ -77,7 +83,7 @@ TEST_F(IntegrationTest, AdminLogging) {
   const char* level_name = spdlog::level::level_names[default_log_level_];
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET",
                                                 fmt::format("/logging?level={}", level_name), "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -85,49 +91,49 @@ TEST_F(IntegrationTest, AdminLogging) {
   }
 }
 
-TEST_F(IntegrationTest, Admin) {
+TEST_P(IntegrationAdminTest, Admin) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/", "", Http::CodecClient::Type::HTTP1);
+      lookupPort("admin"), "GET", "/", "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/server_info", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("400", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/hot_restart_version",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/reset_counters", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/certs", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/listeners", "",
-                                                Http::CodecClient::Type::HTTP1);
+                                                Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
@@ -142,14 +148,15 @@ TEST_F(IntegrationTest, Admin) {
 // Successful call to startProfiler requires tcmalloc.
 #ifdef TCMALLOC
 
-TEST_F(IntegrationTest, AdminCpuProfilerStart) {
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/cpuprofiler?enable=y", "", Http::CodecClient::Type::HTTP1);
+TEST_P(IntegrationAdminTest, AdminCpuProfilerStart) {
+  BufferingStreamDecoderPtr response =
+      IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler?enable=y", "",
+                                         Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler?enable=n",
-                                                "", Http::CodecClient::Type::HTTP1);
+                                                "", Http::CodecClient::Type::HTTP1, GetParam());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -16,58 +16,58 @@ INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationAdminTest,
 
 TEST_P(IntegrationAdminTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/healthcheck", "", Http::CodecClient::Type::HTTP1, GetParam());
+      lookupPort("http"), "GET", "/healthcheck", "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/fail", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/ok", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http_buffer"), "GET", "/healthcheck",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(IntegrationAdminTest, AdminLogging) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/logging", "", Http::CodecClient::Type::HTTP1, GetParam());
+      lookupPort("admin"), "GET", "/logging", "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad level
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?level=blah",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad logger
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?blah=info",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // This is going to stomp over custom log levels that are set on the command line.
   response =
       IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?level=warning", "",
-                                         Http::CodecClient::Type::HTTP1, GetParam());
+                                         Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -75,7 +75,7 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   }
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?assert=trace",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
@@ -83,7 +83,7 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   const char* level_name = spdlog::level::level_names[default_log_level_];
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET",
                                                 fmt::format("/logging?level={}", level_name), "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -93,47 +93,47 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
 
 TEST_P(IntegrationAdminTest, Admin) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/", "", Http::CodecClient::Type::HTTP1, GetParam());
+      lookupPort("admin"), "GET", "/", "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/server_info", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("400", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/hot_restart_version",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/reset_counters", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/certs", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/listeners", "",
-                                                Http::CodecClient::Type::HTTP1, GetParam());
+                                                Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
@@ -151,12 +151,12 @@ TEST_P(IntegrationAdminTest, Admin) {
 TEST_P(IntegrationAdminTest, AdminCpuProfilerStart) {
   BufferingStreamDecoderPtr response =
       IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler?enable=y", "",
-                                         Http::CodecClient::Type::HTTP1, GetParam());
+                                         Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler?enable=n",
-                                                "", Http::CodecClient::Type::HTTP1, GetParam());
+                                                "", Http::CodecClient::Type::HTTP1, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -5,8 +5,9 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-class IntegrationTest : public BaseIntegrationTest,
-                        public testing::TestWithParam<Network::Address::IpVersion> {
+
+class IntegrationAdminTest : public BaseIntegrationTest,
+                             public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   /**
    * Initializer for an individual test.
@@ -28,4 +29,5 @@ public:
     fake_upstreams_.clear();
   }
 };
+
 } // Envoy

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -9,6 +9,7 @@ namespace Envoy {
 class IntegrationAdminTest : public BaseIntegrationTest,
                              public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  IntegrationAdminTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */
@@ -18,7 +19,7 @@ public:
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server.json",
-                     {"http", "http_buffer", "tcp_proxy", "rds"}, GetParam());
+                     {"http", "http_buffer", "tcp_proxy", "rds"});
   }
 
   /**

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -15,30 +15,25 @@ namespace Envoy {
 INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-TEST_P(IntegrationTest, RouterNotFound) {
-  testRouterNotFound(Http::CodecClient::Type::HTTP1, GetParam());
-}
+TEST_P(IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP1); }
 
 TEST_P(IntegrationTest, RouterNotFoundBodyNoBuffer) {
-  testRouterNotFoundWithBody(lookupPort("http"), Http::CodecClient::Type::HTTP1, GetParam());
+  testRouterNotFoundWithBody(lookupPort("http"), Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterNotFoundBodyBuffer) {
-  testRouterNotFoundWithBody(lookupPort("http_buffer"), Http::CodecClient::Type::HTTP1, GetParam());
+  testRouterNotFoundWithBody(lookupPort("http_buffer"), Http::CodecClient::Type::HTTP1);
 }
 
-TEST_P(IntegrationTest, RouterRedirect) {
-  testRouterRedirect(Http::CodecClient::Type::HTTP1, GetParam());
-}
+TEST_P(IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP1); }
 
-TEST_P(IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP1, GetParam()); }
+TEST_P(IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP1); }
 
 TEST_P(IntegrationTest, ConnectionClose) {
   IntegrationCodecClientPtr codec_client;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
   executeActions({[&]() -> void {
-    codec_client =
-        makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1, GetParam());
+    codec_client = makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1);
   },
                   [&]() -> void {
                     codec_client->makeHeaderOnlyRequest(
@@ -56,90 +51,80 @@ TEST_P(IntegrationTest, ConnectionClose) {
 }
 
 TEST_P(IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http"), GetParam()),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, false,
-                                       GetParam());
+  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
 }
 
 TEST_P(IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer"), GetParam()),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, false,
-                                       GetParam());
+  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, false);
 }
 
 TEST_P(IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer"), GetParam()),
+  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
                                        Http::CodecClient::Type::HTTP1, 4 * 1024 * 1024,
-                                       4 * 1024 * 1024, false, GetParam());
+                                       4 * 1024 * 1024, false);
 }
 
 TEST_P(IntegrationTest, RouterRequestAndResponseLargeHeaderNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http"), GetParam()),
-                                       Http::CodecClient::Type::HTTP1, 1024, 512, true, GetParam());
+  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
+                                       Http::CodecClient::Type::HTTP1, 1024, 512, true);
 }
 
 TEST_P(IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
-  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http"), GetParam()),
-                                         Http::CodecClient::Type::HTTP1, GetParam());
+  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http")),
+                                         Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
-  testRouterHeaderOnlyRequestAndResponse(
-      makeClientConnection(lookupPort("http_buffer"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http_buffer")),
+                                         Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
-  testRouterUpstreamDisconnectBeforeRequestComplete(
-      makeClientConnection(lookupPort("http"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterUpstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
+                                                    Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
-  testRouterUpstreamDisconnectBeforeResponseComplete(
-      makeClientConnection(lookupPort("http"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterUpstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
+                                                     Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
-  testRouterDownstreamDisconnectBeforeRequestComplete(
-      makeClientConnection(lookupPort("http"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterDownstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
+                                                      Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
-  testRouterDownstreamDisconnectBeforeResponseComplete(
-      makeClientConnection(lookupPort("http"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterDownstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
+                                                       Http::CodecClient::Type::HTTP1);
 }
 
 TEST_P(IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
-  testRouterUpstreamResponseBeforeRequestComplete(
-      makeClientConnection(lookupPort("http"), GetParam()), Http::CodecClient::Type::HTTP1,
-      GetParam());
+  testRouterUpstreamResponseBeforeRequestComplete(makeClientConnection(lookupPort("http")),
+                                                  Http::CodecClient::Type::HTTP1);
 }
 
-TEST_P(IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP1, GetParam()); }
+TEST_P(IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP1); }
 
-TEST_P(IntegrationTest, TwoRequests) {
-  testTwoRequests(Http::CodecClient::Type::HTTP1, GetParam());
-}
+TEST_P(IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP1); }
 
-TEST_P(IntegrationTest, BadHttpRequest) { testBadHttpRequest(GetParam()); }
+TEST_P(IntegrationTest, BadHttpRequest) { testBadHttpRequest(); }
 
-TEST_P(IntegrationTest, Http10Request) { testHttp10Request(GetParam()); }
+TEST_P(IntegrationTest, Http10Request) { testHttp10Request(); }
 
-TEST_P(IntegrationTest, NoHost) { testNoHost(GetParam()); }
+TEST_P(IntegrationTest, NoHost) { testNoHost(); }
 
-TEST_P(IntegrationTest, BadPath) { testBadPath(GetParam()); }
+TEST_P(IntegrationTest, BadPath) { testBadPath(); }
 
-TEST_P(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(GetParam()); }
+TEST_P(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 
 TEST_P(IntegrationTest, TcpProxyUpstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
   executeActions(
-      {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy"), GetParam()); },
+      {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },
@@ -155,7 +140,7 @@ TEST_P(IntegrationTest, TcpProxyDownstreamDisconnect) {
   IntegrationTcpClientPtr tcp_client;
   FakeRawConnectionPtr fake_upstream_connection;
   executeActions(
-      {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy"), GetParam()); },
+      {[&]() -> void { tcp_client = makeTcpConnection(lookupPort("tcp_proxy")); },
        [&]() -> void { tcp_client->write("hello"); },
        [&]() -> void { fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection(); },
        [&]() -> void { fake_upstream_connection->waitForData(5); },

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -8,6 +8,7 @@ namespace Envoy {
 class IntegrationTest : public BaseIntegrationTest,
                         public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  IntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */
@@ -17,7 +18,7 @@ public:
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server.json",
-                     {"http", "http_buffer", "tcp_proxy", "rds"}, GetParam());
+                     {"http", "http_buffer", "tcp_proxy", "rds"});
   }
 
   /**

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -56,9 +56,8 @@ IntegrationTestServer::~IntegrationTestServer() {
   log().info("stopping integration test server");
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      server_->admin().socket().localAddress()->ip()->version(),
       server_->admin().socket().localAddress()->ip()->port(), "GET", "/quitquitquit", "",
-      Http::CodecClient::Type::HTTP1);
+      Http::CodecClient::Type::HTTP1, server_->admin().socket().localAddress()->ip()->version());
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -51,19 +51,10 @@ void BufferingStreamDecoder::onComplete() {
 
 void BufferingStreamDecoder::onResetStream(Http::StreamResetReason) { ADD_FAILURE(); }
 
-// TODO(hennna): Deprecate when Ipv6 test support is finished.
 BufferingStreamDecoderPtr
 IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, const std::string& url,
                                    const std::string& body, Http::CodecClient::Type type,
-                                   const std::string& host) {
-  return makeSingleRequest(Network::Address::IpVersion::v4, port, method, url, body, type, host);
-}
-
-BufferingStreamDecoderPtr
-IntegrationUtil::makeSingleRequest(const Network::Address::IpVersion version, uint32_t port,
-                                   const std::string& method, const std::string& url,
-                                   const std::string& body, Http::CodecClient::Type type,
-                                   const std::string& host) {
+                                   Network::Address::IpVersion version, const std::string& host) {
   Api::Impl api(std::chrono::milliseconds(9000));
   Event::DispatcherPtr dispatcher(api.allocateDispatcher());
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
@@ -94,9 +85,9 @@ IntegrationUtil::makeSingleRequest(const Network::Address::IpVersion version, ui
   return response;
 }
 
-RawConnectionDriver::RawConnectionDriver(uint32_t port, const Network::Address::IpVersion version,
-                                         Buffer::Instance& initial_data,
-                                         ReadCallback data_callback) {
+RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data,
+                                         ReadCallback data_callback,
+                                         Network::Address::IpVersion version) {
   api_.reset(new Api::Impl(std::chrono::milliseconds(10000)));
   dispatcher_ = api_->allocateDispatcher();
   client_ = dispatcher_->createClientConnection(Network::Utility::resolveUrl(
@@ -105,11 +96,6 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, const Network::Address::
   client_->write(initial_data);
   client_->connect();
 }
-
-// TODO(hennna): Deprecate when IPv6 test support is finished.
-RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data,
-                                         ReadCallback data_callback)
-    : RawConnectionDriver(port, Network::Address::IpVersion::v4, initial_data, data_callback) {}
 
 RawConnectionDriver::~RawConnectionDriver() {}
 

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -53,10 +53,8 @@ class RawConnectionDriver {
 public:
   typedef std::function<void(Network::ClientConnection&, const Buffer::Instance&)> ReadCallback;
 
-  // TODO(hennna): Deprecate when IPv6 test support is finished.
-  RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data, ReadCallback data_callback);
-  RawConnectionDriver(uint32_t port, const Network::Address::IpVersion version,
-                      Buffer::Instance& initial_data, ReadCallback data_callback);
+  RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data, ReadCallback data_callback,
+                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
   ~RawConnectionDriver();
   void run();
   void close();
@@ -89,25 +87,20 @@ class IntegrationUtil {
 public:
   /**
    * Make a new connection, issues a request, and then disconnect when the request is complete.
-   * @param version the IP addess version of the client and server.
    * @param port supplies the port to connect to on localhost.
    * @param method supplies the request method.
    * @param url supplies the request url.
    * @param body supplies the optional request body to send.
    * @param type supplies the codec to use for the request.
+   * @param version the IP addess version of the client and server.
    * @param host supplies the host header to use for the request.
    * @return BufferingStreamDecoderPtr the complete request or a partial request if there was
    *         remote easly disconnection.
    */
   static BufferingStreamDecoderPtr
-  makeSingleRequest(const Network::Address::IpVersion version, uint32_t port,
-                    const std::string& method, const std::string& url, const std::string& body,
-                    Http::CodecClient::Type type, const std::string& host = "host");
-  // TODO(henna): Deprecate when IPv6 test support is finished.
-  static BufferingStreamDecoderPtr makeSingleRequest(uint32_t port, const std::string& method,
-                                                     const std::string& url,
-                                                     const std::string& body,
-                                                     Http::CodecClient::Type type,
-                                                     const std::string& host = "host");
+  makeSingleRequest(uint32_t port, const std::string& method, const std::string& url,
+                    const std::string& body, Http::CodecClient::Type type,
+                    Network::Address::IpVersion version = Network::Address::IpVersion::v4,
+                    const std::string& host = "host");
 };
 } // Envoy

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -118,15 +118,9 @@ std::string TestEnvironment::substitute(const std::string str) {
   return out_json_string;
 }
 
-// TODO(hennna): Deprecate when IPv6 test support is finished.
 std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
-                                                     const PortMap& port_map) {
-  return TestEnvironment::temporaryFileSubstitute(path, Network::Address::IpVersion::v4, port_map);
-}
-
-std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
-                                                     const Network::Address::IpVersion& version,
-                                                     const PortMap& port_map) {
+                                                     const PortMap& port_map,
+                                                     Network::Address::IpVersion version) {
   // Load the entire file as a string, regex replace one at a time and write it back out. Proper
   // templating might be better one day, but this works for now.
   const std::string json_path = TestEnvironment::runfilesPath(path);
@@ -152,6 +146,16 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   const std::regex loopback_address_regex("\\{\\{ ip_loopback_address \\}\\}");
   out_json_string = std::regex_replace(out_json_string, loopback_address_regex,
                                        Network::Test::getLoopbackAddressUrlString(version));
+
+  // Substitute dns lookup family.
+  const std::regex lookup_family_regex("\\{\\{ dns_lookup_family \\}\\}");
+  switch (version) {
+  case Network::Address::IpVersion::v4:
+    out_json_string = std::regex_replace(out_json_string, lookup_family_regex, "v4_only");
+  case Network::Address::IpVersion::v6:
+    out_json_string = std::regex_replace(out_json_string, lookup_family_regex, "v6_only");
+  }
+  // std::cout << out_json_string << std::endl;
   // Substitute paths.
   out_json_string = substitute(out_json_string);
   const std::string out_json_path = TestEnvironment::temporaryPath(path + ".with.ports.json");

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -155,7 +155,7 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   case Network::Address::IpVersion::v6:
     out_json_string = std::regex_replace(out_json_string, lookup_family_regex, "v6_only");
   }
-  // std::cout << out_json_string << std::endl;
+
   // Substitute paths.
   out_json_string = substitute(out_json_string);
   const std::string out_json_path = TestEnvironment::temporaryPath(path + ".with.ports.json");

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -104,26 +104,17 @@ public:
    */
   static std::string substitute(const std::string str);
 
-  // TODO(hennna): Deprecate after IPv6 test support is finished.
-  /**
-   * Substitue ports and paths in a JSON file in the private writable test temporary directory.
-   * @param path path prefix for the input file with port and path templates.
-   * @param port_map map from port name to port number.
-   * @return std::string path for the generated file.
-   */
-  static std::string temporaryFileSubstitute(const std::string& path, const PortMap& port_map);
-
   /**
    * Substitue ports, paths, and IP loopback addressses in a JSON file in the
    * private writable test temporary directory.
    * @param path path prefix for the input file with port and path templates.
-   * @param version IP address version to substitute.
    * @param port_map map from port name to port number.
+   * @param version IP address version to substitute.
    * @return std::string path for the generated file.
    */
-  static std::string temporaryFileSubstitute(const std::string& path,
-                                             const Network::Address::IpVersion& version,
-                                             const PortMap& port_map);
+  static std::string
+  temporaryFileSubstitute(const std::string& path, const PortMap& port_map,
+                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   /**
    * Build JSON object from a string subject to environment path substitution.


### PR DESCRIPTION
This PR parameterizes two integration tests: integration_test.cc and integration_admin_test.cc. The majority of the line changes are plumbing through the parameter `version` to allow code that originally hard coded an IPv4 address to now be parameterized.

This is the second step in parameterizing IPv4 and IPv6 testing in the integration tests. The first step was parameterizing the echo_integration_test in #953 . In this PR, we update many of the functions in integration.cc that are called in integration_test.cc to take the parameter `version`. Because other integration tests currently also rely on these functions, we set the default value to be Network::Address::IpVersion::v4. In a subsequent PR, we will also parameterize the other integration tests and the default value will be removed.

The constructor for RawConnectionDriver and function makeSingleRequest in test/integration/utility.h were also updated to set the default version value to v4. This required reordering the function parameters.

createTestServer and temporaryFileSubstitute were also updated in a similar fashion.

asan and tsan tests passing requires https://github.com/lyft/envoy-filter-example/pull/4/files due to dependence on changes made in this PR.

Supports ongoing work in #351 