### PR TITLE
Refactor main() into site specific and common code.

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -17,7 +17,7 @@ alias(
 envoy_cc_binary(
     name = "envoy-static",
     stamped = True,
-    deps = ["envoy_main_lib"],
+    deps = ["envoy_main_entry_lib"],
 )
 
 envoy_cc_library(
@@ -53,17 +53,28 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "envoy_main_lib",
+    name = "envoy_main_entry_lib",
     srcs = ["main.cc"],
     deps = [
-        "//source/common/common:compiler_requirements_lib",
-        ":envoy_common_lib",
+        ":envoy_main_common_lib",
         ":hot_restart_lib",
-        "//source/server/config_validation:server_lib",
+        "//source/server:options_lib",
     ] + select({
         "//bazel:disable_signal_trace": [],
         "//conditions:default": [":sigaction_lib"],
     }),
+)
+
+envoy_cc_library(
+    name = "envoy_main_common_lib",
+    srcs = ["main_common.cc"],
+    hdrs = ["main_common.h"],
+    deps = [
+        ":envoy_common_lib",
+        ":hot_restart_lib",
+        "//source/common/common:compiler_requirements_lib",
+        "//source/server/config_validation:server_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,70 +1,34 @@
 #include <iostream>
 #include <memory>
 
-#include "common/common/compiler_requirements.h"
-#include "common/event/libevent.h"
-#include "common/local_info/local_info_impl.h"
-#include "common/network/utility.h"
-#include "common/stats/stats_impl.h"
-#include "common/stats/thread_local_store.h"
-
 #include "exe/hot_restart.h"
+#include "exe/main_common.h"
 
 #ifdef ENVOY_HANDLE_SIGNALS
 #include "exe/signal_action.h"
 #endif
 
-#include "server/config_validation/server.h"
-#include "server/drain_manager_impl.h"
 #include "server/options_impl.h"
-#include "server/server.h"
-#include "server/test_hooks.h"
 
-#include "ares.h"
 #include "spdlog/spdlog.h"
 
-namespace Envoy {
-namespace Server {
+// NOLINT(namespace-envoy)
 
-class ProdComponentFactory : public ComponentFactory {
-public:
-  // Server::DrainManagerFactory
-  DrainManagerPtr createDrainManager(Instance& server) override {
-    return DrainManagerPtr{new DrainManagerImpl(server)};
-  }
-
-  Runtime::LoaderPtr createRuntime(Server::Instance& server,
-                                   Server::Configuration::Initial& config) override {
-    return Server::InstanceUtil::createRuntime(server, config);
-  }
-};
-
-} // Server
-} // Envoy
-
+/**
+ * Basic Site-Specific main()
+ *
+ * This should be used to do setup tasks specific to a particular site's
+ * deployment such as initializing signal handling.  It calls main_common
+ * after setting up command line options and the hot restarter.
+ */
 int main(int argc, char** argv) {
 #ifdef ENVOY_HANDLE_SIGNALS
   // Enabled by default. Control with "bazel --define=signal_trace=disabled"
   Envoy::SignalAction handle_sigs;
 #endif
-  Envoy::Event::Libevent::Global::initialize();
+
   Envoy::OptionsImpl options(argc, argv, Envoy::Server::SharedMemory::version(),
                              spdlog::level::warn);
-  Envoy::Server::ProdComponentFactory component_factory;
-  Envoy::LocalInfo::LocalInfoImpl local_info(
-      Envoy::Network::Utility::getLocalAddress(Envoy::Network::Address::IpVersion::v4),
-      options.serviceZone(), options.serviceClusterName(), options.serviceNodeName());
-
-  switch (options.mode()) {
-  case Envoy::Server::Mode::Serve:
-    break;
-  case Envoy::Server::Mode::Validate:
-    Envoy::Thread::MutexBasicLockable log_lock;
-    Envoy::Logger::Registry::initialize(options.logLevel(), log_lock);
-    return Envoy::Server::validateConfig(options, component_factory, local_info) ? 0 : 1;
-  }
-
-  ares_library_init(ARES_LIB_INIT_ALL);
 
   std::unique_ptr<Envoy::Server::HotRestartImpl> restarter;
   try {
@@ -74,13 +38,5 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  Envoy::Logger::Registry::initialize(options.logLevel(), restarter->logLock());
-  Envoy::DefaultTestHooks default_test_hooks;
-  Envoy::Stats::ThreadLocalStoreImpl stats_store(*restarter);
-  // TODO(henna): Add CLI option for local address IP version.
-  Envoy::Server::InstanceImpl server(options, default_test_hooks, *restarter, stats_store,
-                                     restarter->accessLogLock(), component_factory, local_info);
-  server.run();
-  ares_library_cleanup();
-  return 0;
+  return Envoy::main_common(options, *restarter);
 }

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <memory>
+
+#include "common/common/compiler_requirements.h"
+#include "common/event/libevent.h"
+#include "common/local_info/local_info_impl.h"
+#include "common/network/utility.h"
+#include "common/stats/stats_impl.h"
+#include "common/stats/thread_local_store.h"
+
+#include "exe/hot_restart.h"
+
+#include "server/config_validation/server.h"
+#include "server/drain_manager_impl.h"
+#include "server/options_impl.h"
+#include "server/server.h"
+#include "server/test_hooks.h"
+
+#include "ares.h"
+#include "spdlog/spdlog.h"
+
+namespace Envoy {
+namespace Server {
+
+class ProdComponentFactory : public ComponentFactory {
+public:
+  // Server::DrainManagerFactory
+  DrainManagerPtr createDrainManager(Instance& server) override {
+    return DrainManagerPtr{new DrainManagerImpl(server)};
+  }
+
+  Runtime::LoaderPtr createRuntime(Server::Instance& server,
+                                   Server::Configuration::Initial& config) override {
+    return Server::InstanceUtil::createRuntime(server, config);
+  }
+};
+
+} // Server
+
+int main_common(Envoy::OptionsImpl& options, Envoy::Server::HotRestartImpl& restarter) {
+  Envoy::Event::Libevent::Global::initialize();
+  Envoy::Server::ProdComponentFactory component_factory;
+  Envoy::LocalInfo::LocalInfoImpl local_info(
+      Envoy::Network::Utility::getLocalAddress(Envoy::Network::Address::IpVersion::v4),
+      options.serviceZone(), options.serviceClusterName(), options.serviceNodeName());
+
+  switch (options.mode()) {
+  case Envoy::Server::Mode::Serve:
+    break;
+  case Envoy::Server::Mode::Validate:
+    Envoy::Thread::MutexBasicLockable log_lock;
+    Envoy::Logger::Registry::initialize(options.logLevel(), log_lock);
+    return Envoy::Server::validateConfig(options, component_factory, local_info) ? 0 : 1;
+  }
+
+  ares_library_init(ARES_LIB_INIT_ALL);
+
+  Envoy::Logger::Registry::initialize(options.logLevel(), restarter.logLock());
+  Envoy::DefaultTestHooks default_test_hooks;
+  Envoy::Stats::ThreadLocalStoreImpl stats_store(restarter);
+  // TODO(henna): Add CLI option for local address IP version.
+  Envoy::Server::InstanceImpl server(options, default_test_hooks, restarter, stats_store,
+                                     restarter.accessLogLock(), component_factory, local_info);
+  server.run();
+  ares_library_cleanup();
+  return 0;
+}
+
+} // Envoy

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "exe/hot_restart.h"
+
+#include "server/options_impl.h"
+
+namespace Envoy {
+/**
+ * This is the real main body that executes after site-specific
+ * main() runs.
+ *
+ * @param options Options object initialized by site-specific code
+ * @param restarter HotRestart object initialized in site-specific code.
+ * @return int Return code that should be returned from the actual main()
+ */
+int main_common(Envoy::OptionsImpl& options, Envoy::Server::HotRestartImpl& restarter);
+
+} // Envoy


### PR DESCRIPTION
The actual main() entry point is reduced to some basic setup code that
can be substituted out as a module when more complex executable setup
is required with certain site's deployments.  Left in main() is
SignalAction initialization, Options parsing, and HotRestarter
allocation.  Everything else is moved into main_common().

A future commit will further shift the hot restart related code into
the site-specific main() so deployments not using hot restart do not
have to depend on the code.

This is a purely mechanical refactoring, no logic is changed.