### PR TITLE
build: fix envoy api dep

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,5 +6,5 @@ load("//bazel:cc_configure.bzl", "cc_configure")
 envoy_dependencies()
 cc_configure()
 
-load("@envoy_api_git//bazel:repositories.bzl", "api_dependencies")
+load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -83,13 +83,13 @@ def python_deps(skip_targets):
 def envoy_api_deps(skip_targets):
   if 'envoy_api' not in skip_targets:
     native.git_repository(
-        name = "envoy_api_git",
+        name = "envoy_api",
         remote = "https://github.com/lyft/envoy-api.git",
-        commit = "959278cc35a89a4d2f1895f66a59c6b3de98d5e1",
+        commit = "7506a93e2cbe4a987af5b9ff489462959697c121",
     )
     native.bind(
         name = "envoy_eds",
-        actual = "@envoy_api_git//api:eds",
+        actual = "@envoy_api//api:eds",
     )
 
 def envoy_dependencies(path = "@envoy_deps//", skip_protobuf_bzl = False, skip_targets = []):


### PR DESCRIPTION
@htuch we forgot to update the sha for the dependency after updating the envoy api PR, so the referenced sha is out of sync. I am actually curious as to why CI did not fail, although haven't explored that at all yet.

I also noticed that if we give the dep a name different than the one in its own WORKSPACE bazel complains with `WARNING: /home/junr03/.cache/bazel/_bazel_junr03/5acf8b8c9bd7e76ecced4d8107574707/external/envoy_api_git/WORKSPACE:1: Workspace name in /home/junr03/.cache/bazel/_bazel_junr03/5acf8b8c9bd7e76ecced4d8107574707/external/envoy_api_git/WORKSPACE (@envoy_api) does not match the name given in the repository's definition (@envoy_api_git); this will cause a build error in future versions.` So I fixed in this change as well.