### PR TITLE
test: server test and integration test ipv6

### DIFF
--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -1,13 +1,13 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
       { "type": "read", "name": "echo", "config": {} }
     ]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -88,7 +88,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -175,7 +175,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
       { "type": "read", "name":
         "tcp_proxy",
@@ -193,8 +193,8 @@
     ]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:0" },
-  "statsd_local_udp_port": 8125,
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
   "statsd_tcp_cluster_name": "statsd",
   "tracing": {
     "http": {
@@ -221,13 +221,14 @@
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://127.0.0.1:{{ upstream_0 }}"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
     },
     {
       "name": "cluster_2",
       "connect_timeout_ms": 5000,
       "type": "logical_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:{{ upstream_1 }}"}]
     },
     {
@@ -235,6 +236,7 @@
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:10009"}]
     },
     {
@@ -243,6 +245,7 @@
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:10010"}]
     }]
   }

--- a/test/config/integration/server_http2_upstream.json
+++ b/test/config/integration/server_http2_upstream.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -82,7 +82,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -169,7 +169,7 @@
     }]
   },
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -255,7 +255,7 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:0" },
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
 
   "cluster_manager": {
     "clusters": [
@@ -265,7 +265,7 @@
       "type": "static",
       "lb_type": "round_robin",
       "features": "http2",
-      "hosts": [{"url": "tcp://127.0.0.1:{{ upstream_0 }}"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
     },
     {
       "name": "cluster_2",
@@ -273,6 +273,7 @@
       "type": "strict_dns",
       "lb_type": "round_robin",
       "features": "http2",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:{{ upstream_1 }}"}]
     }]
   }

--- a/test/config/integration/server_proxy_proto.json
+++ b/test/config/integration/server_proxy_proto.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "use_proxy_proto": true,
     "filters": [
     {
@@ -82,8 +82,8 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:0" },
-  "statsd_local_udp_port": 8125,
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
 
   "cluster_manager": {
     "clusters": [
@@ -92,13 +92,14 @@
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://127.0.0.1:{{ upstream_0 }}"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
     },
     {
       "name": "cluster_2",
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:11001"}]
     }]
   }

--- a/test/config/integration/server_ssl.json
+++ b/test/config/integration/server_ssl.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "ssl_context": {
       "ca_cert_file": "{{ test_rundir }}/test/config/integration/certs/cacert.pem",
       "cert_chain_file": "{{ test_rundir }}/test/config/integration/certs/servercert.pem",
@@ -89,8 +89,8 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:0" },
-  "statsd_local_udp_port": 8125,
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
 
   "cluster_manager": {
     "clusters": [
@@ -103,7 +103,7 @@
       },
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://127.0.0.1:{{ upstream_0 }}"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
     },
     {
       "name": "cluster_2",
@@ -114,6 +114,7 @@
       },
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:{{ upstream_1 }}"}]
     }]
   }

--- a/test/config/integration/server_uds.json
+++ b/test/config/integration/server_uds.json
@@ -1,7 +1,7 @@
 {
   "listeners": [
   {
-    "address": "tcp://127.0.0.1:0",
+    "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
       "type": "read",
@@ -81,8 +81,8 @@
     }]
   }],
 
-  "admin": { "access_log_path": "/dev/null", "address": "tcp://127.0.0.1:0" },
-  "statsd_local_udp_port": 8125,
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
 
   "cluster_manager": {
     "clusters": [

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -10,9 +10,9 @@ public:
     * Initializer for an individual test.
     */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/echo_server.json", {"echo"});
   }
@@ -37,7 +37,7 @@ TEST_P(EchoIntegrationTest, Hello) {
       buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         connection.close();
-      }, GetParam());
+      }, version_);
 
   connection.run();
   EXPECT_EQ("hello", response);

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -200,9 +200,8 @@ FakeUpstream::FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type
   log().info("starting fake server on unix domain socket {}", uds_path);
 }
 
-static Network::ListenSocketPtr
-makeTcpListenSocket(uint32_t port,
-                    Network::Address::IpVersion version = Network::Address::IpVersion::v4) {
+static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port,
+                                                    Network::Address::IpVersion version) {
   return Network::ListenSocketPtr{new Network::TcpListenSocket(
       Network::Utility::parseInternetAddressAndPort(
           fmt::format("{}:{}", Network::Test::getAnyAddressUrlString(version), port)),
@@ -217,9 +216,10 @@ FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port,
-                           FakeHttpConnection::Type type)
-    : FakeUpstream(ssl_ctx, makeTcpListenSocket(port), type) {
-  log().info("starting fake SSL server on port {}", this->localAddress()->ip()->port());
+                           FakeHttpConnection::Type type, Network::Address::IpVersion version)
+    : FakeUpstream(ssl_ctx, makeTcpListenSocket(port, version), type) {
+  log().info("starting fake SSL server on port {}. Address version is {}",
+             this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr&& listen_socket,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -200,9 +200,9 @@ typedef std::unique_ptr<FakeRawConnection> FakeRawConnectionPtr;
 class FakeUpstream : Logger::Loggable<Logger::Id::testing>, public Network::FilterChainFactory {
 public:
   FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type type);
-  FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
-               Network::Address::IpVersion version = Network::Address::IpVersion::v4);
-  FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port, FakeHttpConnection::Type type);
+  FakeUpstream(uint32_t port, FakeHttpConnection::Type type, Network::Address::IpVersion version);
+  FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port, FakeHttpConnection::Type type,
+               Network::Address::IpVersion version);
   ~FakeUpstream();
 
   FakeHttpConnection::Type httpType() { return http_type_; }

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -138,7 +138,7 @@ TEST_P(Http2IntegrationTest, BadMagic) {
       lookupPort("http"),
       buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
-      }, GetParam());
+      }, version_);
 
   connection.run();
   EXPECT_EQ("", response);
@@ -151,7 +151,7 @@ TEST_P(Http2IntegrationTest, BadFrame) {
       lookupPort("http"),
       buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
-      }, GetParam());
+      }, version_);
 
   connection.run();
   EXPECT_TRUE(response.find("SETTINGS expected") != std::string::npos);

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -13,81 +13,85 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-TEST_F(Http2IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2IntegrationTest, RouterNotFoundBodyNoBuffer) {
+INSTANTIATE_TEST_CASE_P(IpVersions, Http2IntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(Http2IntegrationTest, RouterNotFound) { testRouterNotFound(Http::CodecClient::Type::HTTP2); }
+
+TEST_P(Http2IntegrationTest, RouterNotFoundBodyNoBuffer) {
   testRouterNotFoundWithBody(lookupPort("http"), Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterNotFoundBodyBuffer) {
+TEST_P(Http2IntegrationTest, RouterNotFoundBodyBuffer) {
   testRouterNotFoundWithBody(lookupPort("http_buffer"), Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+TEST_P(Http2IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP2, 1024, 512, false);
 }
 
-TEST_F(Http2IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
+TEST_P(Http2IntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
                                        Http::CodecClient::Type::HTTP2, 1024, 512, false);
 }
 
-TEST_F(Http2IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
+TEST_P(Http2IntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
                                        Http::CodecClient::Type::HTTP2, 1024 * 1024, 1024 * 1024,
                                        false);
 }
 
-TEST_F(Http2IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
+TEST_P(Http2IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http")),
                                          Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
+TEST_P(Http2IntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http_buffer")),
                                          Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterRequestAndResponseLargeHeaderNoBuffer) {
+TEST_P(Http2IntegrationTest, RouterRequestAndResponseLargeHeaderNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP2, 1024, 512, true);
 }
 
-TEST_F(Http2IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
+TEST_P(Http2IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
   testRouterUpstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                     Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
+TEST_P(Http2IntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
   testRouterUpstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                      Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
+TEST_P(Http2IntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
   testRouterDownstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                       Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
+TEST_P(Http2IntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
   testRouterDownstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                        Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
+TEST_P(Http2IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
   testRouterUpstreamResponseBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                   Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2IntegrationTest, MaxHeadersInCodec) {
+TEST_P(Http2IntegrationTest, MaxHeadersInCodec) {
   Http::TestHeaderMapImpl big_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
@@ -104,7 +108,7 @@ TEST_F(Http2IntegrationTest, MaxHeadersInCodec) {
        [&]() -> void { response->waitForReset(); }, [&]() -> void { codec_client->close(); }});
 }
 
-TEST_F(Http2IntegrationTest, MaxHeadersInConnectionManager) {
+TEST_P(Http2IntegrationTest, MaxHeadersInConnectionManager) {
   Http::TestHeaderMapImpl big_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
@@ -123,35 +127,37 @@ TEST_F(Http2IntegrationTest, MaxHeadersInConnectionManager) {
   EXPECT_STREQ("400", response->headers().Status()->value().c_str());
 }
 
-TEST_F(Http2IntegrationTest, DownstreamResetBeforeResponseComplete) {
+TEST_P(Http2IntegrationTest, DownstreamResetBeforeResponseComplete) {
   testDownstreamResetBeforeResponseComplete();
 }
 
-TEST_F(Http2IntegrationTest, BadMagic) {
+TEST_P(Http2IntegrationTest, BadMagic) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection&, const Buffer::Instance& data)
-          -> void { response.append(TestUtility::bufferToString(data)); });
+      lookupPort("http"),
+      buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+      }, GetParam());
 
   connection.run();
   EXPECT_EQ("", response);
 }
 
-TEST_F(Http2IntegrationTest, BadFrame) {
+TEST_P(Http2IntegrationTest, BadFrame) {
   Buffer::OwnedImpl buffer("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nhelloworldcauseanerror");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection&, const Buffer::Instance& data)
-          -> void { response.append(TestUtility::bufferToString(data)); });
+      lookupPort("http"),
+      buffer, [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+      }, GetParam());
 
   connection.run();
   EXPECT_TRUE(response.find("SETTINGS expected") != std::string::npos);
 }
 
-TEST_F(Http2IntegrationTest, GoAway) {
+TEST_P(Http2IntegrationTest, GoAway) {
   IntegrationCodecClientPtr codec_client;
   Http::StreamEncoder* encoder;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
@@ -174,11 +180,11 @@ TEST_F(Http2IntegrationTest, GoAway) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
-TEST_F(Http2IntegrationTest, Trailers) { testTrailers(1024, 2048); }
+TEST_P(Http2IntegrationTest, Trailers) { testTrailers(1024, 2048); }
 
-TEST_F(Http2IntegrationTest, TrailersGiantBody) { testTrailers(1024 * 1024, 1024 * 1024); }
+TEST_P(Http2IntegrationTest, TrailersGiantBody) { testTrailers(1024 * 1024, 1024 * 1024); }
 
-TEST_F(Http2IntegrationTest, SimultaneousRequest) {
+TEST_P(Http2IntegrationTest, SimultaneousRequest) {
   IntegrationCodecClientPtr codec_client;
   FakeHttpConnectionPtr fake_upstream_connection1;
   FakeHttpConnectionPtr fake_upstream_connection2;

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -13,9 +13,9 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_http2.json", {"echo", "http", "http_buffer"});
   }

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -5,15 +5,17 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-class Http2IntegrationTest : public BaseIntegrationTest, public testing::Test {
+class Http2IntegrationTest : public BaseIntegrationTest,
+                             public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  Http2IntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_http2.json", {"echo", "http", "http_buffer"});
   }

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -8,94 +8,98 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-TEST_F(Http2UpstreamIntegrationTest, RouterNotFound) {
+
+INSTANTIATE_TEST_CASE_P(IpVersions, Http2UpstreamIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(Http2UpstreamIntegrationTest, RouterNotFound) {
   testRouterNotFound(Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRedirect) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRedirect) {
   testRouterRedirect(Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2UpstreamIntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP2, 1024, 512, false);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
                                        Http::CodecClient::Type::HTTP2, 1024, 512, false);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithZeroByteBodyNoBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithZeroByteBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP2, 0, 0, false);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithZeroByteBodyBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithZeroByteBodyBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http_buffer")),
                                        Http::CodecClient::Type::HTTP2, 0, 0, false);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyHttp1) {
+TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyHttp1) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http1_buffer")),
                                        Http::CodecClient::Type::HTTP1, 1024, 512, false);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http")),
                                          Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
+TEST_P(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseBuffer) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http_buffer")),
                                          Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseHttp1) {
+TEST_P(Http2UpstreamIntegrationTest, RouterHeaderOnlyRequestAndResponseHttp1) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http1_buffer")),
                                          Http::CodecClient::Type::HTTP1);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
+TEST_P(Http2UpstreamIntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
   testRouterUpstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                     Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
+TEST_P(Http2UpstreamIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
   testRouterUpstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                      Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
+TEST_P(Http2UpstreamIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
   testRouterDownstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                       Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
+TEST_P(Http2UpstreamIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
   testRouterDownstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                        Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
+TEST_P(Http2UpstreamIntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
   testRouterUpstreamResponseBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                   Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, TwoRequests) {
+TEST_P(Http2UpstreamIntegrationTest, TwoRequests) {
   testTwoRequests(Http::CodecClient::Type::HTTP2);
 }
 
-TEST_F(Http2UpstreamIntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP2); }
+TEST_P(Http2UpstreamIntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP2); }
 
-TEST_F(Http2UpstreamIntegrationTest, DownstreamResetBeforeResponseComplete) {
+TEST_P(Http2UpstreamIntegrationTest, DownstreamResetBeforeResponseComplete) {
   testDownstreamResetBeforeResponseComplete();
 }
 
-TEST_F(Http2UpstreamIntegrationTest, Trailers) { testTrailers(1024, 2048); }
+TEST_P(Http2UpstreamIntegrationTest, Trailers) { testTrailers(1024, 2048); }
 
-TEST_F(Http2UpstreamIntegrationTest, BidirectionalStreaming) {
+TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreaming) {
   IntegrationCodecClientPtr codec_client;
   FakeHttpConnectionPtr fake_upstream_connection;
   Http::StreamEncoder* encoder;
@@ -153,7 +157,7 @@ TEST_F(Http2UpstreamIntegrationTest, BidirectionalStreaming) {
   EXPECT_TRUE(response->complete());
 }
 
-TEST_F(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
+TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   IntegrationCodecClientPtr codec_client;
   FakeHttpConnectionPtr fake_upstream_connection;
   Http::StreamEncoder* encoder;
@@ -209,7 +213,7 @@ TEST_F(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   EXPECT_FALSE(response->complete());
 }
 
-TEST_F(Http2UpstreamIntegrationTest, SimultaneousRequest) {
+TEST_P(Http2UpstreamIntegrationTest, SimultaneousRequest) {
   IntegrationCodecClientPtr codec_client;
   FakeHttpConnectionPtr fake_upstream_connection;
   Http::StreamEncoder* encoder1;

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -5,15 +5,17 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-class Http2UpstreamIntegrationTest : public BaseIntegrationTest, public testing::Test {
+class Http2UpstreamIntegrationTest : public BaseIntegrationTest,
+                                     public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  Http2UpstreamIntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, GetParam()));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, GetParam()));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_http2_upstream.json",
                      {"http", "http_buffer", "http1_buffer"});

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -13,9 +13,9 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_http2_upstream.json",
                      {"http", "http_buffer", "http1_buffer"});

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -239,8 +239,6 @@ BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version)
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }
 
-BaseIntegrationTest::BaseIntegrationTest() : BaseIntegrationTest(Network::Address::IpVersion::v4) {}
-
 BaseIntegrationTest::~BaseIntegrationTest() {}
 
 Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t port) {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -113,7 +113,7 @@ typedef std::unique_ptr<IntegrationCodecClient> IntegrationCodecClientPtr;
 class IntegrationTcpClient {
 public:
   IntegrationTcpClient(Event::Dispatcher& dispatcher, uint32_t port,
-                       Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+                       Network::Address::IpVersion version);
 
   void close();
   const std::string& data() { return data_; }
@@ -149,7 +149,6 @@ typedef std::unique_ptr<IntegrationTcpClient> IntegrationTcpClientPtr;
  */
 class BaseIntegrationTest : Logger::Loggable<Logger::Id::testing> {
 public:
-  BaseIntegrationTest();
   ~BaseIntegrationTest();
   BaseIntegrationTest(Network::Address::IpVersion version);
   /**

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -14,9 +14,9 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server.json",
                      {"http", "http_buffer", "tcp_proxy", "rds"});

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -13,9 +13,9 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server.json",
                      {"http", "http_buffer", "tcp_proxy", "rds"});

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -7,7 +7,11 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-TEST_F(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+
+INSTANTIATE_TEST_CASE_P(IpVersions, ProxyProtoIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
 
   Buffer::OwnedImpl buf("PROXY TCP4 1.2.3.4 255.255.255.255 65535 1234\r\n");
@@ -16,4 +20,15 @@ TEST_F(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(std::move(conn), Http::CodecClient::Type::HTTP1, 1024, 512,
                                        false);
 }
+
+TEST_P(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBufferV6) {
+  Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
+
+  Buffer::OwnedImpl buf("PROXY TCP6 1:2:3::4 FF00:: 65535 1234\r\n");
+  conn->write(buf);
+
+  testRouterRequestAndResponseWithBody(std::move(conn), Http::CodecClient::Type::HTTP1, 1024, 512,
+                                       false);
+}
+
 } // Envoy

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -18,7 +18,7 @@ public:
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_proxy_proto.json", {"http"});
   }

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -10,13 +10,15 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-class ProxyProtoIntegrationTest : public BaseIntegrationTest, public testing::Test {
+class ProxyProtoIntegrationTest : public BaseIntegrationTest,
+                                  public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  ProxyProtoIntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1));
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, GetParam()));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_proxy_proto.json", {"http"});
   }

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -25,16 +25,16 @@ void SslIntegrationTest::SetUp() {
   context_manager_.reset(new ContextManagerImpl(*runtime_));
   upstream_ssl_ctx_ = createUpstreamSslContext();
   fake_upstreams_.emplace_back(
-      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, GetParam()));
+      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
   registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
   fake_upstreams_.emplace_back(
-      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, GetParam()));
+      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
   registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
   // TODO(hennna): Add IPv6 support.
   test_server_ = MockRuntimeIntegrationTestServer::create(
       TestEnvironment::temporaryFileSubstitute("test/config/integration/server_ssl.json", port_map_,
-                                               GetParam()),
-      GetParam());
+                                               version_),
+      version_);
   registerTestServerPorts({"http"});
   client_ssl_ctx_plain_ = createClientSslContext(false, false);
   client_ssl_ctx_alpn_ = createClientSslContext(true, false);

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -37,8 +37,10 @@ private:
       : IntegrationTestServer(config_path) {}
 };
 
-class SslIntegrationTest : public BaseIntegrationTest, public testing::Test {
+class SslIntegrationTest : public BaseIntegrationTest,
+                           public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  SslIntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -5,27 +5,31 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-TEST_F(UdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+
+INSTANTIATE_TEST_CASE_P(IpVersions, UdsIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(UdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
                                        Http::CodecClient::Type::HTTP1, 1024, 512, false);
 }
 
-TEST_F(UdsIntegrationTest, RouterHeaderOnlyRequestAndResponse) {
+TEST_P(UdsIntegrationTest, RouterHeaderOnlyRequestAndResponse) {
   testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http")),
                                          Http::CodecClient::Type::HTTP1);
 }
 
-TEST_F(UdsIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
+TEST_P(UdsIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
   testRouterUpstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                      Http::CodecClient::Type::HTTP1);
 }
 
-TEST_F(UdsIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
+TEST_P(UdsIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
   testRouterDownstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")),
                                                       Http::CodecClient::Type::HTTP1);
 }
 
-TEST_F(UdsIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
+TEST_P(UdsIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
   testRouterDownstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")),
                                                        Http::CodecClient::Type::HTTP1);
 }

--- a/test/integration/uds_integration_test.h
+++ b/test/integration/uds_integration_test.h
@@ -11,8 +11,10 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
-class UdsIntegrationTest : public BaseIntegrationTest, public testing::Test {
+class UdsIntegrationTest : public BaseIntegrationTest,
+                           public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  UdsIntegrationTest() : BaseIntegrationTest(GetParam()) {}
   /**
    * Initializer for an individual test.
    */

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -54,7 +54,7 @@ public:
   typedef std::function<void(Network::ClientConnection&, const Buffer::Instance&)> ReadCallback;
 
   RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data, ReadCallback data_callback,
-                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+                      Network::Address::IpVersion version);
   ~RawConnectionDriver();
   void run();
   void close();
@@ -100,7 +100,6 @@ public:
   static BufferingStreamDecoderPtr
   makeSingleRequest(uint32_t port, const std::string& method, const std::string& url,
                     const std::string& body, Http::CodecClient::Type type,
-                    Network::Address::IpVersion version = Network::Address::IpVersion::v4,
-                    const std::string& host = "host");
+                    Network::Address::IpVersion version, const std::string& host = "host");
 };
 } // Envoy

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -54,7 +54,7 @@ void TestEnvironment::initializeOptions(int argc, char** argv) {
   argv_ = argv;
 }
 
-bool TestEnvironment::shouldRunTestForIpVersion(const Network::Address::IpVersion& type) {
+bool TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion type) {
   const char* value = ::getenv("ENVOY_IP_TEST_VERSIONS");
   std::string option(value ? value : "");
   if (option.empty()) {

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -28,7 +28,7 @@ public:
    * @param Network::Address::IpVersion IP address version to check.
    * @return bool if testing only with IP type addresses only.
    */
-  static bool shouldRunTestForIpVersion(const Network::Address::IpVersion& type);
+  static bool shouldRunTestForIpVersion(Network::Address::IpVersion type);
 
   /**
    * Return a vector of IP address parameters to test. Tests can be run with
@@ -112,9 +112,8 @@ public:
    * @param version IP address version to substitute.
    * @return std::string path for the generated file.
    */
-  static std::string
-  temporaryFileSubstitute(const std::string& path, const PortMap& port_map,
-                          Network::Address::IpVersion version = Network::Address::IpVersion::v4);
+  static std::string temporaryFileSubstitute(const std::string& path, const PortMap& port_map,
+                                             Network::Address::IpVersion version);
 
   /**
    * Build JSON object from a string subject to environment path substitution.


### PR DESCRIPTION
This PR parameterizes IPv4/IPv6 testing for 

- the server_test unit test
- the rest of the integration tests except for the hot restart test. 

See #1036 and #953 .