### PR TITLE
Removed unnecessary includes for statically registered tracers

### DIFF
--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -16,9 +16,6 @@
 #include "common/json/config_schemas.h"
 #include "common/ratelimit/ratelimit_impl.h"
 #include "common/ssl/context_config_impl.h"
-#include "common/tracing/http_tracer_impl.h"
-#include "common/tracing/lightstep_tracer_impl.h"
-#include "common/tracing/zipkin/zipkin_tracer_impl.h"
 #include "common/upstream/cluster_manager_impl.h"
 
 #include "spdlog/spdlog.h"


### PR DESCRIPTION
This will allow users to optionally compile out these tracers without needing to modify the source.