### PR TITLE
cleanup: Fix clang-tidy for performance-unnecessary-value-param

### DIFF
--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -10,7 +10,7 @@
 namespace Envoy {
 namespace Thread {
 
-Thread::Thread(std::function<void()> thread_routine) : thread_routine_(thread_routine) {
+Thread::Thread(std::function<void()> thread_routine) : thread_routine_(std::move(thread_routine)) {
   int rc = pthread_create(&thread_id_, nullptr, [](void* arg) -> void* {
     static_cast<Thread*>(arg)->thread_routine_();
     return nullptr;

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -12,7 +12,7 @@ namespace Event {
 
 FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, int fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
-    : cb_(cb), base_(&dispatcher.base()), fd_(fd), trigger_(trigger) {
+    : cb_(std::move(cb)), base_(&dispatcher.base()), fd_(fd), trigger_(trigger) {
   assignEvents(events);
   event_add(&raw_event_, nullptr);
 }

--- a/source/common/event/signal_impl.cc
+++ b/source/common/event/signal_impl.cc
@@ -8,7 +8,7 @@ namespace Envoy {
 namespace Event {
 
 SignalEventImpl::SignalEventImpl(DispatcherImpl& dispatcher, int signal_num, SignalCb cb)
-    : cb_(cb) {
+    : cb_(std::move(cb)) {
   evsignal_assign(&raw_event_, &dispatcher.base(),
                   signal_num, [](evutil_socket_t, short, void* arg) -> void {
                     static_cast<SignalEventImpl*>(arg)->cb_();

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -10,7 +10,7 @@
 namespace Envoy {
 namespace Event {
 
-TimerImpl::TimerImpl(DispatcherImpl& dispatcher, TimerCb cb) : cb_(cb) {
+TimerImpl::TimerImpl(DispatcherImpl& dispatcher, TimerCb cb) : cb_(std::move(cb)) {
   ASSERT(cb_);
   evtimer_assign(&raw_event_, &dispatcher.base(), [](evutil_socket_t, short, void* arg) -> void {
     static_cast<TimerImpl*>(arg)->cb_();

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -107,7 +107,7 @@ private:
  */
 class Instance : public Network::ReadFilter, public Network::ConnectionCallbacks {
 public:
-  Instance(ConfigSharedPtr config) : config_(config) {}
+  Instance(ConfigSharedPtr config) : config_(std::move(config)) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;

--- a/source/common/filter/ratelimit.h
+++ b/source/common/filter/ratelimit.h
@@ -70,7 +70,7 @@ class Instance : public Network::ReadFilter,
                  public RequestCallbacks {
 public:
   Instance(ConfigSharedPtr config, ClientPtr&& client)
-      : config_(config), client_(std::move(client)) {}
+      : config_(std::move(config)), client_(std::move(client)) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data) override;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -89,7 +89,7 @@ const std::string& TcpProxyConfig::getRouteFromEntries(Network::Connection& conn
 }
 
 TcpProxy::TcpProxy(TcpProxyConfigSharedPtr config, Upstream::ClusterManager& cluster_manager)
-    : config_(config), cluster_manager_(cluster_manager), downstream_callbacks_(*this),
+    : config_(std::move(config)), cluster_manager_(cluster_manager), downstream_callbacks_(*this),
       upstream_callbacks_(new UpstreamCallbacks(*this)) {}
 
 TcpProxy::~TcpProxy() {

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -13,7 +13,7 @@ namespace Http {
 
 CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
                          Upstream::HostDescriptionConstSharedPtr host)
-    : type_(type), connection_(std::move(connection)), host_(host) {
+    : type_(type), connection_(std::move(connection)), host_(std::move(host)) {
 
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(Network::ReadFilterSharedPtr{new CodecReadFilter(*this)});

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -300,7 +300,7 @@ private:
                                      LinkedObject<ActiveStreamDecoderFilter> {
     ActiveStreamDecoderFilter(ActiveStream& parent, StreamDecoderFilterSharedPtr filter,
                               bool dual_filter)
-        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
+        : ActiveStreamFilterBase(parent, dual_filter), handle_(std::move(filter)) {}
 
     // ActiveStreamFilterBase
     Buffer::InstancePtr& bufferedData() override { return parent_.buffered_request_data_; }
@@ -337,7 +337,7 @@ private:
                                      LinkedObject<ActiveStreamEncoderFilter> {
     ActiveStreamEncoderFilter(ActiveStream& parent, StreamEncoderFilterSharedPtr filter,
                               bool dual_filter)
-        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
+        : ActiveStreamFilterBase(parent, dual_filter), handle_(std::move(filter)) {}
 
     // ActiveStreamFilterBase
     Buffer::InstancePtr& bufferedData() override { return parent_.buffered_response_data_; }

--- a/source/common/http/filter/buffer_filter.cc
+++ b/source/common/http/filter/buffer_filter.cc
@@ -15,7 +15,7 @@
 namespace Envoy {
 namespace Http {
 
-BufferFilter::BufferFilter(BufferFilterConfigConstSharedPtr config) : config_(config) {}
+BufferFilter::BufferFilter(BufferFilterConfigConstSharedPtr config) : config_(std::move(config)) {}
 
 BufferFilter::~BufferFilter() { ASSERT(!request_timeout_); }
 

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -60,7 +60,7 @@ FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::L
   upstream_cluster_ = json_config.getString("upstream_cluster", EMPTY_STRING);
 }
 
-FaultFilter::FaultFilter(FaultFilterConfigSharedPtr config) : config_(config) {}
+FaultFilter::FaultFilter(FaultFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
 FaultFilter::~FaultFilter() { ASSERT(!delay_timer_); }
 

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -77,7 +77,7 @@ typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
 class Filter : public StreamDecoderFilter, public Envoy::RateLimit::RequestCallbacks {
 public:
   Filter(FilterConfigSharedPtr config, Envoy::RateLimit::ClientPtr&& client)
-      : config_(config), client_(std::move(client)) {}
+      : config_(std::move(config)), client_(std::move(client)) {}
 
   // Http::StreamFilterBase
   void onDestroy() override;

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -29,7 +29,7 @@ class ConnPoolImpl : Logger::Loggable<Logger::Id::pool>, public ConnectionPool::
 public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority)
-      : dispatcher_(dispatcher), host_(host), priority_(priority) {}
+      : dispatcher_(dispatcher), host_(std::move(host)), priority_(priority) {}
 
   ~ConnPoolImpl();
 
@@ -131,7 +131,7 @@ class ConnPoolImplProd : public ConnPoolImpl {
 public:
   ConnPoolImplProd(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                    Upstream::ResourcePriority priority)
-      : ConnPoolImpl(dispatcher, host, priority) {}
+      : ConnPoolImpl(dispatcher, std::move(host), priority) {}
 
   // ConnPoolImpl
   CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -16,7 +16,7 @@ namespace Http2 {
 
 ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                            Upstream::ResourcePriority priority)
-    : dispatcher_(dispatcher), host_(host), priority_(priority) {}
+    : dispatcher_(dispatcher), host_(std::move(host)), priority_(priority) {}
 
 ConnPoolImpl::~ConnPoolImpl() {
   if (primary_client_) {

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -53,13 +53,13 @@ public:
     return FieldSharedPtr{new Field(value)};
   }
 
-  void append(FieldSharedPtr field_ptr) {
+  void append(const FieldSharedPtr& field_ptr) {
     checkType(Type::Array);
     value_.array_value_.push_back(field_ptr);
   }
   void insert(const std::string& key, FieldSharedPtr field_ptr) {
     checkType(Type::Object);
-    value_.object_value_[key] = field_ptr;
+    value_.object_value_[key] = std::move(field_ptr);
   }
 
   uint64_t hash() const override;
@@ -215,7 +215,7 @@ public:
   ObjectSharedPtr getRoot() { return root_; }
 
 private:
-  bool handleValueEvent(FieldSharedPtr ptr);
+  bool handleValueEvent(const FieldSharedPtr& ptr);
 
   enum State {
     expectRoot,
@@ -638,7 +638,7 @@ bool ObjectHandler::RawNumber(const char*, rapidjson::SizeType, bool) {
   NOT_REACHED;
 }
 
-bool ObjectHandler::handleValueEvent(FieldSharedPtr ptr) {
+bool ObjectHandler::handleValueEvent(const FieldSharedPtr& ptr) {
   ptr->setLineNumberStart(stream_.getLineNumber());
 
   switch (state_) {

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -9,9 +9,9 @@ namespace LocalInfo {
 
 class LocalInfoImpl : public LocalInfo {
 public:
-  LocalInfoImpl(Network::Address::InstanceConstSharedPtr address, const std::string zone_name,
-                const std::string cluster_name, const std::string node_name)
-      : address_(address), zone_name_(zone_name), cluster_name_(cluster_name),
+  LocalInfoImpl(Network::Address::InstanceConstSharedPtr address, const std::string& zone_name,
+                const std::string& cluster_name, const std::string& node_name)
+      : address_(std::move(address)), zone_name_(zone_name), cluster_name_(cluster_name),
         node_name_(node_name) {}
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }

--- a/source/common/mongo/bson_impl.h
+++ b/source/common/mongo/bson_impl.h
@@ -48,7 +48,7 @@ public:
 
   explicit FieldImpl(Type type, const std::string& key, DocumentSharedPtr value)
       : type_(type), key_(key) {
-    value_.document_value_ = value;
+    value_.document_value_ = std::move(value);
   }
 
   explicit FieldImpl(const std::string& key, ObjectId&& value) : type_(Type::OBJECT_ID), key_(key) {

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -38,7 +38,7 @@ void AccessLog::logMessage(const Message& message, bool full,
 ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Store& store,
                          Runtime::Loader& runtime, AccessLogSharedPtr access_log)
     : stat_prefix_(stat_prefix), stat_store_(store), stats_(generateStats(stat_prefix, store)),
-      runtime_(runtime), access_log_(access_log) {
+      runtime_(runtime), access_log_(std::move(access_log)) {
 
   if (!runtime_.snapshot().featureEnabled("mongo.connection_logging_enabled", 100)) {
     // If we are not logging at the connection level, just release the shared pointer so that we

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -50,8 +50,9 @@ const Address::InstanceConstSharedPtr
 ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                Address::InstanceConstSharedPtr remote_address,
                                Address::InstanceConstSharedPtr local_address)
-    : filter_manager_(*this, *this), remote_address_(remote_address), local_address_(local_address),
-      dispatcher_(dispatcher), fd_(fd), id_(++next_global_id_) {
+    : filter_manager_(*this, *this), remote_address_(std::move(remote_address)),
+      local_address_(std::move(local_address)), dispatcher_(dispatcher), fd_(fd),
+      id_(++next_global_id_) {
 
   // Treat the lack of a valid fd (which in practice only happens if we run out of FDs) as an OOM
   // condition and just crash.

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -37,7 +37,7 @@ private:
   struct PendingResolution : public ActiveDnsQuery {
     // Network::ActiveDnsQuery
     PendingResolution(ResolveCb callback, ares_channel channel, const std::string& dns_name)
-        : callback_(callback), channel_(channel), dns_name_(dns_name) {}
+        : callback_(std::move(callback)), channel_(channel), dns_name_(dns_name) {}
 
     void cancel() override {
       // c-ares only supports channel-wide cancellation, so we just allow the

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -47,7 +47,7 @@ public:
 private:
   struct ActiveReadFilter : public ReadFilterCallbacks, LinkedObject<ActiveReadFilter> {
     ActiveReadFilter(FilterManagerImpl& parent, ReadFilterSharedPtr filter)
-        : parent_(parent), filter_(filter) {}
+        : parent_(parent), filter_(std::move(filter)) {}
 
     Connection& connection() override { return parent_.connection_; }
     void continueReading() override { parent_.onContinueReading(this); }

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -31,7 +31,7 @@ void ListenSocketImpl::doBind() {
 }
 
 TcpListenSocket::TcpListenSocket(Address::InstanceConstSharedPtr address, bool bind_to_port) {
-  local_address_ = address;
+  local_address_ = std::move(address);
   fd_ = local_address_->socket(Address::SocketType::Stream);
   RELEASE_ASSERT(fd_ != -1);
 
@@ -46,7 +46,7 @@ TcpListenSocket::TcpListenSocket(Address::InstanceConstSharedPtr address, bool b
 
 TcpListenSocket::TcpListenSocket(int fd, Address::InstanceConstSharedPtr address) {
   fd_ = fd;
-  local_address_ = address;
+  local_address_ = std::move(address);
 }
 
 UdsListenSocket::UdsListenSocket(const std::string& uds_path) {

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -100,7 +100,8 @@ void ListenerImpl::errorCallback(evconnlistener*, void*) {
 
 void ListenerImpl::newConnection(int fd, Address::InstanceConstSharedPtr remote_address,
                                  Address::InstanceConstSharedPtr local_address) {
-  ConnectionPtr new_connection(new ConnectionImpl(dispatcher_, fd, remote_address, local_address));
+  ConnectionPtr new_connection(
+      new ConnectionImpl(dispatcher_, fd, std::move(remote_address), std::move(local_address)));
   new_connection->setReadBufferLimit(options_.per_connection_buffer_limit_bytes_);
   cb_.onNewConnection(std::move(new_connection));
 }

--- a/source/common/redis/proxy_filter.cc
+++ b/source/common/redis/proxy_filter.cc
@@ -33,7 +33,7 @@ ProxyStats ProxyFilterConfig::generateStats(const std::string& prefix, Stats::Sc
 ProxyFilter::ProxyFilter(DecoderFactory& factory, EncoderPtr&& encoder,
                          CommandSplitter::Instance& splitter, ProxyFilterConfigSharedPtr config)
     : decoder_(factory.create(*this)), encoder_(std::move(encoder)), splitter_(splitter),
-      config_(config) {
+      config_(std::move(config)) {
   config_->stats().downstream_cx_total_.inc();
   config_->stats().downstream_cx_active_.inc();
 }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -284,7 +284,7 @@ private:
    */
   class WeightedClusterEntry : public DynanmicRouteEntry {
   public:
-    WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string runtime_key,
+    WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string& runtime_key,
                          Runtime::Loader& loader, const std::string& name, uint64_t weight)
         : DynanmicRouteEntry(parent, name), runtime_key_(runtime_key), loader_(loader),
           cluster_weight_(weight) {}

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -92,7 +92,7 @@ public:
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {
-    ThreadLocalConfig(ConfigConstSharedPtr initial_config) : config_(initial_config) {}
+    ThreadLocalConfig(ConfigConstSharedPtr initial_config) : config_(std::move(initial_config)) {}
 
     // ThreadLocal::ThreadLocalObject
     void shutdown() override {}

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -135,7 +135,7 @@ void Filter::chargeUpstreamCode(Http::Code code,
                                 Upstream::HostDescriptionConstSharedPtr upstream_host) {
   Http::HeaderMapImpl fake_response_headers{
       {Http::Headers::get().Status, std::to_string(enumToInt(code))}};
-  chargeUpstreamCode(fake_response_headers, upstream_host);
+  chargeUpstreamCode(fake_response_headers, std::move(upstream_host));
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool end_stream) {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -140,7 +140,7 @@ private:
     void setupPerTryTimeout();
     void onPerTryTimeout();
 
-    void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
+    void onUpstreamHostSelected(const Upstream::HostDescriptionConstSharedPtr& host) {
       upstream_host_ = host;
       parent_.callbacks_->requestInfo().onUpstreamHostSelected(host);
     }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -19,7 +19,7 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                Network::Address::InstanceConstSharedPtr remote_address,
                                Network::Address::InstanceConstSharedPtr local_address, Context& ctx,
                                InitialState state)
-    : Network::ConnectionImpl(dispatcher, fd, remote_address, local_address),
+    : Network::ConnectionImpl(dispatcher, fd, std::move(remote_address), std::move(local_address)),
       ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
   BIO* bio = BIO_new_socket(fd, 0);
   SSL_set_bio(ssl_.get(), bio, bio);

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -61,7 +61,7 @@ void Writer::send(const std::string& message) {
 
 UdpStatsdSink::UdpStatsdSink(ThreadLocal::Instance& tls,
                              Network::Address::InstanceConstSharedPtr address)
-    : tls_(tls), tls_slot_(tls.allocateSlot()), server_address_(address) {
+    : tls_(tls), tls_slot_(tls.allocateSlot()), server_address_(std::move(address)) {
   tls.set(tls_slot_, [this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<Writer>(this->server_address_);
   });

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -59,7 +59,7 @@ void InstanceImpl::setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr obj
     thread_local_data_.data_.resize(index + 1);
   }
 
-  thread_local_data_.data_[index] = object;
+  thread_local_data_.data_[index] = std::move(object);
 }
 
 void InstanceImpl::shutdownThread() {

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -101,7 +101,7 @@ void LightStepRecorder::flushSpans() {
 
 LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(lightstep::Tracer tracer,
                                                         LightStepDriver& driver)
-    : tracer_(new lightstep::Tracer(tracer)), driver_(driver) {}
+    : tracer_(new lightstep::Tracer(std::move(tracer))), driver_(driver) {}
 
 LightStepDriver::LightStepDriver(const Json::Object& config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,

--- a/source/common/tracing/zipkin/tracer.h
+++ b/source/common/tracing/zipkin/tracer.h
@@ -55,7 +55,7 @@ public:
    */
   Tracer(const std::string& service_name, Network::Address::InstanceConstSharedPtr address,
          Runtime::RandomGenerator& random_generator)
-      : service_name_(service_name), address_(address), reporter_(nullptr),
+      : service_name_(service_name), address_(std::move(address)), reporter_(nullptr),
         random_generator_(random_generator) {}
 
   /**

--- a/source/common/tracing/zipkin/zipkin_core_types.h
+++ b/source/common/tracing/zipkin/zipkin_core_types.h
@@ -59,7 +59,7 @@ public:
    * @param address Pointer to an object representing the endpoint's network address
    */
   Endpoint(const std::string& service_name, Network::Address::InstanceConstSharedPtr address)
-      : service_name_(service_name), address_(address) {}
+      : service_name_(service_name), address_(std::move(address)) {}
 
   /**
    * @return the endpoint's address.
@@ -69,7 +69,9 @@ public:
   /**
    * Sets the endpoint's address
    */
-  void setAddress(Network::Address::InstanceConstSharedPtr address) { address_ = address; }
+  void setAddress(Network::Address::InstanceConstSharedPtr address) {
+    address_ = std::move(address);
+  }
 
   /**
    * @return the endpoint's service name attribute.
@@ -122,7 +124,7 @@ public:
    * appear on ZipkinCoreConstants. The most commonly used values are "cs", "cr", "ss" and "sr".
    * @param endpoint The endpoint object representing the annotation's endpoint attribute.
    */
-  Annotation(uint64_t timestamp, const std::string value, Endpoint& endpoint)
+  Annotation(uint64_t timestamp, const std::string& value, Endpoint& endpoint)
       : timestamp_(timestamp), value_(value), endpoint_(endpoint) {}
 
   /**

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -473,7 +473,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
 
   ASSERT(config.thread_local_clusters_.find(name) != config.thread_local_clusters_.end());
   config.thread_local_clusters_[name]->host_set_.updateHosts(
-      hosts, healthy_hosts, hosts_per_zone, healthy_hosts_per_zone, hosts_added, hosts_removed);
+      std::move(hosts), std::move(healthy_hosts), std::move(hosts_per_zone),
+      std::move(healthy_hosts_per_zone), hosts_added, hosts_removed);
 }
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::shutdown() {

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -235,7 +235,7 @@ HttpHealthCheckerImpl::HttpHealthCheckerImpl(const Cluster& cluster, const Json:
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSession(
     HttpHealthCheckerImpl& parent, HostSharedPtr host)
-    : ActiveHealthCheckSession(parent, host), parent_(parent) {}
+    : ActiveHealthCheckSession(parent, std::move(host)), parent_(parent) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {
   if (client_) {
@@ -462,7 +462,7 @@ RedisHealthCheckerImpl::RedisHealthCheckerImpl(const Cluster& cluster, const Jso
 
 RedisHealthCheckerImpl::RedisActiveHealthCheckSession::RedisActiveHealthCheckSession(
     RedisHealthCheckerImpl& parent, HostSharedPtr host)
-    : ActiveHealthCheckSession(parent, host), parent_(parent) {}
+    : ActiveHealthCheckSession(parent, std::move(host)), parent_(parent) {}
 
 RedisHealthCheckerImpl::RedisActiveHealthCheckSession::~RedisActiveHealthCheckSession() {
   if (current_request_) {

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -289,7 +289,7 @@ private:
 
   struct TcpActiveHealthCheckSession : public ActiveHealthCheckSession {
     TcpActiveHealthCheckSession(TcpHealthCheckerImpl& parent, HostSharedPtr host)
-        : ActiveHealthCheckSession(parent, host), parent_(parent) {}
+        : ActiveHealthCheckSession(parent, std::move(host)), parent_(parent) {}
     ~TcpActiveHealthCheckSession();
 
     void onData(Buffer::Instance& data);

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -49,7 +49,8 @@ private:
   struct LogicalHost : public HostImpl {
     LogicalHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                 Network::Address::InstanceConstSharedPtr address, LogicalDnsCluster& parent)
-        : HostImpl(cluster, hostname, address, false, 1, ""), parent_(parent) {}
+        : HostImpl(std::move(cluster), hostname, std::move(address), false, 1, ""),
+          parent_(parent) {}
 
     // Upstream::Host
     CreateConnectionData createConnection(Event::Dispatcher& dispatcher) const override;
@@ -60,7 +61,7 @@ private:
   struct RealHostDescription : public HostDescription {
     RealHostDescription(Network::Address::InstanceConstSharedPtr address,
                         HostConstSharedPtr logical_host)
-        : address_(address), logical_host_(logical_host) {}
+        : address_(std::move(address)), logical_host_(std::move(logical_host)) {}
 
     // Upstream:HostDescription
     bool canary() const override { return false; }

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -53,7 +53,7 @@ public:
  */
 struct HostSuccessRatePair {
   HostSuccessRatePair(HostSharedPtr host, double success_rate)
-      : host_(host), success_rate_(success_rate) {}
+      : host_(std::move(host)), success_rate_(success_rate) {}
   HostSharedPtr host_;
   double success_rate_;
 };
@@ -102,7 +102,7 @@ class DetectorImpl;
  */
 class DetectorHostSinkImpl : public DetectorHostSink {
 public:
-  DetectorHostSinkImpl(std::shared_ptr<DetectorImpl> detector, HostSharedPtr host)
+  DetectorHostSinkImpl(const std::shared_ptr<DetectorImpl>& detector, const HostSharedPtr& host)
       : detector_(detector), host_(host), success_rate_(-1) {
     // Point the success_rate_accumulator_bucket_ pointer to a bucket.
     updateCurrentSuccessRateBucket();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -139,7 +139,7 @@ ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& 
   }
 
   new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
-      *new_cluster, cluster, dispatcher, runtime, outlier_event_logger));
+      *new_cluster, cluster, dispatcher, runtime, std::move(outlier_event_logger)));
   return std::move(new_cluster);
 }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -38,7 +38,8 @@ public:
   HostDescriptionImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                       Network::Address::InstanceConstSharedPtr address, bool canary,
                       const std::string& zone)
-      : cluster_(cluster), hostname_(hostname), address_(address), canary_(canary), zone_(zone),
+      : cluster_(std::move(cluster)), hostname_(hostname), address_(std::move(address)),
+        canary_(canary), zone_(zone),
         stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))} {}
 
   // Upstream::HostDescription
@@ -80,7 +81,7 @@ public:
   HostImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
            Network::Address::InstanceConstSharedPtr address, bool canary, uint32_t initial_weight,
            const std::string& zone)
-      : HostDescriptionImpl(cluster, hostname, address, canary, zone) {
+      : HostDescriptionImpl(std::move(cluster), hostname, std::move(address), canary, zone) {
     weight(initial_weight);
   }
 
@@ -128,10 +129,10 @@ public:
                    HostListsConstSharedPtr healthy_hosts_per_zone,
                    const std::vector<HostSharedPtr>& hosts_added,
                    const std::vector<HostSharedPtr>& hosts_removed) {
-    hosts_ = hosts;
-    healthy_hosts_ = healthy_hosts;
-    hosts_per_zone_ = hosts_per_zone;
-    healthy_hosts_per_zone_ = healthy_hosts_per_zone;
+    hosts_ = std::move(hosts);
+    healthy_hosts_ = std::move(healthy_hosts);
+    hosts_per_zone_ = std::move(hosts_per_zone);
+    healthy_hosts_per_zone_ = std::move(healthy_hosts_per_zone);
     runUpdateCallbacks(hosts_added, hosts_removed);
   }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -338,7 +338,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
                      const std::string& address_out_path,
                      Network::Address::InstanceConstSharedPtr address, Server::Instance& server)
     : server_(server), profile_path_(profile_path),
-      socket_(new Network::TcpListenSocket(address, true)),
+      socket_(new Network::TcpListenSocket(std::move(address), true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
                                                                        server_.stats())),

--- a/source/server/http/health_check.h
+++ b/source/server/http/health_check.h
@@ -60,8 +60,8 @@ class HealthCheckFilter : public Http::StreamFilter {
 public:
   HealthCheckFilter(Server::Instance& server, bool pass_through_mode,
                     HealthCheckCacheManagerSharedPtr cache_manager, const std::string& endpoint)
-      : server_(server), pass_through_mode_(pass_through_mode), cache_manager_(cache_manager),
-        endpoint_(endpoint) {}
+      : server_(server), pass_through_mode_(pass_through_mode),
+        cache_manager_(std::move(cache_manager)), endpoint_(endpoint) {}
 
   // Http::StreamFilterBase
   void onDestroy() override {}

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -14,7 +14,7 @@ namespace Event {
 
 class TestDeferredDeletable : public DeferredDeletable {
 public:
-  TestDeferredDeletable(std::function<void()> on_destroy) : on_destroy_(on_destroy) {}
+  TestDeferredDeletable(std::function<void()> on_destroy) : on_destroy_(std::move(on_destroy)) {}
   ~TestDeferredDeletable() { on_destroy_(); }
 
 private:

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -19,8 +19,8 @@ public:
 
   CodecClientForTest(Network::ClientConnectionPtr&& connection, Http::ClientConnection* codec,
                      DestroyCb destroy_cb, Upstream::HostDescriptionConstSharedPtr host)
-      : CodecClient(CodecClient::Type::HTTP1, std::move(connection), host),
-        destroy_cb_(destroy_cb) {
+      : CodecClient(CodecClient::Type::HTTP1, std::move(connection), std::move(host)),
+        destroy_cb_(std::move(destroy_cb)) {
     codec_.reset(codec);
   }
 

--- a/test/common/http/filter/fault_filter_test.cc
+++ b/test/common/http/filter/fault_filter_test.cc
@@ -96,7 +96,7 @@ public:
     }
     )EOF";
 
-  void SetUpTest(const std::string json) {
+  void SetUpTest(const std::string& json) {
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     config_.reset(new FaultFilterConfig(*config, runtime_, "", stats_));
     filter_.reset(new FaultFilter(config_));

--- a/test/common/http/filter/ratelimit_test.cc
+++ b/test/common/http/filter/ratelimit_test.cc
@@ -43,7 +43,7 @@ public:
         .WillByDefault(Return(true));
   }
 
-  void SetUpTest(const std::string json) {
+  void SetUpTest(const std::string& json) {
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     config_.reset(new FilterConfig(*config, local_info_, stats_store_, runtime_, cm_));
 

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -40,11 +40,11 @@ class ConnPoolImplForTest : public ConnPoolImpl {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher,
                       Upstream::ClusterInfoConstSharedPtr cluster)
-      : ConnPoolImpl(
-            dispatcher,
-            Upstream::HostSharedPtr{new Upstream::HostImpl(
-                cluster, "", Network::Utility::resolveUrl("tcp://127.0.0.1:9000"), false, 1, "")},
-            Upstream::ResourcePriority::Default),
+      : ConnPoolImpl(dispatcher,
+                     Upstream::HostSharedPtr{new Upstream::HostImpl(
+                         std::move(cluster), "",
+                         Network::Utility::resolveUrl("tcp://127.0.0.1:9000"), false, 1, "")},
+                     Upstream::ResourcePriority::Default),
         mock_dispatcher_(dispatcher) {}
 
   ~ConnPoolImplForTest() {

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -96,7 +96,7 @@ static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::st
 
 class RateLimitConfiguration : public testing::Test {
 public:
-  void SetUpTest(const std::string json) {
+  void SetUpTest(const std::string& json) {
     Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
     config_.reset(new ConfigImpl(*loader, runtime_, cm_, true));
   }
@@ -337,7 +337,7 @@ TEST_F(RateLimitConfiguration, Stages) {
 
 class RateLimitPolicyEntryTest : public testing::Test {
 public:
-  void SetUpTest(const std::string json) {
+  void SetUpTest(const std::string& json) {
     Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
     rate_limit_entry_.reset(new RateLimitPolicyEntryImpl(*loader));
     descriptors_.clear();

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -22,7 +22,7 @@ namespace Upstream {
 static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
                                  const std::string& url, uint32_t weight = 1) {
   return HostSharedPtr{
-      new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, weight, "")};
+      new HostImpl(std::move(cluster), "", Network::Utility::resolveUrl(url), false, weight, "")};
 }
 
 class RoundRobinLoadBalancerTest : public testing::Test {

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -24,7 +24,7 @@ static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
                                  const std::string& url, uint32_t weight = 1,
                                  const std::string& zone = "") {
   return HostSharedPtr{
-      new HostImpl(cluster, "", Network::Utility::resolveUrl(url), false, weight, zone)};
+      new HostImpl(std::move(cluster), "", Network::Utility::resolveUrl(url), false, weight, zone)};
 }
 
 /**
@@ -49,8 +49,9 @@ public:
    * @param healthy_destination_cluster total number of healthy hosts in each zone in upstream
    * cluster.
    */
-  void run(std::vector<uint32_t> originating_cluster, std::vector<uint32_t> all_destination_cluster,
-           std::vector<uint32_t> healthy_destination_cluster) {
+  void run(const std::vector<uint32_t>& originating_cluster,
+           const std::vector<uint32_t>& all_destination_cluster,
+           const std::vector<uint32_t>& healthy_destination_cluster) {
     local_host_set_ = new HostSetImpl();
     // TODO(mattklein123): make load balancer per originating cluster host.
     RandomLoadBalancer lb(cluster_, local_host_set_, stats_, runtime_, random_);

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -73,7 +73,7 @@ public:
     }
   }
 
-  void loadRq(HostSharedPtr host, int num_rq, int http_code) {
+  void loadRq(const HostSharedPtr& host, int num_rq, int http_code) {
     for (int i = 0; i < num_rq; i++) {
       host->outlierDetector().putHttpResponseCode(http_code);
     }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -97,7 +97,7 @@ void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason) {
 IntegrationCodecClient::IntegrationCodecClient(
     Event::Dispatcher& dispatcher, Network::ClientConnectionPtr&& conn,
     Upstream::HostDescriptionConstSharedPtr host_description, CodecClient::Type type)
-    : CodecClientProd(type, std::move(conn), host_description), callbacks_(*this),
+    : CodecClientProd(type, std::move(conn), std::move(host_description)), callbacks_(*this),
       codec_callbacks_(*this) {
   connection_->addConnectionCallbacks(callbacks_);
   setCodecConnectionCallbacks(codec_callbacks_);

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -92,7 +92,8 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
   dispatcher_ = api_->allocateDispatcher();
   client_ = dispatcher_->createClientConnection(Network::Utility::resolveUrl(
       fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)));
-  client_->addReadFilter(Network::ReadFilterSharedPtr{new ForwardingFilter(*this, data_callback)});
+  client_->addReadFilter(
+      Network::ReadFilterSharedPtr{new ForwardingFilter(*this, std::move(data_callback))});
   client_->write(initial_data);
   client_->connect();
 }

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -21,7 +21,8 @@ namespace Envoy {
  */
 class BufferingStreamDecoder : public Http::StreamDecoder, public Http::StreamCallbacks {
 public:
-  BufferingStreamDecoder(std::function<void()> on_complete_cb) : on_complete_cb_(on_complete_cb) {}
+  BufferingStreamDecoder(std::function<void()> on_complete_cb)
+      : on_complete_cb_(std::move(on_complete_cb)) {}
 
   bool complete() { return complete_; }
   const Http::HeaderMap& headers() { return *headers_; }
@@ -62,7 +63,7 @@ public:
 private:
   struct ForwardingFilter : public Network::ReadFilterBaseImpl {
     ForwardingFilter(RawConnectionDriver& parent, ReadCallback cb)
-        : parent_(parent), data_callback_(cb) {}
+        : parent_(parent), data_callback_(std::move(cb)) {}
 
     // Network::ReadFilter
     Network::FilterStatus onData(Buffer::Instance& data) override {

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -27,8 +27,8 @@ public:
 
   uint32_t allocateSlot_() { return current_slot_++; }
   ThreadLocalObjectSharedPtr get_(uint32_t index) { return data_[index]; }
-  void runOnAllThreads_(Event::PostCb cb) { cb(); }
-  void set_(uint32_t index, InitializeCb cb) { data_[index] = cb(dispatcher_); }
+  void runOnAllThreads_(const Event::PostCb& cb) { cb(); }
+  void set_(uint32_t index, const InitializeCb& cb) { data_[index] = cb(dispatcher_); }
   void shutdownThread_() {
     for (auto& entry : data_) {
       entry.second->shutdown();

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -46,7 +46,7 @@ public:
   MockDetector();
   ~MockDetector();
 
-  void runCallbacks(HostSharedPtr host) {
+  void runCallbacks(const HostSharedPtr& host) {
     for (const ChangeStateCb& cb : callbacks_) {
       cb(host);
     }

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -29,8 +29,8 @@ public:
   MockCluster();
   ~MockCluster();
 
-  void runCallbacks(const std::vector<HostSharedPtr> added,
-                    const std::vector<HostSharedPtr> removed) {
+  void runCallbacks(const std::vector<HostSharedPtr>& added,
+                    const std::vector<HostSharedPtr>& removed) {
     for (const MemberUpdateCb& cb : callbacks_) {
       cb(added, removed);
     }


### PR DESCRIPTION
Wherever safe, avoid unnecessary expensive copies due to value-typed function parameters, either by making them const references or by using std::move. See http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html for details.

This is the same tool that I ran in #1024, but now without changing the `HostSharedPtr` argument to `HealthCheckerImplBase::runCallbacks()` -- as @dnoe points out, that copy is necessary for reference counting, and that's why #1024 broke asan/tsan.