### PR TITLE
Converted all logs to macros and modified existing log macros.

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -10,4 +10,7 @@ The following features have been DEPRECATED and will be removed in the specified
   `statsd_udp_ip_address`.
   * `HttpFilterConfigFactory` filter API has been deprecated in favor of `NamedHttpFilterConfigFactory`.
   * Config option `http_codec_options` has been deprecated and has been replaced with `http2_settings`.
-  * The following log macros have been deprecated: `log_trace`, `log_debug`, `conn_log`, `conn_log_info`, `conn_log_debug`, `conn_log_trace`, `stream_log`, `stream_log_info`, `stream_log_debug`, `stream_log_trace`.  For replacements, please see [logger.h](https://github.com/lyft/envoy/blob/master/source/common/common/logger.h).
+  * The following log macros have been deprecated: `log_trace`, `log_debug`, `conn_log`,
+  `conn_log_info`, `conn_log_debug`, `conn_log_trace`, `stream_log`, `stream_log_info`,
+  `stream_log_debug`, `stream_log_trace`.  For replacements, please see
+  [logger.h](https://github.com/lyft/envoy/blob/master/source/common/common/logger.h).

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -10,3 +10,4 @@ The following features have been DEPRECATED and will be removed in the specified
   `statsd_udp_ip_address`.
   * `HttpFilterConfigFactory` filter API has been deprecated in favor of `NamedHttpFilterConfigFactory`.
   * Config option `http_codec_options` has been deprecated and has been replaced with `http2_settings`.
+  * The following log macros have been deprecated: `log_trace`, `log_debug`, `conn_log`, `conn_log_info`, `conn_log_debug`, `conn_log_trace`, `stream_log`, `stream_log_info`, `stream_log_debug`, `stream_log_trace`.  For replacements, please see [logger.h](https://github.com/lyft/envoy/blob/master/source/common/common/logger.h).

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -197,6 +197,16 @@ Similarly, for [thread sanitizer (TSAN)](https://github.com/google/sanitizers/wi
 bazel test -c dbg --config=clang-tsan //test/...
 ```
 
+## Log Verbosity
+
+By default, log verbosity is controlled at runtime in all builds. However, it may be desirable to
+remove log statements of lower importance during compilation to enhance performance. To remove
+`trace` and `debug` log statements during compilation define `NVLOG`:
+```
+bazel build --copt=-DNVLOG //source/exe:envoy-static
+```
+
+
 # Release builds
 
 Release builds should be built in `opt` mode, processed with `strip` and have a

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -128,7 +128,7 @@ protected:
  * Base logging macros.  It is expected that users will use the convenience macros below rather than
  * invoke these directly.
  */
-#ifdef NDEBUG
+#ifdef NVLOG
 #define log_trace_to_logger(LOGGER, ...)
 #define log_debug_to_logger(LOGGER, ...)
 #else
@@ -183,7 +183,7 @@ protected:
 /**
  * DEPRECATED: Logging macros.
  */
-#ifdef NDEBUG
+#ifdef NVLOG
 #define log_trace(...)
 #define log_debug(...)
 #else
@@ -197,7 +197,7 @@ protected:
 #define conn_log(LOG, LEVEL, FORMAT, CONNECTION, ...)                                              \
   LOG.LEVEL("[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
 
-#ifdef NDEBUG
+#ifdef NVLOG
 #define conn_log_trace(...)
 #define conn_log_debug(...)
 #else
@@ -216,7 +216,7 @@ protected:
 #define stream_log(LOG, LEVEL, FORMAT, STREAM, ...)                                                \
   LOG.LEVEL("[C{}][S{}] " FORMAT, (STREAM).connectionId(), (STREAM).streamId(), ##__VA_ARGS__)
 
-#ifdef NDEBUG
+#ifdef NVLOG
 #define stream_log_trace(...)
 #define stream_log_debug(...)
 #else

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -22,6 +22,7 @@ namespace Logger {
   FUNCTION(client)               \
   FUNCTION(config)               \
   FUNCTION(connection)           \
+  FUNCTION(general)              \
   FUNCTION(file)                 \
   FUNCTION(filter)               \
   FUNCTION(hc)                   \
@@ -123,48 +124,51 @@ protected:
 
 } // Logger
 
+/**
+ * Base logging macros.
+ */
 #ifdef NDEBUG
-#define log_trace(...)
-#define log_debug(...)
+#define log_trace(LOGGER, ...)
+#define log_debug(LOGGER, ...)
 #else
-#define log_trace(...) log().trace(__VA_ARGS__)
-#define log_debug(...) log().debug(__VA_ARGS__)
+#define log_trace(LOGGER, ...) LOGGER.trace(__VA_ARGS__)
+#define log_debug(LOGGER, ...) LOGGER.debug(__VA_ARGS__)
 #endif
+
+#define log_info(LOGGER, ...) LOGGER.info(__VA_ARGS__)
+#define log_warn(LOGGER, ...) LOGGER.warn(__VA_ARGS__)
+#define log_err(LOGGER, ...) LOGGER.err(__VA_ARGS__)
+#define log_critical(LOGGER, ...) LOGGER.critical(__VA_ARGS__)
+
+/**
+ * Convenience macros to call the above macros with or without a logger.
+ */
+#define log_facility(LEVEL, ...) log_##LEVEL(log(), ##__VA_ARGS__)
+#define log_to_logger(LOGGER, LEVEL, ...) log_##LEVEL(LOGGER, ##__VA_ARGS__)
+
+/**
+ * Convenience macros to log to the general logger.
+ */
+#define get_general_logger() Logger::Loggable<Logger::Id::general>::log()
+#define log_general(LEVEL, ...) log_to_logger(get_general_logger(), LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with connection ID.
  */
-#define conn_log(LOG, LEVEL, FORMAT, CONNECTION, ...)                                              \
-  LOG.LEVEL("[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
+#define conn_log_to_logger(LOGGER, LEVEL, FORMAT, CONNECTION, ...)                                 \
+  log_to_logger(LOGGER, LEVEL, "[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
 
-#ifdef NDEBUG
-#define conn_log_trace(...)
-#define conn_log_debug(...)
-#else
-#define conn_log_trace(FORMAT, CONNECTION, ...)                                                    \
-  conn_log(log(), trace, FORMAT, CONNECTION, ##__VA_ARGS__)
-#define conn_log_debug(FORMAT, CONNECTION, ...)                                                    \
-  conn_log(log(), debug, FORMAT, CONNECTION, ##__VA_ARGS__)
-#endif
-
-#define conn_log_info(FORMAT, CONNECTION, ...)                                                     \
-  conn_log(log(), info, FORMAT, CONNECTION, ##__VA_ARGS__)
+#define conn_log_facility(LEVEL, FORMAT, CONNECTION, ...)                                          \
+  conn_log_to_logger(log(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with a stream ID and a connection ID.
  */
-#define stream_log(LOG, LEVEL, FORMAT, STREAM, ...)                                                \
-  LOG.LEVEL("[C{}][S{}] " FORMAT, (STREAM).connectionId(), (STREAM).streamId(), ##__VA_ARGS__)
+#define stream_log_to_logger(LOGGER, LEVEL, FORMAT, STREAM, ...)                                   \
+  log_to_logger(LOGGER, LEVEL, "[C{}][S{}] " FORMAT, (STREAM).connectionId(), (STREAM).streamId(), \
+                ##__VA_ARGS__)
 
-#ifdef NDEBUG
-#define stream_log_trace(...)
-#define stream_log_debug(...)
-#else
-#define stream_log_trace(FORMAT, STREAM, ...)                                                      \
-  stream_log(log(), trace, FORMAT, STREAM, ##__VA_ARGS__)
-#define stream_log_debug(FORMAT, STREAM, ...)                                                      \
-  stream_log(log(), debug, FORMAT, STREAM, ##__VA_ARGS__)
-#endif
+#define stream_log_facility(LEVEL, FORMAT, STREAM, ...)                                            \
+  stream_log_to_logger(log(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
-#define stream_log_info(FORMAT, STREAM, ...) stream_log(log(), info, FORMAT, STREAM, ##__VA_ARGS__)
 } // Envoy

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -22,7 +22,7 @@ namespace Logger {
   FUNCTION(client)               \
   FUNCTION(config)               \
   FUNCTION(connection)           \
-  FUNCTION(misc)              \
+  FUNCTION(misc)                 \
   FUNCTION(file)                 \
   FUNCTION(filter)               \
   FUNCTION(hc)                   \
@@ -124,6 +124,12 @@ protected:
 
 } // Logger
 
+// Convert the line macro to a string literal for concatenation in log macros.
+#define DO_STRINGIZE(x) STRINGIZE(x)
+#define STRINGIZE(x) #x
+#define LINE_STRING DO_STRINGIZE(__LINE__)
+#define LOG_PREFIX __FILE__ ":" LINE_STRING "] "
+
 /**
  * Base logging macros.  It is expected that users will use the convenience macros below rather than
  * invoke these directly.
@@ -132,14 +138,14 @@ protected:
 #define log_trace_to_logger(LOGGER, ...)
 #define log_debug_to_logger(LOGGER, ...)
 #else
-#define log_trace_to_logger(LOGGER, ...) LOGGER.trace(__VA_ARGS__)
-#define log_debug_to_logger(LOGGER, ...) LOGGER.debug(__VA_ARGS__)
+#define log_trace_to_logger(LOGGER, ...) LOGGER.trace(LOG_PREFIX __VA_ARGS__)
+#define log_debug_to_logger(LOGGER, ...) LOGGER.debug(LOG_PREFIX __VA_ARGS__)
 #endif
 
-#define log_info_to_logger(LOGGER, ...) LOGGER.info(__VA_ARGS__)
-#define log_warn_to_logger(LOGGER, ...) LOGGER.warn(__VA_ARGS__)
-#define log_err_to_logger(LOGGER, ...) LOGGER.err(__VA_ARGS__)
-#define log_critical_to_logger(LOGGER, ...) LOGGER.critical(__VA_ARGS__)
+#define log_info_to_logger(LOGGER, ...) LOGGER.info(LOG_PREFIX __VA_ARGS__)
+#define log_warn_to_logger(LOGGER, ...) LOGGER.warn(LOG_PREFIX __VA_ARGS__)
+#define log_err_to_logger(LOGGER, ...) LOGGER.err(LOG_PREFIX __VA_ARGS__)
+#define log_critical_to_logger(LOGGER, ...) LOGGER.critical(LOG_PREFIX __VA_ARGS__)
 
 /**
  * Convenience macro to log to a user-specified logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -135,56 +135,53 @@ protected:
  * invoke these directly.
  */
 #ifdef NVLOG
-#define log_trace_to_logger(LOGGER, ...)
-#define log_debug_to_logger(LOGGER, ...)
+#define LOG_trace_TO_LOGGER(LOGGER, ...)
+#define LOG_debug_TO_LOGGER(LOGGER, ...)
 #else
-#define log_trace_to_logger(LOGGER, ...) LOGGER.trace(LOG_PREFIX __VA_ARGS__)
-#define log_debug_to_logger(LOGGER, ...) LOGGER.debug(LOG_PREFIX __VA_ARGS__)
+#define LOG_trace_TO_LOGGER(LOGGER, ...) LOGGER.trace(LOG_PREFIX __VA_ARGS__)
+#define LOG_debug_TO_LOGGER(LOGGER, ...) LOGGER.debug(LOG_PREFIX __VA_ARGS__)
 #endif
 
-#define log_info_to_logger(LOGGER, ...) LOGGER.info(LOG_PREFIX __VA_ARGS__)
-#define log_warn_to_logger(LOGGER, ...) LOGGER.warn(LOG_PREFIX __VA_ARGS__)
-#define log_err_to_logger(LOGGER, ...) LOGGER.err(LOG_PREFIX __VA_ARGS__)
-#define log_critical_to_logger(LOGGER, ...) LOGGER.critical(LOG_PREFIX __VA_ARGS__)
+#define LOG_info_TO_LOGGER(LOGGER, ...) LOGGER.info(LOG_PREFIX __VA_ARGS__)
+#define LOG_warn_TO_LOGGER(LOGGER, ...) LOGGER.warn(LOG_PREFIX __VA_ARGS__)
+#define LOG_err_TO_LOGGER(LOGGER, ...) LOGGER.err(LOG_PREFIX __VA_ARGS__)
+#define LOG_critical_TO_LOGGER(LOGGER, ...) LOGGER.critical(LOG_PREFIX __VA_ARGS__)
 
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define log_to_logger(LOGGER, LEVEL, ...) log_##LEVEL##_to_logger(LOGGER, ##__VA_ARGS__)
+#define LOG_TO_LOGGER(LOGGER, LEVEL, ...) LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
 
 /**
- * Convenience macro to log to the facility of the class in which the macro is invoked. Note:
- * facilities are a way of grouping classes within envoy. A facility is specified by Id enum values
- * listed above. The facility_log is enabled within a class when the class inherits from the
- * Loggable class templated by the choice of facility.
+ * Convenience macro to log to the class' logger.
  */
-#define log_facility(LEVEL, ...) log_to_logger(log(), LEVEL, ##__VA_ARGS__)
+#define LOG(LEVEL, ...) LOG_TO_LOGGER(log(), LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macro to log to the misc logger, which allows for logging without of direct access to
  * a logger.
  */
-#define get_misc_logger() Logger::Registry::getLog(Logger::Id::misc)
-#define log_misc(LEVEL, ...) log_to_logger(get_misc_logger(), LEVEL, ##__VA_ARGS__)
+#define GET_MISC_LOGGER() Logger::Registry::getLog(Logger::Id::misc)
+#define LOG_MISC(LEVEL, ...) LOG_TO_LOGGER(GET_MISC_LOGGER(), LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with connection ID.
  */
-#define conn_log_to_logger(LOGGER, LEVEL, FORMAT, CONNECTION, ...)                                 \
-  log_to_logger(LOGGER, LEVEL, "[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
+#define CONN_LOG_TO_LOGGER(LOGGER, LEVEL, FORMAT, CONNECTION, ...)                                 \
+  LOG_TO_LOGGER(LOGGER, LEVEL, "[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
 
-#define conn_log_facility(LEVEL, FORMAT, CONNECTION, ...)                                          \
-  conn_log_to_logger(log(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
+#define CONN_LOG(LEVEL, FORMAT, CONNECTION, ...)                                                   \
+  CONN_LOG_TO_LOGGER(log(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with a stream ID and a connection ID.
  */
-#define stream_log_to_logger(LOGGER, LEVEL, FORMAT, STREAM, ...)                                   \
-  log_to_logger(LOGGER, LEVEL, "[C{}][S{}] " FORMAT, (STREAM).connectionId(), (STREAM).streamId(), \
+#define STREAM_LOG_TO_LOGGER(LOGGER, LEVEL, FORMAT, STREAM, ...)                                   \
+  LOG_TO_LOGGER(LOGGER, LEVEL, "[C{}][S{}] " FORMAT, (STREAM).connectionId(), (STREAM).streamId(), \
                 ##__VA_ARGS__)
 
-#define stream_log_facility(LEVEL, FORMAT, STREAM, ...)                                            \
-  stream_log_to_logger(log(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
+#define STREAM_LOG(LEVEL, FORMAT, STREAM, ...)                                                     \
+  STREAM_LOG_TO_LOGGER(log(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
 /**
  * DEPRECATED: Logging macros.

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -40,7 +40,7 @@ void DispatcherImpl::clearDeferredDeleteList() {
     return;
   }
 
-  log_trace("clearing deferred deletion list (size={})", num_to_delete);
+  log_facility(trace, "clearing deferred deletion list (size={})", num_to_delete);
 
   // Swap the current deletion vector so that if we do deferred delete while we are deleting, we
   // use the other vector. We will get another callback to delete that vector.
@@ -110,7 +110,7 @@ TimerPtr DispatcherImpl::createTimer(TimerCb cb) { return TimerPtr{new TimerImpl
 
 void DispatcherImpl::deferredDelete(DeferredDeletablePtr&& to_delete) {
   current_to_delete_->emplace_back(std::move(to_delete));
-  log_trace("item added to deferred deletion list (size={})", current_to_delete_->size());
+  log_facility(trace, "item added to deferred deletion list (size={})", current_to_delete_->size());
   if (1 == current_to_delete_->size()) {
     deferred_delete_timer_->enableTimer(std::chrono::milliseconds(0));
   }

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -40,7 +40,7 @@ void DispatcherImpl::clearDeferredDeleteList() {
     return;
   }
 
-  log_facility(trace, "clearing deferred deletion list (size={})", num_to_delete);
+  LOG(trace, "clearing deferred deletion list (size={})", num_to_delete);
 
   // Swap the current deletion vector so that if we do deferred delete while we are deleting, we
   // use the other vector. We will get another callback to delete that vector.
@@ -110,7 +110,7 @@ TimerPtr DispatcherImpl::createTimer(TimerCb cb) { return TimerPtr{new TimerImpl
 
 void DispatcherImpl::deferredDelete(DeferredDeletablePtr&& to_delete) {
   current_to_delete_->emplace_back(std::move(to_delete));
-  log_facility(trace, "item added to deferred deletion list (size={})", current_to_delete_->size());
+  LOG(trace, "item added to deferred deletion list (size={})", current_to_delete_->size());
   if (1 == current_to_delete_->size()) {
     deferred_delete_timer_->enableTimer(std::chrono::milliseconds(0));
   }

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -44,8 +44,7 @@ void WatcherImpl::addWatch(const std::string& path, uint32_t events, OnChangedCb
         fmt::format("unable to add filesystem watch for file {}: {}", path, strerror(errno)));
   }
 
-  log_facility(debug, "added watch for directory: '{}' file: '{}' fd: {}", directory, file,
-               watch_fd);
+  LOG(debug, "added watch for directory: '{}' file: '{}' fd: {}", directory, file, watch_fd);
   callback_map_[watch_fd].watches_.push_back({file, events, callback});
 }
 
@@ -67,8 +66,8 @@ void WatcherImpl::onInotifyEvent() {
         file.assign(file_event->name);
       }
 
-      log_facility(debug, "notification: fd: {} mask: {:x} file: {}", file_event->wd,
-                   file_event->mask, file);
+      LOG(debug, "notification: fd: {} mask: {:x} file: {}", file_event->wd, file_event->mask,
+          file);
 
       uint32_t events = 0;
       if (file_event->mask & IN_MOVED_TO) {
@@ -77,7 +76,7 @@ void WatcherImpl::onInotifyEvent() {
 
       for (FileWatch& watch : callback_map_[file_event->wd].watches_) {
         if (watch.file_ == file && (watch.events_ & events)) {
-          log_facility(debug, "matched callback: file: {}", file);
+          LOG(debug, "matched callback: file: {}", file);
           watch.cb_(events);
         }
       }

--- a/source/common/filesystem/watcher_impl.cc
+++ b/source/common/filesystem/watcher_impl.cc
@@ -44,7 +44,8 @@ void WatcherImpl::addWatch(const std::string& path, uint32_t events, OnChangedCb
         fmt::format("unable to add filesystem watch for file {}: {}", path, strerror(errno)));
   }
 
-  log_debug("added watch for directory: '{}' file: '{}' fd: {}", directory, file, watch_fd);
+  log_facility(debug, "added watch for directory: '{}' file: '{}' fd: {}", directory, file,
+               watch_fd);
   callback_map_[watch_fd].watches_.push_back({file, events, callback});
 }
 
@@ -66,7 +67,8 @@ void WatcherImpl::onInotifyEvent() {
         file.assign(file_event->name);
       }
 
-      log_debug("notification: fd: {} mask: {:x} file: {}", file_event->wd, file_event->mask, file);
+      log_facility(debug, "notification: fd: {} mask: {:x} file: {}", file_event->wd,
+                   file_event->mask, file);
 
       uint32_t events = 0;
       if (file_event->mask & IN_MOVED_TO) {
@@ -75,7 +77,7 @@ void WatcherImpl::onInotifyEvent() {
 
       for (FileWatch& watch : callback_map_[file_event->wd].watches_) {
         if (watch.file_ == file && (watch.events_ & events)) {
-          log_debug("matched callback: file: {}", file);
+          log_facility(debug, "matched callback: file: {}", file);
           watch.cb_(events);
         }
       }

--- a/source/common/filter/echo.cc
+++ b/source/common/filter/echo.cc
@@ -9,7 +9,7 @@ namespace Envoy {
 namespace Filter {
 
 Network::FilterStatus Echo::onData(Buffer::Instance& data) {
-  conn_log_trace("echo: got {} bytes", read_callbacks_->connection(), data.length());
+  conn_log_facility(trace, "echo: got {} bytes", read_callbacks_->connection(), data.length());
   read_callbacks_->connection().write(data);
   ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;

--- a/source/common/filter/echo.cc
+++ b/source/common/filter/echo.cc
@@ -9,7 +9,7 @@ namespace Envoy {
 namespace Filter {
 
 Network::FilterStatus Echo::onData(Buffer::Instance& data) {
-  conn_log_facility(trace, "echo: got {} bytes", read_callbacks_->connection(), data.length());
+  CONN_LOG(trace, "echo: got {} bytes", read_callbacks_->connection(), data.length());
   read_callbacks_->connection().write(data);
   ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -114,7 +114,7 @@ TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Stor
 
 void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
-  conn_log_facility(info, "new tcp proxy session", read_callbacks_->connection());
+  CONN_LOG(info, "new tcp proxy session", read_callbacks_->connection());
   config_->stats().downstream_cx_total_.inc();
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
   read_callbacks_->connection().setBufferStats({config_->stats().downstream_cx_rx_bytes_total_,
@@ -129,8 +129,8 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
   Upstream::ThreadLocalCluster* thread_local_cluster = cluster_manager_.get(cluster_name);
 
   if (thread_local_cluster) {
-    conn_log_facility(debug, "Creating connection to cluster {}", read_callbacks_->connection(),
-                      cluster_name);
+    CONN_LOG(debug, "Creating connection to cluster {}", read_callbacks_->connection(),
+             cluster_name);
   } else {
     config_->stats().downstream_cx_no_route_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
@@ -180,7 +180,7 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
 }
 
 void TcpProxy::onConnectTimeout() {
-  conn_log_facility(debug, "connect timeout", read_callbacks_->connection());
+  CONN_LOG(debug, "connect timeout", read_callbacks_->connection());
   read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_connect_timeout_.inc();
 
   // This will close the upstream connection as well.
@@ -188,7 +188,7 @@ void TcpProxy::onConnectTimeout() {
 }
 
 Network::FilterStatus TcpProxy::onData(Buffer::Instance& data) {
-  conn_log_facility(trace, "received {} bytes", read_callbacks_->connection(), data.length());
+  CONN_LOG(trace, "received {} bytes", read_callbacks_->connection(), data.length());
   upstream_connection_->write(data);
   ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -114,7 +114,7 @@ TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Stor
 
 void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
-  conn_log_info("new tcp proxy session", read_callbacks_->connection());
+  conn_log_facility(info, "new tcp proxy session", read_callbacks_->connection());
   config_->stats().downstream_cx_total_.inc();
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
   read_callbacks_->connection().setBufferStats({config_->stats().downstream_cx_rx_bytes_total_,
@@ -129,8 +129,8 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
   Upstream::ThreadLocalCluster* thread_local_cluster = cluster_manager_.get(cluster_name);
 
   if (thread_local_cluster) {
-    conn_log_debug("Creating connection to cluster {}", read_callbacks_->connection(),
-                   cluster_name);
+    conn_log_facility(debug, "Creating connection to cluster {}", read_callbacks_->connection(),
+                      cluster_name);
   } else {
     config_->stats().downstream_cx_no_route_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
@@ -180,7 +180,7 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
 }
 
 void TcpProxy::onConnectTimeout() {
-  conn_log_debug("connect timeout", read_callbacks_->connection());
+  conn_log_facility(debug, "connect timeout", read_callbacks_->connection());
   read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_connect_timeout_.inc();
 
   // This will close the upstream connection as well.
@@ -188,7 +188,7 @@ void TcpProxy::onConnectTimeout() {
 }
 
 Network::FilterStatus TcpProxy::onData(Buffer::Instance& data) {
-  conn_log_trace("received {} bytes", read_callbacks_->connection(), data.length());
+  conn_log_facility(trace, "received {} bytes", read_callbacks_->connection(), data.length());
   upstream_connection_->write(data);
   ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -71,7 +71,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
 }
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
-#ifndef NDEBUG
+#ifndef NVLOG
   log_facility(debug, "async http request response headers (end_stream={}):", end_stream);
   headers->iterate([](const HeaderEntry& header, void*) -> void {
     log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
@@ -90,7 +90,7 @@ void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
 }
 
 void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
-#ifndef NDEBUG
+#ifndef NVLOG
   log_facility(debug, "async http request response trailers:");
   trailers->iterate([](const HeaderEntry& header, void*) -> void {
     log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -72,9 +72,9 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 #ifndef NVLOG
-  log_facility(debug, "async http request response headers (end_stream={}):", end_stream);
+  LOG(debug, "async http request response headers (end_stream={}):", end_stream);
   headers->iterate([](const HeaderEntry& header, void*) -> void {
-    log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+    LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
   }, nullptr);
 #endif
 
@@ -83,17 +83,17 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 }
 
 void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
-  log_facility(trace, "async http request response data (length={} end_stream={})", data.length(),
-               end_stream);
+  LOG(trace, "async http request response data (length={} end_stream={})", data.length(),
+      end_stream);
   stream_callbacks_.onData(data, end_stream);
   closeRemote(end_stream);
 }
 
 void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
 #ifndef NVLOG
-  log_facility(debug, "async http request response trailers:");
+  LOG(debug, "async http request response trailers:");
   trailers->iterate([](const HeaderEntry& header, void*) -> void {
-    log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+    LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
   }, nullptr);
 #endif
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -72,9 +72,9 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 #ifndef NDEBUG
-  log_debug("async http request response headers (end_stream={}):", end_stream);
+  log_facility(debug, "async http request response headers (end_stream={}):", end_stream);
   headers->iterate([](const HeaderEntry& header, void*) -> void {
-    log_debug("  '{}':'{}'", header.key().c_str(), header.value().c_str());
+    log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
   }, nullptr);
 #endif
 
@@ -83,17 +83,17 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 }
 
 void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
-  log_trace("async http request response data (length={} end_stream={})", data.length(),
-            end_stream);
+  log_facility(trace, "async http request response data (length={} end_stream={})", data.length(),
+               end_stream);
   stream_callbacks_.onData(data, end_stream);
   closeRemote(end_stream);
 }
 
 void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
 #ifndef NDEBUG
-  log_debug("async http request response trailers:");
+  log_facility(debug, "async http request response trailers:");
   trailers->iterate([](const HeaderEntry& header, void*) -> void {
-    log_debug("  '{}':'{}'", header.key().c_str(), header.value().c_str());
+    log_facility(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
   }, nullptr);
 #endif
 

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -18,7 +18,7 @@ CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(Network::ReadFilterSharedPtr{new CodecReadFilter(*this)});
 
-  conn_log_info("connecting", *connection_);
+  conn_log_facility(info, "connecting", *connection_);
   connection_->connect();
 
   // We just universally set no delay on connections. Theoretically we might at some point want
@@ -47,7 +47,7 @@ StreamEncoder& CodecClient::newStream(StreamDecoder& response_decoder) {
 
 void CodecClient::onEvent(uint32_t events) {
   if (events & Network::ConnectionEvent::Connected) {
-    conn_log_debug("connected", *connection_);
+    conn_log_facility(debug, "connected", *connection_);
     connected_ = true;
   }
 
@@ -64,8 +64,8 @@ void CodecClient::onEvent(uint32_t events) {
 
   if ((events & Network::ConnectionEvent::RemoteClose) ||
       (events & Network::ConnectionEvent::LocalClose)) {
-    conn_log_debug("disconnect. resetting {} pending requests", *connection_,
-                   active_requests_.size());
+    conn_log_facility(debug, "disconnect. resetting {} pending requests", *connection_,
+                      active_requests_.size());
     while (!active_requests_.empty()) {
       // Fake resetting all active streams so that reset() callbacks get invoked.
       active_requests_.front()->encoder_->getStream().resetStream(
@@ -76,7 +76,7 @@ void CodecClient::onEvent(uint32_t events) {
 }
 
 void CodecClient::responseDecodeComplete(ActiveRequest& request) {
-  conn_log_debug("response complete", *connection_);
+  conn_log_facility(debug, "response complete", *connection_);
   deleteRequest(request);
 
   // HTTP/2 can send us a reset after a complete response if the request was not complete. Users
@@ -86,7 +86,7 @@ void CodecClient::responseDecodeComplete(ActiveRequest& request) {
 }
 
 void CodecClient::onReset(ActiveRequest& request, StreamResetReason reason) {
-  conn_log_debug("request reset", *connection_);
+  conn_log_facility(debug, "request reset", *connection_);
   if (codec_client_callbacks_) {
     codec_client_callbacks_->onStreamReset(reason);
   }
@@ -99,11 +99,11 @@ void CodecClient::onData(Buffer::Instance& data) {
   try {
     codec_->dispatch(data);
   } catch (CodecProtocolException& e) {
-    conn_log_info("protocol error: {}", *connection_, e.what());
+    conn_log_facility(info, "protocol error: {}", *connection_, e.what());
     close();
     protocol_error = true;
   } catch (PrematureResponseException& e) {
-    conn_log_info("premature response", *connection_);
+    conn_log_facility(info, "premature response", *connection_);
     close();
 
     // Don't count 408 responses where we have no active requests as protocol errors

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -18,7 +18,7 @@ CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(Network::ReadFilterSharedPtr{new CodecReadFilter(*this)});
 
-  conn_log_facility(info, "connecting", *connection_);
+  CONN_LOG(info, "connecting", *connection_);
   connection_->connect();
 
   // We just universally set no delay on connections. Theoretically we might at some point want
@@ -47,7 +47,7 @@ StreamEncoder& CodecClient::newStream(StreamDecoder& response_decoder) {
 
 void CodecClient::onEvent(uint32_t events) {
   if (events & Network::ConnectionEvent::Connected) {
-    conn_log_facility(debug, "connected", *connection_);
+    CONN_LOG(debug, "connected", *connection_);
     connected_ = true;
   }
 
@@ -64,8 +64,8 @@ void CodecClient::onEvent(uint32_t events) {
 
   if ((events & Network::ConnectionEvent::RemoteClose) ||
       (events & Network::ConnectionEvent::LocalClose)) {
-    conn_log_facility(debug, "disconnect. resetting {} pending requests", *connection_,
-                      active_requests_.size());
+    CONN_LOG(debug, "disconnect. resetting {} pending requests", *connection_,
+             active_requests_.size());
     while (!active_requests_.empty()) {
       // Fake resetting all active streams so that reset() callbacks get invoked.
       active_requests_.front()->encoder_->getStream().resetStream(
@@ -76,7 +76,7 @@ void CodecClient::onEvent(uint32_t events) {
 }
 
 void CodecClient::responseDecodeComplete(ActiveRequest& request) {
-  conn_log_facility(debug, "response complete", *connection_);
+  CONN_LOG(debug, "response complete", *connection_);
   deleteRequest(request);
 
   // HTTP/2 can send us a reset after a complete response if the request was not complete. Users
@@ -86,7 +86,7 @@ void CodecClient::responseDecodeComplete(ActiveRequest& request) {
 }
 
 void CodecClient::onReset(ActiveRequest& request, StreamResetReason reason) {
-  conn_log_facility(debug, "request reset", *connection_);
+  CONN_LOG(debug, "request reset", *connection_);
   if (codec_client_callbacks_) {
     codec_client_callbacks_->onStreamReset(reason);
   }
@@ -99,11 +99,11 @@ void CodecClient::onData(Buffer::Instance& data) {
   try {
     codec_->dispatch(data);
   } catch (CodecProtocolException& e) {
-    conn_log_facility(info, "protocol error: {}", *connection_, e.what());
+    CONN_LOG(info, "protocol error: {}", *connection_, e.what());
     close();
     protocol_error = true;
   } catch (PrematureResponseException& e) {
-    conn_log_facility(info, "premature response", *connection_);
+    CONN_LOG(info, "premature response", *connection_);
     close();
 
     // Don't count 408 responses where we have no active requests as protocol errors

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -162,7 +162,7 @@ StreamDecoder& ConnectionManagerImpl::newStream(StreamEncoder& response_encoder)
     idle_timer_->disableTimer();
   }
 
-  conn_log_facility(debug, "new stream", read_callbacks_->connection());
+  CONN_LOG(debug, "new stream", read_callbacks_->connection());
   ActiveStreamPtr new_stream(new ActiveStream(*this));
   new_stream->response_encoder_ = &response_encoder;
   new_stream->response_encoder_->getStream().addCallbacks(*new_stream);
@@ -192,7 +192,7 @@ Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
     } catch (const CodecProtocolException& e) {
       // HTTP/1.1 codec has already sent a 400 response if possible. HTTP/2 codec has already sent
       // GOAWAY.
-      conn_log_facility(debug, "dispatch error: {}", read_callbacks_->connection(), e.what());
+      CONN_LOG(debug, "dispatch error: {}", read_callbacks_->connection(), e.what());
       stats_.named_.downstream_cx_protocol_error_.inc();
 
       // In the protocol error case, we need to reset all streams now. Since we do a flush write,
@@ -274,7 +274,7 @@ void ConnectionManagerImpl::onGoAway() {
 }
 
 void ConnectionManagerImpl::onIdleTimeout() {
-  conn_log_facility(debug, "idle timeout", read_callbacks_->connection());
+  CONN_LOG(debug, "idle timeout", read_callbacks_->connection());
   stats_.named_.downstream_cx_idle_timeout_.inc();
   if (!codec_) {
     read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
@@ -399,11 +399,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   state_.remote_complete_ = end_stream;
 
   request_headers_ = std::move(headers);
-  stream_log_facility(debug, "request headers complete (end_stream={}):", *this, end_stream);
+  STREAM_LOG(debug, "request headers complete (end_stream={}):", *this, end_stream);
 #ifndef NVLOG
   request_headers_->iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                        header.key().c_str(), header.value().c_str());
+    STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
+               header.value().c_str());
   }, this);
 #endif
 
@@ -502,8 +502,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilte
     FilterHeadersStatus status = (*entry)->handle_->decodeHeaders(
         headers, end_stream && continue_data_entry == decoder_filters_.end());
     state_.filter_call_state_ &= ~FilterCallState::DecodeHeaders;
-    stream_log_facility(trace, "decode headers called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "decode headers called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterHeadersCallback(status) &&
         std::next(entry) != decoder_filters_.end()) {
       // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
@@ -533,7 +533,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(Buffer::Instance& data, boo
   ASSERT(!state_.remote_complete_);
   state_.remote_complete_ = end_stream;
   if (state_.remote_complete_) {
-    stream_log_facility(debug, "request end stream", *this);
+    STREAM_LOG(debug, "request end stream", *this);
   }
 
   decodeData(nullptr, data, end_stream);
@@ -559,8 +559,8 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
     state_.filter_call_state_ |= FilterCallState::DecodeData;
     FilterDataStatus status = (*entry)->handle_->decodeData(data, end_stream);
     state_.filter_call_state_ &= ~FilterCallState::DecodeData;
-    stream_log_facility(trace, "decode data called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "decode data called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterDataCallback(status, data)) {
       return;
     }
@@ -611,8 +611,8 @@ void ConnectionManagerImpl::ActiveStream::decodeTrailers(ActiveStreamDecoderFilt
     state_.filter_call_state_ |= FilterCallState::DecodeTrailers;
     FilterTrailersStatus status = (*entry)->handle_->decodeTrailers(trailers);
     state_.filter_call_state_ &= ~FilterCallState::DecodeTrailers;
-    stream_log_facility(trace, "decode trailers called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "decode trailers called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
       return;
     }
@@ -656,8 +656,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(
         headers, end_stream && continue_data_entry == encoder_filters_.end());
     state_.filter_call_state_ &= ~FilterCallState::EncodeHeaders;
-    stream_log_facility(trace, "encode headers called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "encode headers called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterHeadersCallback(status)) {
       return;
     }
@@ -685,11 +685,11 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     // HTTP/1.1 and HTTP/2.
     connection_manager_.startDrainSequence();
     connection_manager_.stats_.named_.downstream_cx_drain_close_.inc();
-    stream_log_facility(debug, "drain closing connection", *this);
+    STREAM_LOG(debug, "drain closing connection", *this);
   }
 
   if (connection_manager_.drain_state_ == DrainState::NotDraining && state_.saw_connection_close_) {
-    stream_log_facility(debug, "closing connection due to connection close header", *this);
+    STREAM_LOG(debug, "closing connection due to connection close header", *this);
     connection_manager_.drain_state_ = DrainState::Closing;
   }
 
@@ -711,12 +711,12 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 
   chargeStats(headers);
 
-  stream_log_facility(debug, "encoding headers via codec (end_stream={}):", *this,
-                      end_stream && continue_data_entry == encoder_filters_.end());
+  STREAM_LOG(debug, "encoding headers via codec (end_stream={}):", *this,
+             end_stream && continue_data_entry == encoder_filters_.end());
 #ifndef NVLOG
   headers.iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                        header.key().c_str(), header.value().c_str());
+    STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
+               header.value().c_str());
   }, this);
 #endif
 
@@ -761,15 +761,15 @@ void ConnectionManagerImpl::ActiveStream::encodeData(ActiveStreamEncoderFilter* 
     state_.filter_call_state_ |= FilterCallState::EncodeData;
     FilterDataStatus status = (*entry)->handle_->encodeData(data, end_stream);
     state_.filter_call_state_ &= ~FilterCallState::EncodeData;
-    stream_log_facility(trace, "encode data called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "encode data called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterDataCallback(status, data)) {
       return;
     }
   }
 
-  stream_log_facility(trace, "encoding data via codec (size={} end_stream={})", *this,
-                      data.length(), end_stream);
+  STREAM_LOG(trace, "encoding data via codec (size={} end_stream={})", *this, data.length(),
+             end_stream);
 
   request_info_.bytes_sent_ += data.length();
   response_encoder_->encodeData(data, end_stream);
@@ -784,18 +784,18 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
     state_.filter_call_state_ |= FilterCallState::EncodeTrailers;
     FilterTrailersStatus status = (*entry)->handle_->encodeTrailers(trailers);
     state_.filter_call_state_ &= ~FilterCallState::EncodeTrailers;
-    stream_log_facility(trace, "encode trailers called: filter={} status={}", *this,
-                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    STREAM_LOG(trace, "encode trailers called: filter={} status={}", *this,
+               static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
       return;
     }
   }
 
-  stream_log_facility(debug, "encoding trailers via codec", *this);
+  STREAM_LOG(debug, "encoding trailers via codec", *this);
 #ifndef NVLOG
   trailers.iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                        header.key().c_str(), header.value().c_str());
+    STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
+               header.value().c_str());
   }, this);
 #endif
 
@@ -831,8 +831,7 @@ ConnectionManagerImpl::ActiveStream::requestHeadersForTags() const {
 
 void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
   // TODO(mattklein123): Raise an error if this is called during a callback.
-  stream_log_facility(trace, "continuing filter chain: filter={}", parent_,
-                      static_cast<const void*>(this));
+  STREAM_LOG(trace, "continuing filter chain: filter={}", parent_, static_cast<const void*>(this));
   ASSERT(stopped_);
   stopped_ = false;
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -162,7 +162,7 @@ StreamDecoder& ConnectionManagerImpl::newStream(StreamEncoder& response_encoder)
     idle_timer_->disableTimer();
   }
 
-  conn_log_debug("new stream", read_callbacks_->connection());
+  conn_log_facility(debug, "new stream", read_callbacks_->connection());
   ActiveStreamPtr new_stream(new ActiveStream(*this));
   new_stream->response_encoder_ = &response_encoder;
   new_stream->response_encoder_->getStream().addCallbacks(*new_stream);
@@ -192,7 +192,7 @@ Network::FilterStatus ConnectionManagerImpl::onData(Buffer::Instance& data) {
     } catch (const CodecProtocolException& e) {
       // HTTP/1.1 codec has already sent a 400 response if possible. HTTP/2 codec has already sent
       // GOAWAY.
-      conn_log_debug("dispatch error: {}", read_callbacks_->connection(), e.what());
+      conn_log_facility(debug, "dispatch error: {}", read_callbacks_->connection(), e.what());
       stats_.named_.downstream_cx_protocol_error_.inc();
 
       // In the protocol error case, we need to reset all streams now. Since we do a flush write,
@@ -274,7 +274,7 @@ void ConnectionManagerImpl::onGoAway() {
 }
 
 void ConnectionManagerImpl::onIdleTimeout() {
-  conn_log_debug("idle timeout", read_callbacks_->connection());
+  conn_log_facility(debug, "idle timeout", read_callbacks_->connection());
   stats_.named_.downstream_cx_idle_timeout_.inc();
   if (!codec_) {
     read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
@@ -399,11 +399,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   state_.remote_complete_ = end_stream;
 
   request_headers_ = std::move(headers);
-  stream_log_debug("request headers complete (end_stream={}):", *this, end_stream);
+  stream_log_facility(debug, "request headers complete (end_stream={}):", *this, end_stream);
 #ifndef NDEBUG
   request_headers_->iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_debug("  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
-                     header.value().c_str());
+    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
+                        header.key().c_str(), header.value().c_str());
   }, this);
 #endif
 
@@ -502,8 +502,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilte
     FilterHeadersStatus status = (*entry)->handle_->decodeHeaders(
         headers, end_stream && continue_data_entry == decoder_filters_.end());
     state_.filter_call_state_ &= ~FilterCallState::DecodeHeaders;
-    stream_log_trace("decode headers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "decode headers called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterHeadersCallback(status) &&
         std::next(entry) != decoder_filters_.end()) {
       // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
@@ -533,7 +533,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(Buffer::Instance& data, boo
   ASSERT(!state_.remote_complete_);
   state_.remote_complete_ = end_stream;
   if (state_.remote_complete_) {
-    stream_log_debug("request end stream", *this);
+    stream_log_facility(debug, "request end stream", *this);
   }
 
   decodeData(nullptr, data, end_stream);
@@ -559,8 +559,8 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
     state_.filter_call_state_ |= FilterCallState::DecodeData;
     FilterDataStatus status = (*entry)->handle_->decodeData(data, end_stream);
     state_.filter_call_state_ &= ~FilterCallState::DecodeData;
-    stream_log_trace("decode data called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "decode data called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterDataCallback(status, data)) {
       return;
     }
@@ -611,8 +611,8 @@ void ConnectionManagerImpl::ActiveStream::decodeTrailers(ActiveStreamDecoderFilt
     state_.filter_call_state_ |= FilterCallState::DecodeTrailers;
     FilterTrailersStatus status = (*entry)->handle_->decodeTrailers(trailers);
     state_.filter_call_state_ &= ~FilterCallState::DecodeTrailers;
-    stream_log_trace("decode trailers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "decode trailers called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
       return;
     }
@@ -656,8 +656,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(
         headers, end_stream && continue_data_entry == encoder_filters_.end());
     state_.filter_call_state_ &= ~FilterCallState::EncodeHeaders;
-    stream_log_trace("encode headers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "encode headers called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterHeadersCallback(status)) {
       return;
     }
@@ -685,11 +685,11 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     // HTTP/1.1 and HTTP/2.
     connection_manager_.startDrainSequence();
     connection_manager_.stats_.named_.downstream_cx_drain_close_.inc();
-    stream_log_debug("drain closing connection", *this);
+    stream_log_facility(debug, "drain closing connection", *this);
   }
 
   if (connection_manager_.drain_state_ == DrainState::NotDraining && state_.saw_connection_close_) {
-    stream_log_debug("closing connection due to connection close header", *this);
+    stream_log_facility(debug, "closing connection due to connection close header", *this);
     connection_manager_.drain_state_ = DrainState::Closing;
   }
 
@@ -711,12 +711,12 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 
   chargeStats(headers);
 
-  stream_log_debug("encoding headers via codec (end_stream={}):", *this,
-                   end_stream && continue_data_entry == encoder_filters_.end());
+  stream_log_facility(debug, "encoding headers via codec (end_stream={}):", *this,
+                      end_stream && continue_data_entry == encoder_filters_.end());
 #ifndef NDEBUG
   headers.iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_debug("  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
-                     header.value().c_str());
+    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
+                        header.key().c_str(), header.value().c_str());
   }, this);
 #endif
 
@@ -761,15 +761,15 @@ void ConnectionManagerImpl::ActiveStream::encodeData(ActiveStreamEncoderFilter* 
     state_.filter_call_state_ |= FilterCallState::EncodeData;
     FilterDataStatus status = (*entry)->handle_->encodeData(data, end_stream);
     state_.filter_call_state_ &= ~FilterCallState::EncodeData;
-    stream_log_trace("encode data called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "encode data called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterDataCallback(status, data)) {
       return;
     }
   }
 
-  stream_log_trace("encoding data via codec (size={} end_stream={})", *this, data.length(),
-                   end_stream);
+  stream_log_facility(trace, "encoding data via codec (size={} end_stream={})", *this,
+                      data.length(), end_stream);
 
   request_info_.bytes_sent_ += data.length();
   response_encoder_->encodeData(data, end_stream);
@@ -784,18 +784,18 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
     state_.filter_call_state_ |= FilterCallState::EncodeTrailers;
     FilterTrailersStatus status = (*entry)->handle_->encodeTrailers(trailers);
     state_.filter_call_state_ &= ~FilterCallState::EncodeTrailers;
-    stream_log_trace("encode trailers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    stream_log_facility(trace, "encode trailers called: filter={} status={}", *this,
+                        static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
       return;
     }
   }
 
-  stream_log_debug("encoding trailers via codec", *this);
+  stream_log_facility(debug, "encoding trailers via codec", *this);
 #ifndef NDEBUG
   trailers.iterate([](const HeaderEntry& header, void* context) -> void {
-    stream_log_debug("  '{}':'{}'", *static_cast<ActiveStream*>(context), header.key().c_str(),
-                     header.value().c_str());
+    stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
+                        header.key().c_str(), header.value().c_str());
   }, this);
 #endif
 
@@ -831,7 +831,8 @@ ConnectionManagerImpl::ActiveStream::requestHeadersForTags() const {
 
 void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
   // TODO(mattklein123): Raise an error if this is called during a callback.
-  stream_log_trace("continuing filter chain: filter={}", parent_, static_cast<const void*>(this));
+  stream_log_facility(trace, "continuing filter chain: filter={}", parent_,
+                      static_cast<const void*>(this));
   ASSERT(stopped_);
   stopped_ = false;
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -400,7 +400,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   request_headers_ = std::move(headers);
   stream_log_facility(debug, "request headers complete (end_stream={}):", *this, end_stream);
-#ifndef NDEBUG
+#ifndef NVLOG
   request_headers_->iterate([](const HeaderEntry& header, void* context) -> void {
     stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                         header.key().c_str(), header.value().c_str());
@@ -713,7 +713,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 
   stream_log_facility(debug, "encoding headers via codec (end_stream={}):", *this,
                       end_stream && continue_data_entry == encoder_filters_.end());
-#ifndef NDEBUG
+#ifndef NVLOG
   headers.iterate([](const HeaderEntry& header, void* context) -> void {
     stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                         header.key().c_str(), header.value().c_str());
@@ -792,7 +792,7 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
   }
 
   stream_log_facility(debug, "encoding trailers via codec", *this);
-#ifndef NDEBUG
+#ifndef NVLOG
   trailers.iterate([](const HeaderEntry& header, void* context) -> void {
     stream_log_facility(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                         header.key().c_str(), header.value().c_str());

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -262,8 +262,8 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, http_parser_type
 }
 
 void ConnectionImpl::completeLastHeader() {
-  conn_log_trace("completed header: key={} value={}", connection_, current_header_field_.c_str(),
-                 current_header_value_.c_str());
+  conn_log_facility(trace, "completed header: key={} value={}", connection_,
+                    current_header_field_.c_str(), current_header_value_.c_str());
   if (!current_header_field_.empty()) {
     toLowerTable().toLowerCase(current_header_field_.buffer(), current_header_field_.size());
     current_header_map_->addViaMove(std::move(current_header_field_),
@@ -276,7 +276,7 @@ void ConnectionImpl::completeLastHeader() {
 }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
-  conn_log_trace("parsing {} bytes", connection_, data.length());
+  conn_log_facility(trace, "parsing {} bytes", connection_, data.length());
 
   // Always unpause before dispatch.
   http_parser_pause(&parser_, 0);
@@ -293,7 +293,7 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
     dispatchSlice(nullptr, 0);
   }
 
-  conn_log_trace("parsed {} bytes", connection_, total_parsed);
+  conn_log_facility(trace, "parsed {} bytes", connection_, total_parsed);
   data.drain(total_parsed);
 }
 
@@ -332,7 +332,7 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
 }
 
 int ConnectionImpl::onHeadersCompleteBase() {
-  conn_log_trace("headers complete", connection_);
+  conn_log_facility(trace, "headers complete", connection_);
   completeLastHeader();
   if (!(parser_.http_major == 1 && parser_.http_minor == 1)) {
     // This is not necessarily true, but it's good enough since higher layers only care if this is
@@ -436,7 +436,7 @@ void ServerConnectionImpl::onUrl(const char* data, size_t length) {
 void ServerConnectionImpl::onBody(const char* data, size_t length) {
   ASSERT(!deferred_end_stream_headers_);
   if (active_request_) {
-    conn_log_trace("body size={}", connection_, length);
+    conn_log_facility(trace, "body size={}", connection_, length);
     Buffer::OwnedImpl buffer(data, length);
     active_request_->request_decoder_->decodeData(buffer, false);
   }
@@ -444,7 +444,7 @@ void ServerConnectionImpl::onBody(const char* data, size_t length) {
 
 void ServerConnectionImpl::onMessageComplete() {
   if (active_request_) {
-    conn_log_trace("message complete", connection_);
+    conn_log_facility(trace, "message complete", connection_);
     Buffer::OwnedImpl buffer;
     active_request_->remote_complete_ = true;
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -262,8 +262,8 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, http_parser_type
 }
 
 void ConnectionImpl::completeLastHeader() {
-  conn_log_facility(trace, "completed header: key={} value={}", connection_,
-                    current_header_field_.c_str(), current_header_value_.c_str());
+  CONN_LOG(trace, "completed header: key={} value={}", connection_, current_header_field_.c_str(),
+           current_header_value_.c_str());
   if (!current_header_field_.empty()) {
     toLowerTable().toLowerCase(current_header_field_.buffer(), current_header_field_.size());
     current_header_map_->addViaMove(std::move(current_header_field_),
@@ -276,7 +276,7 @@ void ConnectionImpl::completeLastHeader() {
 }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
-  conn_log_facility(trace, "parsing {} bytes", connection_, data.length());
+  CONN_LOG(trace, "parsing {} bytes", connection_, data.length());
 
   // Always unpause before dispatch.
   http_parser_pause(&parser_, 0);
@@ -293,7 +293,7 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
     dispatchSlice(nullptr, 0);
   }
 
-  conn_log_facility(trace, "parsed {} bytes", connection_, total_parsed);
+  CONN_LOG(trace, "parsed {} bytes", connection_, total_parsed);
   data.drain(total_parsed);
 }
 
@@ -332,7 +332,7 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
 }
 
 int ConnectionImpl::onHeadersCompleteBase() {
-  conn_log_facility(trace, "headers complete", connection_);
+  CONN_LOG(trace, "headers complete", connection_);
   completeLastHeader();
   if (!(parser_.http_major == 1 && parser_.http_minor == 1)) {
     // This is not necessarily true, but it's good enough since higher layers only care if this is
@@ -436,7 +436,7 @@ void ServerConnectionImpl::onUrl(const char* data, size_t length) {
 void ServerConnectionImpl::onBody(const char* data, size_t length) {
   ASSERT(!deferred_end_stream_headers_);
   if (active_request_) {
-    conn_log_facility(trace, "body size={}", connection_, length);
+    CONN_LOG(trace, "body size={}", connection_, length);
     Buffer::OwnedImpl buffer(data, length);
     active_request_->request_decoder_->decodeData(buffer, false);
   }
@@ -444,7 +444,7 @@ void ServerConnectionImpl::onBody(const char* data, size_t length) {
 
 void ServerConnectionImpl::onMessageComplete() {
   if (active_request_) {
-    conn_log_facility(trace, "message complete", connection_);
+    CONN_LOG(trace, "message complete", connection_);
     Buffer::OwnedImpl buffer;
     active_request_->remote_complete_ = true;
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -58,7 +58,7 @@ void ConnPoolImpl::checkForDrained() {
 }
 
 void ConnPoolImpl::createNewConnection() {
-  log_facility(debug, "creating a new connection");
+  LOG(debug, "creating a new connection");
   ActiveClientPtr client(new ActiveClient(*this));
   client->moveIntoList(std::move(client), busy_clients_);
 }
@@ -67,7 +67,7 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_dec
                                                      ConnectionPool::Callbacks& callbacks) {
   if (!ready_clients_.empty()) {
     ready_clients_.front()->moveBetweenLists(ready_clients_, busy_clients_);
-    conn_log_facility(debug, "using existing connection", *busy_clients_.front()->codec_client_);
+    CONN_LOG(debug, "using existing connection", *busy_clients_.front()->codec_client_);
     attachRequestToClient(*busy_clients_.front(), response_decoder, callbacks);
     return nullptr;
   }
@@ -84,12 +84,12 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_dec
       createNewConnection();
     }
 
-    log_facility(debug, "queueing request due to no available connections");
+    LOG(debug, "queueing request due to no available connections");
     PendingRequestPtr pending_request(new PendingRequest(*this, response_decoder, callbacks));
     pending_request->moveIntoList(std::move(pending_request), pending_requests_);
     return pending_requests_.front().get();
   } else {
-    log_facility(debug, "max pending requests overflow");
+    LOG(debug, "max pending requests overflow");
     callbacks.onPoolFailure(ConnectionPool::PoolFailureReason::Overflow, nullptr);
     host_->cluster().stats().upstream_rq_pending_overflow_.inc();
     return nullptr;
@@ -100,7 +100,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, uint32_t events) {
   if ((events & Network::ConnectionEvent::RemoteClose) ||
       (events & Network::ConnectionEvent::LocalClose)) {
     // The client died.
-    conn_log_facility(debug, "client disconnected", *client.codec_client_);
+    CONN_LOG(debug, "client disconnected", *client.codec_client_);
     ActiveClientPtr removed;
     bool check_for_drained = true;
     if (client.stream_wrapper_) {
@@ -172,22 +172,22 @@ void ConnPoolImpl::onDownstreamReset(ActiveClient& client) {
 }
 
 void ConnPoolImpl::onPendingRequestCancel(PendingRequest& request) {
-  log_facility(debug, "cancelling pending request");
+  LOG(debug, "cancelling pending request");
   request.removeFromList(pending_requests_);
   host_->cluster().stats().upstream_rq_cancelled_.inc();
   checkForDrained();
 }
 
 void ConnPoolImpl::onResponseComplete(ActiveClient& client) {
-  conn_log_facility(debug, "response complete", *client.codec_client_);
+  CONN_LOG(debug, "response complete", *client.codec_client_);
   if (!client.stream_wrapper_->encode_complete_) {
-    conn_log_facility(debug, "response before request complete", *client.codec_client_);
+    CONN_LOG(debug, "response before request complete", *client.codec_client_);
     onDownstreamReset(client);
   } else if (client.stream_wrapper_->saw_close_header_ || client.codec_client_->remoteClosed()) {
-    conn_log_facility(debug, "saw upstream connection: close", *client.codec_client_);
+    CONN_LOG(debug, "saw upstream connection: close", *client.codec_client_);
     onDownstreamReset(client);
   } else if (client.remaining_requests_ > 0 && --client.remaining_requests_ == 0) {
-    conn_log_facility(debug, "maximum requests per connection", *client.codec_client_);
+    CONN_LOG(debug, "maximum requests per connection", *client.codec_client_);
     host_->cluster().stats().upstream_cx_max_requests_.inc();
     onDownstreamReset(client);
   } else {
@@ -199,12 +199,12 @@ void ConnPoolImpl::processIdleClient(ActiveClient& client) {
   client.stream_wrapper_.reset();
   if (pending_requests_.empty()) {
     // There is nothing to service so just move the connection into the ready list.
-    conn_log_facility(debug, "moving to ready", *client.codec_client_);
+    CONN_LOG(debug, "moving to ready", *client.codec_client_);
     client.moveBetweenLists(busy_clients_, ready_clients_);
   } else {
     // There is work to do so bind a request to the client and move it to the busy list. Pending
     // requests are pushed onto the front, so pull from the back.
-    conn_log_facility(debug, "attaching to next request", *client.codec_client_);
+    CONN_LOG(debug, "attaching to next request", *client.codec_client_);
     attachRequestToClient(client, pending_requests_.back()->decoder_,
                           pending_requests_.back()->callbacks_);
     pending_requests_.pop_back();
@@ -297,7 +297,7 @@ ConnPoolImpl::ActiveClient::~ActiveClient() {
 void ConnPoolImpl::ActiveClient::onConnectTimeout() {
   // We just close the client at this point. This will result in both a timeout and a connect
   // failure and will fold into all the normal connect failure logic.
-  conn_log_facility(debug, "connect timeout", *codec_client_);
+  CONN_LOG(debug, "connect timeout", *codec_client_);
   parent_.host_->cluster().stats().upstream_cx_connect_timeout_.inc();
   codec_client_->close();
 }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -224,7 +224,7 @@ void ConnectionImpl::StreamImpl::resetStreamWorker(StreamResetReason reason) {
 ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
 
 void ConnectionImpl::dispatch(Buffer::Instance& data) {
-  conn_log_trace("dispatching {} bytes", connection_, data.length());
+  conn_log_facility(trace, "dispatching {} bytes", connection_, data.length());
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
   Buffer::RawSlice slices[num_slices];
   data.getRawSlices(slices, num_slices);
@@ -239,7 +239,7 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
     dispatching_ = false;
   }
 
-  conn_log_trace("dispatched {} bytes", connection_, data.length());
+  conn_log_facility(trace, "dispatched {} bytes", connection_, data.length());
   data.drain(data.length());
 
   // Decoding incoming frames can generate outbound frames so flush pending.
@@ -274,7 +274,8 @@ void ConnectionImpl::shutdownNotice() {
 }
 
 int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
-  conn_log_trace("recv frame type={}", connection_, static_cast<uint64_t>(frame->hd.type));
+  conn_log_facility(trace, "recv frame type={}", connection_,
+                    static_cast<uint64_t>(frame->hd.type));
 
   // Only raise GOAWAY once, since we don't currently expose stream information. Shutdown
   // notifications are the same as a normal GOAWAY.
@@ -373,7 +374,7 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
     break;
   }
   case NGHTTP2_RST_STREAM: {
-    conn_log_trace("remote reset: {}", connection_, frame->rst_stream.error_code);
+    conn_log_facility(trace, "remote reset: {}", connection_, frame->rst_stream.error_code);
     stats_.rx_reset_.inc();
     break;
   }
@@ -387,7 +388,8 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
   // data from our peer. Sometimes it raises the invalid frame callback, and sometimes it does not.
   // In all cases however it will attempt to send a GOAWAY frame with an error status. If we see
   // an outgoing frame of this type, we will return an error code so that we can abort execution.
-  conn_log_trace("sent frame type={}", connection_, static_cast<uint64_t>(frame->hd.type));
+  conn_log_facility(trace, "sent frame type={}", connection_,
+                    static_cast<uint64_t>(frame->hd.type));
   switch (frame->hd.type) {
   case NGHTTP2_GOAWAY: {
     if (frame->goaway.error_code != NGHTTP2_NO_ERROR) {
@@ -397,7 +399,7 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
   }
 
   case NGHTTP2_RST_STREAM: {
-    conn_log_debug("sent reset code={}", connection_, frame->rst_stream.error_code);
+    conn_log_facility(debug, "sent reset code={}", connection_, frame->rst_stream.error_code);
     stats_.tx_reset_.inc();
     break;
   }
@@ -416,14 +418,14 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
 int ConnectionImpl::onInvalidFrame(int error_code) {
   UNREFERENCED_PARAMETER(error_code);
 
-  conn_log_debug("invalid frame: {}", connection_, nghttp2_strerror(error_code));
+  conn_log_facility(debug, "invalid frame: {}", connection_, nghttp2_strerror(error_code));
   // Cause dispatch to return with an error code.
   return NGHTTP2_ERR_CALLBACK_FAILURE;
 }
 
 ssize_t ConnectionImpl::onSend(const uint8_t* data, size_t length) {
   // TODO(mattklein123): Back pressure.
-  conn_log_trace("send data: bytes={}", connection_, length);
+  conn_log_facility(trace, "send data: bytes={}", connection_, length);
   Buffer::OwnedImpl buffer(data, length);
   connection_.write(buffer);
   return length;
@@ -434,7 +436,7 @@ int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
 
   StreamImpl* stream = getStream(stream_id);
   if (stream) {
-    conn_log_debug("stream closed: {}", connection_, error_code);
+    conn_log_facility(debug, "stream closed: {}", connection_, error_code);
     if (!stream->remote_end_stream_ || !stream->local_end_stream_) {
       stream->runResetCallbacks(error_code == NGHTTP2_REFUSED_STREAM
                                     ? StreamResetReason::RemoteRefusedStreamReset
@@ -522,20 +524,21 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings) {
 
   if (http2_settings.hpack_table_size_ != NGHTTP2_DEFAULT_HEADER_TABLE_SIZE) {
     iv.push_back({NGHTTP2_SETTINGS_HEADER_TABLE_SIZE, http2_settings.hpack_table_size_});
-    conn_log_debug("setting HPACK table size to {}", connection_, http2_settings.hpack_table_size_);
+    conn_log_facility(debug, "setting HPACK table size to {}", connection_,
+                      http2_settings.hpack_table_size_);
   }
 
   if (http2_settings.max_concurrent_streams_ != NGHTTP2_INITIAL_MAX_CONCURRENT_STREAMS) {
     iv.push_back({NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, http2_settings.max_concurrent_streams_});
-    conn_log_debug("setting max concurrent streams to {}", connection_,
-                   http2_settings.max_concurrent_streams_);
+    conn_log_facility(debug, "setting max concurrent streams to {}", connection_,
+                      http2_settings.max_concurrent_streams_);
   }
 
   if (http2_settings.initial_stream_window_size_ != NGHTTP2_INITIAL_WINDOW_SIZE) {
     iv.push_back(
         {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, http2_settings.initial_stream_window_size_});
-    conn_log_debug("setting stream-level initial window size to {}", connection_,
-                   http2_settings.initial_stream_window_size_);
+    conn_log_facility(debug, "setting stream-level initial window size to {}", connection_,
+                      http2_settings.initial_stream_window_size_);
   }
 
   if (!iv.empty()) {
@@ -551,8 +554,8 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings) {
 
   // Increase connection window size up to our default size.
   if (http2_settings.initial_connection_window_size_ != NGHTTP2_INITIAL_CONNECTION_WINDOW_SIZE) {
-    conn_log_debug("updating connection-level initial window size to {}", connection_,
-                   http2_settings.initial_connection_window_size_);
+    conn_log_facility(debug, "updating connection-level initial window size to {}", connection_,
+                      http2_settings.initial_connection_window_size_);
     int rc = nghttp2_submit_window_update(session_, NGHTTP2_FLAG_NONE, 0,
                                           http2_settings.initial_connection_window_size_ -
                                               NGHTTP2_INITIAL_CONNECTION_WINDOW_SIZE);

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -57,7 +57,7 @@ void ConnPoolImpl::checkForDrained() {
   }
 
   if (drained) {
-    log_debug("invoking drained callbacks");
+    log_facility(debug, "invoking drained callbacks");
     for (const DrainedCb& cb : drained_callbacks_) {
       cb();
     }
@@ -83,11 +83,11 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(Http::StreamDecoder& respon
   }
 
   if (!host_->cluster().resourceManager(priority_).requests().canCreate()) {
-    log_debug("max requests overflow");
+    log_facility(debug, "max requests overflow");
     callbacks.onPoolFailure(ConnectionPool::PoolFailureReason::Overflow, nullptr);
     host_->cluster().stats().upstream_rq_pending_overflow_.inc();
   } else {
-    conn_log_debug("creating stream", *primary_client_->client_);
+    conn_log_facility(debug, "creating stream", *primary_client_->client_);
     primary_client_->total_streams_++;
     host_->stats().rq_total_.inc();
     host_->stats().rq_active_.inc();
@@ -115,10 +115,10 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, uint32_t events) {
     }
 
     if (&client == primary_client_.get()) {
-      conn_log_debug("destroying primary client", *client.client_);
+      conn_log_facility(debug, "destroying primary client", *client.client_);
       dispatcher_.deferredDelete(std::move(primary_client_));
     } else {
-      conn_log_debug("destroying draining client", *client.client_);
+      conn_log_facility(debug, "destroying draining client", *client.client_);
       dispatcher_.deferredDelete(std::move(draining_client_));
     }
 
@@ -143,7 +143,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, uint32_t events) {
 }
 
 void ConnPoolImpl::movePrimaryClientToDraining() {
-  conn_log_debug("moving primary to draining", *primary_client_->client_);
+  conn_log_facility(debug, "moving primary to draining", *primary_client_->client_);
   if (draining_client_) {
     // This should pretty much never happen, but is possible if we start draining and then get
     // a goaway for example. In this case just kill the current draining connection. It's not
@@ -164,21 +164,21 @@ void ConnPoolImpl::movePrimaryClientToDraining() {
 }
 
 void ConnPoolImpl::onConnectTimeout(ActiveClient& client) {
-  conn_log_debug("connect timeout", *client.client_);
+  conn_log_facility(debug, "connect timeout", *client.client_);
   host_->cluster().stats().upstream_cx_connect_timeout_.inc();
   client.client_->close();
 }
 
 void ConnPoolImpl::onGoAway(ActiveClient& client) {
-  conn_log_debug("remote goaway", *client.client_);
+  conn_log_facility(debug, "remote goaway", *client.client_);
   if (&client == primary_client_.get()) {
     movePrimaryClientToDraining();
   }
 }
 
 void ConnPoolImpl::onStreamDestroy(ActiveClient& client) {
-  conn_log_debug("destroying stream: {} remaining", *client.client_,
-                 client.client_->numActiveRequests());
+  conn_log_facility(debug, "destroying stream: {} remaining", *client.client_,
+                    client.client_->numActiveRequests());
   host_->stats().rq_active_.dec();
   host_->cluster().stats().upstream_rq_active_.dec();
   host_->cluster().resourceManager(priority_).requests().dec();

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -57,7 +57,7 @@ void ConnPoolImpl::checkForDrained() {
   }
 
   if (drained) {
-    log_facility(debug, "invoking drained callbacks");
+    LOG(debug, "invoking drained callbacks");
     for (const DrainedCb& cb : drained_callbacks_) {
       cb();
     }
@@ -83,11 +83,11 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(Http::StreamDecoder& respon
   }
 
   if (!host_->cluster().resourceManager(priority_).requests().canCreate()) {
-    log_facility(debug, "max requests overflow");
+    LOG(debug, "max requests overflow");
     callbacks.onPoolFailure(ConnectionPool::PoolFailureReason::Overflow, nullptr);
     host_->cluster().stats().upstream_rq_pending_overflow_.inc();
   } else {
-    conn_log_facility(debug, "creating stream", *primary_client_->client_);
+    CONN_LOG(debug, "creating stream", *primary_client_->client_);
     primary_client_->total_streams_++;
     host_->stats().rq_total_.inc();
     host_->stats().rq_active_.inc();
@@ -115,10 +115,10 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, uint32_t events) {
     }
 
     if (&client == primary_client_.get()) {
-      conn_log_facility(debug, "destroying primary client", *client.client_);
+      CONN_LOG(debug, "destroying primary client", *client.client_);
       dispatcher_.deferredDelete(std::move(primary_client_));
     } else {
-      conn_log_facility(debug, "destroying draining client", *client.client_);
+      CONN_LOG(debug, "destroying draining client", *client.client_);
       dispatcher_.deferredDelete(std::move(draining_client_));
     }
 
@@ -143,7 +143,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveClient& client, uint32_t events) {
 }
 
 void ConnPoolImpl::movePrimaryClientToDraining() {
-  conn_log_facility(debug, "moving primary to draining", *primary_client_->client_);
+  CONN_LOG(debug, "moving primary to draining", *primary_client_->client_);
   if (draining_client_) {
     // This should pretty much never happen, but is possible if we start draining and then get
     // a goaway for example. In this case just kill the current draining connection. It's not
@@ -164,21 +164,21 @@ void ConnPoolImpl::movePrimaryClientToDraining() {
 }
 
 void ConnPoolImpl::onConnectTimeout(ActiveClient& client) {
-  conn_log_facility(debug, "connect timeout", *client.client_);
+  CONN_LOG(debug, "connect timeout", *client.client_);
   host_->cluster().stats().upstream_cx_connect_timeout_.inc();
   client.client_->close();
 }
 
 void ConnPoolImpl::onGoAway(ActiveClient& client) {
-  conn_log_facility(debug, "remote goaway", *client.client_);
+  CONN_LOG(debug, "remote goaway", *client.client_);
   if (&client == primary_client_.get()) {
     movePrimaryClientToDraining();
   }
 }
 
 void ConnPoolImpl::onStreamDestroy(ActiveClient& client) {
-  conn_log_facility(debug, "destroying stream: {} remaining", *client.client_,
-                    client.client_->numActiveRequests());
+  CONN_LOG(debug, "destroying stream: {} remaining", *client.client_,
+           client.client_->numActiveRequests());
   host_->stats().rq_active_.dec();
   host_->cluster().stats().upstream_rq_active_.dec();
   host_->cluster().resourceManager(priority_).requests().dec();

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -361,12 +361,11 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
     throw EnvoyException("invalid BSON message length");
   }
 
-  log_facility(trace, "BSON document length: {} data length: {}", message_length,
-               original_buffer_length);
+  LOG(trace, "BSON document length: {} data length: {}", message_length, original_buffer_length);
 
   while (true) {
     uint64_t document_bytes_remaining = data.length() - (original_buffer_length - message_length);
-    log_facility(trace, "BSON document bytes remaining: {}", document_bytes_remaining);
+    LOG(trace, "BSON document bytes remaining: {}", document_bytes_remaining);
     if (document_bytes_remaining == 1) {
       uint8_t last_byte = BufferHelper::removeByte(data);
       if (last_byte != 0) {
@@ -378,37 +377,37 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
 
     uint8_t element_type = BufferHelper::removeByte(data);
     std::string key = BufferHelper::removeCString(data);
-    log_facility(trace, "BSON element type: {:#x} key: {}", element_type, key);
+    LOG(trace, "BSON element type: {:#x} key: {}", element_type, key);
     switch (static_cast<Field::Type>(element_type)) {
     case Field::Type::DOUBLE: {
       double value = BufferHelper::removeDouble(data);
-      log_facility(trace, "BSON double: {}", value);
+      LOG(trace, "BSON double: {}", value);
       addDouble(key, value);
       break;
     }
 
     case Field::Type::STRING: {
       std::string value = BufferHelper::removeString(data);
-      log_facility(trace, "BSON string: {}", value);
+      LOG(trace, "BSON string: {}", value);
       addString(key, std::move(value));
       break;
     }
 
     case Field::Type::DOCUMENT: {
-      log_facility(trace, "BSON document");
+      LOG(trace, "BSON document");
       addDocument(key, DocumentImpl::create(data));
       break;
     }
 
     case Field::Type::ARRAY: {
-      log_facility(trace, "BSON array");
+      LOG(trace, "BSON array");
       addArray(key, DocumentImpl::create(data));
       break;
     }
 
     case Field::Type::BINARY: {
       std::string value = BufferHelper::removeBinary(data);
-      log_facility(trace, "BSON binary: {}", value);
+      LOG(trace, "BSON binary: {}", value);
       addBinary(key, std::move(value));
       break;
     }
@@ -422,20 +421,20 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
 
     case Field::Type::BOOLEAN: {
       bool value = BufferHelper::removeByte(data) != 0;
-      log_facility(trace, "BSON boolean: {}", value);
+      LOG(trace, "BSON boolean: {}", value);
       addBoolean(key, value);
       break;
     }
 
     case Field::Type::DATETIME: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_facility(trace, "BSON datetime: {}", value);
+      LOG(trace, "BSON datetime: {}", value);
       addDatetime(key, value);
       break;
     }
 
     case Field::Type::NULL_VALUE: {
-      log_facility(trace, "BSON null value");
+      LOG(trace, "BSON null value");
       addNull(key);
       break;
     }
@@ -444,28 +443,28 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
       Field::Regex value;
       value.pattern_ = BufferHelper::removeCString(data);
       value.options_ = BufferHelper::removeCString(data);
-      log_facility(trace, "BSON regex pattern: {} options: {}", value.pattern_, value.options_);
+      LOG(trace, "BSON regex pattern: {} options: {}", value.pattern_, value.options_);
       addRegex(key, std::move(value));
       break;
     }
 
     case Field::Type::INT32: {
       int32_t value = BufferHelper::removeInt32(data);
-      log_facility(trace, "BSON int32: {}", value);
+      LOG(trace, "BSON int32: {}", value);
       addInt32(key, value);
       break;
     }
 
     case Field::Type::TIMESTAMP: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_facility(trace, "BSON timestamp: {}", value);
+      LOG(trace, "BSON timestamp: {}", value);
       addTimestamp(key, value);
       break;
     }
 
     case Field::Type::INT64: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_facility(trace, "BSON int64: {}", value);
+      LOG(trace, "BSON int64: {}", value);
       addInt64(key, value);
       break;
     }

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -361,11 +361,12 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
     throw EnvoyException("invalid BSON message length");
   }
 
-  log_trace("BSON document length: {} data length: {}", message_length, original_buffer_length);
+  log_facility(trace, "BSON document length: {} data length: {}", message_length,
+               original_buffer_length);
 
   while (true) {
     uint64_t document_bytes_remaining = data.length() - (original_buffer_length - message_length);
-    log_trace("BSON document bytes remaining: {}", document_bytes_remaining);
+    log_facility(trace, "BSON document bytes remaining: {}", document_bytes_remaining);
     if (document_bytes_remaining == 1) {
       uint8_t last_byte = BufferHelper::removeByte(data);
       if (last_byte != 0) {
@@ -377,37 +378,37 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
 
     uint8_t element_type = BufferHelper::removeByte(data);
     std::string key = BufferHelper::removeCString(data);
-    log_trace("BSON element type: {:#x} key: {}", element_type, key);
+    log_facility(trace, "BSON element type: {:#x} key: {}", element_type, key);
     switch (static_cast<Field::Type>(element_type)) {
     case Field::Type::DOUBLE: {
       double value = BufferHelper::removeDouble(data);
-      log_trace("BSON double: {}", value);
+      log_facility(trace, "BSON double: {}", value);
       addDouble(key, value);
       break;
     }
 
     case Field::Type::STRING: {
       std::string value = BufferHelper::removeString(data);
-      log_trace("BSON string: {}", value);
+      log_facility(trace, "BSON string: {}", value);
       addString(key, std::move(value));
       break;
     }
 
     case Field::Type::DOCUMENT: {
-      log_trace("BSON document");
+      log_facility(trace, "BSON document");
       addDocument(key, DocumentImpl::create(data));
       break;
     }
 
     case Field::Type::ARRAY: {
-      log_trace("BSON array");
+      log_facility(trace, "BSON array");
       addArray(key, DocumentImpl::create(data));
       break;
     }
 
     case Field::Type::BINARY: {
       std::string value = BufferHelper::removeBinary(data);
-      log_trace("BSON binary: {}", value);
+      log_facility(trace, "BSON binary: {}", value);
       addBinary(key, std::move(value));
       break;
     }
@@ -421,20 +422,20 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
 
     case Field::Type::BOOLEAN: {
       bool value = BufferHelper::removeByte(data) != 0;
-      log_trace("BSON boolean: {}", value);
+      log_facility(trace, "BSON boolean: {}", value);
       addBoolean(key, value);
       break;
     }
 
     case Field::Type::DATETIME: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_trace("BSON datetime: {}", value);
+      log_facility(trace, "BSON datetime: {}", value);
       addDatetime(key, value);
       break;
     }
 
     case Field::Type::NULL_VALUE: {
-      log_trace("BSON null value");
+      log_facility(trace, "BSON null value");
       addNull(key);
       break;
     }
@@ -443,28 +444,28 @@ void DocumentImpl::fromBuffer(Buffer::Instance& data) {
       Field::Regex value;
       value.pattern_ = BufferHelper::removeCString(data);
       value.options_ = BufferHelper::removeCString(data);
-      log_trace("BSON regex pattern: {} options: {}", value.pattern_, value.options_);
+      log_facility(trace, "BSON regex pattern: {} options: {}", value.pattern_, value.options_);
       addRegex(key, std::move(value));
       break;
     }
 
     case Field::Type::INT32: {
       int32_t value = BufferHelper::removeInt32(data);
-      log_trace("BSON int32: {}", value);
+      log_facility(trace, "BSON int32: {}", value);
       addInt32(key, value);
       break;
     }
 
     case Field::Type::TIMESTAMP: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_trace("BSON timestamp: {}", value);
+      log_facility(trace, "BSON timestamp: {}", value);
       addTimestamp(key, value);
       break;
     }
 
     case Field::Type::INT64: {
       int64_t value = BufferHelper::removeInt64(data);
-      log_trace("BSON int64: {}", value);
+      log_facility(trace, "BSON int64: {}", value);
       addInt64(key, value);
       break;
     }

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -37,12 +37,12 @@ MessageImpl::documentListToString(const std::list<Bson::DocumentSharedPtr>& docu
 }
 
 void GetMoreMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_facility(trace, "decoding get more message");
+  LOG(trace, "decoding get more message");
   Bson::BufferHelper::removeInt32(data); // "zero" (unused)
   full_collection_name_ = Bson::BufferHelper::removeCString(data);
   number_to_return_ = Bson::BufferHelper::removeInt32(data);
   cursor_id_ = Bson::BufferHelper::removeInt64(data);
-  log_facility(trace, "{}", toString(true));
+  LOG(trace, "{}", toString(true));
 }
 
 bool GetMoreMessageImpl::operator==(const GetMoreMessage& rhs) const {
@@ -59,7 +59,7 @@ std::string GetMoreMessageImpl::toString(bool) const {
 }
 
 void InsertMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& data) {
-  log_facility(trace, "decoding insert message");
+  LOG(trace, "decoding insert message");
   uint64_t original_buffer_length = data.length();
   ASSERT(message_length <= original_buffer_length);
 
@@ -69,7 +69,7 @@ void InsertMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& da
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_facility(trace, "{}", toString(true));
+  LOG(trace, "{}", toString(true));
 }
 
 bool InsertMessageImpl::operator==(const InsertMessage& rhs) const {
@@ -98,14 +98,14 @@ std::string InsertMessageImpl::toString(bool full) const {
 }
 
 void KillCursorsMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_facility(trace, "decoding kill cursors message");
+  LOG(trace, "decoding kill cursors message");
   Bson::BufferHelper::removeInt32(data); // zero
   number_of_cursor_ids_ = Bson::BufferHelper::removeInt32(data);
   for (int32_t i = 0; i < number_of_cursor_ids_; i++) {
     cursor_ids_.push_back(Bson::BufferHelper::removeInt64(data));
   }
 
-  log_facility(trace, "{}", toString(true));
+  LOG(trace, "{}", toString(true));
 }
 
 bool KillCursorsMessageImpl::operator==(const KillCursorsMessage& rhs) const {
@@ -132,7 +132,7 @@ std::string KillCursorsMessageImpl::toString(bool) const {
 }
 
 void QueryMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& data) {
-  log_facility(trace, "decoding query message");
+  LOG(trace, "decoding query message");
   uint64_t original_buffer_length = data.length();
   ASSERT(message_length <= original_buffer_length);
 
@@ -146,7 +146,7 @@ void QueryMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& dat
     return_fields_selector_ = Bson::DocumentImpl::create(data);
   }
 
-  log_facility(trace, "{}", toString(true));
+  LOG(trace, "{}", toString(true));
 }
 
 bool QueryMessageImpl::operator==(const QueryMessage& rhs) const {
@@ -182,7 +182,7 @@ std::string QueryMessageImpl::toString(bool full) const {
 }
 
 void ReplyMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_facility(trace, "decoding reply message");
+  LOG(trace, "decoding reply message");
   flags_ = Bson::BufferHelper::removeInt32(data);
   cursor_id_ = Bson::BufferHelper::removeInt64(data);
   starting_from_ = Bson::BufferHelper::removeInt32(data);
@@ -191,7 +191,7 @@ void ReplyMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_facility(trace, "{}", toString(true));
+  LOG(trace, "{}", toString(true));
 }
 
 bool ReplyMessageImpl::operator==(const ReplyMessage& rhs) const {
@@ -222,13 +222,13 @@ std::string ReplyMessageImpl::toString(bool full) const {
 
 bool DecoderImpl::decode(Buffer::Instance& data) {
   // See if we have enough data for the message length.
-  log_facility(trace, "decoding {} bytes", data.length());
+  LOG(trace, "decoding {} bytes", data.length());
   if (data.length() < sizeof(int32_t)) {
     return false;
   }
 
   uint32_t message_length = Bson::BufferHelper::peakInt32(data);
-  log_facility(trace, "message is {} bytes", message_length);
+  LOG(trace, "message is {} bytes", message_length);
   if (data.length() < message_length) {
     return false;
   }
@@ -237,7 +237,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
   int32_t request_id = Bson::BufferHelper::removeInt32(data);
   int32_t response_to = Bson::BufferHelper::removeInt32(data);
   Message::OpCode op_code = static_cast<Message::OpCode>(Bson::BufferHelper::removeInt32(data));
-  log_facility(trace, "message op: {}", static_cast<int32_t>(op_code));
+  LOG(trace, "message op: {}", static_cast<int32_t>(op_code));
 
   // Some messages need to know how long they are to parse. Subtract the header that we have already
   // parsed off before passing the final value.
@@ -284,7 +284,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
     throw EnvoyException(fmt::format("invalid mongo op {}", static_cast<int32_t>(op_code)));
   }
 
-  log_facility(trace, "{} bytes remaining after decoding", data.length());
+  LOG(trace, "{} bytes remaining after decoding", data.length());
   return true;
 }
 

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -42,7 +42,7 @@ void GetMoreMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
   full_collection_name_ = Bson::BufferHelper::removeCString(data);
   number_to_return_ = Bson::BufferHelper::removeInt32(data);
   cursor_id_ = Bson::BufferHelper::removeInt64(data);
-  log_facility(trace, toString(true));
+  log_facility(trace, "{}", toString(true));
 }
 
 bool GetMoreMessageImpl::operator==(const GetMoreMessage& rhs) const {
@@ -69,7 +69,7 @@ void InsertMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& da
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_facility(trace, toString(true));
+  log_facility(trace, "{}", toString(true));
 }
 
 bool InsertMessageImpl::operator==(const InsertMessage& rhs) const {
@@ -105,7 +105,7 @@ void KillCursorsMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
     cursor_ids_.push_back(Bson::BufferHelper::removeInt64(data));
   }
 
-  log_facility(trace, toString(true));
+  log_facility(trace, "{}", toString(true));
 }
 
 bool KillCursorsMessageImpl::operator==(const KillCursorsMessage& rhs) const {
@@ -146,7 +146,7 @@ void QueryMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& dat
     return_fields_selector_ = Bson::DocumentImpl::create(data);
   }
 
-  log_facility(trace, toString(true));
+  log_facility(trace, "{}", toString(true));
 }
 
 bool QueryMessageImpl::operator==(const QueryMessage& rhs) const {
@@ -191,7 +191,7 @@ void ReplyMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_facility(trace, toString(true));
+  log_facility(trace, "{}", toString(true));
 }
 
 bool ReplyMessageImpl::operator==(const ReplyMessage& rhs) const {

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -37,12 +37,12 @@ MessageImpl::documentListToString(const std::list<Bson::DocumentSharedPtr>& docu
 }
 
 void GetMoreMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_trace("decoding get more message");
+  log_facility(trace, "decoding get more message");
   Bson::BufferHelper::removeInt32(data); // "zero" (unused)
   full_collection_name_ = Bson::BufferHelper::removeCString(data);
   number_to_return_ = Bson::BufferHelper::removeInt32(data);
   cursor_id_ = Bson::BufferHelper::removeInt64(data);
-  log_trace(toString(true));
+  log_facility(trace, toString(true));
 }
 
 bool GetMoreMessageImpl::operator==(const GetMoreMessage& rhs) const {
@@ -59,7 +59,7 @@ std::string GetMoreMessageImpl::toString(bool) const {
 }
 
 void InsertMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& data) {
-  log_trace("decoding insert message");
+  log_facility(trace, "decoding insert message");
   uint64_t original_buffer_length = data.length();
   ASSERT(message_length <= original_buffer_length);
 
@@ -69,7 +69,7 @@ void InsertMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& da
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_trace(toString(true));
+  log_facility(trace, toString(true));
 }
 
 bool InsertMessageImpl::operator==(const InsertMessage& rhs) const {
@@ -98,14 +98,14 @@ std::string InsertMessageImpl::toString(bool full) const {
 }
 
 void KillCursorsMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_trace("decoding kill cursors message");
+  log_facility(trace, "decoding kill cursors message");
   Bson::BufferHelper::removeInt32(data); // zero
   number_of_cursor_ids_ = Bson::BufferHelper::removeInt32(data);
   for (int32_t i = 0; i < number_of_cursor_ids_; i++) {
     cursor_ids_.push_back(Bson::BufferHelper::removeInt64(data));
   }
 
-  log_trace(toString(true));
+  log_facility(trace, toString(true));
 }
 
 bool KillCursorsMessageImpl::operator==(const KillCursorsMessage& rhs) const {
@@ -132,7 +132,7 @@ std::string KillCursorsMessageImpl::toString(bool) const {
 }
 
 void QueryMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& data) {
-  log_trace("decoding query message");
+  log_facility(trace, "decoding query message");
   uint64_t original_buffer_length = data.length();
   ASSERT(message_length <= original_buffer_length);
 
@@ -146,7 +146,7 @@ void QueryMessageImpl::fromBuffer(uint32_t message_length, Buffer::Instance& dat
     return_fields_selector_ = Bson::DocumentImpl::create(data);
   }
 
-  log_trace(toString(true));
+  log_facility(trace, toString(true));
 }
 
 bool QueryMessageImpl::operator==(const QueryMessage& rhs) const {
@@ -182,7 +182,7 @@ std::string QueryMessageImpl::toString(bool full) const {
 }
 
 void ReplyMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
-  log_trace("decoding reply message");
+  log_facility(trace, "decoding reply message");
   flags_ = Bson::BufferHelper::removeInt32(data);
   cursor_id_ = Bson::BufferHelper::removeInt64(data);
   starting_from_ = Bson::BufferHelper::removeInt32(data);
@@ -191,7 +191,7 @@ void ReplyMessageImpl::fromBuffer(uint32_t, Buffer::Instance& data) {
     documents_.emplace_back(Bson::DocumentImpl::create(data));
   }
 
-  log_trace(toString(true));
+  log_facility(trace, toString(true));
 }
 
 bool ReplyMessageImpl::operator==(const ReplyMessage& rhs) const {
@@ -222,13 +222,13 @@ std::string ReplyMessageImpl::toString(bool full) const {
 
 bool DecoderImpl::decode(Buffer::Instance& data) {
   // See if we have enough data for the message length.
-  log_trace("decoding {} bytes", data.length());
+  log_facility(trace, "decoding {} bytes", data.length());
   if (data.length() < sizeof(int32_t)) {
     return false;
   }
 
   uint32_t message_length = Bson::BufferHelper::peakInt32(data);
-  log_trace("message is {} bytes", message_length);
+  log_facility(trace, "message is {} bytes", message_length);
   if (data.length() < message_length) {
     return false;
   }
@@ -237,7 +237,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
   int32_t request_id = Bson::BufferHelper::removeInt32(data);
   int32_t response_to = Bson::BufferHelper::removeInt32(data);
   Message::OpCode op_code = static_cast<Message::OpCode>(Bson::BufferHelper::removeInt32(data));
-  log_trace("message op: {}", static_cast<int32_t>(op_code));
+  log_facility(trace, "message op: {}", static_cast<int32_t>(op_code));
 
   // Some messages need to know how long they are to parse. Subtract the header that we have already
   // parsed off before passing the final value.
@@ -284,7 +284,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
     throw EnvoyException(fmt::format("invalid mongo op {}", static_cast<int32_t>(op_code)));
   }
 
-  log_trace("{} bytes remaining after decoding", data.length());
+  log_facility(trace, "{} bytes remaining after decoding", data.length());
   return true;
 }
 

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -52,25 +52,25 @@ ProxyFilter::~ProxyFilter() {}
 void ProxyFilter::decodeGetMore(GetMoreMessagePtr&& message) {
   stats_.op_get_more_.inc();
   logMessage(*message, true);
-  log_debug("decoded GET_MORE: {}", message->toString(true));
+  log_facility(debug, "decoded GET_MORE: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeInsert(InsertMessagePtr&& message) {
   stats_.op_insert_.inc();
   logMessage(*message, true);
-  log_debug("decoded INSERT: {}", message->toString(true));
+  log_facility(debug, "decoded INSERT: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeKillCursors(KillCursorsMessagePtr&& message) {
   stats_.op_kill_cursors_.inc();
   logMessage(*message, true);
-  log_debug("decoded KILL_CURSORS: {}", message->toString(true));
+  log_facility(debug, "decoded KILL_CURSORS: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeQuery(QueryMessagePtr&& message) {
   stats_.op_query_.inc();
   logMessage(*message, true);
-  log_debug("decoded QUERY: {}", message->toString(true));
+  log_facility(debug, "decoded QUERY: {}", message->toString(true));
 
   if (message->flags() & QueryMessage::Flags::TailableCursor) {
     stats_.op_query_tailable_cursor_.inc();
@@ -132,7 +132,7 @@ void ProxyFilter::chargeQueryStats(const std::string& prefix,
 void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
   stats_.op_reply_.inc();
   logMessage(*message, false);
-  log_debug("decoded REPLY: {}", message->toString(true));
+  log_facility(debug, "decoded REPLY: {}", message->toString(true));
 
   if (message->cursorId() != 0) {
     stats_.op_reply_valid_cursor_.inc();
@@ -206,7 +206,7 @@ void ProxyFilter::doDecode(Buffer::Instance& buffer) {
   try {
     decoder_->onData(buffer);
   } catch (EnvoyException& e) {
-    log().info("mongo decoding error: {}", e.what());
+    log_facility(info, "mongo decoding error: {}", e.what());
     stats_.decoding_error_.inc();
     sniffing_ = false;
   }

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -52,25 +52,25 @@ ProxyFilter::~ProxyFilter() {}
 void ProxyFilter::decodeGetMore(GetMoreMessagePtr&& message) {
   stats_.op_get_more_.inc();
   logMessage(*message, true);
-  log_facility(debug, "decoded GET_MORE: {}", message->toString(true));
+  LOG(debug, "decoded GET_MORE: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeInsert(InsertMessagePtr&& message) {
   stats_.op_insert_.inc();
   logMessage(*message, true);
-  log_facility(debug, "decoded INSERT: {}", message->toString(true));
+  LOG(debug, "decoded INSERT: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeKillCursors(KillCursorsMessagePtr&& message) {
   stats_.op_kill_cursors_.inc();
   logMessage(*message, true);
-  log_facility(debug, "decoded KILL_CURSORS: {}", message->toString(true));
+  LOG(debug, "decoded KILL_CURSORS: {}", message->toString(true));
 }
 
 void ProxyFilter::decodeQuery(QueryMessagePtr&& message) {
   stats_.op_query_.inc();
   logMessage(*message, true);
-  log_facility(debug, "decoded QUERY: {}", message->toString(true));
+  LOG(debug, "decoded QUERY: {}", message->toString(true));
 
   if (message->flags() & QueryMessage::Flags::TailableCursor) {
     stats_.op_query_tailable_cursor_.inc();
@@ -132,7 +132,7 @@ void ProxyFilter::chargeQueryStats(const std::string& prefix,
 void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
   stats_.op_reply_.inc();
   logMessage(*message, false);
-  log_facility(debug, "decoded REPLY: {}", message->toString(true));
+  LOG(debug, "decoded REPLY: {}", message->toString(true));
 
   if (message->cursorId() != 0) {
     stats_.op_reply_valid_cursor_.inc();
@@ -206,7 +206,7 @@ void ProxyFilter::doDecode(Buffer::Instance& buffer) {
   try {
     decoder_->onData(buffer);
   } catch (EnvoyException& e) {
-    log_facility(info, "mongo decoding error: {}", e.what());
+    LOG(info, "mongo decoding error: {}", e.what());
     stats_.decoding_error_.inc();
     sniffing_ = false;
   }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -99,7 +99,8 @@ void ConnectionImpl::close(ConnectionCloseType type) {
   }
 
   uint64_t data_to_write = write_buffer_.length();
-  conn_log_debug("closing data_to_write={} type={}", *this, data_to_write, enumToInt(type));
+  conn_log_facility(debug, "closing data_to_write={} type={}", *this, data_to_write,
+                    enumToInt(type));
   if (data_to_write == 0 || type == ConnectionCloseType::NoFlush) {
     if (data_to_write > 0) {
       // We aren't going to wait to flush, but try to write as much as we can if there is pending
@@ -132,7 +133,7 @@ void ConnectionImpl::closeSocket(uint32_t close_type) {
     return;
   }
 
-  conn_log_debug("closing socket: {}", *this, close_type);
+  conn_log_facility(debug, "closing socket: {}", *this, close_type);
 
   // Drain input and output buffers.
   updateReadBufferStats(0, 0);
@@ -194,7 +195,7 @@ void ConnectionImpl::onRead(uint64_t read_buffer_size) {
 void ConnectionImpl::readDisable(bool disable) {
   bool read_enabled = readEnabled();
   UNREFERENCED_PARAMETER(read_enabled);
-  conn_log_trace("readDisable: enabled={} disable={}", *this, read_enabled, disable);
+  conn_log_facility(trace, "readDisable: enabled={} disable={}", *this, read_enabled, disable);
 
   // When we disable reads, we still allow for early close notifications (the equivalent of
   // EPOLLRDHUP for an epoll backend). For backends that support it, this allows us to apply
@@ -247,7 +248,7 @@ void ConnectionImpl::write(Buffer::Instance& data) {
   }
 
   if (data.length() > 0) {
-    conn_log_trace("writing {} bytes", *this, data.length());
+    conn_log_facility(trace, "writing {} bytes", *this, data.length());
     // TODO(mattklein123): All data currently gets moved from the source buffer to the write buffer.
     // This can lead to inefficient behavior if writing a bunch of small chunks. In this case, it
     // would likely be more efficient to copy data below a certain size. VERY IMPORTANT: If this is
@@ -262,10 +263,10 @@ void ConnectionImpl::write(Buffer::Instance& data) {
 }
 
 void ConnectionImpl::onFileEvent(uint32_t events) {
-  conn_log_trace("socket event: {}", *this, events);
+  conn_log_facility(trace, "socket event: {}", *this, events);
 
   if (state_ & InternalState::ImmediateConnectionError) {
-    conn_log_debug("raising immediate connect error", *this);
+    conn_log_facility(debug, "raising immediate connect error", *this);
     closeSocket(ConnectionEvent::RemoteClose);
     return;
   }
@@ -274,7 +275,7 @@ void ConnectionImpl::onFileEvent(uint32_t events) {
     // We never ask for both early close and read at the same time. If we are reading, we want to
     // consume all available data.
     ASSERT(!(events & Event::FileReadyType::Read));
-    conn_log_debug("remote early close", *this);
+    conn_log_facility(debug, "remote early close", *this);
     closeSocket(ConnectionEvent::RemoteClose);
     return;
   }
@@ -302,7 +303,7 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the
     // ioctl(). The extra syscall is not worth it.
     int rc = read_buffer_.read(fd_, 16384);
-    conn_log_trace("read returns: {}", *this, rc);
+    conn_log_facility(trace, "read returns: {}", *this, rc);
 
     // Remote close. Might need to raise data before raising close.
     if (rc == 0) {
@@ -310,7 +311,7 @@ ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
       break;
     } else if (rc == -1) {
       // Remote error (might be no data).
-      conn_log_trace("read error: {}", *this, errno);
+      conn_log_facility(trace, "read error: {}", *this, errno);
       if (errno != EAGAIN) {
         action = PostIoAction::Close;
       }
@@ -338,7 +339,7 @@ void ConnectionImpl::onReadReady() {
 
   // The read callback may have already closed the connection.
   if (result.action_ == PostIoAction::Close) {
-    conn_log_debug("remote close", *this);
+    conn_log_facility(debug, "remote close", *this);
     closeSocket(ConnectionEvent::RemoteClose);
   }
 }
@@ -353,9 +354,9 @@ ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     }
 
     int rc = write_buffer_.write(fd_);
-    conn_log_trace("write returns: {}", *this, rc);
+    conn_log_facility(trace, "write returns: {}", *this, rc);
     if (rc == -1) {
-      conn_log_trace("write error: {}", *this, errno);
+      conn_log_facility(trace, "write error: {}", *this, errno);
       if (errno == EAGAIN) {
         action = PostIoAction::KeepOpen;
       } else {
@@ -374,7 +375,7 @@ ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
 void ConnectionImpl::onConnected() { raiseEvents(ConnectionEvent::Connected); }
 
 void ConnectionImpl::onWriteReady() {
-  conn_log_trace("write ready", *this);
+  conn_log_facility(trace, "write ready", *this);
 
   if (state_ & InternalState::Connecting) {
     int error;
@@ -384,16 +385,16 @@ void ConnectionImpl::onWriteReady() {
     UNREFERENCED_PARAMETER(rc);
 
     if (error == 0) {
-      conn_log_debug("connected", *this);
+      conn_log_facility(debug, "connected", *this);
       state_ &= ~InternalState::Connecting;
       onConnected();
       // It's possible that we closed during the connect callback.
       if (state() != State::Open) {
-        conn_log_debug("close during connected callback", *this);
+        conn_log_facility(debug, "close during connected callback", *this);
         return;
       }
     } else {
-      conn_log_debug("delayed connection error: {}", *this, error);
+      conn_log_facility(debug, "delayed connection error: {}", *this, error);
       closeSocket(ConnectionEvent::RemoteClose);
       return;
     }
@@ -409,13 +410,13 @@ void ConnectionImpl::onWriteReady() {
     // callback, raise a connected event, and close the connection.
     closeSocket(ConnectionEvent::RemoteClose);
   } else if ((state_ & InternalState::CloseWithFlush) && new_buffer_size == 0) {
-    conn_log_debug("write flush complete", *this);
+    conn_log_facility(debug, "write flush complete", *this);
     closeSocket(ConnectionEvent::LocalClose);
   }
 }
 
 void ConnectionImpl::doConnect() {
-  conn_log_debug("connecting to {}", *this, remote_address_->asString());
+  conn_log_facility(debug, "connecting to {}", *this, remote_address_->asString());
   int rc = remote_address_->connect(fd_);
   if (rc == 0) {
     // write will become ready.
@@ -424,11 +425,11 @@ void ConnectionImpl::doConnect() {
     ASSERT(rc == -1);
     if (errno == EINPROGRESS) {
       state_ |= InternalState::Connecting;
-      conn_log_debug("connection in progress", *this);
+      conn_log_facility(debug, "connection in progress", *this);
     } else {
       // read/write will become ready.
       state_ |= InternalState::ImmediateConnectionError;
-      conn_log_debug("immediate connection error: {}", *this, errno);
+      conn_log_facility(debug, "immediate connection error: {}", *this, errno);
     }
   }
 }

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -128,10 +128,10 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
   uint64_t remaining = slice.len_;
 
   while (remaining || state_ == State::ValueComplete) {
-    log_facility(trace, "parse slice: {} remaining", remaining);
+    LOG(trace, "parse slice: {} remaining", remaining);
     switch (state_) {
     case State::ValueRootStart: {
-      log_facility(trace, "parse slice: ValueRootStart");
+      LOG(trace, "parse slice: ValueRootStart");
       pending_value_root_.reset(new RespValue());
       pending_value_stack_.push_front({pending_value_root_.get(), 0});
       state_ = State::ValueStart;
@@ -139,7 +139,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::ValueStart: {
-      log_facility(trace, "parse slice: ValueStart: {}", buffer[0]);
+      LOG(trace, "parse slice: ValueStart: {}", buffer[0]);
       pending_integer_.reset();
       switch (buffer[0]) {
       case '*': {
@@ -176,7 +176,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::IntegerStart: {
-      log_facility(trace, "parse slice: IntegerStart: {}", buffer[0]);
+      LOG(trace, "parse slice: IntegerStart: {}", buffer[0]);
       if (buffer[0] == '-') {
         pending_integer_.negative_ = true;
         remaining--;
@@ -188,7 +188,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::Integer: {
-      log_facility(trace, "parse slice: Integer: {}", buffer[0]);
+      LOG(trace, "parse slice: Integer: {}", buffer[0]);
       char c = buffer[0];
       if (buffer[0] == '\r') {
         state_ = State::IntegerLF;
@@ -210,7 +210,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
         throw ProtocolError("expected new line");
       }
 
-      log_facility(trace, "parse slice: IntegerLF: {}", pending_integer_.integer_);
+      LOG(trace, "parse slice: IntegerLF: {}", pending_integer_.integer_);
       remaining--;
       buffer++;
 
@@ -264,8 +264,8 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
       buffer += length_to_copy;
 
       if (pending_integer_.integer_ == 0) {
-        log_facility(trace, "parse slice: BulkStringBody complete: {}",
-                     pending_value_stack_.front().value_->asString());
+        LOG(trace, "parse slice: BulkStringBody complete: {}",
+            pending_value_stack_.front().value_->asString());
         state_ = State::CR;
       }
 
@@ -273,7 +273,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::CR: {
-      log_facility(trace, "parse slice: CR");
+      LOG(trace, "parse slice: CR");
       if (buffer[0] != '\r') {
         throw ProtocolError("expected carriage return");
       }
@@ -285,7 +285,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::LF: {
-      log_facility(trace, "parse slice: LF");
+      LOG(trace, "parse slice: LF");
       if (buffer[0] != '\n') {
         throw ProtocolError("expected new line");
       }
@@ -297,7 +297,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::SimpleString: {
-      log_facility(trace, "parse slice: SimpleString: {}", buffer[0]);
+      LOG(trace, "parse slice: SimpleString: {}", buffer[0]);
       if (buffer[0] == '\r') {
         state_ = State::LF;
       } else {
@@ -310,7 +310,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::ValueComplete: {
-      log_facility(trace, "parse slice: ValueComplete");
+      LOG(trace, "parse slice: ValueComplete");
       ASSERT(!pending_value_stack_.empty());
       pending_value_stack_.pop_front();
       if (pending_value_stack_.empty()) {

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -128,10 +128,10 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
   uint64_t remaining = slice.len_;
 
   while (remaining || state_ == State::ValueComplete) {
-    log_trace("parse slice: {} remaining", remaining);
+    log_facility(trace, "parse slice: {} remaining", remaining);
     switch (state_) {
     case State::ValueRootStart: {
-      log_trace("parse slice: ValueRootStart");
+      log_facility(trace, "parse slice: ValueRootStart");
       pending_value_root_.reset(new RespValue());
       pending_value_stack_.push_front({pending_value_root_.get(), 0});
       state_ = State::ValueStart;
@@ -139,7 +139,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::ValueStart: {
-      log_trace("parse slice: ValueStart: {}", buffer[0]);
+      log_facility(trace, "parse slice: ValueStart: {}", buffer[0]);
       pending_integer_.reset();
       switch (buffer[0]) {
       case '*': {
@@ -176,7 +176,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::IntegerStart: {
-      log_trace("parse slice: IntegerStart: {}", buffer[0]);
+      log_facility(trace, "parse slice: IntegerStart: {}", buffer[0]);
       if (buffer[0] == '-') {
         pending_integer_.negative_ = true;
         remaining--;
@@ -188,7 +188,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::Integer: {
-      log_trace("parse slice: Integer: {}", buffer[0]);
+      log_facility(trace, "parse slice: Integer: {}", buffer[0]);
       char c = buffer[0];
       if (buffer[0] == '\r') {
         state_ = State::IntegerLF;
@@ -210,7 +210,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
         throw ProtocolError("expected new line");
       }
 
-      log_trace("parse slice: IntegerLF: {}", pending_integer_.integer_);
+      log_facility(trace, "parse slice: IntegerLF: {}", pending_integer_.integer_);
       remaining--;
       buffer++;
 
@@ -264,8 +264,8 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
       buffer += length_to_copy;
 
       if (pending_integer_.integer_ == 0) {
-        log_trace("parse slice: BulkStringBody complete: {}",
-                  pending_value_stack_.front().value_->asString());
+        log_facility(trace, "parse slice: BulkStringBody complete: {}",
+                     pending_value_stack_.front().value_->asString());
         state_ = State::CR;
       }
 
@@ -273,7 +273,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::CR: {
-      log_trace("parse slice: CR");
+      log_facility(trace, "parse slice: CR");
       if (buffer[0] != '\r') {
         throw ProtocolError("expected carriage return");
       }
@@ -285,7 +285,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::LF: {
-      log_trace("parse slice: LF");
+      log_facility(trace, "parse slice: LF");
       if (buffer[0] != '\n') {
         throw ProtocolError("expected new line");
       }
@@ -297,7 +297,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::SimpleString: {
-      log_trace("parse slice: SimpleString: {}", buffer[0]);
+      log_facility(trace, "parse slice: SimpleString: {}", buffer[0]);
       if (buffer[0] == '\r') {
         state_ = State::LF;
       } else {
@@ -310,7 +310,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     }
 
     case State::ValueComplete: {
-      log_trace("parse slice: ValueComplete");
+      log_facility(trace, "parse slice: ValueComplete");
       ASSERT(!pending_value_stack_.empty());
       pending_value_stack_.pop_front();
       if (pending_value_stack_.empty()) {

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -42,7 +42,7 @@ void AllParamsToOneServerCommandHandler::SplitRequestImpl::cancel() {
 
 void AllParamsToOneServerCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& response) {
   handle_ = nullptr;
-  log_facility(debug, "redis: response: '{}'", response->toString());
+  LOG(debug, "redis: response: '{}'", response->toString());
   callbacks_.onResponse(std::move(response));
 }
 
@@ -70,7 +70,7 @@ SplitRequestPtr MGETCommandHandler::startRequest(const RespValue& request,
     SplitRequestImpl::PendingRequest& pending_request = request_handle->pending_requests_.back();
 
     single_mget.asArray()[1].asString() = request.asArray()[i].asString();
-    log_facility(debug, "redis: parallel get: '{}'", single_mget.toString());
+    LOG(debug, "redis: parallel get: '{}'", single_mget.toString());
     pending_request.handle_ =
         conn_pool_.makeRequest(request.asArray()[i].asString(), single_mget, pending_request);
     if (!pending_request.handle_) {
@@ -131,7 +131,7 @@ void MGETCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& value, uint
 
   ASSERT(pending_responses_ > 0);
   if (--pending_responses_ == 0) {
-    log_facility(debug, "redis: response: '{}'", pending_response_->toString());
+    LOG(debug, "redis: response: '{}'", pending_response_->toString());
     callbacks_.onResponse(std::move(pending_response_));
   }
 }
@@ -175,7 +175,7 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
     return nullptr;
   }
 
-  log_facility(debug, "redis: splitting '{}'", request.toString());
+  LOG(debug, "redis: splitting '{}'", request.toString());
   handler->second.total_.inc();
   return handler->second.handler_.get().startRequest(request, callbacks);
 }

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -42,7 +42,7 @@ void AllParamsToOneServerCommandHandler::SplitRequestImpl::cancel() {
 
 void AllParamsToOneServerCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& response) {
   handle_ = nullptr;
-  log_debug("redis: response: '{}'", response->toString());
+  log_facility(debug, "redis: response: '{}'", response->toString());
   callbacks_.onResponse(std::move(response));
 }
 
@@ -70,7 +70,7 @@ SplitRequestPtr MGETCommandHandler::startRequest(const RespValue& request,
     SplitRequestImpl::PendingRequest& pending_request = request_handle->pending_requests_.back();
 
     single_mget.asArray()[1].asString() = request.asArray()[i].asString();
-    log_debug("redis: parallel get: '{}'", single_mget.toString());
+    log_facility(debug, "redis: parallel get: '{}'", single_mget.toString());
     pending_request.handle_ =
         conn_pool_.makeRequest(request.asArray()[i].asString(), single_mget, pending_request);
     if (!pending_request.handle_) {
@@ -131,7 +131,7 @@ void MGETCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& value, uint
 
   ASSERT(pending_responses_ > 0);
   if (--pending_responses_ == 0) {
-    log_debug("redis: response: '{}'", pending_response_->toString());
+    log_facility(debug, "redis: response: '{}'", pending_response_->toString());
     callbacks_.onResponse(std::move(pending_response_));
   }
 }
@@ -175,7 +175,7 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
     return nullptr;
   }
 
-  log_debug("redis: splitting '{}'", request.toString());
+  log_facility(debug, "redis: splitting '{}'", request.toString());
   handler->second.total_.inc();
   return handler->second.handler_.get().startRequest(request, callbacks);
 }

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -92,7 +92,7 @@ MGETCommandHandler::SplitRequestImpl::SplitRequestImpl(SplitCallbacks& callbacks
 }
 
 MGETCommandHandler::SplitRequestImpl::~SplitRequestImpl() {
-#ifndef NDEBUG
+#ifndef NVLOG
   for (const PendingRequest& request : pending_requests_) {
     ASSERT(!request.handle_);
   }

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -92,7 +92,7 @@ MGETCommandHandler::SplitRequestImpl::SplitRequestImpl(SplitCallbacks& callbacks
 }
 
 MGETCommandHandler::SplitRequestImpl::~SplitRequestImpl() {
-#ifndef NVLOG
+#ifndef NDEBUG
   for (const PendingRequest& request : pending_requests_) {
     ASSERT(!request.handle_);
   }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -76,7 +76,7 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
 }
 
 void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
-  log_facility(debug, "rds: starting request");
+  LOG(debug, "rds: starting request");
   stats_.update_attempt_.inc();
   request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(fmt::format("/v1/routes/{}/{}/{}", route_config_name_,
@@ -85,7 +85,7 @@ void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
 }
 
 void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
-  log_facility(debug, "rds: parsing response");
+  LOG(debug, "rds: parsing response");
   Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   uint64_t new_hash = response_json->hash();
   if (new_hash != last_config_hash_ || !initialized_) {
@@ -94,8 +94,8 @@ void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
     initialized_ = true;
     last_config_hash_ = new_hash;
     stats_.config_reload_.inc();
-    log_facility(debug, "rds: loading new configuration: config_name={} hash={}",
-                 route_config_name_, new_hash);
+    LOG(debug, "rds: loading new configuration: config_name={} hash={}", route_config_name_,
+        new_hash);
     tls_.runOnAllThreads([this, new_config]() -> void {
       tls_.getTyped<ThreadLocalConfig>(tls_slot_).config_ = new_config;
     });
@@ -114,9 +114,9 @@ void RdsRouteConfigProviderImpl::onFetchComplete() {
 void RdsRouteConfigProviderImpl::onFetchFailure(EnvoyException* e) {
   stats_.update_failure_.inc();
   if (e) {
-    log_facility(warn, "rds: fetch failure: {}", e->what());
+    LOG(warn, "rds: fetch failure: {}", e->what());
   } else {
-    log_facility(info, "rds: fetch failure: network error");
+    LOG(info, "rds: fetch failure: network error");
   }
 }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -76,7 +76,7 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
 }
 
 void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
-  log_debug("rds: starting request");
+  log_facility(debug, "rds: starting request");
   stats_.update_attempt_.inc();
   request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(fmt::format("/v1/routes/{}/{}/{}", route_config_name_,
@@ -85,7 +85,7 @@ void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
 }
 
 void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
-  log_debug("rds: parsing response");
+  log_facility(debug, "rds: parsing response");
   Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   uint64_t new_hash = response_json->hash();
   if (new_hash != last_config_hash_ || !initialized_) {
@@ -94,8 +94,8 @@ void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
     initialized_ = true;
     last_config_hash_ = new_hash;
     stats_.config_reload_.inc();
-    log_debug("rds: loading new configuration: config_name={} hash={}", route_config_name_,
-              new_hash);
+    log_facility(debug, "rds: loading new configuration: config_name={} hash={}",
+                 route_config_name_, new_hash);
     tls_.runOnAllThreads([this, new_config]() -> void {
       tls_.getTyped<ThreadLocalConfig>(tls_slot_).config_ = new_config;
     });
@@ -114,9 +114,9 @@ void RdsRouteConfigProviderImpl::onFetchComplete() {
 void RdsRouteConfigProviderImpl::onFetchFailure(EnvoyException* e) {
   stats_.update_failure_.inc();
   if (e) {
-    log().warn("rds: fetch failure: {}", e->what());
+    log_facility(warn, "rds: fetch failure: {}", e->what());
   } else {
-    log().info("rds: fetch failure: network error");
+    log_facility(info, "rds: fetch failure: network error");
   }
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -149,8 +149,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   route_ = callbacks_->route();
   if (!route_) {
     config_.stats_.no_route_.inc();
-    stream_log_facility(debug, "no cluster match for URL '{}'", *callbacks_,
-                        headers.Path()->value().c_str());
+    STREAM_LOG(debug, "no cluster match for URL '{}'", *callbacks_,
+               headers.Path()->value().c_str());
 
     callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
     Http::HeaderMapPtr response_headers{new Http::HeaderMapImpl{
@@ -171,7 +171,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   Upstream::ThreadLocalCluster* cluster = config_.cm_.get(route_entry_->clusterName());
   if (!cluster) {
     config_.stats_.no_cluster_.inc();
-    stream_log_facility(debug, "unknown cluster '{}'", *callbacks_, route_entry_->clusterName());
+    STREAM_LOG(debug, "unknown cluster '{}'", *callbacks_, route_entry_->clusterName());
 
     callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
     Http::HeaderMapPtr response_headers{new Http::HeaderMapImpl{
@@ -183,8 +183,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Set up stat prefixes, etc.
   request_vcluster_ = route_entry_->virtualCluster(headers);
-  stream_log_facility(debug, "cluster '{}' match for URL '{}'", *callbacks_,
-                      route_entry_->clusterName(), headers.Path()->value().c_str());
+  STREAM_LOG(debug, "cluster '{}' match for URL '{}'", *callbacks_, route_entry_->clusterName(),
+             headers.Path()->value().c_str());
 
   const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();
   if (request_alt_name) {
@@ -233,9 +233,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
 #ifndef NVLOG
   headers.iterate([](const Http::HeaderEntry& header, void* context) -> void {
-    stream_log_facility(debug, "  '{}':'{}'",
-                        *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
-                        header.key().c_str(), header.value().c_str());
+    STREAM_LOG(debug, "  '{}':'{}'", *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
+               header.key().c_str(), header.value().c_str());
   }, callbacks_);
 #endif
 
@@ -359,7 +358,7 @@ void Filter::onDestroy() {
 }
 
 void Filter::onResponseTimeout() {
-  stream_log_facility(debug, "upstream timeout", *callbacks_);
+  STREAM_LOG(debug, "upstream timeout", *callbacks_);
   cluster_->stats().upstream_rq_timeout_.inc();
 
   // It's possible to timeout during a retry backoff delay when we have no upstream request. In
@@ -378,7 +377,7 @@ void Filter::onUpstreamReset(UpstreamResetType type,
                              const Optional<Http::StreamResetReason>& reset_reason) {
   ASSERT(type == UpstreamResetType::GlobalTimeout || upstream_request_);
   if (type == UpstreamResetType::Reset) {
-    stream_log_facility(debug, "upstream reset", *callbacks_);
+    STREAM_LOG(debug, "upstream reset", *callbacks_);
   }
 
   Upstream::HostDescriptionConstSharedPtr upstream_host;
@@ -448,7 +447,7 @@ Filter::streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason) {
 }
 
 void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
-  stream_log_facility(debug, "upstream headers complete: end_stream={}", *callbacks_, end_stream);
+  STREAM_LOG(debug, "upstream headers complete: end_stream={}", *callbacks_, end_stream);
   ASSERT(!downstream_response_started_);
 
   upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(
@@ -548,7 +547,7 @@ bool Filter::setupRetry(bool end_stream) {
     return false;
   }
 
-  stream_log_facility(debug, "performing retry", *callbacks_);
+  STREAM_LOG(debug, "performing retry", *callbacks_);
   if (!end_stream) {
     upstream_request_->resetStream();
   }
@@ -622,14 +621,14 @@ void Filter::UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream
   encode_complete_ = end_stream;
 
   if (!request_encoder_) {
-    stream_log_facility(trace, "buffering {} bytes", *parent_.callbacks_, data.length());
+    STREAM_LOG(trace, "buffering {} bytes", *parent_.callbacks_, data.length());
     if (!buffered_request_body_) {
       buffered_request_body_.reset(new Buffer::OwnedImpl());
     }
 
     buffered_request_body_->move(data);
   } else {
-    stream_log_facility(trace, "proxying {} bytes", *parent_.callbacks_, data.length());
+    STREAM_LOG(trace, "proxying {} bytes", *parent_.callbacks_, data.length());
     request_encoder_->encodeData(data, end_stream);
   }
 }
@@ -640,9 +639,9 @@ void Filter::UpstreamRequest::encodeTrailers(const Http::HeaderMap& trailers) {
   encode_trailers_ = true;
 
   if (!request_encoder_) {
-    stream_log_facility(trace, "buffering trailers", *parent_.callbacks_);
+    STREAM_LOG(trace, "buffering trailers", *parent_.callbacks_);
   } else {
-    stream_log_facility(trace, "proxying trailers", *parent_.callbacks_);
+    STREAM_LOG(trace, "proxying trailers", *parent_.callbacks_);
     request_encoder_->encodeTrailers(trailers);
   }
 }
@@ -658,14 +657,14 @@ void Filter::UpstreamRequest::onResetStream(Http::StreamResetReason reason) {
 
 void Filter::UpstreamRequest::resetStream() {
   if (conn_pool_stream_handle_) {
-    stream_log_facility(debug, "cancelling pool request", *parent_.callbacks_);
+    STREAM_LOG(debug, "cancelling pool request", *parent_.callbacks_);
     ASSERT(!request_encoder_);
     conn_pool_stream_handle_->cancel();
     conn_pool_stream_handle_ = nullptr;
   }
 
   if (request_encoder_) {
-    stream_log_facility(debug, "resetting pool request", *parent_.callbacks_);
+    STREAM_LOG(debug, "resetting pool request", *parent_.callbacks_);
     request_encoder_->getStream().removeCallbacks(*this);
     request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
   }
@@ -681,7 +680,7 @@ void Filter::UpstreamRequest::setupPerTryTimeout() {
 }
 
 void Filter::UpstreamRequest::onPerTryTimeout() {
-  stream_log_facility(debug, "upstream per try timeout", *parent_.callbacks_);
+  STREAM_LOG(debug, "upstream per try timeout", *parent_.callbacks_);
   parent_.cluster_->stats().upstream_rq_per_try_timeout_.inc();
   upstream_host_->stats().rq_timeout_.inc();
   resetStream();
@@ -708,7 +707,7 @@ void Filter::UpstreamRequest::onPoolFailure(Http::ConnectionPool::PoolFailureRea
 
 void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
                                           Upstream::HostDescriptionConstSharedPtr host) {
-  stream_log_facility(debug, "pool ready", *parent_.callbacks_);
+  STREAM_LOG(debug, "pool ready", *parent_.callbacks_);
   onUpstreamHostSelected(host);
   request_encoder.getStream().addCallbacks(*this);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -149,7 +149,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   route_ = callbacks_->route();
   if (!route_) {
     config_.stats_.no_route_.inc();
-    stream_log_debug("no cluster match for URL '{}'", *callbacks_, headers.Path()->value().c_str());
+    stream_log_facility(debug, "no cluster match for URL '{}'", *callbacks_,
+                        headers.Path()->value().c_str());
 
     callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
     Http::HeaderMapPtr response_headers{new Http::HeaderMapImpl{
@@ -170,7 +171,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   Upstream::ThreadLocalCluster* cluster = config_.cm_.get(route_entry_->clusterName());
   if (!cluster) {
     config_.stats_.no_cluster_.inc();
-    stream_log_debug("unknown cluster '{}'", *callbacks_, route_entry_->clusterName());
+    stream_log_facility(debug, "unknown cluster '{}'", *callbacks_, route_entry_->clusterName());
 
     callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::NoRouteFound);
     Http::HeaderMapPtr response_headers{new Http::HeaderMapImpl{
@@ -182,8 +183,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Set up stat prefixes, etc.
   request_vcluster_ = route_entry_->virtualCluster(headers);
-  stream_log_debug("cluster '{}' match for URL '{}'", *callbacks_, route_entry_->clusterName(),
-                   headers.Path()->value().c_str());
+  stream_log_facility(debug, "cluster '{}' match for URL '{}'", *callbacks_,
+                      route_entry_->clusterName(), headers.Path()->value().c_str());
 
   const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();
   if (request_alt_name) {
@@ -232,8 +233,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
 #ifndef NDEBUG
   headers.iterate([](const Http::HeaderEntry& header, void* context) -> void {
-    stream_log_debug("  '{}':'{}'", *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
-                     header.key().c_str(), header.value().c_str());
+    stream_log_facility(debug, "  '{}':'{}'",
+                        *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
+                        header.key().c_str(), header.value().c_str());
   }, callbacks_);
 #endif
 
@@ -357,7 +359,7 @@ void Filter::onDestroy() {
 }
 
 void Filter::onResponseTimeout() {
-  stream_log_debug("upstream timeout", *callbacks_);
+  stream_log_facility(debug, "upstream timeout", *callbacks_);
   cluster_->stats().upstream_rq_timeout_.inc();
 
   // It's possible to timeout during a retry backoff delay when we have no upstream request. In
@@ -376,7 +378,7 @@ void Filter::onUpstreamReset(UpstreamResetType type,
                              const Optional<Http::StreamResetReason>& reset_reason) {
   ASSERT(type == UpstreamResetType::GlobalTimeout || upstream_request_);
   if (type == UpstreamResetType::Reset) {
-    stream_log_debug("upstream reset", *callbacks_);
+    stream_log_facility(debug, "upstream reset", *callbacks_);
   }
 
   Upstream::HostDescriptionConstSharedPtr upstream_host;
@@ -446,7 +448,7 @@ Filter::streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason) {
 }
 
 void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
-  stream_log_debug("upstream headers complete: end_stream={}", *callbacks_, end_stream);
+  stream_log_facility(debug, "upstream headers complete: end_stream={}", *callbacks_, end_stream);
   ASSERT(!downstream_response_started_);
 
   upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(
@@ -546,7 +548,7 @@ bool Filter::setupRetry(bool end_stream) {
     return false;
   }
 
-  stream_log_debug("performing retry", *callbacks_);
+  stream_log_facility(debug, "performing retry", *callbacks_);
   if (!end_stream) {
     upstream_request_->resetStream();
   }
@@ -620,14 +622,14 @@ void Filter::UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream
   encode_complete_ = end_stream;
 
   if (!request_encoder_) {
-    stream_log_trace("buffering {} bytes", *parent_.callbacks_, data.length());
+    stream_log_facility(trace, "buffering {} bytes", *parent_.callbacks_, data.length());
     if (!buffered_request_body_) {
       buffered_request_body_.reset(new Buffer::OwnedImpl());
     }
 
     buffered_request_body_->move(data);
   } else {
-    stream_log_trace("proxying {} bytes", *parent_.callbacks_, data.length());
+    stream_log_facility(trace, "proxying {} bytes", *parent_.callbacks_, data.length());
     request_encoder_->encodeData(data, end_stream);
   }
 }
@@ -638,9 +640,9 @@ void Filter::UpstreamRequest::encodeTrailers(const Http::HeaderMap& trailers) {
   encode_trailers_ = true;
 
   if (!request_encoder_) {
-    stream_log_trace("buffering trailers", *parent_.callbacks_);
+    stream_log_facility(trace, "buffering trailers", *parent_.callbacks_);
   } else {
-    stream_log_trace("proxying trailers", *parent_.callbacks_);
+    stream_log_facility(trace, "proxying trailers", *parent_.callbacks_);
     request_encoder_->encodeTrailers(trailers);
   }
 }
@@ -656,14 +658,14 @@ void Filter::UpstreamRequest::onResetStream(Http::StreamResetReason reason) {
 
 void Filter::UpstreamRequest::resetStream() {
   if (conn_pool_stream_handle_) {
-    stream_log_debug("cancelling pool request", *parent_.callbacks_);
+    stream_log_facility(debug, "cancelling pool request", *parent_.callbacks_);
     ASSERT(!request_encoder_);
     conn_pool_stream_handle_->cancel();
     conn_pool_stream_handle_ = nullptr;
   }
 
   if (request_encoder_) {
-    stream_log_debug("resetting pool request", *parent_.callbacks_);
+    stream_log_facility(debug, "resetting pool request", *parent_.callbacks_);
     request_encoder_->getStream().removeCallbacks(*this);
     request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
   }
@@ -679,7 +681,7 @@ void Filter::UpstreamRequest::setupPerTryTimeout() {
 }
 
 void Filter::UpstreamRequest::onPerTryTimeout() {
-  stream_log_debug("upstream per try timeout", *parent_.callbacks_);
+  stream_log_facility(debug, "upstream per try timeout", *parent_.callbacks_);
   parent_.cluster_->stats().upstream_rq_per_try_timeout_.inc();
   upstream_host_->stats().rq_timeout_.inc();
   resetStream();
@@ -706,7 +708,7 @@ void Filter::UpstreamRequest::onPoolFailure(Http::ConnectionPool::PoolFailureRea
 
 void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
                                           Upstream::HostDescriptionConstSharedPtr host) {
-  stream_log_debug("pool ready", *parent_.callbacks_);
+  stream_log_facility(debug, "pool ready", *parent_.callbacks_);
   onUpstreamHostSelected(host);
   request_encoder.getStream().addCallbacks(*this);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -231,7 +231,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   do_shadowing_ = FilterUtility::shouldShadow(route_entry_->shadowPolicy(), config_.runtime_,
                                               callbacks_->streamId());
 
-#ifndef NDEBUG
+#ifndef NVLOG
   headers.iterate([](const Http::HeaderEntry& header, void* context) -> void {
     stream_log_facility(debug, "  '{}':'{}'",
                         *static_cast<Http::StreamDecoderFilterCallbacks*>(context),

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -55,7 +55,7 @@ SnapshotImpl::SnapshotImpl(const std::string& root_path, const std::string& over
     stats.load_success_.inc();
   } catch (EnvoyException& e) {
     stats.load_error_.inc();
-    log_facility(debug, "error creating runtime snapshot: {}", e.what());
+    LOG(debug, "error creating runtime snapshot: {}", e.what());
   }
 
   stats.num_keys_.set(values_.size());
@@ -80,7 +80,7 @@ uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value
 }
 
 void SnapshotImpl::walkDirectory(const std::string& path, const std::string& prefix) {
-  log_facility(debug, "walking directory: {}", path);
+  LOG(debug, "walking directory: {}", path);
   Directory current_dir(path);
   while (true) {
     errno = 0;
@@ -108,7 +108,7 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
       // Suck the file into a string. This is not very efficient but it should be good enough
       // for small files. Also, as noted elsewhere, none of this is non-blocking which could
       // theoretically lead to issues.
-      log_facility(debug, "reading file: {}", full_path);
+      LOG(debug, "reading file: {}", full_path);
       Entry entry;
       entry.string_value_ = Filesystem::fileReadToEnd(full_path);
       StringUtil::rtrim(entry.string_value_);

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -55,7 +55,7 @@ SnapshotImpl::SnapshotImpl(const std::string& root_path, const std::string& over
     stats.load_success_.inc();
   } catch (EnvoyException& e) {
     stats.load_error_.inc();
-    log_debug("error creating runtime snapshot: {}", e.what());
+    log_facility(debug, "error creating runtime snapshot: {}", e.what());
   }
 
   stats.num_keys_.set(values_.size());
@@ -80,7 +80,7 @@ uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value
 }
 
 void SnapshotImpl::walkDirectory(const std::string& path, const std::string& prefix) {
-  log_debug("walking directory: {}", path);
+  log_facility(debug, "walking directory: {}", path);
   Directory current_dir(path);
   while (true) {
     errno = 0;
@@ -108,7 +108,7 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
       // Suck the file into a string. This is not very efficient but it should be good enough
       // for small files. Also, as noted elsewhere, none of this is non-blocking which could
       // theoretically lead to issues.
-      log_debug("reading file: {}", full_path);
+      log_facility(debug, "reading file: {}", full_path);
       Entry entry;
       entry.string_value_ = Filesystem::fileReadToEnd(full_path);
       StringUtil::rtrim(entry.string_value_);

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -73,7 +73,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);
     for (uint64_t i = 0; i < num_slices; i++) {
       int rc = SSL_read(ssl_.get(), slices[i].mem_, slices[i].len_);
-      conn_log_trace("ssl read returns: {}", *this, rc);
+      conn_log_facility(trace, "ssl read returns: {}", *this, rc);
       if (rc > 0) {
         slices[i].len_ = rc;
         slices_to_commit++;
@@ -112,9 +112,9 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
   ASSERT(!handshake_complete_);
   int rc = SSL_do_handshake(ssl_.get());
   if (rc == 1) {
-    conn_log_debug("handshake complete", *this);
+    conn_log_facility(debug, "handshake complete", *this);
     if (!ctx_.verifyPeer(ssl_.get())) {
-      conn_log_debug("SSL peer verification failed", *this);
+      conn_log_facility(debug, "SSL peer verification failed", *this);
       return PostIoAction::Close;
     }
 
@@ -125,7 +125,7 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
     return state() == State::Open ? PostIoAction::KeepOpen : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl_.get(), rc);
-    conn_log_debug("handshake error: {}", *this, err);
+    conn_log_facility(debug, "handshake error: {}", *this, err);
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
@@ -145,8 +145,8 @@ void ConnectionImpl::drainErrorQueue() {
       saw_error = true;
     }
 
-    conn_log_debug("SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
-                   ERR_func_error_string(err), ERR_reason_error_string(err));
+    conn_log_facility(debug, "SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
+                      ERR_func_error_string(err), ERR_reason_error_string(err));
     UNREFERENCED_PARAMETER(err);
   }
 }
@@ -181,7 +181,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
       // particular chain to increase in size. So as long as we start writing where we left off we
       // are guaranteed to call SSL_write() with the same parameters.
       int rc = SSL_write(ssl_.get(), slices[i].mem_, slices[i].len_);
-      conn_log_trace("ssl write returns: {}", *this, rc);
+      conn_log_facility(trace, "ssl write returns: {}", *this, rc);
       if (rc > 0) {
         inner_bytes_written += rc;
         total_bytes_written += rc;
@@ -273,7 +273,7 @@ void ConnectionImpl::closeSocket(uint32_t close_type) {
     // there is no room on the socket. We can extend the state machine to handle this at some point
     // if needed.
     int rc = SSL_shutdown(ssl_.get());
-    conn_log_debug("SSL shutdown: rc={}", *this, rc);
+    conn_log_facility(debug, "SSL shutdown: rc={}", *this, rc);
     UNREFERENCED_PARAMETER(rc);
     drainErrorQueue();
   }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -73,7 +73,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);
     for (uint64_t i = 0; i < num_slices; i++) {
       int rc = SSL_read(ssl_.get(), slices[i].mem_, slices[i].len_);
-      conn_log_facility(trace, "ssl read returns: {}", *this, rc);
+      CONN_LOG(trace, "ssl read returns: {}", *this, rc);
       if (rc > 0) {
         slices[i].len_ = rc;
         slices_to_commit++;
@@ -112,9 +112,9 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
   ASSERT(!handshake_complete_);
   int rc = SSL_do_handshake(ssl_.get());
   if (rc == 1) {
-    conn_log_facility(debug, "handshake complete", *this);
+    CONN_LOG(debug, "handshake complete", *this);
     if (!ctx_.verifyPeer(ssl_.get())) {
-      conn_log_facility(debug, "SSL peer verification failed", *this);
+      CONN_LOG(debug, "SSL peer verification failed", *this);
       return PostIoAction::Close;
     }
 
@@ -125,7 +125,7 @@ Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
     return state() == State::Open ? PostIoAction::KeepOpen : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl_.get(), rc);
-    conn_log_facility(debug, "handshake error: {}", *this, err);
+    CONN_LOG(debug, "handshake error: {}", *this, err);
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
@@ -145,8 +145,8 @@ void ConnectionImpl::drainErrorQueue() {
       saw_error = true;
     }
 
-    conn_log_facility(debug, "SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
-                      ERR_func_error_string(err), ERR_reason_error_string(err));
+    CONN_LOG(debug, "SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
+             ERR_func_error_string(err), ERR_reason_error_string(err));
     UNREFERENCED_PARAMETER(err);
   }
 }
@@ -181,7 +181,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
       // particular chain to increase in size. So as long as we start writing where we left off we
       // are guaranteed to call SSL_write() with the same parameters.
       int rc = SSL_write(ssl_.get(), slices[i].mem_, slices[i].len_);
-      conn_log_facility(trace, "ssl write returns: {}", *this, rc);
+      CONN_LOG(trace, "ssl write returns: {}", *this, rc);
       if (rc > 0) {
         inner_bytes_written += rc;
         total_bytes_written += rc;
@@ -273,7 +273,7 @@ void ConnectionImpl::closeSocket(uint32_t close_type) {
     // there is no room on the socket. We can extend the state machine to handle this at some point
     // if needed.
     int rc = SSL_shutdown(ssl_.get());
-    conn_log_facility(debug, "SSL shutdown: rc={}", *this, rc);
+    CONN_LOG(debug, "SSL shutdown: rc={}", *this, rc);
     UNREFERENCED_PARAMETER(rc);
     drainErrorQueue();
   }

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -38,7 +38,7 @@ CdsApiImpl::CdsApiImpl(const Json::Object& config, ClusterManager& cm,
 }
 
 void CdsApiImpl::createRequest(Http::Message& request) {
-  log_facility(debug, "cds: starting request");
+  LOG(debug, "cds: starting request");
   stats_.update_attempt_.inc();
   request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(
@@ -46,7 +46,7 @@ void CdsApiImpl::createRequest(Http::Message& request) {
 }
 
 void CdsApiImpl::parseResponse(const Http::Message& response) {
-  log_facility(debug, "cds: parsing response");
+  LOG(debug, "cds: parsing response");
   Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   response_json->validateSchema(Json::Schema::CDS_SCHEMA);
   std::vector<Json::ObjectSharedPtr> clusters = response_json->getObjectArray("clusters");
@@ -57,13 +57,13 @@ void CdsApiImpl::parseResponse(const Http::Message& response) {
     std::string cluster_name = cluster->getString("name");
     clusters_to_remove.erase(cluster_name);
     if (cm_.addOrUpdatePrimaryCluster(*cluster)) {
-      log_facility(info, "cds: add/update cluster '{}'", cluster_name);
+      LOG(info, "cds: add/update cluster '{}'", cluster_name);
     }
   }
 
   for (auto cluster : clusters_to_remove) {
     if (cm_.removePrimaryCluster(cluster.first)) {
-      log_facility(info, "cds: remove cluster '{}'", cluster.first);
+      LOG(info, "cds: remove cluster '{}'", cluster.first);
     }
   }
 
@@ -80,9 +80,9 @@ void CdsApiImpl::onFetchComplete() {
 void CdsApiImpl::onFetchFailure(EnvoyException* e) {
   stats_.update_failure_.inc();
   if (e) {
-    log_facility(warn, "cds: fetch failure: {}", e->what());
+    LOG(warn, "cds: fetch failure: {}", e->what());
   } else {
-    log_facility(info, "cds: fetch failure: network error");
+    LOG(info, "cds: fetch failure: network error");
   }
 }
 

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -38,7 +38,7 @@ CdsApiImpl::CdsApiImpl(const Json::Object& config, ClusterManager& cm,
 }
 
 void CdsApiImpl::createRequest(Http::Message& request) {
-  log_debug("cds: starting request");
+  log_facility(debug, "cds: starting request");
   stats_.update_attempt_.inc();
   request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(
@@ -46,7 +46,7 @@ void CdsApiImpl::createRequest(Http::Message& request) {
 }
 
 void CdsApiImpl::parseResponse(const Http::Message& response) {
-  log_debug("cds: parsing response");
+  log_facility(debug, "cds: parsing response");
   Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
   response_json->validateSchema(Json::Schema::CDS_SCHEMA);
   std::vector<Json::ObjectSharedPtr> clusters = response_json->getObjectArray("clusters");
@@ -57,13 +57,13 @@ void CdsApiImpl::parseResponse(const Http::Message& response) {
     std::string cluster_name = cluster->getString("name");
     clusters_to_remove.erase(cluster_name);
     if (cm_.addOrUpdatePrimaryCluster(*cluster)) {
-      log().info("cds: add/update cluster '{}'", cluster_name);
+      log_facility(info, "cds: add/update cluster '{}'", cluster_name);
     }
   }
 
   for (auto cluster : clusters_to_remove) {
     if (cm_.removePrimaryCluster(cluster.first)) {
-      log().info("cds: remove cluster '{}'", cluster.first);
+      log_facility(info, "cds: remove cluster '{}'", cluster.first);
     }
   }
 
@@ -80,9 +80,9 @@ void CdsApiImpl::onFetchComplete() {
 void CdsApiImpl::onFetchFailure(EnvoyException* e) {
   stats_.update_failure_.inc();
   if (e) {
-    log().warn("cds: fetch failure: {}", e->what());
+    log_facility(warn, "cds: fetch failure: {}", e->what());
   } else {
-    log().info("cds: fetch failure: network error");
+    log_facility(info, "cds: fetch failure: network error");
   }
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -46,8 +46,8 @@ void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
     }
   }
 
-  log_facility(info, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
-               primary_init_clusters_.size(), secondary_init_clusters_.size());
+  LOG(info, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
+      primary_init_clusters_.size(), secondary_init_clusters_.size());
   cluster.setInitializedCb([&cluster, this]() -> void {
     ASSERT(state_ != State::AllClustersInitialized);
     removeCluster(cluster);
@@ -72,9 +72,8 @@ void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
   // It is possible that the cluster we are removing has already been initialized, and is not
   // present in the initializer list. If so, this is fine.
   cluster_list->remove(&cluster);
-  log_facility(info, "cm init: removing: cluster={} primary={} secondary={}",
-               cluster.info()->name(), primary_init_clusters_.size(),
-               secondary_init_clusters_.size());
+  LOG(info, "cm init: removing: cluster={} primary={} secondary={}", cluster.info()->name(),
+      primary_init_clusters_.size(), secondary_init_clusters_.size());
   maybeFinishInitialize();
 }
 
@@ -95,7 +94,7 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
   // initialize on them. This is only done once.
   if (!secondary_init_clusters_.empty()) {
     if (!started_secondary_initialize_) {
-      log_facility(info, "cm init: initializing secondary clusters");
+      LOG(info, "cm init: initializing secondary clusters");
       started_secondary_initialize_ = true;
       // Cluster::initialize() method can modify the list of secondary_init_clusters_ to remove
       // the item currently being initialized, so we eschew range-based-for and do this complicated
@@ -114,7 +113,7 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
   // directly to initialized.
   started_secondary_initialize_ = false;
   if (state_ == State::WaitingForStaticInitialize && cds_) {
-    log_facility(info, "cm init: initializing cds");
+    LOG(info, "cm init: initializing cds");
     state_ = State::WaitingForCdsInitialize;
     cds_->initialize();
   } else {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -46,8 +46,8 @@ void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
     }
   }
 
-  log().info("cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
-             primary_init_clusters_.size(), secondary_init_clusters_.size());
+  log_facility(info, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
+               primary_init_clusters_.size(), secondary_init_clusters_.size());
   cluster.setInitializedCb([&cluster, this]() -> void {
     ASSERT(state_ != State::AllClustersInitialized);
     removeCluster(cluster);
@@ -72,8 +72,9 @@ void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
   // It is possible that the cluster we are removing has already been initialized, and is not
   // present in the initializer list. If so, this is fine.
   cluster_list->remove(&cluster);
-  log().info("cm init: removing: cluster={} primary={} secondary={}", cluster.info()->name(),
-             primary_init_clusters_.size(), secondary_init_clusters_.size());
+  log_facility(info, "cm init: removing: cluster={} primary={} secondary={}",
+               cluster.info()->name(), primary_init_clusters_.size(),
+               secondary_init_clusters_.size());
   maybeFinishInitialize();
 }
 
@@ -94,7 +95,7 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
   // initialize on them. This is only done once.
   if (!secondary_init_clusters_.empty()) {
     if (!started_secondary_initialize_) {
-      log().info("cm init: initializing secondary clusters");
+      log_facility(info, "cm init: initializing secondary clusters");
       started_secondary_initialize_ = true;
       // Cluster::initialize() method can modify the list of secondary_init_clusters_ to remove
       // the item currently being initialized, so we eschew range-based-for and do this complicated
@@ -113,7 +114,7 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
   // directly to initialized.
   started_secondary_initialize_ = false;
   if (state_ == State::WaitingForStaticInitialize && cds_) {
-    log().info("cm init: initializing cds");
+    log_facility(info, "cm init: initializing cds");
     state_ = State::WaitingForCdsInitialize;
     cds_->initialize();
   } else {

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -290,15 +290,15 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResetStream(Http::St
     return;
   }
 
-  conn_log_facility(debug, "connection/stream error health_flags={}", *client_,
-                    HostUtility::healthFlagsToString(*host_));
+  CONN_LOG(debug, "connection/stream error health_flags={}", *client_,
+           HostUtility::healthFlagsToString(*host_));
   handleFailure(true);
 }
 
 bool HttpHealthCheckerImpl::HttpActiveHealthCheckSession::isHealthCheckSucceeded() {
   uint64_t response_code = Http::Utility::getResponseStatus(*response_headers_);
-  conn_log_facility(debug, "hc response={} health_flags={}", *client_, response_code,
-                    HostUtility::healthFlagsToString(*host_));
+  CONN_LOG(debug, "hc response={} health_flags={}", *client_, response_code,
+           HostUtility::healthFlagsToString(*host_));
 
   if (response_code != enumToInt(Http::Code::OK)) {
     return false;
@@ -336,8 +336,8 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
 }
 
 void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onTimeout() {
-  conn_log_facility(debug, "connection/stream timeout health_flags={}", *client_,
-                    HostUtility::healthFlagsToString(*host_));
+  CONN_LOG(debug, "connection/stream timeout health_flags={}", *client_,
+           HostUtility::healthFlagsToString(*host_));
 
   // If there is an active request it will get reset, so make sure we ignore the reset.
   expect_reset_ = true;
@@ -390,7 +390,7 @@ TcpHealthCheckerImpl::TcpActiveHealthCheckSession::~TcpActiveHealthCheckSession(
 }
 
 void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onData(Buffer::Instance& data) {
-  conn_log_facility(trace, "total pending buffer={}", *client_, data.length());
+  CONN_LOG(trace, "total pending buffer={}", *client_, data.length());
   if (TcpHealthCheckMatcher::match(parent_.receive_bytes_, data)) {
     data.drain(data.length());
     handleSuccess();

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -290,15 +290,15 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResetStream(Http::St
     return;
   }
 
-  conn_log_debug("connection/stream error health_flags={}", *client_,
-                 HostUtility::healthFlagsToString(*host_));
+  conn_log_facility(debug, "connection/stream error health_flags={}", *client_,
+                    HostUtility::healthFlagsToString(*host_));
   handleFailure(true);
 }
 
 bool HttpHealthCheckerImpl::HttpActiveHealthCheckSession::isHealthCheckSucceeded() {
   uint64_t response_code = Http::Utility::getResponseStatus(*response_headers_);
-  conn_log_debug("hc response={} health_flags={}", *client_, response_code,
-                 HostUtility::healthFlagsToString(*host_));
+  conn_log_facility(debug, "hc response={} health_flags={}", *client_, response_code,
+                    HostUtility::healthFlagsToString(*host_));
 
   if (response_code != enumToInt(Http::Code::OK)) {
     return false;
@@ -336,8 +336,8 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
 }
 
 void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onTimeout() {
-  conn_log_debug("connection/stream timeout health_flags={}", *client_,
-                 HostUtility::healthFlagsToString(*host_));
+  conn_log_facility(debug, "connection/stream timeout health_flags={}", *client_,
+                    HostUtility::healthFlagsToString(*host_));
 
   // If there is an active request it will get reset, so make sure we ignore the reset.
   expect_reset_ = true;
@@ -390,7 +390,7 @@ TcpHealthCheckerImpl::TcpActiveHealthCheckSession::~TcpActiveHealthCheckSession(
 }
 
 void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onData(Buffer::Instance& data) {
-  conn_log_trace("total pending buffer={}", *client_, data.length());
+  conn_log_facility(trace, "total pending buffer={}", *client_, data.length());
   if (TcpHealthCheckMatcher::match(parent_.receive_bytes_, data)) {
     data.drain(data.length());
     handleSuccess();

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -55,7 +55,7 @@ LogicalDnsCluster::~LogicalDnsCluster() {
 
 void LogicalDnsCluster::startResolve() {
   std::string dns_address = Network::Utility::hostFromTcpUrl(dns_url_);
-  log_facility(debug, "starting async DNS resolution for {}", dns_address);
+  LOG(debug, "starting async DNS resolution for {}", dns_address);
   info_->stats().update_attempt_.inc();
 
   active_dns_query_ = dns_resolver_->resolve(
@@ -63,7 +63,7 @@ void LogicalDnsCluster::startResolve() {
       [this, dns_address](
           std::list<Network::Address::InstanceConstSharedPtr>&& address_list) -> void {
         active_dns_query_ = nullptr;
-        log_facility(debug, "async DNS resolution complete for {}", dns_address);
+        LOG(debug, "async DNS resolution complete for {}", dns_address);
         info_->stats().update_success_.inc();
 
         if (!address_list.empty()) {

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -55,7 +55,7 @@ LogicalDnsCluster::~LogicalDnsCluster() {
 
 void LogicalDnsCluster::startResolve() {
   std::string dns_address = Network::Utility::hostFromTcpUrl(dns_url_);
-  log_debug("starting async DNS resolution for {}", dns_address);
+  log_facility(debug, "starting async DNS resolution for {}", dns_address);
   info_->stats().update_attempt_.inc();
 
   active_dns_query_ = dns_resolver_->resolve(
@@ -63,7 +63,7 @@ void LogicalDnsCluster::startResolve() {
       [this, dns_address](
           std::list<Network::Address::InstanceConstSharedPtr>&& address_list) -> void {
         active_dns_query_ = nullptr;
-        log_debug("async DNS resolution complete for {}", dns_address);
+        log_facility(debug, "async DNS resolution complete for {}", dns_address);
         info_->stats().update_success_.inc();
 
         if (!address_list.empty()) {

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -77,7 +77,7 @@ HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerCont
 
 void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
                                         const std::vector<HostSharedPtr>& hosts) {
-  log_trace("ring hash: building ring");
+  log_facility(trace, "ring hash: building ring");
   ring_.clear();
   if (hosts.empty()) {
     return;
@@ -101,13 +101,14 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
     }
   }
 
-  log_trace("ring hash: min_ring_size={} hashes_per_host={}", min_ring_size, hashes_per_host);
+  log_facility(trace, "ring hash: min_ring_size={} hashes_per_host={}", min_ring_size,
+               hashes_per_host);
   ring_.reserve(hosts.size() * hashes_per_host);
   for (const auto& host : hosts) {
     for (uint64_t i = 0; i < hashes_per_host; i++) {
       std::string hash_key(host->address()->asString() + "_" + std::to_string(i));
       uint64_t hash = std::hash<std::string>()(hash_key);
-      log_trace("ring hash: hash_key={} hash={}", hash_key, hash);
+      log_facility(trace, "ring hash: hash_key={} hash={}", hash_key, hash);
       ring_.push_back({hash, host});
     }
   }
@@ -116,7 +117,8 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
                                             -> bool { return lhs.hash_ < rhs.hash_; });
 #ifndef NDEBUG
   for (auto entry : ring_) {
-    log_trace("ring hash: host={} hash={}", entry.host_->address()->asString(), entry.hash_);
+    log_facility(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(),
+                 entry.hash_);
   }
 #endif
 }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -77,7 +77,7 @@ HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerCont
 
 void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
                                         const std::vector<HostSharedPtr>& hosts) {
-  log_facility(trace, "ring hash: building ring");
+  LOG(trace, "ring hash: building ring");
   ring_.clear();
   if (hosts.empty()) {
     return;
@@ -101,14 +101,13 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
     }
   }
 
-  log_facility(trace, "ring hash: min_ring_size={} hashes_per_host={}", min_ring_size,
-               hashes_per_host);
+  LOG(trace, "ring hash: min_ring_size={} hashes_per_host={}", min_ring_size, hashes_per_host);
   ring_.reserve(hosts.size() * hashes_per_host);
   for (const auto& host : hosts) {
     for (uint64_t i = 0; i < hashes_per_host; i++) {
       std::string hash_key(host->address()->asString() + "_" + std::to_string(i));
       uint64_t hash = std::hash<std::string>()(hash_key);
-      log_facility(trace, "ring hash: hash_key={} hash={}", hash_key, hash);
+      LOG(trace, "ring hash: hash_key={} hash={}", hash_key, hash);
       ring_.push_back({hash, host});
     }
   }
@@ -117,8 +116,7 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
                                             -> bool { return lhs.hash_ < rhs.hash_; });
 #ifndef NVLOG
   for (auto entry : ring_) {
-    log_facility(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(),
-                 entry.hash_);
+    LOG(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(), entry.hash_);
   }
 #endif
 }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -115,7 +115,7 @@ void RingHashLoadBalancer::Ring::create(Runtime::Loader& runtime,
 
   std::sort(ring_.begin(), ring_.end(), [](const RingEntry& lhs, const RingEntry& rhs)
                                             -> bool { return lhs.hash_ < rhs.hash_; });
-#ifndef NDEBUG
+#ifndef NVLOG
   for (auto entry : ring_) {
     log_facility(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(),
                  entry.hash_);

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -47,7 +47,7 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
   std::vector<HostSharedPtr> hosts_removed;
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
                             health_checker_ != nullptr)) {
-    log_debug("sds hosts changed for cluster: {} ({})", info_->name(), hosts().size());
+    log_facility(debug, "sds hosts changed for cluster: {} ({})", info_->name(), hosts().size());
     HostListsSharedPtr per_zone(new std::vector<std::vector<HostSharedPtr>>());
 
     // If local zone name is not defined then skip populating per zone hosts.
@@ -89,15 +89,15 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
 }
 
 void SdsClusterImpl::onFetchFailure(EnvoyException* e) {
-  log_debug("sds refresh failure for cluster: {}", info_->name());
+  log_facility(debug, "sds refresh failure for cluster: {}", info_->name());
   info_->stats().update_failure_.inc();
   if (e) {
-    log().warn("sds parsing error: {}", e->what());
+    log_facility(warn, "sds parsing error: {}", e->what());
   }
 }
 
 void SdsClusterImpl::createRequest(Http::Message& message) {
-  log_debug("starting sds refresh for cluster: {}", info_->name());
+  log_facility(debug, "starting sds refresh for cluster: {}", info_->name());
   info_->stats().update_attempt_.inc();
 
   message.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
@@ -105,7 +105,7 @@ void SdsClusterImpl::createRequest(Http::Message& message) {
 }
 
 void SdsClusterImpl::onFetchComplete() {
-  log_debug("sds refresh complete for cluster: {}", info_->name());
+  log_facility(debug, "sds refresh complete for cluster: {}", info_->name());
   // If we didn't setup to initialize when our first round of health checking is complete, just
   // do it now.
   if (initialize_callback_ && pending_health_checks_ == 0) {

--- a/source/common/upstream/sds.cc
+++ b/source/common/upstream/sds.cc
@@ -47,7 +47,7 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
   std::vector<HostSharedPtr> hosts_removed;
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
                             health_checker_ != nullptr)) {
-    log_facility(debug, "sds hosts changed for cluster: {} ({})", info_->name(), hosts().size());
+    LOG(debug, "sds hosts changed for cluster: {} ({})", info_->name(), hosts().size());
     HostListsSharedPtr per_zone(new std::vector<std::vector<HostSharedPtr>>());
 
     // If local zone name is not defined then skip populating per zone hosts.
@@ -89,15 +89,15 @@ void SdsClusterImpl::parseResponse(const Http::Message& response) {
 }
 
 void SdsClusterImpl::onFetchFailure(EnvoyException* e) {
-  log_facility(debug, "sds refresh failure for cluster: {}", info_->name());
+  LOG(debug, "sds refresh failure for cluster: {}", info_->name());
   info_->stats().update_failure_.inc();
   if (e) {
-    log_facility(warn, "sds parsing error: {}", e->what());
+    LOG(warn, "sds parsing error: {}", e->what());
   }
 }
 
 void SdsClusterImpl::createRequest(Http::Message& message) {
-  log_facility(debug, "starting sds refresh for cluster: {}", info_->name());
+  LOG(debug, "starting sds refresh for cluster: {}", info_->name());
   info_->stats().update_attempt_.inc();
 
   message.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
@@ -105,7 +105,7 @@ void SdsClusterImpl::createRequest(Http::Message& message) {
 }
 
 void SdsClusterImpl::onFetchComplete() {
-  log_facility(debug, "sds refresh complete for cluster: {}", info_->name());
+  LOG(debug, "sds refresh complete for cluster: {}", info_->name());
   // If we didn't setup to initialize when our first round of health checking is complete, just
   // do it now.
   if (initialize_callback_ && pending_health_checks_ == 0) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -439,14 +439,14 @@ StrictDnsClusterImpl::ResolveTarget::~ResolveTarget() {
 }
 
 void StrictDnsClusterImpl::ResolveTarget::startResolve() {
-  log_debug("starting async DNS resolution for {}", dns_address_);
+  log_facility(debug, "starting async DNS resolution for {}", dns_address_);
   parent_.info_->stats().update_attempt_.inc();
 
   active_query_ = parent_.dns_resolver_->resolve(
       dns_address_, parent_.dns_lookup_family_,
       [this](std::list<Network::Address::InstanceConstSharedPtr>&& address_list) -> void {
         active_query_ = nullptr;
-        log_debug("async DNS resolution complete for {}", dns_address_);
+        log_facility(debug, "async DNS resolution complete for {}", dns_address_);
         parent_.info_->stats().update_success_.inc();
 
         std::vector<HostSharedPtr> new_hosts;
@@ -463,7 +463,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         std::vector<HostSharedPtr> hosts_added;
         std::vector<HostSharedPtr> hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed, false)) {
-          log_debug("DNS hosts have changed for {}", dns_address_);
+          log_facility(debug, "DNS hosts have changed for {}", dns_address_);
           parent_.updateAllHosts(hosts_added, hosts_removed);
         }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -439,14 +439,14 @@ StrictDnsClusterImpl::ResolveTarget::~ResolveTarget() {
 }
 
 void StrictDnsClusterImpl::ResolveTarget::startResolve() {
-  log_facility(debug, "starting async DNS resolution for {}", dns_address_);
+  LOG(debug, "starting async DNS resolution for {}", dns_address_);
   parent_.info_->stats().update_attempt_.inc();
 
   active_query_ = parent_.dns_resolver_->resolve(
       dns_address_, parent_.dns_lookup_family_,
       [this](std::list<Network::Address::InstanceConstSharedPtr>&& address_list) -> void {
         active_query_ = nullptr;
-        log_facility(debug, "async DNS resolution complete for {}", dns_address_);
+        LOG(debug, "async DNS resolution complete for {}", dns_address_);
         parent_.info_->stats().update_success_.inc();
 
         std::vector<HostSharedPtr> new_hosts;
@@ -463,7 +463,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         std::vector<HostSharedPtr> hosts_added;
         std::vector<HostSharedPtr> hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed, false)) {
-          log_facility(debug, "DNS hosts have changed for {}", dns_address_);
+          LOG(debug, "DNS hosts have changed for {}", dns_address_);
           parent_.updateAllHosts(hosts_added, hosts_removed);
         }
 

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -379,7 +379,7 @@ void HotRestartImpl::onSocketEvent() {
     }
 
     case RpcMessageType::TerminateRequest: {
-      log().warn("shutting down due to child request");
+      log_facility(warn, "shutting down due to child request");
       kill(getpid(), SIGTERM);
       break;
     }

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -379,7 +379,7 @@ void HotRestartImpl::onSocketEvent() {
     }
 
     case RpcMessageType::TerminateRequest: {
-      log_facility(warn, "shutting down due to child request");
+      LOG(warn, "shutting down due to child request");
       kill(getpid(), SIGTERM);
       break;
     }

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -73,7 +73,7 @@ public:
     // The size must be at least two for useful info - there is a sentinel frame
     // at the end that we ignore.
     if (stack_trace_.size() < 2) {
-      log().critical("Back trace attempt failed");
+      log_facility(critical, "Back trace attempt failed");
       return;
     }
 
@@ -81,7 +81,8 @@ public:
     backward::ResolvedTrace first_frame_trace = resolver.resolve(stack_trace_[0]);
     auto obj_name = first_frame_trace.object_filename;
 
-    log().critical("Backtrace obj<{}> thr<{}> (use tools/stack_decode.py):", obj_name, thread_id);
+    log_facility(critical, "Backtrace obj<{}> thr<{}> (use tools/stack_decode.py):", obj_name,
+                 thread_id);
 
     // Backtrace gets tagged by ASAN when we try the object name resolution for the last
     // frame on stack, so skip the last one. It has no useful info anyway.
@@ -89,15 +90,16 @@ public:
       backward::ResolvedTrace trace = resolver.resolve(stack_trace_[i]);
       if (trace.object_filename != obj_name) {
         obj_name = trace.object_filename;
-        log().critical("thr<{}> obj<{}>", thread_id, obj_name);
+        log_facility(critical, "thr<{}> obj<{}>", thread_id, obj_name);
       }
-      log().critical("thr<{}> #{} {}", thread_id, stack_trace_[i].idx, stack_trace_[i].addr);
+      log_facility(critical, "thr<{}> #{} {}", thread_id, stack_trace_[i].idx,
+                   stack_trace_[i].addr);
     }
-    log().critical("end backtrace thread {}", stack_trace_.thread_id());
+    log_facility(critical, "end backtrace thread {}", stack_trace_.thread_id());
   }
 
   void logFault(const char* signame, const void* addr) {
-    log().critical("Caught {}, suspect faulting address {}", signame, addr);
+    log_facility(critical, "Caught {}, suspect faulting address {}", signame, addr);
   }
 
 private:

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -73,7 +73,7 @@ public:
     // The size must be at least two for useful info - there is a sentinel frame
     // at the end that we ignore.
     if (stack_trace_.size() < 2) {
-      log_facility(critical, "Back trace attempt failed");
+      LOG(critical, "Back trace attempt failed");
       return;
     }
 
@@ -81,8 +81,7 @@ public:
     backward::ResolvedTrace first_frame_trace = resolver.resolve(stack_trace_[0]);
     auto obj_name = first_frame_trace.object_filename;
 
-    log_facility(critical, "Backtrace obj<{}> thr<{}> (use tools/stack_decode.py):", obj_name,
-                 thread_id);
+    LOG(critical, "Backtrace obj<{}> thr<{}> (use tools/stack_decode.py):", obj_name, thread_id);
 
     // Backtrace gets tagged by ASAN when we try the object name resolution for the last
     // frame on stack, so skip the last one. It has no useful info anyway.
@@ -90,16 +89,15 @@ public:
       backward::ResolvedTrace trace = resolver.resolve(stack_trace_[i]);
       if (trace.object_filename != obj_name) {
         obj_name = trace.object_filename;
-        log_facility(critical, "thr<{}> obj<{}>", thread_id, obj_name);
+        LOG(critical, "thr<{}> obj<{}>", thread_id, obj_name);
       }
-      log_facility(critical, "thr<{}> #{} {}", thread_id, stack_trace_[i].idx,
-                   stack_trace_[i].addr);
+      LOG(critical, "thr<{}> #{} {}", thread_id, stack_trace_[i].idx, stack_trace_[i].addr);
     }
-    log_facility(critical, "end backtrace thread {}", stack_trace_.thread_id());
+    LOG(critical, "end backtrace thread {}", stack_trace_.thread_id());
   }
 
   void logFault(const char* signame, const void* addr) {
-    log_facility(critical, "Caught {}, suspect faulting address {}", signame, addr);
+    LOG(critical, "Caught {}, suspect faulting address {}", signame, addr);
   }
 
 private:

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -150,9 +150,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
     std::string string_name = filters[i]->getString("name");
     Json::ObjectSharedPtr config_object = filters[i]->getObject("config");
 
-    log_facility(info, "    filter #{}", i);
-    log_facility(info, "      type: {}", string_type);
-    log_facility(info, "      name: {}", string_name);
+    LOG(info, "    filter #{}", i);
+    LOG(info, "      type: {}", string_type);
+    LOG(info, "      name: {}", string_name);
 
     HttpFilterType type = stringToType(string_type);
 

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -150,9 +150,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
     std::string string_name = filters[i]->getString("name");
     Json::ObjectSharedPtr config_object = filters[i]->getObject("config");
 
-    log().info("    filter #{}", i);
-    log().info("      type: {}", string_type);
-    log().info("      name: {}", string_name);
+    log_facility(info, "    filter #{}", i);
+    log_facility(info, "      type: {}", string_type);
+    log_facility(info, "      name: {}", string_name);
 
     HttpFilterType type = stringToType(string_type);
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -31,7 +31,8 @@ ValidationInstance::ValidationInstance(Options& options, Stats::IsolatedStoreImp
   try {
     initialize(options, component_factory);
   } catch (const EnvoyException& e) {
-    log().critical("error initializing configuration '{}': {}", options.configPath(), e.what());
+    log_facility(critical, "error initializing configuration '{}': {}", options.configPath(),
+                 e.what());
     thread_local_.shutdownThread();
     throw;
   }

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -31,8 +31,7 @@ ValidationInstance::ValidationInstance(Options& options, Stats::IsolatedStoreImp
   try {
     initialize(options, component_factory);
   } catch (const EnvoyException& e) {
-    log_facility(critical, "error initializing configuration '{}': {}", options.configPath(),
-                 e.what());
+    LOG(critical, "error initializing configuration '{}': {}", options.configPath(), e.what());
     thread_local_.shutdownThread();
     throw;
   }

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -43,9 +43,9 @@ void MainImpl::initialize(const Json::Object& json) {
       server_.random(), server_.localInfo(), server_.accessLogManager());
 
   std::vector<Json::ObjectSharedPtr> listeners = json.getObjectArray("listeners");
-  log_facility(info, "loading {} listener(s)", listeners.size());
+  LOG(info, "loading {} listener(s)", listeners.size());
   for (size_t i = 0; i < listeners.size(); i++) {
-    log_facility(info, "listener #{}:", i);
+    LOG(info, "listener #{}:", i);
     listeners_.emplace_back(
         Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
   }
@@ -95,7 +95,7 @@ void MainImpl::initialize(const Json::Object& json) {
 }
 
 void MainImpl::initializeTracers(const Json::Object& configuration) {
-  log_facility(info, "loading tracing configuration");
+  LOG(info, "loading tracing configuration");
 
   if (!configuration.hasObject("tracing")) {
     http_tracer_.reset(new Tracing::HttpNullTracer());
@@ -118,7 +118,7 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
   Json::ObjectSharedPtr driver = http_tracer_config->getObject("driver");
 
   std::string type = driver->getString("type");
-  log_facility(info, "  loading tracing driver: {}", type);
+  LOG(info, "  loading tracing driver: {}", type);
 
   Json::ObjectSharedPtr driver_config = driver->getObject("config");
 
@@ -142,7 +142,7 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
   std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
 
   scope_ = parent_.server_.stats().createScope(final_stat_name);
-  log_facility(info, "  address={}", address_->asString());
+  LOG(info, "  address={}", address_->asString());
 
   json.validateSchema(Json::Schema::LISTENER_SCHEMA);
 
@@ -163,9 +163,9 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
     std::string string_type = filters[i]->getString("type");
     std::string string_name = filters[i]->getString("name");
     Json::ObjectSharedPtr config = filters[i]->getObject("config");
-    log_facility(info, "  filter #{}:", i);
-    log_facility(info, "    type: {}", string_type);
-    log_facility(info, "    name: {}", string_name);
+    LOG(info, "  filter #{}:", i);
+    LOG(info, "    type: {}", string_type);
+    LOG(info, "    name: {}", string_name);
 
     // Map filter type string to enum.
     NetworkFilterType type;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -43,9 +43,9 @@ void MainImpl::initialize(const Json::Object& json) {
       server_.random(), server_.localInfo(), server_.accessLogManager());
 
   std::vector<Json::ObjectSharedPtr> listeners = json.getObjectArray("listeners");
-  log().info("loading {} listener(s)", listeners.size());
+  log_facility(info, "loading {} listener(s)", listeners.size());
   for (size_t i = 0; i < listeners.size(); i++) {
-    log().info("listener #{}:", i);
+    log_facility(info, "listener #{}:", i);
     listeners_.emplace_back(
         Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
   }
@@ -95,7 +95,7 @@ void MainImpl::initialize(const Json::Object& json) {
 }
 
 void MainImpl::initializeTracers(const Json::Object& configuration) {
-  log().info("loading tracing configuration");
+  log_facility(info, "loading tracing configuration");
 
   if (!configuration.hasObject("tracing")) {
     http_tracer_.reset(new Tracing::HttpNullTracer());
@@ -118,7 +118,7 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
   Json::ObjectSharedPtr driver = http_tracer_config->getObject("driver");
 
   std::string type = driver->getString("type");
-  log().info(fmt::format("  loading tracing driver: {}", type));
+  log_facility(info, fmt::format("  loading tracing driver: {}", type));
 
   Json::ObjectSharedPtr driver_config = driver->getObject("config");
 
@@ -142,7 +142,7 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
   std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
 
   scope_ = parent_.server_.stats().createScope(final_stat_name);
-  log().info("  address={}", address_->asString());
+  log_facility(info, "  address={}", address_->asString());
 
   json.validateSchema(Json::Schema::LISTENER_SCHEMA);
 
@@ -163,9 +163,9 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
     std::string string_type = filters[i]->getString("type");
     std::string string_name = filters[i]->getString("name");
     Json::ObjectSharedPtr config = filters[i]->getObject("config");
-    log().info("  filter #{}:", i);
-    log().info("    type: {}", string_type);
-    log().info("    name: {}", string_name);
+    log_facility(info, "  filter #{}:", i);
+    log_facility(info, "    type: {}", string_type);
+    log_facility(info, "    name: {}", string_name);
 
     // Map filter type string to enum.
     NetworkFilterType type;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -118,7 +118,7 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
   Json::ObjectSharedPtr driver = http_tracer_config->getObject("driver");
 
   std::string type = driver->getString("type");
-  log_facility(info, fmt::format("  loading tracing driver: {}", type));
+  log_facility(info, "  loading tracing driver: {}", type);
 
   Json::ObjectSharedPtr driver_config = driver->getObject("config");
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -48,7 +48,7 @@ void ConnectionHandlerImpl::closeListeners() {
 }
 
 void ConnectionHandlerImpl::removeConnection(ActiveConnection& connection) {
-  conn_log(logger_, info, "adding to cleanup list", *connection.connection_);
+  conn_log_to_logger(logger_, info, "adding to cleanup list", *connection.connection_);
   ActiveConnectionPtr removed = connection.removeFromList(connections_);
   dispatcher_->deferredDelete(std::move(removed));
   num_connections_--;
@@ -106,7 +106,7 @@ ConnectionHandlerImpl::findListenerByAddress(const Network::Address::Instance& a
 
 void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     Network::ConnectionPtr&& new_connection) {
-  conn_log(parent_.logger_, info, "new connection", *new_connection);
+  conn_log_to_logger(parent_.logger_, info, "new connection", *new_connection);
   bool empty_filter_chain = !factory_.createFilterChain(*new_connection);
 
   // If the connection is already closed, we can just let this connection immediately die.
@@ -114,7 +114,7 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     // Close the connection if the filter chain is empty to avoid leaving open connections
     // with nothing to do.
     if (empty_filter_chain) {
-      conn_log(parent_.logger_, info, "closing connection: no filters", *new_connection);
+      conn_log_to_logger(parent_.logger_, info, "closing connection: no filters", *new_connection);
       new_connection->close(Network::ConnectionCloseType::NoFlush);
     } else {
       ActiveConnectionPtr active_connection(

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -48,7 +48,7 @@ void ConnectionHandlerImpl::closeListeners() {
 }
 
 void ConnectionHandlerImpl::removeConnection(ActiveConnection& connection) {
-  conn_log_to_logger(logger_, info, "adding to cleanup list", *connection.connection_);
+  CONN_LOG_TO_LOGGER(logger_, info, "adding to cleanup list", *connection.connection_);
   ActiveConnectionPtr removed = connection.removeFromList(connections_);
   dispatcher_->deferredDelete(std::move(removed));
   num_connections_--;
@@ -106,7 +106,7 @@ ConnectionHandlerImpl::findListenerByAddress(const Network::Address::Instance& a
 
 void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     Network::ConnectionPtr&& new_connection) {
-  conn_log_to_logger(parent_.logger_, info, "new connection", *new_connection);
+  CONN_LOG_TO_LOGGER(parent_.logger_, info, "new connection", *new_connection);
   bool empty_filter_chain = !factory_.createFilterChain(*new_connection);
 
   // If the connection is already closed, we can just let this connection immediately die.
@@ -114,7 +114,7 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     // Close the connection if the filter chain is empty to avoid leaving open connections
     // with nothing to do.
     if (empty_filter_chain) {
-      conn_log_to_logger(parent_.logger_, info, "closing connection: no filters", *new_connection);
+      CONN_LOG_TO_LOGGER(parent_.logger_, info, "closing connection: no filters", *new_connection);
       new_connection->close(Network::ConnectionCloseType::NoFlush);
     } else {
       ActiveConnectionPtr active_connection(

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -31,7 +31,7 @@ bool DrainManagerImpl::drainClose() {
 }
 
 void DrainManagerImpl::drainSequenceTick() {
-  log_facility(trace, "drain tick #{}", drain_time_completed_.count());
+  LOG(trace, "drain tick #{}", drain_time_completed_.count());
   ASSERT(drain_time_completed_ < server_.options().drainTime());
   drain_time_completed_ += std::chrono::seconds(1);
 
@@ -50,7 +50,7 @@ void DrainManagerImpl::startParentShutdownSequence() {
   ASSERT(!parent_shutdown_timer_);
   parent_shutdown_timer_ = server_.dispatcher().createTimer([this]() -> void {
     // Shut down the parent now. It should have already been draining.
-    log_facility(warn, "shutting down parent after drain");
+    LOG(warn, "shutting down parent after drain");
     server_.hotRestart().terminateParent();
   });
 

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -31,7 +31,7 @@ bool DrainManagerImpl::drainClose() {
 }
 
 void DrainManagerImpl::drainSequenceTick() {
-  log_trace("drain tick #{}", drain_time_completed_.count());
+  log_facility(trace, "drain tick #{}", drain_time_completed_.count());
   ASSERT(drain_time_completed_ < server_.options().drainTime());
   drain_time_completed_ += std::chrono::seconds(1);
 
@@ -50,7 +50,7 @@ void DrainManagerImpl::startParentShutdownSequence() {
   ASSERT(!parent_shutdown_timer_);
   parent_shutdown_timer_ = server_.dispatcher().createTimer([this]() -> void {
     // Shut down the parent now. It should have already been draining.
-    log().warn("shutting down parent after drain");
+    log_facility(warn, "shutting down parent after drain");
     server_.hotRestart().terminateParent();
   });
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -85,12 +85,12 @@ bool AdminImpl::changeLogLevel(const Http::Utility::QueryParams& params) {
 
   // Now either change all levels or a single level.
   if (name == "level") {
-    log_debug("change all log levels: level='{}'", level);
+    log_facility(debug, "change all log levels: level='{}'", level);
     for (const Logger::Logger& logger : Logger::Registry::loggers()) {
       logger.setLevel(static_cast<spdlog::level::level_enum>(level_to_use));
     }
   } else {
-    log_debug("change log level: name='{}' level='{}'", name, level);
+    log_facility(debug, "change log level: name='{}' level='{}'", name, level);
     const Logger::Logger* logger_to_change = nullptr;
     for (const Logger::Logger& logger : Logger::Registry::loggers()) {
       if (logger.name() == name) {
@@ -317,7 +317,7 @@ Http::Code AdminImpl::handlerCerts(const std::string&, Buffer::Instance& respons
 
 void AdminFilter::onComplete() {
   std::string path = request_headers_->Path()->value().c_str();
-  stream_log_info("request complete: path: {}", *callbacks_, path);
+  stream_log_facility(info, "request complete: path: {}", *callbacks_, path);
 
   Buffer::OwnedImpl response;
   Http::Code code = parent_.runCallback(path, response);
@@ -363,7 +363,8 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
     if (!address_out_file) {
-      log().critical("cannot open admin address output file {} for writing.", address_out_path);
+      log_facility(critical, "cannot open admin address output file {} for writing.",
+                   address_out_path);
     } else {
       address_out_file << socket_->localAddress()->asString();
     }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -85,12 +85,12 @@ bool AdminImpl::changeLogLevel(const Http::Utility::QueryParams& params) {
 
   // Now either change all levels or a single level.
   if (name == "level") {
-    log_facility(debug, "change all log levels: level='{}'", level);
+    LOG(debug, "change all log levels: level='{}'", level);
     for (const Logger::Logger& logger : Logger::Registry::loggers()) {
       logger.setLevel(static_cast<spdlog::level::level_enum>(level_to_use));
     }
   } else {
-    log_facility(debug, "change log level: name='{}' level='{}'", name, level);
+    LOG(debug, "change log level: name='{}' level='{}'", name, level);
     const Logger::Logger* logger_to_change = nullptr;
     for (const Logger::Logger& logger : Logger::Registry::loggers()) {
       if (logger.name() == name) {
@@ -317,7 +317,7 @@ Http::Code AdminImpl::handlerCerts(const std::string&, Buffer::Instance& respons
 
 void AdminFilter::onComplete() {
   std::string path = request_headers_->Path()->value().c_str();
-  stream_log_facility(info, "request complete: path: {}", *callbacks_, path);
+  STREAM_LOG(info, "request complete: path: {}", *callbacks_, path);
 
   Buffer::OwnedImpl response;
   Http::Code code = parent_.runCallback(path, response);
@@ -363,8 +363,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
     if (!address_out_file) {
-      log_facility(critical, "cannot open admin address output file {} for writing.",
-                   address_out_path);
+      LOG(critical, "cannot open admin address output file {} for writing.", address_out_path);
     } else {
       address_out_file << socket_->localAddress()->asString();
     }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -84,7 +84,8 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   try {
     initialize(options, hooks, component_factory);
   } catch (const EnvoyException& e) {
-    log().critical("error initializing configuration '{}': {}", options.configPath(), e.what());
+    log_facility(critical, "error initializing configuration '{}': {}", options.configPath(),
+                 e.what());
     thread_local_.shutdownThread();
     exit(1);
   }
@@ -97,7 +98,7 @@ Upstream::ClusterManager& InstanceImpl::clusterManager() { return config_->clust
 Tracing::HttpTracer& InstanceImpl::httpTracer() { return config_->httpTracer(); }
 
 void InstanceImpl::drainListeners() {
-  log().warn("closing and draining listeners");
+  log_facility(warn, "closing and draining listeners");
   for (const auto& worker : workers_) {
     Worker& worker_ref = *worker;
     worker->dispatcher().post([&worker_ref]() -> void { worker_ref.handler()->closeListeners(); });
@@ -112,7 +113,7 @@ void InstanceImpl::failHealthcheck(bool fail) {
 }
 
 void InstanceImpl::flushStats() {
-  log_debug("flushing stats");
+  log_facility(debug, "flushing stats");
   HotRestart::GetParentStatsInfo info;
   restarter_.getParentStats(info);
   server_stats_.uptime_.set(time(nullptr) - original_start_time_);
@@ -172,13 +173,13 @@ bool InstanceImpl::healthCheckFailed() { return server_stats_.live_.value() == 0
 
 void InstanceImpl::initialize(Options& options, TestHooks& hooks,
                               ComponentFactory& component_factory) {
-  log().warn("initializing epoch {} (hot restart version={})", options.restartEpoch(),
-             restarter_.version());
+  log_facility(warn, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
+               restarter_.version());
 
   // Handle configuration that needs to take place prior to the main configuration load.
   Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(options.configPath());
   Configuration::InitialImpl initial_config(*config_json);
-  log().info("admin address: {}", initial_config.admin().address()->asString());
+  log_facility(info, "admin address: {}", initial_config.admin().address()->asString());
 
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;
@@ -235,7 +236,7 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
     std::string addr = fmt::format("tcp://{}", listener->address()->asString());
     int fd = restarter_.duplicateParentListenSocket(addr);
     if (fd != -1) {
-      log().info("obtained socket for address {} from parent", addr);
+      log_facility(info, "obtained socket for address {} from parent", addr);
       socket_map_[listener.get()].reset(new Network::TcpListenSocket(fd, listener->address()));
     } else {
       socket_map_[listener.get()].reset(
@@ -245,18 +246,18 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
 
   // Setup signals.
   sigterm_ = handler_.dispatcher().listenForSignal(SIGTERM, [this]() -> void {
-    log().warn("caught SIGTERM");
+    log_facility(warn, "caught SIGTERM");
     restarter_.terminateParent();
     handler_.dispatcher().exit();
   });
 
   sig_usr_1_ = handler_.dispatcher().listenForSignal(SIGUSR1, [this]() -> void {
-    log().warn("caught SIGUSR1");
+    log_facility(warn, "caught SIGUSR1");
     access_log_manager_.reopen();
   });
 
   sig_hup_ = handler_.dispatcher().listenForSignal(SIGHUP, []() -> void {
-    log().warn("caught and eating SIGHUP. See documentation for how to hot restart.");
+    log_facility(warn, "caught and eating SIGHUP. See documentation for how to hot restart.");
   });
 
   initializeStatSinks();
@@ -275,13 +276,13 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   // upstream clusters are initialized which may involve running the event loop. Note however that
   // this can fire immediately if all clusters have already initialized.
   clusterManager().setInitializedCb([this, &hooks]() -> void {
-    log().warn("all clusters initialized. initializing init manager");
+    log_facility(warn, "all clusters initialized. initializing init manager");
     init_manager_.initialize([this, &hooks]() -> void { startWorkers(hooks); });
   });
 }
 
 void InstanceImpl::startWorkers(TestHooks& hooks) {
-  log().warn("all dependencies initialized. starting workers");
+  log_facility(warn, "all dependencies initialized. starting workers");
   for (const WorkerPtr& worker : workers_) {
     try {
       worker->initializeConfiguration(*config_, socket_map_, *guard_dog_);
@@ -290,7 +291,8 @@ void InstanceImpl::startWorkers(TestHooks& hooks) {
       // bind to it above. This happens when there is a race between two applications to listen
       // on the same port. In general if we can't initialize the worker configuration just print
       // the error and exit cleanly without crashing.
-      log().critical("shutting down due to error initializing worker configuration: {}", e.what());
+      log_facility(critical, "shutting down due to error initializing worker configuration: {}",
+                   e.what());
       shutdown();
     }
   }
@@ -305,12 +307,12 @@ void InstanceImpl::startWorkers(TestHooks& hooks) {
 Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
                                                Server::Configuration::Initial& config) {
   if (config.runtime()) {
-    log().info("runtime symlink: {}", config.runtime()->symlinkRoot());
-    log().info("runtime subdirectory: {}", config.runtime()->subdirectory());
+    log_facility(info, "runtime symlink: {}", config.runtime()->symlinkRoot());
+    log_facility(info, "runtime subdirectory: {}", config.runtime()->subdirectory());
 
     std::string override_subdirectory =
         config.runtime()->overrideSubdirectory() + "/" + server.localInfo().clusterName();
-    log().info("runtime override subdirectory: {}", override_subdirectory);
+    log_facility(info, "runtime override subdirectory: {}", override_subdirectory);
 
     return Runtime::LoaderPtr{new Runtime::LoaderImpl(
         server.dispatcher(), server.threadLocal(), config.runtime()->symlinkRoot(),
@@ -322,16 +324,16 @@ Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
 
 void InstanceImpl::initializeStatSinks() {
   if (config_->statsdUdpIpAddress().valid()) {
-    log().info("statsd UDP ip address: {}", config_->statsdUdpIpAddress().value());
+    log_facility(info, "statsd UDP ip address: {}", config_->statsdUdpIpAddress().value());
     stat_sinks_.emplace_back(new Stats::Statsd::UdpStatsdSink(
         thread_local_,
         Network::Utility::parseInternetAddressAndPort(config_->statsdUdpIpAddress().value())));
     stats_store_.addSink(*stat_sinks_.back());
   } else if (config_->statsdUdpPort().valid()) {
     // TODO(hennna): DEPRECATED - statsdUdpPort will be removed in 1.4.0.
-    log().warn("statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0. "
-               "Consider setting statsd_udp_ip_address instead.");
-    log().info("statsd UDP port: {}", config_->statsdUdpPort().value());
+    log_facility(warn, "statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0. "
+                       "Consider setting statsd_udp_ip_address instead.");
+    log_facility(info, "statsd UDP port: {}", config_->statsdUdpPort().value());
     Network::Address::InstanceConstSharedPtr address(
         new Network::Address::Ipv4Instance(config_->statsdUdpPort().value()));
     stat_sinks_.emplace_back(new Stats::Statsd::UdpStatsdSink(thread_local_, address));
@@ -339,7 +341,7 @@ void InstanceImpl::initializeStatSinks() {
   }
 
   if (config_->statsdTcpClusterName().valid()) {
-    log().info("statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
+    log_facility(info, "statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
     stat_sinks_.emplace_back(
         new Stats::Statsd::TcpStatsdSink(local_info_, config_->statsdTcpClusterName().value(),
                                          thread_local_, config_->clusterManager(), stats_store_));
@@ -352,9 +354,9 @@ void InstanceImpl::loadServerFlags(const Optional<std::string>& flags_path) {
     return;
   }
 
-  log().info("server flags path: {}", flags_path.value());
+  log_facility(info, "server flags path: {}", flags_path.value());
   if (handler_.api().fileExists(flags_path.value() + "/drain")) {
-    log().warn("starting server in drain mode");
+    log_facility(warn, "starting server in drain mode");
     failHealthcheck(true);
   }
 }
@@ -372,11 +374,11 @@ uint64_t InstanceImpl::numConnections() {
 
 void InstanceImpl::run() {
   // Run the main dispatch loop waiting to exit.
-  log().warn("starting main dispatch loop");
+  log_facility(warn, "starting main dispatch loop");
   auto watchdog = guard_dog_->createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(handler_.dispatcher());
   handler_.dispatcher().run(Event::Dispatcher::RunType::Block);
-  log().warn("main dispatch loop exited");
+  log_facility(warn, "main dispatch loop exited");
   guard_dog_->stopWatching(watchdog);
   watchdog.reset();
 
@@ -396,24 +398,24 @@ void InstanceImpl::run() {
   config_->clusterManager().shutdown();
   handler_.closeConnections();
   thread_local_.shutdownThread();
-  log().warn("exiting");
+  log_facility(warn, "exiting");
   log().flush();
 }
 
 Runtime::Loader& InstanceImpl::runtime() { return *runtime_loader_; }
 
 void InstanceImpl::shutdown() {
-  log().warn("shutdown invoked. sending SIGTERM to self");
+  log_facility(warn, "shutdown invoked. sending SIGTERM to self");
   kill(getpid(), SIGTERM);
 }
 
 void InstanceImpl::shutdownAdmin() {
-  log().warn("shutting down admin due to child startup");
+  log_facility(warn, "shutting down admin due to child startup");
   stat_flush_timer_.reset();
   handler_.closeListeners();
   admin_->mutable_socket().close();
 
-  log().warn("terminating parent process");
+  log_facility(warn, "terminating parent process");
   restarter_.terminateParent();
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -84,8 +84,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   try {
     initialize(options, hooks, component_factory);
   } catch (const EnvoyException& e) {
-    log_facility(critical, "error initializing configuration '{}': {}", options.configPath(),
-                 e.what());
+    LOG(critical, "error initializing configuration '{}': {}", options.configPath(), e.what());
     thread_local_.shutdownThread();
     exit(1);
   }
@@ -98,7 +97,7 @@ Upstream::ClusterManager& InstanceImpl::clusterManager() { return config_->clust
 Tracing::HttpTracer& InstanceImpl::httpTracer() { return config_->httpTracer(); }
 
 void InstanceImpl::drainListeners() {
-  log_facility(warn, "closing and draining listeners");
+  LOG(warn, "closing and draining listeners");
   for (const auto& worker : workers_) {
     Worker& worker_ref = *worker;
     worker->dispatcher().post([&worker_ref]() -> void { worker_ref.handler()->closeListeners(); });
@@ -113,7 +112,7 @@ void InstanceImpl::failHealthcheck(bool fail) {
 }
 
 void InstanceImpl::flushStats() {
-  log_facility(debug, "flushing stats");
+  LOG(debug, "flushing stats");
   HotRestart::GetParentStatsInfo info;
   restarter_.getParentStats(info);
   server_stats_.uptime_.set(time(nullptr) - original_start_time_);
@@ -173,13 +172,13 @@ bool InstanceImpl::healthCheckFailed() { return server_stats_.live_.value() == 0
 
 void InstanceImpl::initialize(Options& options, TestHooks& hooks,
                               ComponentFactory& component_factory) {
-  log_facility(warn, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
-               restarter_.version());
+  LOG(warn, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
+      restarter_.version());
 
   // Handle configuration that needs to take place prior to the main configuration load.
   Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(options.configPath());
   Configuration::InitialImpl initial_config(*config_json);
-  log_facility(info, "admin address: {}", initial_config.admin().address()->asString());
+  LOG(info, "admin address: {}", initial_config.admin().address()->asString());
 
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;
@@ -236,7 +235,7 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
     std::string addr = fmt::format("tcp://{}", listener->address()->asString());
     int fd = restarter_.duplicateParentListenSocket(addr);
     if (fd != -1) {
-      log_facility(info, "obtained socket for address {} from parent", addr);
+      LOG(info, "obtained socket for address {} from parent", addr);
       socket_map_[listener.get()].reset(new Network::TcpListenSocket(fd, listener->address()));
     } else {
       socket_map_[listener.get()].reset(
@@ -246,18 +245,18 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
 
   // Setup signals.
   sigterm_ = handler_.dispatcher().listenForSignal(SIGTERM, [this]() -> void {
-    log_facility(warn, "caught SIGTERM");
+    LOG(warn, "caught SIGTERM");
     restarter_.terminateParent();
     handler_.dispatcher().exit();
   });
 
   sig_usr_1_ = handler_.dispatcher().listenForSignal(SIGUSR1, [this]() -> void {
-    log_facility(warn, "caught SIGUSR1");
+    LOG(warn, "caught SIGUSR1");
     access_log_manager_.reopen();
   });
 
   sig_hup_ = handler_.dispatcher().listenForSignal(SIGHUP, []() -> void {
-    log_facility(warn, "caught and eating SIGHUP. See documentation for how to hot restart.");
+    LOG(warn, "caught and eating SIGHUP. See documentation for how to hot restart.");
   });
 
   initializeStatSinks();
@@ -276,13 +275,13 @@ void InstanceImpl::initialize(Options& options, TestHooks& hooks,
   // upstream clusters are initialized which may involve running the event loop. Note however that
   // this can fire immediately if all clusters have already initialized.
   clusterManager().setInitializedCb([this, &hooks]() -> void {
-    log_facility(warn, "all clusters initialized. initializing init manager");
+    LOG(warn, "all clusters initialized. initializing init manager");
     init_manager_.initialize([this, &hooks]() -> void { startWorkers(hooks); });
   });
 }
 
 void InstanceImpl::startWorkers(TestHooks& hooks) {
-  log_facility(warn, "all dependencies initialized. starting workers");
+  LOG(warn, "all dependencies initialized. starting workers");
   for (const WorkerPtr& worker : workers_) {
     try {
       worker->initializeConfiguration(*config_, socket_map_, *guard_dog_);
@@ -291,8 +290,7 @@ void InstanceImpl::startWorkers(TestHooks& hooks) {
       // bind to it above. This happens when there is a race between two applications to listen
       // on the same port. In general if we can't initialize the worker configuration just print
       // the error and exit cleanly without crashing.
-      log_facility(critical, "shutting down due to error initializing worker configuration: {}",
-                   e.what());
+      LOG(critical, "shutting down due to error initializing worker configuration: {}", e.what());
       shutdown();
     }
   }
@@ -307,12 +305,12 @@ void InstanceImpl::startWorkers(TestHooks& hooks) {
 Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
                                                Server::Configuration::Initial& config) {
   if (config.runtime()) {
-    log_facility(info, "runtime symlink: {}", config.runtime()->symlinkRoot());
-    log_facility(info, "runtime subdirectory: {}", config.runtime()->subdirectory());
+    LOG(info, "runtime symlink: {}", config.runtime()->symlinkRoot());
+    LOG(info, "runtime subdirectory: {}", config.runtime()->subdirectory());
 
     std::string override_subdirectory =
         config.runtime()->overrideSubdirectory() + "/" + server.localInfo().clusterName();
-    log_facility(info, "runtime override subdirectory: {}", override_subdirectory);
+    LOG(info, "runtime override subdirectory: {}", override_subdirectory);
 
     return Runtime::LoaderPtr{new Runtime::LoaderImpl(
         server.dispatcher(), server.threadLocal(), config.runtime()->symlinkRoot(),
@@ -324,16 +322,16 @@ Runtime::LoaderPtr InstanceUtil::createRuntime(Instance& server,
 
 void InstanceImpl::initializeStatSinks() {
   if (config_->statsdUdpIpAddress().valid()) {
-    log_facility(info, "statsd UDP ip address: {}", config_->statsdUdpIpAddress().value());
+    LOG(info, "statsd UDP ip address: {}", config_->statsdUdpIpAddress().value());
     stat_sinks_.emplace_back(new Stats::Statsd::UdpStatsdSink(
         thread_local_,
         Network::Utility::parseInternetAddressAndPort(config_->statsdUdpIpAddress().value())));
     stats_store_.addSink(*stat_sinks_.back());
   } else if (config_->statsdUdpPort().valid()) {
     // TODO(hennna): DEPRECATED - statsdUdpPort will be removed in 1.4.0.
-    log_facility(warn, "statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0. "
-                       "Consider setting statsd_udp_ip_address instead.");
-    log_facility(info, "statsd UDP port: {}", config_->statsdUdpPort().value());
+    LOG(warn, "statsd_local_udp_port has been DEPRECATED and will be removed in 1.4.0. "
+              "Consider setting statsd_udp_ip_address instead.");
+    LOG(info, "statsd UDP port: {}", config_->statsdUdpPort().value());
     Network::Address::InstanceConstSharedPtr address(
         new Network::Address::Ipv4Instance(config_->statsdUdpPort().value()));
     stat_sinks_.emplace_back(new Stats::Statsd::UdpStatsdSink(thread_local_, address));
@@ -341,7 +339,7 @@ void InstanceImpl::initializeStatSinks() {
   }
 
   if (config_->statsdTcpClusterName().valid()) {
-    log_facility(info, "statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
+    LOG(info, "statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
     stat_sinks_.emplace_back(
         new Stats::Statsd::TcpStatsdSink(local_info_, config_->statsdTcpClusterName().value(),
                                          thread_local_, config_->clusterManager(), stats_store_));
@@ -354,9 +352,9 @@ void InstanceImpl::loadServerFlags(const Optional<std::string>& flags_path) {
     return;
   }
 
-  log_facility(info, "server flags path: {}", flags_path.value());
+  LOG(info, "server flags path: {}", flags_path.value());
   if (handler_.api().fileExists(flags_path.value() + "/drain")) {
-    log_facility(warn, "starting server in drain mode");
+    LOG(warn, "starting server in drain mode");
     failHealthcheck(true);
   }
 }
@@ -374,11 +372,11 @@ uint64_t InstanceImpl::numConnections() {
 
 void InstanceImpl::run() {
   // Run the main dispatch loop waiting to exit.
-  log_facility(warn, "starting main dispatch loop");
+  LOG(warn, "starting main dispatch loop");
   auto watchdog = guard_dog_->createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(handler_.dispatcher());
   handler_.dispatcher().run(Event::Dispatcher::RunType::Block);
-  log_facility(warn, "main dispatch loop exited");
+  LOG(warn, "main dispatch loop exited");
   guard_dog_->stopWatching(watchdog);
   watchdog.reset();
 
@@ -398,24 +396,24 @@ void InstanceImpl::run() {
   config_->clusterManager().shutdown();
   handler_.closeConnections();
   thread_local_.shutdownThread();
-  log_facility(warn, "exiting");
+  LOG(warn, "exiting");
   log().flush();
 }
 
 Runtime::Loader& InstanceImpl::runtime() { return *runtime_loader_; }
 
 void InstanceImpl::shutdown() {
-  log_facility(warn, "shutdown invoked. sending SIGTERM to self");
+  LOG(warn, "shutdown invoked. sending SIGTERM to self");
   kill(getpid(), SIGTERM);
 }
 
 void InstanceImpl::shutdownAdmin() {
-  log_facility(warn, "shutting down admin due to child startup");
+  LOG(warn, "shutting down admin due to child startup");
   stat_flush_timer_.reset();
   handler_.closeListeners();
   admin_->mutable_socket().close();
 
-  log_facility(warn, "terminating parent process");
+  LOG(warn, "terminating parent process");
   restarter_.terminateParent();
 }
 

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -59,11 +59,11 @@ void Worker::onNoExitTimer() {
 }
 
 void Worker::threadRoutine(Server::GuardDog& guard_dog) {
-  log_facility(info, "worker entering dispatch loop");
+  LOG(info, "worker entering dispatch loop");
   auto watchdog = guard_dog.createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(handler_->dispatcher());
   handler_->dispatcher().run(Event::Dispatcher::RunType::Block);
-  log_facility(info, "worker exited dispatch loop");
+  LOG(info, "worker exited dispatch loop");
   guard_dog.stopWatching(watchdog);
 
   // We must close all active connections before we actually exit the thread. This prevents any

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -59,11 +59,11 @@ void Worker::onNoExitTimer() {
 }
 
 void Worker::threadRoutine(Server::GuardDog& guard_dog) {
-  log().info("worker entering dispatch loop");
+  log_facility(info, "worker entering dispatch loop");
   auto watchdog = guard_dog.createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(handler_->dispatcher());
   handler_->dispatcher().run(Event::Dispatcher::RunType::Block);
-  log().info("worker exited dispatch loop");
+  log_facility(info, "worker exited dispatch loop");
   guard_dog.stopWatching(watchdog);
 
   // We must close all active connections before we actually exit the thread. This prevents any

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -30,6 +30,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "log_macros_test",
+    srcs = ["log_macros_test.cc"],
+    deps = [
+        "//source/common/common:logger_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
     deps = ["//source/common/common:utility_lib"],

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <string>
+
+#include "common/common/logger.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/network/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+class TestFilterLog : public Logger::Loggable<Logger::Id::filter> {
+
+public:
+  void deprecatedLogMessage() {
+    log_trace("fake message");
+    log_debug("fake message");
+    conn_log_info("fake message", connection_);
+    stream_log_info("fake message", stream_);
+  }
+
+  void logMessage() {
+    log_facility(trace, "fake message");
+    log_facility(debug, "fake message");
+    conn_log_facility(info, "fake message", connection_);
+    stream_log_facility(info, "fake message", stream_);
+  }
+
+private:
+  Envoy::Network::MockConnection connection_;
+  Envoy::Http::MockStreamDecoderFilterCallbacks stream_;
+};
+
+TEST(Logger, All) {
+  // This test exists just to ensure all macros compile and run with the expected arguments provided
+
+  TestFilterLog filter;
+  filter.logMessage();
+
+  // Ensure the deprecated log macros are still operational.
+  filter.deprecatedLogMessage();
+
+  // Misc logging with no facility.
+  log_misc(info, "fake message");
+}
+} // Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -22,10 +22,10 @@ public:
   }
 
   void logMessage() {
-    log_facility(trace, "fake message");
-    log_facility(debug, "fake message");
-    conn_log_facility(info, "fake message", connection_);
-    stream_log_facility(info, "fake message", stream_);
+    LOG(trace, "fake message");
+    LOG(debug, "fake message");
+    CONN_LOG(info, "fake message", connection_);
+    STREAM_LOG(info, "fake message", stream_);
   }
 
 private:
@@ -43,6 +43,6 @@ TEST(Logger, All) {
   filter.deprecatedLogMessage();
 
   // Misc logging with no facility.
-  log_misc(info, "fake message");
+  LOG_MISC(info, "fake message");
 }
 } // Envoy

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -197,7 +197,7 @@ FakeStreamPtr FakeHttpConnection::waitForNewStream() {
 FakeUpstream::FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type type)
     : FakeUpstream(nullptr, Network::ListenSocketPtr{new Network::UdsListenSocket(uds_path)},
                    type) {
-  log().info("starting fake server on unix domain socket {}", uds_path);
+  log_facility(info, "starting fake server on unix domain socket {}", uds_path);
 }
 
 static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port,
@@ -211,15 +211,15 @@ static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port,
 FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
                            Network::Address::IpVersion version)
     : FakeUpstream(nullptr, makeTcpListenSocket(port, version), type) {
-  log().info("starting fake server on port {}. Address version is {}",
-             this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
+  log_facility(info, "starting fake server on port {}. Address version is {}",
+               this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port,
                            FakeHttpConnection::Type type, Network::Address::IpVersion version)
     : FakeUpstream(ssl_ctx, makeTcpListenSocket(port, version), type) {
-  log().info("starting fake SSL server on port {}. Address version is {}",
-             this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
+  log_facility(info, "starting fake SSL server on port {}. Address version is {}",
+               this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr&& listen_socket,
@@ -280,7 +280,7 @@ FakeHttpConnectionPtr FakeUpstream::waitForHttpConnection(Event::Dispatcher& cli
 FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
   std::unique_lock<std::mutex> lock(lock_);
   if (new_connections_.empty()) {
-    log_debug("waiting for raw connection");
+    log_facility(debug, "waiting for raw connection");
     new_connection_event_.wait(lock);
   }
 
@@ -294,7 +294,7 @@ FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
 void FakeRawConnection::waitForData(uint64_t num_bytes) {
   std::unique_lock<std::mutex> lock(lock_);
   while (data_.size() != num_bytes) {
-    log_debug("waiting for {} bytes of data", num_bytes);
+    log_facility(debug, "waiting for {} bytes of data", num_bytes);
     connection_event_.wait(lock);
   }
 }
@@ -308,7 +308,7 @@ void FakeRawConnection::write(const std::string& data) {
 
 Network::FilterStatus FakeRawConnection::ReadFilter::onData(Buffer::Instance& data) {
   std::unique_lock<std::mutex> lock(parent_.lock_);
-  log_debug("got {} bytes", data.length());
+  log_facility(debug, "got {} bytes", data.length());
   parent_.data_.append(TestUtility::bufferToString(data));
   data.drain(data.length());
   parent_.connection_event_.notify_one();

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -197,7 +197,7 @@ FakeStreamPtr FakeHttpConnection::waitForNewStream() {
 FakeUpstream::FakeUpstream(const std::string& uds_path, FakeHttpConnection::Type type)
     : FakeUpstream(nullptr, Network::ListenSocketPtr{new Network::UdsListenSocket(uds_path)},
                    type) {
-  log_facility(info, "starting fake server on unix domain socket {}", uds_path);
+  LOG(info, "starting fake server on unix domain socket {}", uds_path);
 }
 
 static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port,
@@ -211,15 +211,15 @@ static Network::ListenSocketPtr makeTcpListenSocket(uint32_t port,
 FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type,
                            Network::Address::IpVersion version)
     : FakeUpstream(nullptr, makeTcpListenSocket(port, version), type) {
-  log_facility(info, "starting fake server on port {}. Address version is {}",
-               this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
+  LOG(info, "starting fake server on port {}. Address version is {}",
+      this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, uint32_t port,
                            FakeHttpConnection::Type type, Network::Address::IpVersion version)
     : FakeUpstream(ssl_ctx, makeTcpListenSocket(port, version), type) {
-  log_facility(info, "starting fake SSL server on port {}. Address version is {}",
-               this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
+  LOG(info, "starting fake SSL server on port {}. Address version is {}",
+      this->localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 
 FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr&& listen_socket,
@@ -280,7 +280,7 @@ FakeHttpConnectionPtr FakeUpstream::waitForHttpConnection(Event::Dispatcher& cli
 FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
   std::unique_lock<std::mutex> lock(lock_);
   if (new_connections_.empty()) {
-    log_facility(debug, "waiting for raw connection");
+    LOG(debug, "waiting for raw connection");
     new_connection_event_.wait(lock);
   }
 
@@ -294,7 +294,7 @@ FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
 void FakeRawConnection::waitForData(uint64_t num_bytes) {
   std::unique_lock<std::mutex> lock(lock_);
   while (data_.size() != num_bytes) {
-    log_facility(debug, "waiting for {} bytes of data", num_bytes);
+    LOG(debug, "waiting for {} bytes of data", num_bytes);
     connection_event_.wait(lock);
   }
 }
@@ -308,7 +308,7 @@ void FakeRawConnection::write(const std::string& data) {
 
 Network::FilterStatus FakeRawConnection::ReadFilter::onData(Buffer::Instance& data) {
   std::unique_lock<std::mutex> lock(parent_.lock_);
-  log_facility(debug, "got {} bytes", data.length());
+  LOG(debug, "got {} bytes", data.length());
   parent_.data_.append(TestUtility::bufferToString(data));
   data.drain(data.length());
   parent_.connection_event_.notify_one();

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -40,7 +40,7 @@ IntegrationTestServerPtr IntegrationTestServer::create(const std::string& config
 }
 
 void IntegrationTestServer::start(const Network::Address::IpVersion version) {
-  log().info("starting integration test server");
+  log_facility(info, "starting integration test server");
   ASSERT(!thread_);
   thread_.reset(new Thread::Thread([version, this]() -> void { threadRoutine(version); }));
   // First, we want to wait until we know the server's worker threads are all
@@ -53,7 +53,7 @@ void IntegrationTestServer::start(const Network::Address::IpVersion version) {
 }
 
 IntegrationTestServer::~IntegrationTestServer() {
-  log().info("stopping integration test server");
+  log_facility(info, "stopping integration test server");
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       server_->admin().socket().localAddress()->ip()->port(), "GET", "/quitquitquit", "",

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -40,7 +40,7 @@ IntegrationTestServerPtr IntegrationTestServer::create(const std::string& config
 }
 
 void IntegrationTestServer::start(const Network::Address::IpVersion version) {
-  log_facility(info, "starting integration test server");
+  LOG(info, "starting integration test server");
   ASSERT(!thread_);
   thread_.reset(new Thread::Thread([version, this]() -> void { threadRoutine(version); }));
   // First, we want to wait until we know the server's worker threads are all
@@ -53,7 +53,7 @@ void IntegrationTestServer::start(const Network::Address::IpVersion version) {
 }
 
 IntegrationTestServer::~IntegrationTestServer() {
-  log_facility(info, "stopping integration test server");
+  LOG(info, "stopping integration test server");
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       server_->admin().socket().localAddress()->ip()->port(), "GET", "/quitquitquit", "",


### PR DESCRIPTION
Three types of logging: facility, general, and to a specific logger that the user passes in. I attempted to clean up the way that log macros were being done to make them a bit simpler. They should all filter down to the log_[level] macros for ease of compiling out certain log levels and global modification of log formatting or functionality.