### PR TITLE
Make some minor changes recommended by Clang-tidy.

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -33,8 +33,9 @@ DnsResolverImpl::DnsResolverImpl(
 
   initializeChannel(&options, 0);
 
-  if (resolvers.size() > 0) {
+  if (!resolvers.empty()) {
     std::vector<std::string> resolver_addrs;
+    resolver_addrs.reserve(resolvers.size());
     for (const auto& resolver : resolvers) {
       resolver_addrs.push_back(resolver->asString());
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -127,6 +127,7 @@ ClusterPtr ClusterImplBase::create(const Json::Object& cluster, ClusterManager& 
   if (cluster.hasObject("dns_resolvers")) {
     auto resolver_addrs = cluster.getStringArray("dns_resolvers");
     std::vector<Network::Address::InstanceConstSharedPtr> resolvers;
+    resolvers.reserve(resolver_addrs.size());
     for (const auto& resolver_addr : resolver_addrs) {
       resolvers.push_back(Network::Utility::parseInternetAddressAndPort(resolver_addr));
     }


### PR DESCRIPTION
Performance recommendations:

Pre-reserve vectors prior to inserting a known number of items with
push_back.

Use empty() instead of size()>0.

Skipped the recommendation about moving a shared_ptr.