### PR TITLE
build: Disable libunwind in gperftools config. (#1071)

### DIFF
--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -7,5 +7,6 @@ VERSION=2.5
 wget -O gperftools-$VERSION.tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-$VERSION/gperftools-$VERSION.tar.gz
 tar xf gperftools-$VERSION.tar.gz
 cd gperftools-$VERSION
-LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers
+LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers --disable-libunwind
 make V=1 install
+


### PR DESCRIPTION
gperftools uses libunwind if the build system has it, but envoy
build system is unaware of this dependency, which causes a build
failure due to libunwind not being included in the link.  On the
other hand, linking libunwind unconditionally causes a link
failure in build environments without libunwind.

gperftools can decode stack traces without libunwind if stack frame
pointers are used.  We already do that for Envoy, so not using
libunwind is only a problem for collectiong stack traces system and
compiler libraries compiled without stack frame pointers.

Disable libunwind in gperftools configuration for now, and revisit
later if needed.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>