### PR TITLE
Fix Bazel coverage.

### DIFF
--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=1d2a2100708d1012cd61054ce04d4dc4e3b03ff2
+ENVOY_BUILD_SHA=fc747b3c2fd49b1260484572071fe4194cd6824d
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ENVOY_BUILD_SHA=fc747b3c2fd49b1260484572071fe4194cd6824d
+ENVOY_BUILD_SHA=1d2a2100708d1012cd61054ce04d4dc4e3b03ff2
 
 # Script that lists all the steps take by the CI system when doing Envoy builds.
 set -e

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -101,7 +101,6 @@ elif [[ "$1" == "bazel.coverage" ]]; then
   # some Bazel created symlinks to the source directory in its output
   # directory. Wow.
   cd "${ENVOY_BUILD_DIR}"
-  export BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} -c dbg"
   SRCDIR="${GCOVR_DIR}" "${ENVOY_SRCDIR}"/test/run_envoy_bazel_coverage.sh
   rsync -av "${ENVOY_BUILD_DIR}"/bazel-envoy/generated/coverage/ "${ENVOY_COVERAGE_DIR}"
   exit 0

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -91,6 +91,7 @@ elif [[ "$1" == "bazel.coverage" ]]; then
   export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"
   export TESTLOGS_DIR="${ENVOY_BUILD_DIR}/bazel-testlogs"
   export BUILDIFIER_BIN="/usr/lib/go/bin/buildifier"
+  export WORKSPACE=ci
   # There is a bug in gcovr 3.3, where it takes the -r path,
   # in our case /source, and does a regex replacement of various
   # source file paths during HTML generation. It attempts to strip

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -50,6 +50,9 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 pushd "${GCOVR_DIR}"
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
+  echo $f
+  ls -l bazel-out/local-fastbuild/bin/test/coverage/coverage_tests.runfiles
+  "${BAZEL_COVERAGE}" version
   cp --parents "$f" bazel-out/local-fastbuild/bin/test/coverage/coverage_tests.runfiles/envoy
 done
 popd

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -52,8 +52,6 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 # Copy .gcno objects into the same location that we find the .gcda.
 # TODO(htuch): Should use rsync, but there are some symlink loops to fight.
 pushd "${GCOVR_DIR}"
-env
-ls -lR  bazel-out/local-dbg/bin/test
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
   cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/"${WORKSPACE}"

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -45,6 +45,15 @@ COVERAGE_DIR="${SRCDIR}"/generated/coverage
 mkdir -p "${COVERAGE_DIR}"
 COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 
+# Copy .gcno objects into the same location that we find the .gcda.
+# TODO(htuch): Should use rsync, but there are some symlink loops to fight.
+pushd "${GCOVR_DIR}"
+for f in $(find -L bazel-out/ -name "*.gcno")
+do
+  cp --parents "$f" bazel-out/local-fastbuild/bin/test/coverage/coverage_tests.runfiles/envoy
+done
+popd
+
 # gcovr is extremely picky about where it is run and where the paths of the
 # original source are relative to its execution location.
 cd "${SRCDIR}"

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -53,6 +53,7 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 pushd "${GCOVR_DIR}"
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
+  ls -lR  bazel-out/local-dbg/bin/test
   cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/envoy
 done
 popd

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -23,6 +23,9 @@ do
 done
 echo "Cleanup completed."
 
+# Force dbg for path consistency later, don't include debug code in coverage.
+BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} -c dbg --copt=-DNDEBUG"
+
 # Run all tests under "bazel test", no sandbox. We're going to generate the
 # .gcda inplace in the bazel-out/ directory. This is in contrast to the "bazel
 # coverage" method, which is currently broken for C++ (see
@@ -50,10 +53,11 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 pushd "${GCOVR_DIR}"
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
+  set +e
   echo $f
-  ls -l bazel-out/local-fastbuild/bin/test/coverage/coverage_tests.runfiles
   "${BAZEL_COVERAGE}" version
-  cp --parents "$f" bazel-out/local-fastbuild/bin/test/coverage/coverage_tests.runfiles/envoy
+  ls -l bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles
+  cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/envoy
 done
 popd
 

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -7,6 +7,7 @@ set -e
 [[ -z "${TESTLOGS_DIR}" ]] && TESTLOGS_DIR="${SRCDIR}/bazel-testlogs"
 [[ -z "${BAZEL_COVERAGE}" ]] && BAZEL_COVERAGE=bazel
 [[ -z "${GCOVR}" ]] && GCOVR=gcovr
+[[ -z "${WORKSPACE}" ]] && WORKSPACE=envoy
 
 # This is the target that will be run to generate coverage data. It can be overriden by consumer
 # projects that want to run coverage on a different/combined target.
@@ -51,10 +52,11 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 # Copy .gcno objects into the same location that we find the .gcda.
 # TODO(htuch): Should use rsync, but there are some symlink loops to fight.
 pushd "${GCOVR_DIR}"
+env
+ls -lR  bazel-out/local-dbg/bin/test
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
-  ls -lR  bazel-out/local-dbg/bin/test
-  cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/envoy
+  cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/"${WORKSPACE}"
 done
 popd
 

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -53,10 +53,6 @@ COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
 pushd "${GCOVR_DIR}"
 for f in $(find -L bazel-out/ -name "*.gcno")
 do
-  set +e
-  echo $f
-  "${BAZEL_COVERAGE}" version
-  ls -l bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles
   cp --parents "$f" bazel-out/local-dbg/bin/test/coverage/coverage_tests.runfiles/envoy
 done
 popd


### PR DESCRIPTION
Looks like Bazel 0.5.1 caused the .gcda to appear under runfiles, which
confuses gcov as it doesn't match the location of the .gcno.