### PR TITLE
config: refactor filter registration

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -77,7 +77,7 @@ then
 fi
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 48f83f5c697e61863b085e353cbdf77c4bba6d2a)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout b85101b303b3c256c70927a8389c15bde871a2aa)
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -88,4 +88,15 @@ envoy_cc_library(
 envoy_cc_library(
     name = "filter_config_interface",
     hdrs = ["filter_config.h"],
+    deps = [
+        ":drain_manager_interface",
+        "//include/envoy/access_log:access_log_interface",
+        "//include/envoy/init:init_interface",
+        "//include/envoy/local_info:local_info_interface",
+        "//include/envoy/ratelimit:ratelimit_interface",
+        "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/tracing:http_tracer_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
+    ],
 )

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -84,3 +84,8 @@ envoy_cc_library(
         "//include/envoy/network:address_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "filter_config_interface",
+    hdrs = ["filter_config.h"],
+)

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <functional>
+
+#include "envoy/access_log/access_log.h"
+#include "envoy/http/filter.h"
+#include "envoy/init/init.h"
+#include "envoy/json/json_object.h"
+#include "envoy/network/filter.h"
+#include "envoy/ratelimit/ratelimit.h"
+#include "envoy/runtime/runtime.h"
+#include "envoy/server/drain_manager.h"
+#include "envoy/server/instance.h" // TODO(mattklein123): Remove post 1.4.0
+#include "envoy/tracing/http_tracer.h"
+#include "envoy/upstream/cluster_manager.h"
+
+namespace Envoy {
+namespace Server {
+namespace Configuration {
+
+/**
+ * Context passed to network and HTTP filters to access server resources.
+ * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only
+ * access the rest of the server via interfaces exposed here.
+ */
+class FactoryContext {
+public:
+  virtual ~FactoryContext() {}
+
+  /**
+   * @return AccessLogManager for use by the entire server.
+   */
+  virtual AccessLog::AccessLogManager& accessLogManager() PURE;
+
+  /**
+   * @return Upstream::ClusterManager& singleton for use by the entire server.
+   */
+  virtual Upstream::ClusterManager& clusterManager() PURE;
+
+  /**
+   * @return Event::Dispatcher& the main thread's dispatcher. This dispatcher should be used
+   *         for all singleton processing.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * @return DrainManager& singleton for use by the entire server.
+   */
+  virtual DrainManager& drainManager() PURE;
+
+  /**
+   * @return whether external healthchecks are currently failed or not.
+   */
+  virtual bool healthCheckFailed() PURE;
+
+  /**
+   * @return the server-wide http tracer.
+   */
+  virtual Tracing::HttpTracer& httpTracer() PURE;
+
+  /**
+   * @return the server's init manager. This can be used for extensions that need to initialize
+   *         after cluster manager init but before the server starts listening. All extensions
+   *         should register themselves during configuration load. initialize() will be called on
+   *         each registered target after cluster manager init but before the server starts
+   *         listening. Once all targets have initialized and invoked their callbacks, the server
+   *         will start listening.
+   */
+  virtual Init::Manager& initManager() PURE;
+
+  /**
+   * @return information about the local environment the server is running in.
+   */
+  virtual const LocalInfo::LocalInfo& localInfo() PURE;
+
+  /**
+   * @return RandomGenerator& the random generator for the server.
+   */
+  virtual Envoy::Runtime::RandomGenerator& random() PURE;
+
+  /**
+   * @return a new ratelimit client. The implementation depends on the configuration of the server.
+   */
+  virtual RateLimit::ClientPtr
+  rateLimitClient(const Optional<std::chrono::milliseconds>& timeout) PURE;
+
+  /**
+   * @return Runtime::Loader& the singleton runtime loader for the server.
+   */
+  virtual Envoy::Runtime::Loader& runtime() PURE;
+
+  /**
+   * DEPRECATED: Do not call this function. It will be removed post 1.4.0 and is needed for other
+   * deprecated functionality.
+   */
+  virtual Instance& server() PURE;
+
+  /**
+   * @return Stats::Scope& the filter's stats scope.
+   */
+  virtual Stats::Scope& scope() PURE;
+
+  /**
+   * @return ThreadLocal::Instance& the thread local storage engine for the server. This is used to
+   *         allow runtime lockless updates to configuration, etc. across multiple threads.
+   */
+  virtual ThreadLocal::Instance& threadLocal() PURE;
+};
+
+enum class NetworkFilterType { Read, Write, Both };
+
+/**
+ * This lambda is used to wrap the creation of a network filter chain for new connections as they
+ * come in. Filter factories create the lambda at configuration initialization time, and then they
+ * are used at runtime. This maps JSON -> runtime configuration.
+ */
+typedef std::function<void(Network::FilterManager& filter_manager)> NetworkFilterFactoryCb;
+
+/**
+ * Implemented by each network filter and registered via registerNamedNetworkFilterConfigFactory()
+ * or the convenience class RegisterNamedNetworkFilterConfigFactory.
+ */
+class NamedNetworkFilterConfigFactory {
+public:
+  virtual ~NamedNetworkFilterConfigFactory() {}
+
+  /**
+   * Create a particular network filter factory implementation.  If the implementation is unable to
+   * produce a factory with the provided parameters, it should throw an EnvoyException in the case
+   * of general error or a Json::Exception if the json configuration is erroneous.  The returned
+   * callback should always be initialized.
+   * @param config supplies the general json configuration for the filter
+   * @param context supplies the filter's context.
+   */
+  virtual NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                                     FactoryContext& context) PURE;
+
+  /**
+   * Returns the identifying name for a particular implementation of a network filter produced by
+   * the factory.
+   */
+  virtual std::string name() PURE;
+
+  /**
+   * @return NetworkFilterType the type of filter.
+   */
+  virtual NetworkFilterType type() PURE;
+};
+
+enum class HttpFilterType { Decoder, Encoder, Both };
+
+/**
+ * Callback lambda used for dynamic HTTP filter chain construction.
+ */
+typedef std::function<void(Http::FilterChainFactoryCallbacks&)> HttpFilterFactoryCb;
+
+/**
+ * Implemented by each HTTP filter and registered via registerNamedHttpFilterConfigFactory() or the
+ * convenience class RegisterNamedHttpFilterConfigFactory.
+ */
+class NamedHttpFilterConfigFactory {
+public:
+  virtual ~NamedHttpFilterConfigFactory() {}
+
+  /**
+  * Create a particular http filter factory implementation.  If the implementation is unable to
+  * produce a factory with the provided parameters, it should throw an EnvoyException in the case of
+  * general error or a Json::Exception if the json configuration is erroneous.  The returned
+  * callback should always be initialized.
+  * @param config supplies the general json configuration for the filter
+  * @param stat_prefix prefix for stat logging
+  * @param context supplies the filter's context.
+  */
+  virtual HttpFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                                  const std::string& stat_prefix,
+                                                  FactoryContext& context) PURE;
+
+  /**
+   * Returns the identifying name for a particular implementation of an http filter produced by the
+   * factory.
+   */
+  virtual std::string name() PURE;
+
+  /**
+   * @return HttpFilterType the type of filter.
+   */
+  virtual HttpFilterType type() PURE;
+};
+
+} // Configuration
+} // Server
+} // Envoy

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -134,7 +134,7 @@ public:
    * callback should always be initialized.
    * @param config supplies the general json configuration for the filter
    * @param context supplies the filter's context.
-   * @return NetworkFilterFactoryCb fixfix
+   * @return NetworkFilterFactoryCb the factory creation function.
    */
   virtual NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
                                                      FactoryContext& context) PURE;
@@ -180,7 +180,7 @@ public:
    * @param config supplies the general json configuration for the filter
    * @param stat_prefix prefix for stat logging
    * @param context supplies the filter's context.
-   * @return HttpFilterFactoryCb fixfix
+   * @return HttpFilterFactoryCb the factory creation function.
    */
   virtual HttpFilterFactoryCb createFilterFactory(const Json::Object& config,
                                                   const std::string& stat_prefix,

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -110,9 +110,12 @@ public:
 enum class NetworkFilterType { Read, Write, Both };
 
 /**
- * This lambda is used to wrap the creation of a network filter chain for new connections as they
- * come in. Filter factories create the lambda at configuration initialization time, and then they
- * are used at runtime. This maps JSON -> runtime configuration.
+ * This function is used to wrap the creation of a network filter chain for new connections as
+ * they come in. Filter factories create the lambda at configuration initialization time, and then
+ * they are used at runtime.
+ * @param filter_manager supplies the filter manager for the connection to install filters
+ * to. Typically the function will install a single filter, but it's technically possibly to
+ * install more than one of desired.
  */
 typedef std::function<void(Network::FilterManager& filter_manager)> NetworkFilterFactoryCb;
 
@@ -131,13 +134,14 @@ public:
    * callback should always be initialized.
    * @param config supplies the general json configuration for the filter
    * @param context supplies the filter's context.
+   * @return NetworkFilterFactoryCb fixfix
    */
   virtual NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
                                                      FactoryContext& context) PURE;
 
   /**
-   * Returns the identifying name for a particular implementation of a network filter produced by
-   * the factory.
+   * @return std::string the identifying name for a particular implementation of a network filter
+   * produced by the factory.
    */
   virtual std::string name() PURE;
 
@@ -150,9 +154,14 @@ public:
 enum class HttpFilterType { Decoder, Encoder, Both };
 
 /**
- * Callback lambda used for dynamic HTTP filter chain construction.
+ * This function is used to wrap the creation of an HTTP filter chain for new streams as they
+ * come in. Filter factories create the function at configuration initialization time, and then
+ * they are used at runtime.
+ * @param callbacks supplies the callbacks for the stream to install filters to. Typically the
+ * function will install a single filter, but it's technically possibly to install more than one
+ * of desired.
  */
-typedef std::function<void(Http::FilterChainFactoryCallbacks&)> HttpFilterFactoryCb;
+typedef std::function<void(Http::FilterChainFactoryCallbacks& callbacks)> HttpFilterFactoryCb;
 
 /**
  * Implemented by each HTTP filter and registered via registerNamedHttpFilterConfigFactory() or the
@@ -163,21 +172,23 @@ public:
   virtual ~NamedHttpFilterConfigFactory() {}
 
   /**
-  * Create a particular http filter factory implementation.  If the implementation is unable to
-  * produce a factory with the provided parameters, it should throw an EnvoyException in the case of
-  * general error or a Json::Exception if the json configuration is erroneous.  The returned
-  * callback should always be initialized.
-  * @param config supplies the general json configuration for the filter
-  * @param stat_prefix prefix for stat logging
-  * @param context supplies the filter's context.
-  */
+   * Create a particular http filter factory implementation.  If the implementation is unable to
+   * produce a factory with the provided parameters, it should throw an EnvoyException in the case
+   * of
+   * general error or a Json::Exception if the json configuration is erroneous.  The returned
+   * callback should always be initialized.
+   * @param config supplies the general json configuration for the filter
+   * @param stat_prefix prefix for stat logging
+   * @param context supplies the filter's context.
+   * @return HttpFilterFactoryCb fixfix
+   */
   virtual HttpFilterFactoryCb createFilterFactory(const Json::Object& config,
                                                   const std::string& stat_prefix,
                                                   FactoryContext& context) PURE;
 
   /**
-   * Returns the identifying name for a particular implementation of an http filter produced by the
-   * factory.
+   * @return std::string the identifying name for a particular implementation of an http filter
+   * produced by the factory.
    */
   virtual std::string name() PURE;
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -115,7 +115,7 @@ enum class NetworkFilterType { Read, Write, Both };
  * they are used at runtime.
  * @param filter_manager supplies the filter manager for the connection to install filters
  * to. Typically the function will install a single filter, but it's technically possibly to
- * install more than one of desired.
+ * install more than one if desired.
  */
 typedef std::function<void(Network::FilterManager& filter_manager)> NetworkFilterFactoryCb;
 
@@ -159,7 +159,7 @@ enum class HttpFilterType { Decoder, Encoder, Both };
  * they are used at runtime.
  * @param callbacks supplies the callbacks for the stream to install filters to. Typically the
  * function will install a single filter, but it's technically possibly to install more than one
- * of desired.
+ * if desired.
  */
 typedef std::function<void(Http::FilterChainFactoryCallbacks& callbacks)> HttpFilterFactoryCb;
 

--- a/source/common/dynamo/dynamo_filter.h
+++ b/source/common/dynamo/dynamo_filter.h
@@ -21,7 +21,7 @@ namespace Dynamo {
  */
 class DynamoFilter : public Http::StreamFilter {
 public:
-  DynamoFilter(Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Store& stats)
+  DynamoFilter(Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Scope& stats)
       : runtime_(runtime), stat_prefix_(stat_prefix + "dynamodb."), stats_(stats) {
     enabled_ = runtime_.snapshot().featureEnabled("dynamodb.filter_enabled", 100);
   }
@@ -58,7 +58,7 @@ private:
 
   Runtime::Loader& runtime_;
   std::string stat_prefix_;
-  Stats::Store& stats_;
+  Stats::Scope& stats_;
 
   bool enabled_{};
   std::string operation_{};

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -22,7 +22,7 @@ namespace Auth {
 namespace ClientSsl {
 
 Config::Config(const Json::Object& config, ThreadLocal::Instance& tls, Upstream::ClusterManager& cm,
-               Event::Dispatcher& dispatcher, Stats::Store& stats_store,
+               Event::Dispatcher& dispatcher, Stats::Scope& stats_store,
                Runtime::RandomGenerator& random)
     : RestApiFetcher(cm, config.getString("auth_api_cluster"), dispatcher, random,
                      std::chrono::milliseconds(config.getInteger("refresh_delay_ms", 60000))),
@@ -43,7 +43,7 @@ Config::Config(const Json::Object& config, ThreadLocal::Instance& tls, Upstream:
 
 ConfigSharedPtr Config::create(const Json::Object& config, ThreadLocal::Instance& tls,
                                Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-                               Stats::Store& stats_store, Runtime::RandomGenerator& random) {
+                               Stats::Scope& stats_store, Runtime::RandomGenerator& random) {
   ConfigSharedPtr new_config(new Config(config, tls, cm, dispatcher, stats_store, random));
   new_config->initialize();
   return new_config;
@@ -53,7 +53,7 @@ const AllowedPrincipals& Config::allowedPrincipals() {
   return tls_.getTyped<AllowedPrincipals>(tls_slot_);
 }
 
-GlobalStats Config::generateStats(Stats::Store& store, const std::string& prefix) {
+GlobalStats Config::generateStats(Stats::Scope& store, const std::string& prefix) {
   std::string final_prefix = fmt::format("auth.clientssl.{}.", prefix);
   GlobalStats stats{ALL_CLIENT_SSL_AUTH_STATS(POOL_COUNTER_PREFIX(store, final_prefix),
                                               POOL_GAUGE_PREFIX(store, final_prefix))};

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -77,7 +77,7 @@ class Config : public Http::RestApiFetcher {
 public:
   static ConfigSharedPtr create(const Json::Object& config, ThreadLocal::Instance& tls,
                                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-                                Stats::Store& stats_store, Runtime::RandomGenerator& random);
+                                Stats::Scope& stats_store, Runtime::RandomGenerator& random);
 
   const AllowedPrincipals& allowedPrincipals();
   const Network::IpList& ipWhiteList() { return ip_white_list_; }
@@ -85,10 +85,10 @@ public:
 
 private:
   Config(const Json::Object& config, ThreadLocal::Instance& tls, Upstream::ClusterManager& cm,
-         Event::Dispatcher& dispatcher, Stats::Store& stats_store,
+         Event::Dispatcher& dispatcher, Stats::Scope& stats_store,
          Runtime::RandomGenerator& random);
 
-  static GlobalStats generateStats(Stats::Store& store, const std::string& prefix);
+  static GlobalStats generateStats(Stats::Scope& store, const std::string& prefix);
 
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override;

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -12,7 +12,7 @@ namespace Envoy {
 namespace RateLimit {
 namespace TcpFilter {
 
-Config::Config(const Json::Object& config, Stats::Store& stats_store, Runtime::Loader& runtime)
+Config::Config(const Json::Object& config, Stats::Scope& stats_store, Runtime::Loader& runtime)
     : domain_(config.getString("domain")),
       stats_(generateStats(config.getString("stat_prefix"), stats_store)), runtime_(runtime) {
 
@@ -27,7 +27,7 @@ Config::Config(const Json::Object& config, Stats::Store& stats_store, Runtime::L
   }
 }
 
-InstanceStats Config::generateStats(const std::string& name, Stats::Store& store) {
+InstanceStats Config::generateStats(const std::string& name, Stats::Scope& store) {
   std::string final_prefix = fmt::format("ratelimit.{}.", name);
   return {ALL_TCP_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(store, final_prefix),
                                    POOL_GAUGE_PREFIX(store, final_prefix))};

--- a/source/common/filter/ratelimit.h
+++ b/source/common/filter/ratelimit.h
@@ -42,14 +42,14 @@ struct InstanceStats {
  */
 class Config {
 public:
-  Config(const Json::Object& config, Stats::Store& stats_store, Runtime::Loader& runtime);
+  Config(const Json::Object& config, Stats::Scope& stats_store, Runtime::Loader& runtime);
   const std::string& domain() { return domain_; }
   const std::vector<Descriptor>& descriptors() { return descriptors_; }
   Runtime::Loader& runtime() { return runtime_; }
   const InstanceStats& stats() { return stats_; }
 
 private:
-  static InstanceStats generateStats(const std::string& name, Stats::Store& store);
+  static InstanceStats generateStats(const std::string& name, Stats::Scope& store);
 
   std::string domain_;
   std::vector<Descriptor> descriptors_;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -43,7 +43,7 @@ TcpProxyConfig::Route::Route(const Json::Object& config) {
 }
 
 TcpProxyConfig::TcpProxyConfig(const Json::Object& config,
-                               Upstream::ClusterManager& cluster_manager, Stats::Store& stats_store)
+                               Upstream::ClusterManager& cluster_manager, Stats::Scope& stats_store)
     : stats_(generateStats(config.getString("stat_prefix"), stats_store)) {
   config.validateSchema(Json::Schema::TCP_PROXY_NETWORK_FILTER_SCHEMA);
 
@@ -106,7 +106,7 @@ TcpProxy::~TcpProxy() {
   }
 }
 
-TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Store& store) {
+TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Scope& store) {
   std::string final_prefix = fmt::format("tcp.{}.", name);
   return {ALL_TCP_PROXY_STATS(POOL_COUNTER_PREFIX(store, final_prefix),
                               POOL_GAUGE_PREFIX(store, final_prefix))};

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -45,7 +45,7 @@ struct TcpProxyStats {
 class TcpProxyConfig {
 public:
   TcpProxyConfig(const Json::Object& config, Upstream::ClusterManager& cluster_manager,
-                 Stats::Store& stats_store);
+                 Stats::Scope& stats_store);
 
   /**
    * Find out which cluster an upstream connection should be opened to based on the
@@ -70,7 +70,7 @@ private:
     std::string cluster_name_;
   };
 
-  static TcpProxyStats generateStats(const std::string& name, Stats::Store& store);
+  static TcpProxyStats generateStats(const std::string& name, Stats::Scope& store);
 
   std::vector<Route> routes_;
   const TcpProxyStats stats_;

--- a/source/common/http/codes.h
+++ b/source/common/http/codes.h
@@ -23,7 +23,7 @@ public:
                                       Code response_code);
 
   struct ResponseStatInfo {
-    Stats::Store& global_store_;
+    Stats::Scope& global_store_;
     Stats::Scope& cluster_scope_;
     const std::string& prefix_;
     const HeaderMap& response_headers_;
@@ -43,7 +43,7 @@ public:
   static void chargeResponseStat(const ResponseStatInfo& info);
 
   struct ResponseTimingInfo {
-    Stats::Store& global_store_;
+    Stats::Scope& global_store_;
     Stats::Scope& cluster_scope_;
     const std::string& prefix_;
     std::chrono::milliseconds response_time_;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -34,7 +34,7 @@ namespace Envoy {
 namespace Http {
 
 ConnectionManagerStats ConnectionManagerImpl::generateStats(const std::string& prefix,
-                                                            Stats::Store& stats) {
+                                                            Stats::Scope& stats) {
   return {
       {ALL_HTTP_CONN_MAN_STATS(POOL_COUNTER_PREFIX(stats, prefix), POOL_GAUGE_PREFIX(stats, prefix),
                                POOL_TIMER_PREFIX(stats, prefix))},
@@ -43,7 +43,7 @@ ConnectionManagerStats ConnectionManagerImpl::generateStats(const std::string& p
 }
 
 ConnectionManagerTracingStats ConnectionManagerImpl::generateTracingStats(const std::string& prefix,
-                                                                          Stats::Store& stats) {
+                                                                          Stats::Scope& stats) {
   return {CONN_MAN_TRACING_STATS(POOL_COUNTER_PREFIX(stats, prefix + "tracing."))};
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -84,7 +84,7 @@ struct ConnectionManagerNamedStats {
 struct ConnectionManagerStats {
   ConnectionManagerNamedStats named_;
   std::string prefix_;
-  Stats::Store& store_;
+  Stats::Scope& store_;
 };
 
 /**
@@ -232,9 +232,9 @@ public:
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info);
   ~ConnectionManagerImpl();
 
-  static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Store& stats);
+  static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& stats);
   static ConnectionManagerTracingStats generateTracingStats(const std::string& prefix,
-                                                            Stats::Store& stats);
+                                                            Stats::Scope& stats);
   static void chargeTracingStats(const Tracing::Reason& tracing_reason,
                                  ConnectionManagerTracingStats& tracing_stats);
 

--- a/source/common/http/filter/buffer_filter.cc
+++ b/source/common/http/filter/buffer_filter.cc
@@ -52,7 +52,7 @@ FilterTrailersStatus BufferFilter::decodeTrailers(HeaderMap&) {
   return FilterTrailersStatus::Continue;
 }
 
-BufferFilterStats BufferFilter::generateStats(const std::string& prefix, Stats::Store& store) {
+BufferFilterStats BufferFilter::generateStats(const std::string& prefix, Stats::Scope& store) {
   std::string final_prefix = prefix + "buffer.";
   return {ALL_BUFFER_FILTER_STATS(POOL_COUNTER_PREFIX(store, final_prefix))};
 }

--- a/source/common/http/filter/buffer_filter.h
+++ b/source/common/http/filter/buffer_filter.h
@@ -48,7 +48,7 @@ public:
   BufferFilter(BufferFilterConfigConstSharedPtr config);
   ~BufferFilter();
 
-  static BufferFilterStats generateStats(const std::string& prefix, Stats::Store& store);
+  static BufferFilterStats generateStats(const std::string& prefix, Stats::Scope& store);
 
   // Http::StreamFilterBase
   void onDestroy() override;

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -27,7 +27,7 @@ const std::string FaultFilter::DELAY_DURATION_KEY = "fault.http.delay.fixed_dura
 const std::string FaultFilter::ABORT_HTTP_STATUS_KEY = "fault.http.abort.http_status";
 
 FaultFilterConfig::FaultFilterConfig(const Json::Object& json_config, Runtime::Loader& runtime,
-                                     const std::string& stats_prefix, Stats::Store& stats)
+                                     const std::string& stats_prefix, Stats::Scope& stats)
     : runtime_(runtime), stats_(generateStats(stats_prefix, stats)), stats_prefix_(stats_prefix),
       store_(stats) {
 
@@ -216,7 +216,7 @@ FilterTrailersStatus FaultFilter::decodeTrailers(HeaderMap&) {
   return FilterTrailersStatus::Continue;
 }
 
-FaultFilterStats FaultFilterConfig::generateStats(const std::string& prefix, Stats::Store& store) {
+FaultFilterStats FaultFilterConfig::generateStats(const std::string& prefix, Stats::Scope& store) {
   std::string final_prefix = prefix + "fault.";
   return {ALL_FAULT_FILTER_STATS(POOL_COUNTER_PREFIX(store, final_prefix))};
 }

--- a/source/common/http/filter/fault_filter.h
+++ b/source/common/http/filter/fault_filter.h
@@ -37,7 +37,7 @@ struct FaultFilterStats {
 class FaultFilterConfig {
 public:
   FaultFilterConfig(const Json::Object& json_config, Runtime::Loader& runtime,
-                    const std::string& stats_prefix, Stats::Store& stats);
+                    const std::string& stats_prefix, Stats::Scope& stats);
 
   const std::vector<Router::ConfigUtility::HeaderData>& filterHeaders() {
     return fault_filter_headers_;
@@ -51,10 +51,10 @@ public:
   FaultFilterStats& stats() { return stats_; }
   const std::unordered_set<std::string>& downstreamNodes() { return downstream_nodes_; }
   const std::string& statsPrefix() { return stats_prefix_; }
-  Stats::Store& statsStore() { return store_; }
+  Stats::Scope& statsStore() { return store_; }
 
 private:
-  static FaultFilterStats generateStats(const std::string& prefix, Stats::Store& store);
+  static FaultFilterStats generateStats(const std::string& prefix, Stats::Scope& store);
 
   uint64_t abort_percent_{};       // 0-100
   uint64_t http_status_{};         // HTTP or gRPC return codes
@@ -67,7 +67,7 @@ private:
   Runtime::Loader& runtime_;
   FaultFilterStats stats_;
   const std::string stats_prefix_;
-  Stats::Store& store_;
+  Stats::Scope& store_;
 };
 
 typedef std::shared_ptr<FaultFilterConfig> FaultFilterConfigSharedPtr;

--- a/source/common/http/filter/ratelimit.h
+++ b/source/common/http/filter/ratelimit.h
@@ -32,7 +32,7 @@ enum class FilterRequestType { Internal, External, Both };
 class FilterConfig : Json::Validator {
 public:
   FilterConfig(const Json::Object& config, const LocalInfo::LocalInfo& local_info,
-               Stats::Store& global_store, Runtime::Loader& runtime, Upstream::ClusterManager& cm)
+               Stats::Scope& global_store, Runtime::Loader& runtime, Upstream::ClusterManager& cm)
       : Json::Validator(config, Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA),
         domain_(config.getString("domain")),
         stage_(static_cast<uint64_t>(config.getInteger("stage", 0))),
@@ -43,7 +43,7 @@ public:
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   uint64_t stage() const { return stage_; }
   Runtime::Loader& runtime() { return runtime_; }
-  Stats::Store& globalStore() { return global_store_; }
+  Stats::Scope& globalStore() { return global_store_; }
   Upstream::ClusterManager& cm() { return cm_; }
   FilterRequestType requestType() const { return request_type_; }
 
@@ -63,7 +63,7 @@ private:
   const uint64_t stage_;
   const FilterRequestType request_type_;
   const LocalInfo::LocalInfo& local_info_;
-  Stats::Store& global_store_;
+  Stats::Scope& global_store_;
   Runtime::Loader& runtime_;
   Upstream::ClusterManager& cm_;
 };

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -683,7 +683,7 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 
 ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
-                                           Stats::Store& stats, const Http2Settings& http2_settings)
+                                           Stats::Scope& stats, const Http2Settings& http2_settings)
     : ConnectionImpl(connection, stats), callbacks_(callbacks) {
   nghttp2_session_server_new2(&session_, http2_callbacks_.callbacks(), base(),
                               http2_options_.options());

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -247,7 +247,7 @@ private:
 class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
-                       Stats::Store& stats, const Http2Settings& http2_settings);
+                       Stats::Scope& stats, const Http2Settings& http2_settings);
 
 private:
   // ConnectionImpl

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -20,7 +20,7 @@ void UserAgent::completeConnectionLength(Stats::Timespan& span) {
 }
 
 void UserAgent::initializeFromHeaders(const HeaderMap& headers, const std::string& prefix,
-                                      Stats::Store& stat_store) {
+                                      Stats::Scope& stat_store) {
   // We assume that the user-agent is consistent based on the first request.
   if (type_ != Type::NotInitialized) {
     return;

--- a/source/common/http/user_agent.h
+++ b/source/common/http/user_agent.h
@@ -46,7 +46,7 @@ public:
    * @param stat_store supplies the backing stat store.
    */
   void initializeFromHeaders(const HeaderMap& headers, const std::string& prefix,
-                             Stats::Store& stat_store);
+                             Stats::Scope& stat_store);
 
   /**
    * Called when a connection is being destroyed.

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -35,7 +35,7 @@ void AccessLog::logMessage(const Message& message, bool full,
   file_->write(log_line);
 }
 
-ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Store& store,
+ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Scope& store,
                          Runtime::Loader& runtime, AccessLogSharedPtr access_log)
     : stat_prefix_(stat_prefix), stat_store_(store), stats_(generateStats(stat_prefix, store)),
       runtime_(runtime), access_log_(access_log) {

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -81,7 +81,7 @@ class ProxyFilter : public Network::Filter,
                     public Network::ConnectionCallbacks,
                     Logger::Loggable<Logger::Id::mongo> {
 public:
-  ProxyFilter(const std::string& stat_prefix, Stats::Store& store, Runtime::Loader& runtime,
+  ProxyFilter(const std::string& stat_prefix, Stats::Scope& store, Runtime::Loader& runtime,
               AccessLogSharedPtr access_log);
   ~ProxyFilter();
 
@@ -124,7 +124,7 @@ private:
 
   typedef std::unique_ptr<ActiveQuery> ActiveQueryPtr;
 
-  MongoProxyStats generateStats(const std::string& prefix, Stats::Store& store) {
+  MongoProxyStats generateStats(const std::string& prefix, Stats::Scope& store) {
     return MongoProxyStats{ALL_MONGO_PROXY_STATS(POOL_COUNTER_PREFIX(store, prefix),
                                                  POOL_GAUGE_PREFIX(store, prefix),
                                                  POOL_TIMER_PREFIX(store, prefix))};
@@ -138,7 +138,7 @@ private:
 
   std::unique_ptr<Decoder> decoder_;
   std::string stat_prefix_;
-  Stats::Store& stat_store_;
+  Stats::Scope& stat_store_;
   MongoProxyStats stats_;
   Runtime::Loader& runtime_;
   Buffer::OwnedImpl read_buffer_;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -78,7 +78,7 @@ public:
 class FilterConfig {
 public:
   FilterConfig(const std::string& stat_prefix, const LocalInfo::LocalInfo& local_info,
-               Stats::Store& stats, Upstream::ClusterManager& cm, Runtime::Loader& runtime,
+               Stats::Scope& stats, Upstream::ClusterManager& cm, Runtime::Loader& runtime,
                Runtime::RandomGenerator& random, ShadowWriterPtr&& shadow_writer,
                bool emit_dynamic_stats)
       : global_store_(stats), local_info_(local_info), cm_(cm), runtime_(runtime), random_(random),
@@ -87,7 +87,7 @@ public:
 
   ShadowWriter& shadowWriter() { return *shadow_writer_; }
 
-  Stats::Store& global_store_;
+  Stats::Scope& global_store_;
   const LocalInfo::LocalInfo& local_info_;
   Upstream::ClusterManager& cm_;
   Runtime::Loader& runtime_;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//include/envoy/network:filter_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/server:configuration_interface",
+        "//include/envoy/server:filter_config_interface",
         "//include/envoy/server:instance_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//source/common/common:assert_lib",

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -13,7 +13,6 @@ envoy_cc_library(
     srcs = ["buffer.cc"],
     hdrs = ["buffer.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/http/filter:buffer_filter_lib",
         "//source/common/json:config_schemas_lib",
         "//source/server/config/network:http_connection_manager_lib",
@@ -35,7 +34,6 @@ envoy_cc_library(
     srcs = ["fault.cc"],
     hdrs = ["fault.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/http/filter:fault_filter_lib",
         "//source/common/json:config_schemas_lib",
         "//source/server/config/network:http_connection_manager_lib",
@@ -47,7 +45,6 @@ envoy_cc_library(
     srcs = ["grpc_http1_bridge.cc"],
     hdrs = ["grpc_http1_bridge.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/grpc:http1_bridge_filter_lib",
         "//source/server/config/network:http_connection_manager_lib",
     ],
@@ -58,7 +55,6 @@ envoy_cc_library(
     srcs = ["grpc_web.cc"],
     hdrs = ["grpc_web.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/grpc:grpc_web_filter_lib",
         "//source/server/config/network:http_connection_manager_lib",
     ],
@@ -69,7 +65,6 @@ envoy_cc_library(
     srcs = ["ip_tagging.cc"],
     hdrs = ["ip_tagging.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/http/filter:ip_tagging_filter_lib",
         "//source/common/json:config_schemas_lib",
         "//source/server/config/network:http_connection_manager_lib",
@@ -81,7 +76,6 @@ envoy_cc_library(
     srcs = ["lightstep_http_tracer.cc"],
     hdrs = ["lightstep_http_tracer.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/tracing:http_tracer_lib",
         "//source/common/tracing:lightstep_tracer_lib",
         "//source/server:configuration_lib",
@@ -93,7 +87,6 @@ envoy_cc_library(
     srcs = ["ratelimit.cc"],
     hdrs = ["ratelimit.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/http/filter:ratelimit_includes",
         "//source/common/http/filter:ratelimit_lib",
         "//source/server/config/network:http_connection_manager_lib",
@@ -105,7 +98,6 @@ envoy_cc_library(
     srcs = ["router.cc"],
     hdrs = ["router.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/json:config_schemas_lib",
         "//source/common/router:router_lib",
         "//source/common/router:shadow_writer_lib",
@@ -118,7 +110,6 @@ envoy_cc_library(
     srcs = ["zipkin_http_tracer.cc"],
     hdrs = ["zipkin_http_tracer.h"],
     deps = [
-        "//include/envoy/server:instance_interface",
         "//source/common/tracing/zipkin:zipkin_lib",
         "//source/server:configuration_lib",
     ],

--- a/source/server/config/http/buffer.cc
+++ b/source/server/config/http/buffer.cc
@@ -7,23 +7,19 @@
 #include "common/http/filter/buffer_filter.h"
 #include "common/json/config_schemas.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb BufferFilterConfig::createFilterFactory(HttpFilterType type,
-                                                            const Json::Object& json_config,
+HttpFilterFactoryCb BufferFilterConfig::createFilterFactory(const Json::Object& json_config,
                                                             const std::string& stats_prefix,
-                                                            Server::Instance& server) {
-  if (type != HttpFilterType::Decoder) {
-    throw EnvoyException(
-        fmt::format("{} http filter must be configured as a decoder filter.", name()));
-  }
-
+                                                            FactoryContext& context) {
   json_config.validateSchema(Json::Schema::BUFFER_HTTP_FILTER_SCHEMA);
 
   Http::BufferFilterConfigConstSharedPtr config(new Http::BufferFilterConfig{
-      Http::BufferFilter::generateStats(stats_prefix, server.stats()),
+      Http::BufferFilter::generateStats(stats_prefix, context.scope()),
       static_cast<uint64_t>(json_config.getInteger("max_request_bytes")),
       std::chrono::seconds(json_config.getInteger("max_request_time_s"))});
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -31,8 +27,6 @@ HttpFilterFactoryCb BufferFilterConfig::createFilterFactory(HttpFilterType type,
         Http::StreamDecoderFilterSharedPtr{new Http::BufferFilter(config)});
   };
 }
-
-std::string BufferFilterConfig::name() { return "buffer"; }
 
 /**
  * Static registration for the buffer filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/buffer.h
+++ b/source/server/config/http/buffer.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,10 +13,11 @@ namespace Configuration {
  */
 class BufferFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& json_config,
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                           const std::string& stats_prefix,
-                                          Server::Instance& server) override;
-  std::string name() override;
+                                          FactoryContext& context) override;
+  std::string name() override { return "buffer"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // Configuration

--- a/source/server/config/http/dynamo.cc
+++ b/source/server/config/http/dynamo.cc
@@ -4,26 +4,20 @@
 
 #include "common/dynamo/dynamo_filter.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb DynamoFilterConfig::createFilterFactory(HttpFilterType type,
-                                                            const Json::Object&,
+HttpFilterFactoryCb DynamoFilterConfig::createFilterFactory(const Json::Object&,
                                                             const std::string& stat_prefix,
-                                                            Server::Instance& server) {
-  if (type != HttpFilterType::Both) {
-    throw EnvoyException(fmt::format(
-        "{} http filter must be configured as both a decoder and encoder filter.", name()));
-  }
-
-  return [&server, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+                                                            FactoryContext& context) {
+  return [&context, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{
-        new Dynamo::DynamoFilter(server.runtime(), stat_prefix, server.stats())});
+        new Dynamo::DynamoFilter(context.runtime(), stat_prefix, context.scope())});
   };
 }
-
-std::string DynamoFilterConfig::name() { return "http_dynamo_filter"; }
 
 /**
  * Static registration for the http dynamodb filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/dynamo.h
+++ b/source/server/config/http/dynamo.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -13,10 +13,10 @@ namespace Configuration {
  */
 class DynamoFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object&,
-                                          const std::string& stat_prefix,
-                                          Server::Instance& server) override;
-  std::string name() override;
+  HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string& stat_prefix,
+                                          FactoryContext& context) override;
+  std::string name() override { return "http_dynamo_filter"; }
+  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // Configuration

--- a/source/server/config/http/fault.cc
+++ b/source/server/config/http/fault.cc
@@ -5,28 +5,22 @@
 #include "common/http/filter/fault_filter.h"
 #include "common/json/config_schemas.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb FaultFilterConfig::createFilterFactory(HttpFilterType type,
-                                                           const Json::Object& json_config,
+HttpFilterFactoryCb FaultFilterConfig::createFilterFactory(const Json::Object& json_config,
                                                            const std::string& stats_prefix,
-                                                           Server::Instance& server) {
-  if (type != HttpFilterType::Decoder) {
-    throw EnvoyException(
-        fmt::format("{} http filter must be configured as a decoder filter.", name()));
-  }
-
+                                                           FactoryContext& context) {
   Http::FaultFilterConfigSharedPtr config(
-      new Http::FaultFilterConfig(json_config, server.runtime(), stats_prefix, server.stats()));
+      new Http::FaultFilterConfig(json_config, context.runtime(), stats_prefix, context.scope()));
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(
         Http::StreamDecoderFilterSharedPtr{new Http::FaultFilter(config)});
   };
 }
-
-std::string FaultFilterConfig::name() { return "fault"; }
 
 /**
  * Static registration for the fault filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/fault.h
+++ b/source/server/config/http/fault.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,10 +13,11 @@ namespace Configuration {
  */
 class FaultFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& json_config,
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                           const std::string& stats_prefix,
-                                          Server::Instance& server) override;
-  std::string name() override;
+                                          FactoryContext& context) override;
+  std::string name() override { return "fault"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // Configuration

--- a/source/server/config/http/grpc_http1_bridge.cc
+++ b/source/server/config/http/grpc_http1_bridge.cc
@@ -4,26 +4,20 @@
 
 #include "common/grpc/http1_bridge_filter.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactory(HttpFilterType type,
-                                                                     const Json::Object&,
+HttpFilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactory(const Json::Object&,
                                                                      const std::string&,
-                                                                     Server::Instance& server) {
-  if (type != HttpFilterType::Both) {
-    throw EnvoyException(fmt::format(
-        "{} http filter must be configured as both a decoder and encoder filter.", name()));
-  }
-
-  return [&server](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+                                                                     FactoryContext& context) {
+  return [&context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(
-        Http::StreamFilterSharedPtr{new Grpc::Http1BridgeFilter(server.clusterManager())});
+        Http::StreamFilterSharedPtr{new Grpc::Http1BridgeFilter(context.clusterManager())});
   };
 }
-
-std::string GrpcHttp1BridgeFilterConfig::name() { return "grpc_http1_bridge"; }
 
 /**
  * Static registration for the grpc HTTP1 bridge filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/grpc_http1_bridge.h
+++ b/source/server/config/http/grpc_http1_bridge.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,9 +13,10 @@ namespace Configuration {
  */
 class GrpcHttp1BridgeFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object&,
-                                          const std::string&, Server::Instance& server) override;
-  std::string name() override;
+  HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
+                                          FactoryContext& context) override;
+  std::string name() override { return "grpc_http1_bridge"; }
+  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // Configuration

--- a/source/server/config/http/grpc_web.cc
+++ b/source/server/config/http/grpc_web.cc
@@ -2,25 +2,18 @@
 
 #include "common/grpc/grpc_web_filter.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb GrpcWebFilterConfig::createFilterFactory(HttpFilterType type,
-                                                             const Json::Object&,
-                                                             const std::string&,
-                                                             Server::Instance&) {
-  if (type != HttpFilterType::Both) {
-    throw EnvoyException(fmt::format(
-        "{} gRPC-Web filter must be configured as both a decoder and encoder filter.", name()));
-  }
-
+HttpFilterFactoryCb GrpcWebFilterConfig::createFilterFactory(const Json::Object&,
+                                                             const std::string&, FactoryContext&) {
   return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new Grpc::GrpcWebFilter()});
   };
 }
-
-std::string GrpcWebFilterConfig::name() { return "grpc_web"; }
 
 /**
  * Static registration for the gRPC-Web filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/grpc_web.h
+++ b/source/server/config/http/grpc_web.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -8,10 +8,10 @@ namespace Configuration {
 
 class GrpcWebFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object&,
-                                          const std::string&, Server::Instance&) override;
-
-  std::string name() override;
+  HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
+                                          FactoryContext&) override;
+  std::string name() override { return "grpc_web"; }
+  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/ip_tagging.cc
+++ b/source/server/config/http/ip_tagging.cc
@@ -5,27 +5,21 @@
 #include "common/http/filter/ip_tagging_filter.h"
 #include "common/json/config_schemas.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb IpTaggingFilterConfig::createFilterFactory(HttpFilterType type,
-                                                               const Json::Object& json_config,
+HttpFilterFactoryCb IpTaggingFilterConfig::createFilterFactory(const Json::Object& json_config,
                                                                const std::string&,
-                                                               Server::Instance&) {
-  if (type != HttpFilterType::Decoder) {
-    throw EnvoyException(
-        fmt::format("{} ip tagging filter must be configured as a decoder filter.", name()));
-  }
-
+                                                               FactoryContext&) {
   Http::IpTaggingFilterConfigSharedPtr config(new Http::IpTaggingFilterConfig(json_config));
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(
         Http::StreamDecoderFilterSharedPtr{new Http::IpTaggingFilter(config)});
   };
 }
-
-std::string IpTaggingFilterConfig::name() { return "ip_tagging"; }
 
 /**
  * Static registration for the ip tagging filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/ip_tagging.h
+++ b/source/server/config/http/ip_tagging.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,11 +13,11 @@ namespace Configuration {
  */
 class IpTaggingFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& json_config,
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                           const std::string& stat_prefix,
-                                          Server::Instance& server) override;
-
-  std::string name() override;
+                                          FactoryContext& context) override;
+  std::string name() override { return "ip_tagging"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // Configuration

--- a/source/server/config/http/ratelimit.h
+++ b/source/server/config/http/ratelimit.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,9 +13,10 @@ namespace Configuration {
  */
 class RateLimitFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& config,
-                                          const std::string&, Server::Instance& server) override;
-  std::string name() override;
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& config, const std::string&,
+                                          FactoryContext& context) override;
+  std::string name() override { return "rate_limit"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // Configuration

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -6,32 +6,26 @@
 #include "common/router/router.h"
 #include "common/router/shadow_writer_impl.h"
 
+#include "server/config/network/http_connection_manager.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb RouterFilterConfig::createFilterFactory(HttpFilterType type,
-                                                            const Json::Object& json_config,
+HttpFilterFactoryCb RouterFilterConfig::createFilterFactory(const Json::Object& json_config,
                                                             const std::string& stat_prefix,
-                                                            Server::Instance& server) {
-  if (type != HttpFilterType::Decoder) {
-    throw EnvoyException(
-        fmt::format("{} http filter must be configured as a decoder filter.", name()));
-  }
-
+                                                            FactoryContext& context) {
   json_config.validateSchema(Json::Schema::ROUTER_HTTP_FILTER_SCHEMA);
 
   Router::FilterConfigSharedPtr config(new Router::FilterConfig(
-      stat_prefix, server.localInfo(), server.stats(), server.clusterManager(), server.runtime(),
-      server.random(),
-      Router::ShadowWriterPtr{new Router::ShadowWriterImpl(server.clusterManager())},
+      stat_prefix, context.localInfo(), context.scope(), context.clusterManager(),
+      context.runtime(), context.random(),
+      Router::ShadowWriterPtr{new Router::ShadowWriterImpl(context.clusterManager())},
       json_config.getBoolean("dynamic_stats", true)));
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks)
       -> void { callbacks.addStreamDecoderFilter(std::make_shared<Router::ProdFilter>(*config)); };
 }
-
-std::string RouterFilterConfig::name() { return "router"; }
 
 /**
  * Static registration for the router filter. @see RegisterNamedHttpFilterConfigFactory.

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -2,9 +2,7 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-
-#include "server/config/network/http_connection_manager.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -15,10 +13,11 @@ namespace Configuration {
  */
 class RouterFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& json_config,
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                           const std::string& stat_prefix,
-                                          Server::Instance& server) override;
-  std::string name() override;
+                                          FactoryContext& context) override;
+  std::string name() override { return "router"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // Configuration

--- a/source/server/config/network/BUILD
+++ b/source/server/config/network/BUILD
@@ -13,8 +13,6 @@ envoy_cc_library(
     srcs = ["client_ssl_auth.cc"],
     hdrs = ["client_ssl_auth.h"],
     deps = [
-        "//include/envoy/network:connection_interface",
-        "//include/envoy/server:instance_interface",
         "//source/common/filter/auth:client_ssl_lib",
         "//source/server:configuration_lib",
     ],
@@ -24,7 +22,6 @@ envoy_cc_library(
     name = "echo_lib",
     srcs = ["echo.cc"],
     deps = [
-        "//include/envoy/network:connection_interface",
         "//source/common/filter:echo_lib",
         "//source/server:configuration_lib",
     ],
@@ -37,8 +34,6 @@ envoy_cc_library(
     deps = [
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/http:filter_interface",
-        "//include/envoy/network:connection_interface",
-        "//include/envoy/server:instance_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:logger_lib",
@@ -60,8 +55,6 @@ envoy_cc_library(
     srcs = ["mongo_proxy.cc"],
     hdrs = ["mongo_proxy.h"],
     deps = [
-        "//include/envoy/network:connection_interface",
-        "//include/envoy/server:instance_interface",
         "//source/common/json:config_schemas_lib",
         "//source/common/mongo:proxy_lib",
         "//source/server:configuration_lib",
@@ -73,7 +66,6 @@ envoy_cc_library(
     srcs = ["ratelimit.cc"],
     hdrs = ["ratelimit.h"],
     deps = [
-        "//include/envoy/network:connection_interface",
         "//source/common/filter:ratelimit_lib",
         "//source/server:configuration_lib",
     ],
@@ -97,8 +89,6 @@ envoy_cc_library(
     srcs = ["tcp_proxy.cc"],
     hdrs = ["tcp_proxy.h"],
     deps = [
-        "//include/envoy/network:connection_interface",
-        "//include/envoy/server:instance_interface",
         "//source/common/filter:tcp_proxy_lib",
         "//source/server:configuration_lib",
     ],

--- a/source/server/config/network/client_ssl_auth.cc
+++ b/source/server/config/network/client_ssl_auth.cc
@@ -3,31 +3,26 @@
 #include <string>
 
 #include "envoy/network/connection.h"
-#include "envoy/server/instance.h"
 
 #include "common/filter/auth/client_ssl.h"
+
+#include "server/configuration_impl.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-NetworkFilterFactoryCb ClientSslAuthConfigFactory::createFilterFactory(
-    NetworkFilterType type, const Json::Object& json_config, Server::Instance& server) {
-  if (type != NetworkFilterType::Read) {
-    throw EnvoyException(
-        fmt::format("{} network filter must be configured as a read filter.", name()));
-  }
-
+NetworkFilterFactoryCb
+ClientSslAuthConfigFactory::createFilterFactory(const Json::Object& json_config,
+                                                FactoryContext& context) {
   Filter::Auth::ClientSsl::ConfigSharedPtr config(Filter::Auth::ClientSsl::Config::create(
-      json_config, server.threadLocal(), server.clusterManager(), server.dispatcher(),
-      server.stats(), server.random()));
+      json_config, context.threadLocal(), context.clusterManager(), context.dispatcher(),
+      context.scope(), context.random()));
   return [config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(
         Network::ReadFilterSharedPtr{new Filter::Auth::ClientSsl::Instance(config)});
   };
 }
-
-std::string ClientSslAuthConfigFactory::name() { return "client_ssl_auth"; }
 
 /**
  * Static registration for the client SSL auth filter. @see RegisterNamedNetworkFilterConfigFactory.

--- a/source/server/config/network/client_ssl_auth.h
+++ b/source/server/config/network/client_ssl_auth.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/configuration_impl.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -14,10 +14,10 @@ namespace Configuration {
 class ClientSslAuthConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type,
-                                             const Json::Object& json_config,
-                                             Server::Instance& server) override;
-  std::string name() override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
+                                             FactoryContext& context) override;
+  std::string name() override { return "client_ssl_auth"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // Configuration

--- a/source/server/config/network/echo.cc
+++ b/source/server/config/network/echo.cc
@@ -1,7 +1,5 @@
 #include <string>
 
-#include "envoy/network/connection.h"
-
 #include "common/filter/echo.h"
 
 #include "server/configuration_impl.h"
@@ -16,18 +14,13 @@ namespace Configuration {
 class EchoConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type, const Json::Object&,
-                                             Server::Instance&) override {
-    if (type != NetworkFilterType::Read) {
-      throw EnvoyException(
-          fmt::format("{} network filter must be configured as a read filter.", name()));
-    }
-
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
     return [](Network::FilterManager& filter_manager)
         -> void { filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo()}); };
   }
 
   std::string name() override { return "echo"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 /**

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -26,23 +26,17 @@ namespace Configuration {
 
 const std::string HttpConnectionManagerConfig::DEFAULT_SERVER_STRING = "envoy";
 
-NetworkFilterFactoryCb HttpConnectionManagerFilterConfigFactory::createFilterFactory(
-    NetworkFilterType type, const Json::Object& config, Server::Instance& server) {
-  if (type != NetworkFilterType::Read) {
-    throw EnvoyException(
-        fmt::format("{} network filter must be configured as a read filter.", name()));
-  }
-
+NetworkFilterFactoryCb
+HttpConnectionManagerFilterConfigFactory::createFilterFactory(const Json::Object& config,
+                                                              FactoryContext& context) {
   std::shared_ptr<HttpConnectionManagerConfig> http_config(
-      new HttpConnectionManagerConfig(config, server));
-  return [http_config, &server](Network::FilterManager& filter_manager) mutable -> void {
+      new HttpConnectionManagerConfig(config, context));
+  return [http_config, &context](Network::FilterManager& filter_manager) mutable -> void {
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
-        *http_config, server.drainManager(), server.random(), server.httpTracer(), server.runtime(),
-        server.localInfo())});
+        *http_config, context.drainManager(), context.random(), context.httpTracer(),
+        context.runtime(), context.localInfo())});
   };
 }
-
-std::string HttpConnectionManagerFilterConfigFactory::name() { return "http_connection_manager"; }
 
 /**
  * Static registration for the HTTP connection manager filter. @see
@@ -71,28 +65,28 @@ HttpConnectionManagerConfigUtility::determineNextProtocol(Network::Connection& c
 }
 
 HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& config,
-                                                         Server::Instance& server)
-    : Json::Validator(config, Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA), server_(server),
+                                                         FactoryContext& context)
+    : Json::Validator(config, Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA), context_(context),
       stats_prefix_(fmt::format("http.{}.", config.getString("stat_prefix"))),
-      stats_(Http::ConnectionManagerImpl::generateStats(stats_prefix_, server.stats())),
+      stats_(Http::ConnectionManagerImpl::generateStats(stats_prefix_, context_.scope())),
       tracing_stats_(
-          Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, server.stats())),
+          Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       http2_settings_(Http::Utility::parseHttp2Settings(config)),
       drain_timeout_(config.getInteger("drain_timeout_ms", 5000)),
       generate_request_id_(config.getBoolean("generate_request_id", true)),
-      date_provider_(server.dispatcher(), server.threadLocal()) {
+      date_provider_(context_.dispatcher(), context_.threadLocal()) {
 
   route_config_provider_ = Router::RouteConfigProviderUtil::create(
-      config, server.runtime(), server.clusterManager(), server.dispatcher(), server.random(),
-      server.localInfo(), server.stats(), stats_prefix_, server.threadLocal(),
-      server.initManager());
+      config, context_.runtime(), context_.clusterManager(), context_.dispatcher(),
+      context_.random(), context_.localInfo(), context_.scope(), stats_prefix_,
+      context_.threadLocal(), context_.initManager());
 
   if (config.hasObject("use_remote_address")) {
     use_remote_address_ = config.getBoolean("use_remote_address");
   }
 
   if (config.hasObject("add_user_agent") && config.getBoolean("add_user_agent")) {
-    user_agent_.value(server.localInfo().clusterName());
+    user_agent_.value(context_.localInfo().clusterName());
   }
 
   if (config.hasObject("tracing")) {
@@ -126,8 +120,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
   if (config.hasObject("access_log")) {
     for (const Json::ObjectSharedPtr& access_log : config.getObjectArray("access_log")) {
       Http::AccessLog::InstanceSharedPtr current_access_log =
-          Http::AccessLog::InstanceImpl::fromJson(*access_log, server.runtime(),
-                                                  server.accessLogManager());
+          Http::AccessLog::InstanceImpl::fromJson(*access_log, context_.runtime(),
+                                                  context_.accessLogManager());
       access_logs_.push_back(current_access_log);
     }
   }
@@ -158,9 +152,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
 
     // Now see if there is a factory that will accept the config.
     auto search_it = namedFilterConfigFactories().find(string_name);
-    if (search_it != namedFilterConfigFactories().end()) {
+    if (search_it != namedFilterConfigFactories().end() && search_it->second->type() == type) {
       HttpFilterFactoryCb callback =
-          search_it->second->createFilterFactory(type, *config_object, stats_prefix_, server);
+          search_it->second->createFilterFactory(*config_object, stats_prefix_, context_);
       filter_factories_.push_back(callback);
     } else {
       // DEPRECATED
@@ -168,7 +162,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(const Json::Object& con
       bool found_filter = false;
       for (HttpFilterConfigFactory* config_factory : filterConfigFactories()) {
         HttpFilterFactoryCb callback = config_factory->tryCreateFilterFactory(
-            type, string_name, *config_object, stats_prefix_, server);
+            type, string_name, *config_object, stats_prefix_, context_.server());
         if (callback) {
           filter_factories_.push_back(callback);
           found_filter = true;
@@ -193,12 +187,12 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
     return Http::ServerConnectionPtr{new Http::Http1::ServerConnectionImpl(connection, callbacks)};
   case CodecType::HTTP2:
     return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
-        connection, callbacks, server_.stats(), http2_settings_)};
+        connection, callbacks, context_.scope(), http2_settings_)};
   case CodecType::AUTO:
     if (HttpConnectionManagerConfigUtility::determineNextProtocol(connection, data) ==
         Http::Http2::ALPN_STRING) {
       return Http::ServerConnectionPtr{new Http::Http2::ServerConnectionImpl(
-          connection, callbacks, server_.stats(), http2_settings_)};
+          connection, callbacks, context_.scope(), http2_settings_)};
     } else {
       return Http::ServerConnectionPtr{
           new Http::Http1::ServerConnectionImpl(connection, callbacks)};
@@ -226,7 +220,7 @@ HttpFilterType HttpConnectionManagerConfig::stringToType(const std::string& type
 }
 
 const Network::Address::Instance& HttpConnectionManagerConfig::localAddress() {
-  return *server_.localInfo().address();
+  return *context_.localInfo().address();
 }
 
 } // Configuration

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "envoy/http/filter.h"
-#include "envoy/server/instance.h"
 
 #include "common/common/logger.h"
 #include "common/http/conn_manager_impl.h"
@@ -21,8 +20,6 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-enum class HttpFilterType { Decoder, Encoder, Both };
-
 /**
  * Config registration for the HTTP connection manager filter. @see NamedNetworkFilterConfigFactory.
  */
@@ -30,16 +27,12 @@ class HttpConnectionManagerFilterConfigFactory : Logger::Loggable<Logger::Id::co
                                                  public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type, const Json::Object& config,
-                                             Server::Instance& server) override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                             FactoryContext& context) override;
 
-  std::string name() override;
+  std::string name() override { return "http_connection_manager"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
-
-/**
- * Callback lambda used for dynamic HTTP filter chain construction.
- */
-typedef std::function<void(Http::FilterChainFactoryCallbacks&)> HttpFilterFactoryCb;
 
 /**
  * DEPRECATED - Implemented by each HTTP filter and registered via registerHttpFilterConfigFactory()
@@ -53,35 +46,6 @@ public:
                                                      const Json::Object& config,
                                                      const std::string& stat_prefix,
                                                      Server::Instance& server) PURE;
-};
-
-/**
- * Implemented by each HTTP filter and registered via registerNamedHttpFilterConfigFactory() or the
- * convenience class RegisterNamedHttpFilterConfigFactory.
- */
-class NamedHttpFilterConfigFactory {
-public:
-  virtual ~NamedHttpFilterConfigFactory() {}
-
-  /**
-  * Create a particular http filter factory implementation.  If the implementation is unable to
-  * produce a factory with the provided parameters, it should throw an EnvoyException in the case of
-  * general error or a Json::Exception if the json configuration is erroneous.  The returned
-  * callback should always be initialized.
-  * @param type supplies type of filter to initialize (decoder, encoder, or both)
-  * @param config supplies the general json configuration for the filter
-  * @param stat_prefix prefix for stat logging
-  * @param server supplies the server instance
-  */
-  virtual HttpFilterFactoryCb createFilterFactory(HttpFilterType type, const Json::Object& config,
-                                                  const std::string& stat_prefix,
-                                                  Server::Instance& server) PURE;
-
-  /**
-  * Returns the identifying name for a particular implementation of an http filter produced by the
-  * factory.
-  */
-  virtual std::string name() PURE;
 };
 
 /**
@@ -106,7 +70,7 @@ class HttpConnectionManagerConfig : Logger::Loggable<Logger::Id::config>,
                                     public Http::ConnectionManagerConfig,
                                     Json::Validator {
 public:
-  HttpConnectionManagerConfig(const Json::Object& config, Server::Instance& server);
+  HttpConnectionManagerConfig(const Json::Object& config, FactoryContext& context);
 
   // Http::FilterChainFactory
   void createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) override;
@@ -188,7 +152,7 @@ private:
 
   HttpFilterType stringToType(const std::string& type);
 
-  Server::Instance& server_;
+  FactoryContext& context_;
   std::list<HttpFilterFactoryCb> filter_factories_;
   std::list<Http::AccessLog::InstanceSharedPtr> access_logs_;
   const std::string stats_prefix_;

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -3,38 +3,33 @@
 #include <string>
 
 #include "envoy/network/connection.h"
-#include "envoy/server/instance.h"
 
 #include "common/json/config_schemas.h"
 #include "common/mongo/proxy.h"
+
+#include "server/configuration_impl.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-NetworkFilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactory(
-    NetworkFilterType type, const Json::Object& config, Server::Instance& server) {
-  if (type != NetworkFilterType::Both) {
-    throw EnvoyException(fmt::format(
-        "{} network filter must be configured as both a read and write filter.", name()));
-  }
-
+NetworkFilterFactoryCb
+MongoProxyFilterConfigFactory::createFilterFactory(const Json::Object& config,
+                                                   FactoryContext& context) {
   config.validateSchema(Json::Schema::MONGO_PROXY_NETWORK_FILTER_SCHEMA);
 
   std::string stat_prefix = "mongo." + config.getString("stat_prefix") + ".";
   Mongo::AccessLogSharedPtr access_log;
   if (config.hasObject("access_log")) {
     access_log.reset(
-        new Mongo::AccessLog(config.getString("access_log"), server.accessLogManager()));
+        new Mongo::AccessLog(config.getString("access_log"), context.accessLogManager()));
   }
 
-  return [stat_prefix, &server, access_log](Network::FilterManager& filter_manager) -> void {
+  return [stat_prefix, &context, access_log](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(Network::FilterSharedPtr{
-        new Mongo::ProdProxyFilter(stat_prefix, server.stats(), server.runtime(), access_log)});
+        new Mongo::ProdProxyFilter(stat_prefix, context.scope(), context.runtime(), access_log)});
   };
 }
-
-std::string MongoProxyFilterConfigFactory::name() { return "mongo_proxy"; }
 
 /**
  * Static registration for the mongo filter. @see RegisterNamedNetworkFilterConfigFactory.

--- a/source/server/config/network/mongo_proxy.h
+++ b/source/server/config/network/mongo_proxy.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/configuration_impl.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -14,10 +14,11 @@ namespace Configuration {
 class MongoProxyFilterConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type, const Json::Object& config,
-                                             Server::Instance& server) override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                             FactoryContext& context) override;
 
-  std::string name() override;
+  std::string name() override { return "mongo_proxy"; }
+  NetworkFilterType type() override { return NetworkFilterType::Both; }
 };
 
 } // Configuration

--- a/source/server/config/network/ratelimit.h
+++ b/source/server/config/network/ratelimit.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/configuration_impl.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -14,11 +14,10 @@ namespace Configuration {
 class RateLimitConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type,
-                                             const Json::Object& json_config,
-                                             Server::Instance& server) override;
-
-  std::string name() override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
+                                             FactoryContext& context) override;
+  std::string name() override { return "ratelimit"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // Configuration

--- a/source/server/config/network/redis_proxy.cc
+++ b/source/server/config/network/redis_proxy.cc
@@ -8,25 +8,23 @@
 #include "common/redis/conn_pool_impl.h"
 #include "common/redis/proxy_filter.h"
 
+#include "server/configuration_impl.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-NetworkFilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactory(
-    NetworkFilterType type, const Json::Object& config, Server::Instance& server) {
-  if (type != NetworkFilterType::Read) {
-    throw EnvoyException(
-        fmt::format("{} network filter must be configured as a read filter.", name()));
-  }
-
-  Redis::ProxyFilterConfigSharedPtr filter_config(
-      std::make_shared<Redis::ProxyFilterConfig>(config, server.clusterManager(), server.stats()));
+NetworkFilterFactoryCb
+RedisProxyFilterConfigFactory::createFilterFactory(const Json::Object& config,
+                                                   FactoryContext& context) {
+  Redis::ProxyFilterConfigSharedPtr filter_config(std::make_shared<Redis::ProxyFilterConfig>(
+      config, context.clusterManager(), context.scope()));
   Redis::ConnPool::InstancePtr conn_pool(
-      new Redis::ConnPool::InstanceImpl(filter_config->clusterName(), server.clusterManager(),
+      new Redis::ConnPool::InstanceImpl(filter_config->clusterName(), context.clusterManager(),
                                         Redis::ConnPool::ClientFactoryImpl::instance_,
-                                        server.threadLocal(), *config.getObject("conn_pool")));
+                                        context.threadLocal(), *config.getObject("conn_pool")));
   std::shared_ptr<Redis::CommandSplitter::Instance> splitter(
-      new Redis::CommandSplitter::InstanceImpl(std::move(conn_pool), server.stats(),
+      new Redis::CommandSplitter::InstanceImpl(std::move(conn_pool), context.scope(),
                                                filter_config->statPrefix()));
   return [splitter, filter_config](Network::FilterManager& filter_manager) -> void {
     Redis::DecoderFactoryImpl factory;
@@ -34,8 +32,6 @@ NetworkFilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactory(
         factory, Redis::EncoderPtr{new Redis::EncoderImpl()}, *splitter, filter_config));
   };
 }
-
-std::string RedisProxyFilterConfigFactory::name() { return "redis_proxy"; }
 
 /**
  * Static registration for the redis filter. @see RegisterNamedNetworkFilterConfigFactory.

--- a/source/server/config/network/redis_proxy.h
+++ b/source/server/config/network/redis_proxy.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/configuration_impl.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -14,9 +14,10 @@ namespace Configuration {
 class RedisProxyFilterConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type, const Json::Object& config,
-                                             Server::Instance& server) override;
-  std::string name() override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                             FactoryContext& context) override;
+  std::string name() override { return "redis_proxy"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // Configuration

--- a/source/server/config/network/tcp_proxy.h
+++ b/source/server/config/network/tcp_proxy.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/configuration_impl.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Server {
@@ -14,9 +14,10 @@ namespace Configuration {
 class TcpProxyConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type, const Json::Object& config,
-                                             Server::Instance& server) override;
-  std::string name() override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+                                             FactoryContext& context) override;
+  std::string name() override { return "tcp_proxy"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // Configuration

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -33,8 +33,7 @@ bool FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager
   return filter_manager.initializeReadFilters();
 }
 
-MainImpl::MainImpl(Server::Instance& server,
-                   Upstream::ClusterManagerFactory& cluster_manager_factory)
+MainImpl::MainImpl(Instance& server, Upstream::ClusterManagerFactory& cluster_manager_factory)
     : server_(server), cluster_manager_factory_(cluster_manager_factory) {}
 
 void MainImpl::initialize(const Json::Object& json) {
@@ -46,8 +45,7 @@ void MainImpl::initialize(const Json::Object& json) {
   log().info("loading {} listener(s)", listeners.size());
   for (size_t i = 0; i < listeners.size(); i++) {
     log().info("listener #{}:", i);
-    listeners_.emplace_back(
-        Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
+    listeners_.emplace_back(ListenerPtr{new ListenerConfig(server_, *listeners[i])});
   }
 
   if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {
@@ -131,9 +129,9 @@ void MainImpl::initializeTracers(const Json::Object& configuration) {
   }
 }
 
-const std::list<Server::Configuration::ListenerPtr>& MainImpl::listeners() { return listeners_; }
+const std::list<ListenerPtr>& MainImpl::listeners() { return listeners_; }
 
-MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) : parent_(parent) {
+MainImpl::ListenerConfig::ListenerConfig(Instance& server, Json::Object& json) : server_(server) {
   address_ = Network::Utility::resolveUrl(json.getString("address"));
 
   // ':' is a reserved char in statsd. Do the translation here to avoid costly inline translations
@@ -141,15 +139,14 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
   std::string final_stat_name = fmt::format("listener.{}.", address_->asString());
   std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
 
-  scope_ = parent_.server_.stats().createScope(final_stat_name);
+  scope_ = server.stats().createScope(final_stat_name);
   log().info("  address={}", address_->asString());
 
   json.validateSchema(Json::Schema::LISTENER_SCHEMA);
 
   if (json.hasObject("ssl_context")) {
     Ssl::ContextConfigImpl context_config(*json.getObject("ssl_context"));
-    ssl_context_ =
-        parent_.server_.sslContextManager().createSslServerContext(*scope_, context_config);
+    ssl_context_ = server.sslContextManager().createSslServerContext(*scope_, context_config);
   }
 
   bind_to_port_ = json.getBoolean("bind_to_port", true);
@@ -180,9 +177,8 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
 
     // Now see if there is a factory that will accept the config.
     auto search_it = namedFilterConfigFactories().find(string_name);
-    if (search_it != namedFilterConfigFactories().end()) {
-      NetworkFilterFactoryCb callback =
-          search_it->second->createFilterFactory(type, *config, parent_.server_);
+    if (search_it != namedFilterConfigFactories().end() && search_it->second->type() == type) {
+      NetworkFilterFactoryCb callback = search_it->second->createFilterFactory(*config, *this);
       filter_factories_.push_back(callback);
     } else {
       // DEPRECATED
@@ -190,7 +186,7 @@ MainImpl::ListenerConfig::ListenerConfig(MainImpl& parent, Json::Object& json) :
       bool found_filter = false;
       for (NetworkFilterConfigFactory* config_factory : filterConfigFactories()) {
         NetworkFilterFactoryCb callback =
-            config_factory->tryCreateFilterFactory(type, string_name, *config, parent_.server_);
+            config_factory->tryCreateFilterFactory(type, string_name, *config, server);
         if (callback) {
           filter_factories_.push_back(callback);
           found_filter = true;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -44,14 +44,8 @@ void MainImpl::initialize(const Json::Object& json) {
   std::vector<Json::ObjectSharedPtr> listeners = json.getObjectArray("listeners");
   LOG(info, "loading {} listener(s)", listeners.size());
   for (size_t i = 0; i < listeners.size(); i++) {
-<<<<<<< HEAD
-    log().info("listener #{}:", i);
-    listeners_.emplace_back(ListenerPtr{new ListenerConfig(server_, *listeners[i])});
-=======
     LOG(info, "listener #{}:", i);
-    listeners_.emplace_back(
-        Server::Configuration::ListenerPtr{new ListenerConfig(*this, *listeners[i])});
->>>>>>> origin/master
+    listeners_.emplace_back(ListenerPtr{new ListenerConfig(server_, *listeners[i])});
   }
 
   if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -12,6 +12,7 @@
 #include "envoy/http/filter.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/configuration.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/server/instance.h"
 #include "envoy/tracing/http_tracer.h"
 
@@ -22,15 +23,6 @@
 namespace Envoy {
 namespace Server {
 namespace Configuration {
-
-enum class NetworkFilterType { Read, Write, Both };
-
-/**
- * This lambda is used to wrap the creation of a network filter chain for new connections as they
- * come in. Filter factories create the lambda at configuration initialization time, and then they
- * are used at runtime. This maps JSON -> runtime configuration.
- */
-typedef std::function<void(Network::FilterManager& filter_manager)> NetworkFilterFactoryCb;
 
 /**
  * DEPRECATED - Implemented by each network filter and registered via
@@ -43,35 +35,7 @@ public:
   virtual NetworkFilterFactoryCb tryCreateFilterFactory(NetworkFilterType type,
                                                         const std::string& name,
                                                         const Json::Object& config,
-                                                        Server::Instance& server) PURE;
-};
-
-/**
- * Implemented by each network filter and registered via registerNamedNetworkFilterConfigFactory()
- * or the convenience class RegisterNamedNetworkFilterConfigFactory.
- */
-class NamedNetworkFilterConfigFactory {
-public:
-  virtual ~NamedNetworkFilterConfigFactory() {}
-
-  /**
-   * Create a particular network filter factory implementation.  If the implementation is unable to
-   * produce a factory with the provided parameters, it should throw an EnvoyException in the case
-   * of general error or a Json::Exception if the json configuration is erroneous.  The returned
-   * callback should always be initialized.
-   * @param type supplies type of filter to initialize (read, write, or both)
-   * @param config supplies the general json configuration for the filter
-   * @param server supplies the server instance
-   */
-  virtual NetworkFilterFactoryCb createFilterFactory(NetworkFilterType type,
-                                                     const Json::Object& config,
-                                                     Server::Instance& server) PURE;
-
-  /**
-  * Returns the identifying name for a particular implementation of a network filter produced by
-  * the factory.
-  */
-  virtual std::string name() PURE;
+                                                        Instance& server) PURE;
 };
 
 /**
@@ -91,8 +55,7 @@ public:
   * @param server supplies the server instance
   * @param cluster_manager supplies the cluster_manager instance
   */
-  virtual Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
-                                                  Server::Instance& server,
+  virtual Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config, Instance& server,
                                                   Upstream::ClusterManager& cluster_manager) PURE;
 
   /**
@@ -120,7 +83,7 @@ public:
  */
 class MainImpl : Logger::Loggable<Logger::Id::config>, public Main {
 public:
-  MainImpl(Server::Instance& server, Upstream::ClusterManagerFactory& cluster_manager_factory_);
+  MainImpl(Instance& server, Upstream::ClusterManagerFactory& cluster_manager_factory_);
 
   /**
    * DEPRECATED - Register an NetworkFilterConfigFactory implementation as an option to create
@@ -199,10 +162,11 @@ private:
   /**
    * Maps JSON config to runtime config for a listener with network filter chain.
    */
-  class ListenerConfig : public Server::Configuration::Listener,
+  class ListenerConfig : public Listener,
+                         public FactoryContext,
                          public Network::FilterChainFactory {
   public:
-    ListenerConfig(MainImpl& parent, Json::Object& json);
+    ListenerConfig(Instance& server, Json::Object& json);
 
     // Server::Configuration::Listener
     Network::FilterChainFactory& filterChainFactory() override { return *this; }
@@ -212,13 +176,31 @@ private:
     bool useProxyProto() override { return use_proxy_proto_; }
     bool useOriginalDst() override { return use_original_dst_; }
     uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
+
+    // Server::Configuration::FactoryContext
+    AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
+    Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
+    Event::Dispatcher& dispatcher() override { return server_.dispatcher(); }
+    DrainManager& drainManager() override { return server_.drainManager(); }
+    bool healthCheckFailed() override { return server_.healthCheckFailed(); }
+    Tracing::HttpTracer& httpTracer() override { return server_.httpTracer(); }
+    Init::Manager& initManager() override { return server_.initManager(); }
+    const LocalInfo::LocalInfo& localInfo() override { return server_.localInfo(); }
+    Envoy::Runtime::RandomGenerator& random() override { return server_.random(); }
+    RateLimit::ClientPtr
+    rateLimitClient(const Optional<std::chrono::milliseconds>& timeout) override {
+      return server_.rateLimitClient(timeout);
+    }
+    Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
+    Instance& server() override { return server_; }
     Stats::Scope& scope() override { return *scope_; }
+    ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
 
     // Network::FilterChainFactory
     bool createFilterChain(Network::Connection& connection) override;
 
   private:
-    MainImpl& parent_;
+    Instance& server_;
     Network::Address::InstanceConstSharedPtr address_;
     bool bind_to_port_{};
     Stats::ScopePtr scope_;
@@ -258,11 +240,11 @@ private:
     return *http_tracer_factories;
   }
 
-  Server::Instance& server_;
+  Instance& server_;
   Upstream::ClusterManagerFactory& cluster_manager_factory_;
   std::unique_ptr<Upstream::ClusterManager> cluster_manager_;
   Tracing::HttpTracerPtr http_tracer_;
-  std::list<Server::Configuration::ListenerPtr> listeners_;
+  std::list<ListenerPtr> listeners_;
   Optional<std::string> statsd_tcp_cluster_name_;
   Optional<uint32_t> statsd_udp_port_;
   Optional<std::string> statsd_udp_ip_address_;

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -57,7 +57,6 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/http:header_map_interface",
-        "//include/envoy/server:instance_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:enum_to_int",
         "//source/common/http:codes_lib",

--- a/test/common/dynamo/dynamo_filter_test.cc
+++ b/test/common/dynamo/dynamo_filter_test.cc
@@ -35,6 +35,8 @@ public:
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
   }
 
+  ~DynamoFilterTest() { filter_->onDestroy(); }
+
   std::unique_ptr<DynamoFilter> filter_;
   NiceMock<Runtime::MockLoader> loader_;
   std::string stat_prefix_{"prefix."};

--- a/test/common/grpc/http1_bridge_filter_test.cc
+++ b/test/common/grpc/http1_bridge_filter_test.cc
@@ -27,6 +27,8 @@ public:
     ON_CALL(decoder_callbacks_.request_info_, protocol()).WillByDefault(ReturnPointee(&protocol_));
   }
 
+  ~GrpcHttp1BridgeFilterTest() { filter_.onDestroy(); }
+
   NiceMock<Upstream::MockClusterManager> cm_;
   Http1BridgeFilter filter_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -16,6 +16,7 @@ envoy_cc_mock(
         "//include/envoy/server:admin_interface",
         "//include/envoy/server:configuration_interface",
         "//include/envoy/server:drain_manager_interface",
+        "//include/envoy/server:filter_config_interface",
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/ssl:context_manager_interface",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -5,13 +5,13 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 using testing::_;
 using testing::Return;
 using testing::ReturnNew;
 using testing::ReturnRef;
 using testing::SaveArg;
 
+namespace Envoy {
 namespace Server {
 
 MockOptions::MockOptions(const std::string& config_path)
@@ -53,6 +53,7 @@ MockInstance::MockInstance() : ssl_context_manager_(runtime_loader_) {
 MockInstance::~MockInstance() {}
 
 namespace Configuration {
+
 MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
     : wd_miss_(wd_miss), wd_megamiss_(wd_megamiss), wd_kill_(wd_kill), wd_multikill_(wd_multikill) {
   ON_CALL(*this, wdMissTimeout()).WillByDefault(Return(wd_miss_));
@@ -60,7 +61,24 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
   ON_CALL(*this, wdKillTimeout()).WillByDefault(Return(wd_kill_));
   ON_CALL(*this, wdMultiKillTimeout()).WillByDefault(Return(wd_multikill_));
 }
-} // Configuration
 
+MockFactoryContext::MockFactoryContext() {
+  ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
+  ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
+  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
+  ON_CALL(*this, drainManager()).WillByDefault(ReturnRef(drain_manager_));
+  ON_CALL(*this, httpTracer()).WillByDefault(ReturnRef(http_tracer_));
+  ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
+  ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
+  ON_CALL(*this, random()).WillByDefault(ReturnRef(random_));
+  ON_CALL(*this, runtime()).WillByDefault(ReturnRef(runtime_loader_));
+  ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
+  ON_CALL(*this, server()).WillByDefault(ReturnRef(server_));
+  ON_CALL(*this, threadLocal()).WillByDefault(ReturnRef(thread_local_));
+}
+
+MockFactoryContext::~MockFactoryContext() {}
+
+} // Configuration
 } // Server
 } // Envoy

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -8,6 +8,7 @@
 #include "envoy/server/admin.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/drain_manager.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
 #include "envoy/ssl/context_manager.h"
@@ -34,8 +35,6 @@
 #include "spdlog/spdlog.h"
 
 namespace Envoy {
-using testing::NiceMock;
-
 namespace Server {
 
 class MockOptions : public Options {
@@ -166,6 +165,7 @@ class MockMain : public Main {
 public:
   MockMain() : MockMain(0, 0, 0, 0) {}
   MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill);
+
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
   MOCK_METHOD0(listeners, std::list<ListenerPtr>&());
@@ -183,6 +183,44 @@ public:
   std::chrono::milliseconds wd_megamiss_;
   std::chrono::milliseconds wd_kill_;
   std::chrono::milliseconds wd_multikill_;
+};
+
+class MockFactoryContext : public FactoryContext {
+public:
+  MockFactoryContext();
+  ~MockFactoryContext();
+
+  RateLimit::ClientPtr rateLimitClient(const Optional<std::chrono::milliseconds>&) override {
+    return RateLimit::ClientPtr{rateLimitClient_()};
+  }
+
+  MOCK_METHOD0(accessLogManager, AccessLog::AccessLogManager&());
+  MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
+  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+  MOCK_METHOD0(drainManager, DrainManager&());
+  MOCK_METHOD0(healthCheckFailed, bool());
+  MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
+  MOCK_METHOD0(initManager, Init::Manager&());
+  MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
+  MOCK_METHOD0(random, Envoy::Runtime::RandomGenerator&());
+  MOCK_METHOD0(rateLimitClient_, RateLimit::Client*());
+  MOCK_METHOD0(runtime, Envoy::Runtime::Loader&());
+  MOCK_METHOD0(scope, Stats::Scope&());
+  MOCK_METHOD0(server, Instance&());
+  MOCK_METHOD0(threadLocal, ThreadLocal::Instance&());
+
+  testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
+  testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
+  testing::NiceMock<Event::MockDispatcher> dispatcher_;
+  testing::NiceMock<MockDrainManager> drain_manager_;
+  testing::NiceMock<Tracing::MockHttpTracer> http_tracer_;
+  testing::NiceMock<Init::MockManager> init_manager_;
+  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  testing::NiceMock<Envoy::Runtime::MockRandomGenerator> random_;
+  testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;
+  Stats::IsolatedStoreImpl scope_;
+  testing::NiceMock<MockInstance> server_;
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 } // Configuration

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -10,6 +10,7 @@
 #include "server/config/http/ratelimit.h"
 #include "server/config/http/router.h"
 #include "server/config/http/zipkin_http_tracer.h"
+#include "server/config/network/http_connection_manager.h"
 #include "server/http/health_check.h"
 
 #include "test/mocks/server/mocks.h"
@@ -35,10 +36,10 @@ TEST(HttpFilterConfigTest, BufferFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   BufferFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -53,10 +54,9 @@ TEST(HttpFilterConfigTest, BadBufferFilterConfig) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   BufferFilterConfig factory;
-  EXPECT_THROW(factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server),
-               Json::Exception);
+  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
 }
 
 TEST(HttpFilterConfigTest, DynamoFilter) {
@@ -66,10 +66,10 @@ TEST(HttpFilterConfigTest, DynamoFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   DynamoFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Both, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Both, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -87,10 +87,10 @@ TEST(HttpFilterConfigTest, FaultFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   FaultFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -103,10 +103,10 @@ TEST(HttpFilterConfigTest, GrpcHttp1BridgeFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   GrpcHttp1BridgeFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Both, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Both, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -119,10 +119,10 @@ TEST(HttpFilterConfigTest, GrpcWebFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   GrpcWebFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Both, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Both, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -137,10 +137,10 @@ TEST(HttpFilterConfigTest, HealthCheckFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   HealthCheckFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Both, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Both, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -156,10 +156,9 @@ TEST(HttpFilterConfigTest, BadHealthCheckFilterConfig) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   HealthCheckFilterConfig factory;
-  EXPECT_THROW(factory.createFilterFactory(HttpFilterType::Both, *json_config, "stats", server),
-               Json::Exception);
+  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
 }
 
 TEST(HttpFilterConfigTest, RouterFilter) {
@@ -170,10 +169,10 @@ TEST(HttpFilterConfigTest, RouterFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   RouterFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -188,10 +187,9 @@ TEST(HttpFilterConfigTest, BadRouterFilterConfig) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   RouterFilterConfig factory;
-  EXPECT_THROW(factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server),
-               Json::Exception);
+  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
 }
 
 TEST(HttpFilterConfigTest, IpTaggingFilter) {
@@ -207,10 +205,10 @@ TEST(HttpFilterConfigTest, IpTaggingFilter) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   IpTaggingFilterConfig factory;
-  HttpFilterFactoryCb cb =
-      factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server);
+  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -228,10 +226,9 @@ TEST(HttpFilterConfigTest, BadIpTaggingFilterConfig) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   IpTaggingFilterConfig factory;
-  EXPECT_THROW(factory.createFilterFactory(HttpFilterType::Decoder, *json_config, "stats", server),
-               Json::Exception);
+  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
 }
 
 TEST(HttpFilterConfigTest, DoubleRegistrationTest) {

--- a/test/server/config/network/BUILD
+++ b/test/server/config/network/BUILD
@@ -32,5 +32,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/server/config/network:http_connection_manager_lib",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -34,10 +34,10 @@ TEST(NetworkFilterConfigTest, RedisProxy) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
-  NetworkFilterFactoryCb cb =
-      factory.createFilterFactory(NetworkFilterType::Read, *json_config, server);
+  EXPECT_EQ(NetworkFilterType::Read, factory.type());
+  NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
@@ -52,10 +52,10 @@ TEST(NetworkFilterConfigTest, MongoProxy) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   MongoProxyFilterConfigFactory factory;
-  NetworkFilterFactoryCb cb =
-      factory.createFilterFactory(NetworkFilterType::Both, *json_config, server);
+  EXPECT_EQ(NetworkFilterType::Both, factory.type());
+  NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addFilter(_));
   cb(connection);
@@ -71,10 +71,9 @@ TEST(NetworkFilterConfigTest, BadMongoProxyConfig) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   MongoProxyFilterConfigFactory factory;
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Both, *json_config, server),
-               Json::Exception);
+  EXPECT_THROW(factory.createFilterFactory(*json_config, context), Json::Exception);
 }
 
 TEST(NetworkFilterConfigTest, TcpProxy) {
@@ -106,16 +105,15 @@ TEST(NetworkFilterConfigTest, TcpProxy) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   TcpProxyConfigFactory factory;
-  NetworkFilterFactoryCb cb =
-      factory.createFilterFactory(NetworkFilterType::Read, *json_config, server);
+  EXPECT_EQ(NetworkFilterType::Read, factory.type());
+  NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
 
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Both, *json_config, server),
-               EnvoyException);
+  factory.createFilterFactory(*json_config, context);
 }
 
 TEST(NetworkFilterConfigTest, ClientSslAuth) {
@@ -128,10 +126,10 @@ TEST(NetworkFilterConfigTest, ClientSslAuth) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   ClientSslAuthConfigFactory factory;
-  NetworkFilterFactoryCb cb =
-      factory.createFilterFactory(NetworkFilterType::Read, *json_config, server);
+  EXPECT_EQ(NetworkFilterType::Read, factory.type());
+  NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
@@ -147,10 +145,10 @@ TEST(NetworkFilterConfigTest, Ratelimit) {
   )EOF";
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<MockInstance> server;
+  NiceMock<MockFactoryContext> context;
   RateLimitConfigFactory factory;
-  NetworkFilterFactoryCb cb =
-      factory.createFilterFactory(NetworkFilterType::Read, *json_config, server);
+  EXPECT_EQ(NetworkFilterType::Read, factory.type());
+  NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
@@ -181,9 +179,8 @@ TEST(NetworkFilterConfigTest, BadHttpConnectionMangerConfig) {
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
-  NiceMock<MockInstance> server;
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Read, *json_config, server),
-               Json::Exception);
+  NiceMock<MockFactoryContext> context;
+  EXPECT_THROW(factory.createFilterFactory(*json_config, context), Json::Exception);
 }
 
 TEST(NetworkFilterConfigTest, BadAccessLogConfig) {
@@ -223,9 +220,8 @@ TEST(NetworkFilterConfigTest, BadAccessLogConfig) {
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
-  NiceMock<MockInstance> server;
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Read, *json_config, server),
-               Json::Exception);
+  NiceMock<MockFactoryContext> context;
+  EXPECT_THROW(factory.createFilterFactory(*json_config, context), Json::Exception);
 }
 
 TEST(NetworkFilterConfigTest, BadAccessLogType) {
@@ -267,9 +263,8 @@ TEST(NetworkFilterConfigTest, BadAccessLogType) {
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
-  NiceMock<MockInstance> server;
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Read, *json_config, server),
-               Json::Exception);
+  NiceMock<MockFactoryContext> context;
+  EXPECT_THROW(factory.createFilterFactory(*json_config, context), Json::Exception);
 }
 
 TEST(NetworkFilterConfigTest, BadAccessLogNestedTypes) {
@@ -321,9 +316,8 @@ TEST(NetworkFilterConfigTest, BadAccessLogNestedTypes) {
 
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   HttpConnectionManagerFilterConfigFactory factory;
-  NiceMock<MockInstance> server;
-  EXPECT_THROW(factory.createFilterFactory(NetworkFilterType::Read, *json_config, server),
-               Json::Exception);
+  NiceMock<MockFactoryContext> context;
+  EXPECT_THROW(factory.createFilterFactory(*json_config, context), Json::Exception);
 }
 
 /**
@@ -382,8 +376,8 @@ TEST(NetworkFilterConfigTest, DeprecatedHttpFilterConfigFactoryTest) {
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
 
   HttpConnectionManagerFilterConfigFactory factory;
-  NiceMock<Server::MockInstance> server;
-  factory.createFilterFactory(NetworkFilterType::Read, *loader, server);
+  NiceMock<MockFactoryContext> context;
+  factory.createFilterFactory(*loader, context);
 }
 
 TEST(NetworkFilterConfigTest, DoubleRegistrationTest) {

--- a/test/server/config/network/http_connection_manager_test.cc
+++ b/test/server/config/network/http_connection_manager_test.cc
@@ -3,7 +3,9 @@
 #include "server/config/network/http_connection_manager.h"
 
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/server/mocks.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -13,6 +15,39 @@ using testing::Return;
 
 namespace Server {
 namespace Configuration {
+
+TEST(HttpConnectionManagerConfigTest, invalidFilter) {
+  std::string json_string = R"EOF(
+  {
+    "codec_type": "http1",
+    "stat_prefix": "router",
+    "route_config":
+    {
+      "virtual_hosts": [
+        {
+          "name": "service",
+          "domains": [ "*" ],
+          "routes": [
+            {
+              "prefix": "/",
+              "cluster": "cluster"
+            }
+          ]
+        }
+      ]
+    },
+    "filters": [
+      { "type": "encoder", "name": "foo", "config": {}
+      }
+    ]
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
+  NiceMock<MockFactoryContext> context;
+  EXPECT_THROW_WITH_MESSAGE(HttpConnectionManagerConfig(*json_config, context), EnvoyException,
+                            "unable to create http filter factory for 'foo'/'encoder'");
+}
 
 TEST(HttpConnectionManagerConfigUtilityTest, determineNextProtocol) {
   {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -289,7 +289,7 @@ TEST_F(ConfigurationImplTest, BadFilterName) {
         "address": "tcp://127.0.0.1:1234",
         "filters": [
           {
-            "type" : "read",
+            "type" : "write",
             "name" : "invalid",
             "config" : {}
           }
@@ -306,7 +306,7 @@ TEST_F(ConfigurationImplTest, BadFilterName) {
 
   MainImpl config(server_, cluster_manager_factory_);
   EXPECT_THROW_WITH_MESSAGE(config.initialize(*loader), EnvoyException,
-                            "unable to create filter factory for 'invalid'/'read'");
+                            "unable to create filter factory for 'invalid'/'write'");
 }
 
 TEST_F(ConfigurationImplTest, ServiceClusterNotSetWhenLSTracing) {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -309,6 +309,34 @@ TEST_F(ConfigurationImplTest, BadFilterName) {
                             "unable to create filter factory for 'invalid'/'write'");
 }
 
+TEST_F(ConfigurationImplTest, BadFilterType) {
+  std::string json = R"EOF(
+  {
+    "listeners" : [
+      {
+        "address": "tcp://127.0.0.1:1234",
+        "filters": [
+          {
+            "type" : "write",
+            "name" : "echo",
+            "config" : {}
+          }
+        ]
+      }
+    ],
+    "cluster_manager": {
+      "clusters": []
+    }
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+
+  MainImpl config(server_, cluster_manager_factory_);
+  EXPECT_THROW_WITH_MESSAGE(config.initialize(*loader), EnvoyException,
+                            "unable to create filter factory for 'echo'/'write'");
+}
+
 TEST_F(ConfigurationImplTest, ServiceClusterNotSetWhenLSTracing) {
   std::string json = R"EOF(
   {


### PR DESCRIPTION
For LDS, we need to plumb a stats scope through to all of the filter
factory creation functions. This commit takes the opportunity to no
longer pass the full server and instead passes a new FactoryContext
interface which will allow us to more easily alter what is seen by
filters in the future. While making the same breaking change, I
took the opportunity to encode the type of filter into the registration
which removes a ton of boilerplate from various places. (We have
decided to remove the ability to explicitly configure filter type in the
v2 API).

Though this is a breaking change, since we
are still in the 1.4.0 release cycle I will not be deprecating
the new network/http filter registration functions that were
added during this cycle.

This commit also improves some related coverage and gets us up to
around 98.2%. I will do a follow up change with some other easy
coverage wins that I notice.