### PR TITLE
Set DNS request timeout timer.

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -183,6 +183,9 @@ ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
     // example, localhost lookup.
     return nullptr;
   } else {
+    // Enable timer to wake us up if the request times out.
+    updateAresTimer();
+
     // The PendingResolution will self-delete when the request completes
     // (including if cancelled or if ~DnsResolverImpl() happens).
     pending_resolution->owned_ = true;

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/network/dns.h"
 
 #include "common/common/linked_object.h"
+#include "common/common/logger.h"
 #include "common/common/utility.h"
 
 #include "ares.h"
@@ -24,7 +25,7 @@ class DnsResolverImplPeer;
  * Implementation of DnsResolver that uses c-ares. All calls and callbacks are assumed to
  * happen on the thread that owns the creating dispatcher.
  */
-class DnsResolverImpl : public DnsResolver {
+class DnsResolverImpl : public DnsResolver, protected Logger::Loggable<Logger::Id::upstream> {
 public:
   DnsResolverImpl(Event::Dispatcher& dispatcher,
                   const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers);
@@ -50,9 +51,10 @@ private:
     /**
      * c-ares ares_gethostbyname() query callback.
      * @param status return status of call to ares_gethostbyname.
+     * @param timeouts the number of times the request timed out.
      * @param hostent structure that stores information about a given host.
      */
-    void onAresHostCallback(int status, hostent* hostent);
+    void onAresHostCallback(int status, int timeouts, hostent* hostent);
     /**
      * wrapper function of call to ares_gethostbyname.
      * @param family currently AF_INET and AF_INET6 are supported.


### PR DESCRIPTION
Running the google_com_proxy.json example, refreshing of the DNS resolution for google.com initially happens every 5 seconds, but then stops. The number of queries completed varies from run to run, for example:

```
$ bazel-out/local-fastbuild/bin/source/exe/envoy-static -c configs/google_com_proxy.json -l debug
[2017-06-12 11:21:58.716][5420][warning][main] initializing epoch 0 (hot restart version=8.2490552)
[2017-06-12 11:21:58.717][5420][info][main] admin address: 127.0.0.1:9901
[2017-06-12 11:21:58.720][5420][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 11:21:58.720][5420][info][upstream] cm init: adding: cluster=service_google primary=1 secondary=0
[2017-06-12 11:21:58.720][5420][info][config] loading 1 listener(s)
[2017-06-12 11:21:58.721][5420][info][config] listener #0:
[2017-06-12 11:21:58.721][5420][info][config]   address=127.0.0.1:10000
[2017-06-12 11:21:58.721][5420][info][config]   filter #0:
[2017-06-12 11:21:58.721][5420][info][config]     type: read
[2017-06-12 11:21:58.721][5420][info][config]     name: http_connection_manager
[2017-06-12 11:21:58.723][5420][info][config]     filter #0
[2017-06-12 11:21:58.724][5420][info][config]       type: decoder
[2017-06-12 11:21:58.724][5420][info][config]       name: router
[2017-06-12 11:21:58.724][5420][info][config] loading tracing configuration
[2017-06-12 11:21:58.724][5420][warning][main] starting main dispatch loop
[2017-06-12 11:21:58.744][5420][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 11:21:58.744][5420][info][upstream] cm init: removing: cluster=service_google primary=0 secondary=0
[2017-06-12 11:21:58.744][5420][warning][main] all clusters initialized. initializing init manager
[2017-06-12 11:21:58.744][5420][warning][main] all dependencies initialized. starting workers
[2017-06-12 11:21:58.744][5422][info][main] worker entering dispatch loop
[2017-06-12 11:21:58.744][5424][info][main] worker entering dispatch loop
[2017-06-12 11:21:58.745][5423][info][main] worker entering dispatch loop
[2017-06-12 11:21:58.745][5425][info][main] worker entering dispatch loop
[2017-06-12 11:22:03.726][5420][debug][main] flushing stats
[2017-06-12 11:22:03.753][5420][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 11:22:03.969][5420][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 11:22:08.727][5420][debug][main] flushing stats
[2017-06-12 11:22:08.973][5420][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 11:22:09.064][5420][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 11:22:13.727][5420][debug][main] flushing stats
[2017-06-12 11:22:14.074][5420][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 11:22:18.754][5420][debug][main] flushing stats
[2017-06-12 11:22:23.756][5420][debug][main] flushing stats
[2017-06-12 11:22:28.760][5420][debug][main] flushing stats
[2017-06-12 11:22:33.765][5420][debug][main] flushing stats
[2017-06-12 11:22:38.765][5420][debug][main] flushing stats
[2017-06-12 11:22:43.776][5420][debug][main] flushing stats
[2017-06-12 11:22:48.780][5420][debug][main] flushing stats
[2017-06-12 11:22:53.785][5420][debug][main] flushing stats
[2017-06-12 11:22:58.793][5420][debug][main] flushing stats
^C
```

Typically the resolution result appears after a fraction of a second after the query, but if there is no immediate response resolution stops completely, as if there is no timeout for non-response.

The first commit adds debugging, and still produces the output above. The second commit adds a new call to updateAresTimer() right after an asynchronous DNS request has been made. With this change the output is like this:

```
$ bazel-out/local-fastbuild/bin/source/exe/envoy-static -c configs/google_com_proxy.json -l debug
[2017-06-12 14:51:01.948][12968][warning][main] initializing epoch 0 (hot restart version=8.2490552)
[2017-06-12 14:51:01.950][12968][info][main] admin address: 127.0.0.1:9901
[2017-06-12 14:51:01.951][12968][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 14:51:01.952][12968][debug][upstream] Setting DNS resolution timer for 5000 milliseconds
[2017-06-12 14:51:01.952][12968][info][upstream] cm init: adding: cluster=service_google primary=1 secondary=0
[2017-06-12 14:51:01.952][12968][info][config] loading 1 listener(s)
[2017-06-12 14:51:01.952][12968][info][config] listener #0:
[2017-06-12 14:51:01.952][12968][info][config]   address=127.0.0.1:10000
[2017-06-12 14:51:01.952][12968][info][config]   filter #0:
[2017-06-12 14:51:01.953][12968][info][config]     type: read
[2017-06-12 14:51:01.953][12968][info][config]     name: http_connection_manager
[2017-06-12 14:51:01.955][12968][info][config]     filter #0
[2017-06-12 14:51:01.955][12968][info][config]       type: decoder
[2017-06-12 14:51:01.955][12968][info][config]       name: router
[2017-06-12 14:51:01.955][12968][info][config] loading tracing configuration
[2017-06-12 14:51:01.955][12968][warning][main] starting main dispatch loop
[2017-06-12 14:51:01.965][12968][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 14:51:01.965][12968][info][upstream] cm init: removing: cluster=service_google primary=0 secondary=0
[2017-06-12 14:51:01.965][12968][warning][main] all clusters initialized. initializing init manager
[2017-06-12 14:51:01.965][12968][warning][main] all dependencies initialized. starting workers
[2017-06-12 14:51:01.966][12970][info][main] worker entering dispatch loop
[2017-06-12 14:51:01.966][12972][info][main] worker entering dispatch loop
[2017-06-12 14:51:01.966][12973][info][main] worker entering dispatch loop
[2017-06-12 14:51:01.966][12971][info][main] worker entering dispatch loop
[2017-06-12 14:51:06.957][12968][debug][main] flushing stats
[2017-06-12 14:51:06.971][12968][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 14:51:06.972][12968][debug][upstream] Setting DNS resolution timer for 4687 milliseconds
[2017-06-12 14:51:11.661][12968][debug][upstream] Setting DNS resolution timer for 0 milliseconds
[2017-06-12 14:51:11.661][12968][debug][upstream] Setting DNS resolution timer for 3124 milliseconds
[2017-06-12 14:51:11.961][12968][debug][main] flushing stats
[2017-06-12 14:51:14.791][12968][debug][upstream] Setting DNS resolution timer for 7499 milliseconds
[2017-06-12 14:51:14.811][12968][debug][upstream] DNS request timed out 2 times
[2017-06-12 14:51:14.811][12968][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 14:51:16.975][12968][debug][main] flushing stats
[2017-06-12 14:51:19.815][12968][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 14:51:19.816][12968][debug][upstream] Setting DNS resolution timer for 3124 milliseconds
[2017-06-12 14:51:19.831][12968][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 14:51:21.978][12968][debug][main] flushing stats
[2017-06-12 14:51:24.834][12968][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 14:51:24.835][12968][debug][upstream] Setting DNS resolution timer for 5000 milliseconds
[2017-06-12 14:51:24.869][12968][debug][upstream] async DNS resolution complete for google.com
[2017-06-12 14:51:26.981][12968][debug][main] flushing stats
[2017-06-12 14:51:29.875][12968][debug][upstream] starting async DNS resolution for google.com
[2017-06-12 14:51:29.876][12968][debug][upstream] Setting DNS resolution timer for 3436 milliseconds
[2017-06-12 14:51:29.888][12968][debug][upstream] async DNS resolution complete for google.com
^C
```

Note that now the timer is actually set, and that the process recovers from missing/dropped DNS responses.