### PR TITLE
network: network utility is local address

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -243,18 +243,30 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
 }
 
 bool Utility::isInternalAddress(const char* address) {
+  // First try as an IPv4 address.
   in_addr addr;
   int rc = inet_pton(AF_INET, address, &addr);
-  if (1 != rc) {
-    return false;
+  if (rc == 1) {
+    // Handle the RFC1918 space for IPV4. Also count loopback as internal.
+    uint8_t* address_bytes = reinterpret_cast<uint8_t*>(&addr.s_addr);
+    if ((address_bytes[0] == 10) || (address_bytes[0] == 192 && address_bytes[1] == 168) ||
+        (address_bytes[0] == 172 && address_bytes[1] >= 16 && address_bytes[1] <= 31) ||
+        addr.s_addr == htonl(INADDR_LOOPBACK)) {
+      return true;
+    }
   }
 
-  // Handle the RFC1918 space for IPV4. Also count loopback as internal.
-  uint8_t* address_bytes = reinterpret_cast<uint8_t*>(&addr.s_addr);
-  if ((address_bytes[0] == 10) || (address_bytes[0] == 192 && address_bytes[1] == 168) ||
-      (address_bytes[0] == 172 && address_bytes[1] >= 16 && address_bytes[1] <= 31) ||
-      addr.s_addr == htonl(INADDR_LOOPBACK)) {
-    return true;
+  // Now try as an IPv6 address.
+  in6_addr addr6;
+  int rc6 = inet_pton(AF_INET6, address, &addr6);
+  if (rc6 == 1) {
+    // Local IPv6 address prefix defined in RFC4193. Local addresses have prefix FC00::/7.
+    // Currently, the FD00::/8 prefix is locally assigned and FC00::/8 may be defined in the future.
+    uint8_t* address6_bytes = reinterpret_cast<uint8_t*>(&addr6.s6_addr);
+    if (address6_bytes[0] == 0xfd ||
+        memcmp(address6_bytes, &in6addr_loopback, sizeof(in6addr_loopback)) == 0) {
+      return true;
+    }
   }
 
   return false;
@@ -316,7 +328,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
   int status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
 
   if (status == 0) {
-    // TODO(mattklein123): IPv6 support
+    // TODO(mattklein123): IPv6 support. See github issue #1094.
     ASSERT(orig_addr.ss_family == AF_INET);
     return Address::InstanceConstSharedPtr{
         new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -253,6 +253,8 @@ bool Utility::isInternalAddress(const char* address) {
         (address_bytes[0] == 172 && address_bytes[1] >= 16 && address_bytes[1] <= 31) ||
         addr.s_addr == htonl(INADDR_LOOPBACK)) {
       return true;
+    } else {
+      return false;
     }
   }
 

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -229,6 +229,30 @@ TEST_P(NetworkUtilityGetLocalAddress, GetLocalAddress) {
 
 TEST(NetworkUtility, GetOriginalDst) { EXPECT_EQ(nullptr, Utility::getOriginalDst(-1)); }
 
+TEST(NetworkUtility, InternalAddress) {
+  EXPECT_TRUE(Utility::isInternalAddress("127.0.0.1"));
+  EXPECT_TRUE(Utility::isInternalAddress("10.0.0.1"));
+  EXPECT_TRUE(Utility::isInternalAddress("192.168.0.0"));
+  EXPECT_TRUE(Utility::isInternalAddress("172.16.0.0"));
+  EXPECT_TRUE(Utility::isInternalAddress("172.30.2.1"));
+  EXPECT_FALSE(Utility::isInternalAddress(""));
+  EXPECT_FALSE(Utility::isInternalAddress("127"));
+  EXPECT_FALSE(Utility::isInternalAddress("192.167.0.0"));
+  EXPECT_FALSE(Utility::isInternalAddress("172.32.0.0"));
+  EXPECT_FALSE(Utility::isInternalAddress("11.0.0.1"));
+
+  EXPECT_TRUE(Utility::isInternalAddress("fd00::"));
+  EXPECT_TRUE(Utility::isInternalAddress("::1"));
+  EXPECT_TRUE(Utility::isInternalAddress("fdff::"));
+  EXPECT_TRUE(Utility::isInternalAddress("fd01::"));
+  EXPECT_TRUE(Utility::isInternalAddress("fd12:3456:7890:1234:5678:9012:3456:7890"));
+  EXPECT_FALSE(Utility::isInternalAddress("fd::"));
+  EXPECT_FALSE(Utility::isInternalAddress("::"));
+  EXPECT_FALSE(Utility::isInternalAddress("fc00::"));
+  EXPECT_FALSE(Utility::isInternalAddress("fe00::"));
+  EXPECT_FALSE(Utility::isInternalAddress("fd00:::"));
+}
+
 TEST(NetworkUtility, LoopbackAddress) {
   {
     Address::Ipv4Instance address("127.0.0.1");


### PR DESCRIPTION
IPv6 support for network utility function isInternalAddress.


Finishes basic support for #351 . Network utility function getOriginalDst will not be updated now. See #1094 .

Fixes #1044 .