### PR TITLE
Upgrade to nghttp2 1.23.1.

### DIFF
--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=1.20.0
+VERSION=1.23.1
 
 wget -O nghttp2-$VERSION.tar.gz https://github.com/nghttp2/nghttp2/releases/download/v$VERSION/nghttp2-$VERSION.tar.gz
 tar xf nghttp2-$VERSION.tar.gz

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -11,7 +11,7 @@ Envoy has the following requirements:
 * GCC 4.9+ (for C++11 regex support)
 * `spdlog <https://github.com/gabime/spdlog>`_ (last tested with 0.11.0)
 * `http-parser <https://github.com/nodejs/http-parser>`_ (last tested with 2.7.0)
-* `nghttp2 <https://github.com/nghttp2/nghttp2>`_ (last tested with 1.20.0)
+* `nghttp2 <https://github.com/nghttp2/nghttp2>`_ (last tested with 1.23.1)
 * `libevent <http://libevent.org/>`_ (last tested with 2.1.8)
 * `tclap <http://tclap.sourceforge.net/>`_ (last tested with 1.2.1)
 * `gperftools <https://github.com/gperftools/gperftools>`_ (last tested with 2.5.0)


### PR DESCRIPTION
Upgrade to the latest version of nghttp2 - 1.23.1. I've been running this for over a week without issue (low volume light usage). Passes all tests.

@PiotrSikora Since 1.20.0 there have been a number of fixes related to TLS and boringssl outlined in the release notes at https://github.com/nghttp2/nghttp2/releases (some of which you contributed).