### PR TITLE
stats: fix listener/filter scope prefixes

### DIFF
--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -68,7 +68,7 @@ public:
   /**
    * @return Stats::Scope& the stats scope to use for all listener specific stats.
    */
-  virtual Stats::Scope& scope() PURE;
+  virtual Stats::Scope& listenerScope() PURE;
 };
 
 typedef std::unique_ptr<Listener> ListenerPtr;

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -176,6 +176,7 @@ private:
     bool useProxyProto() override { return use_proxy_proto_; }
     bool useOriginalDst() override { return use_original_dst_; }
     uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
+    Stats::Scope& listenerScope() override { return *listener_scope_; }
 
     // Server::Configuration::FactoryContext
     AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
@@ -193,7 +194,7 @@ private:
     }
     Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
     Instance& server() override { return server_; }
-    Stats::Scope& scope() override { return *scope_; }
+    Stats::Scope& scope() override { return *global_scope_; }
     ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
 
     // Network::FilterChainFactory
@@ -203,7 +204,8 @@ private:
     Instance& server_;
     Network::Address::InstanceConstSharedPtr address_;
     bool bind_to_port_{};
-    Stats::ScopePtr scope_;
+    Stats::ScopePtr global_scope_;   // Stats with global named scope, but needed for LDS cleanup.
+    Stats::ScopePtr listener_scope_; // Stats with listener named scope.
     Ssl::ServerContextPtr ssl_context_;
     bool use_proxy_proto_{};
     bool use_original_dst_{};

--- a/source/server/worker.cc
+++ b/source/server/worker.cc
@@ -29,10 +29,11 @@ void Worker::initializeConfiguration(Server::Configuration::Main& config,
         .per_connection_buffer_limit_bytes_ = listener->perConnectionBufferLimitBytes()};
     if (listener->sslContext()) {
       handler_->addSslListener(listener->filterChainFactory(), *listener->sslContext(),
-                               *socket_map.at(listener.get()), listener->scope(), listener_options);
+                               *socket_map.at(listener.get()), listener->listenerScope(),
+                               listener_options);
     } else {
       handler_->addListener(listener->filterChainFactory(), *socket_map.at(listener.get()),
-                            listener->scope(), listener_options);
+                            listener->listenerScope(), listener_options);
     }
   }
 

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -459,6 +459,50 @@ TEST_F(ConfigurationImplTest, ConfigurationFailsWhenInvalidTracerSpecified) {
                             "No HttpTracerFactory found for type: invalid");
 }
 
+class TestStatsConfigFactory : public NamedNetworkFilterConfigFactory {
+public:
+  // NetworkFilterConfigFactory
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object&,
+                                             FactoryContext& context) override {
+    context.scope().counter("bar").inc();
+    return [](Network::FilterManager&) -> void {};
+  }
+  std::string name() override { return "stats_test"; }
+  NetworkFilterType type() override { return NetworkFilterType::Read; }
+};
+
+TEST_F(ConfigurationImplTest, StatsScopeTest) {
+  RegisterNamedNetworkFilterConfigFactory<TestStatsConfigFactory> registered;
+
+  std::string json = R"EOF(
+  {
+    "listeners" : [
+      {
+        "address": "tcp://127.0.0.1:1234",
+        "filters": [
+          {
+            "type" : "read",
+            "name" : "stats_test",
+            "config" : {}
+          }
+        ]
+      }
+    ],
+    "cluster_manager": {
+      "clusters": []
+    }
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  MainImpl config(server_, cluster_manager_factory_);
+  config.initialize(*loader);
+  config.listeners().front()->listenerScope().counter("foo").inc();
+
+  EXPECT_EQ(1UL, server_.stats_store_.counter("bar").value());
+  EXPECT_EQ(1UL, server_.stats_store_.counter("listener.127.0.0.1_1234.foo").value());
+}
+
 /**
  * Config registration for the echo filter using the deprecated registration class.
  */
@@ -507,6 +551,7 @@ TEST_F(ConfigurationImplTest, DeprecatedFilterConfigFactoryRegistrationTest) {
   MainImpl config(server_, cluster_manager_factory_);
   config.initialize(*loader);
 }
+
 } // Configuration
 } // Server
 } // Envoy


### PR DESCRIPTION
Regression from https://github.com/lyft/envoy/pull/1083. The listener
config needs two scopes. One for listener named stats, and one for global
named stats that need to be reaped during LDS processing.