### PR TITLE
DNS unit test to cover #1096 behavior.

### DIFF
--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -29,6 +29,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::InSequence;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
@@ -579,19 +580,18 @@ TEST_P(DnsImplZeroTimeoutTest, Timeout) {
 // Validate that the resolution timeout timer is enabled if we don't resolve
 // immediately.
 TEST(DnsImplUnitTest, PendingTimerEnable) {
+  InSequence s;
   Event::MockDispatcher dispatcher;
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>();
   EXPECT_CALL(dispatcher, createTimer_(_)).WillOnce(Return(timer));
   DnsResolverImpl resolver(dispatcher, {});
   Event::FileEvent* file_event = new NiceMock<Event::MockFileEvent>();
   EXPECT_CALL(dispatcher, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event));
-  EXPECT_CALL(*timer, disableTimer());
   EXPECT_CALL(*timer, enableTimer(_));
   EXPECT_NE(nullptr, resolver.resolve("some.bad.domain.invalid", DnsLookupFamily::V4Only,
                                       [&](std::list<Address::InstanceConstSharedPtr>&& results) {
                                         UNREFERENCED_PARAMETER(results);
                                       }));
-  Mock::VerifyAndClearExpectations(timer);
 }
 
 } // Network

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -587,7 +587,7 @@ TEST(DnsImplUnitTest, PendingTimerEnable) {
   EXPECT_CALL(dispatcher, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event));
   EXPECT_CALL(*timer, disableTimer());
   EXPECT_CALL(*timer, enableTimer(_));
-  EXPECT_NE(nullptr, resolver.resolve("some.bad.domain", DnsLookupFamily::V4Only,
+  EXPECT_NE(nullptr, resolver.resolve("some.bad.domain.invalid", DnsLookupFamily::V4Only,
                                       [&](std::list<Address::InstanceConstSharedPtr>&& results) {
                                         UNREFERENCED_PARAMETER(results);
                                       }));

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -32,5 +32,8 @@ MockTimer::MockTimer(MockDispatcher* dispatcher) {
 
 MockTimer::~MockTimer() {}
 
+MockFileEvent::MockFileEvent() {}
+MockFileEvent::~MockFileEvent() {}
+
 } // Event
 } // Envoy

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -127,5 +127,14 @@ public:
   TimerCb callback_;
 };
 
+class MockFileEvent : public FileEvent {
+public:
+  MockFileEvent();
+  ~MockFileEvent();
+
+  MOCK_METHOD1(activate, void(uint32_t events));
+  MOCK_METHOD1(setEnabled, void(uint32_t events));
+};
+
 } // Event
 } // Envoy


### PR DESCRIPTION
Not entirely satisfying, since we don't have a mock c-ares
implementation, so we still perform a real DNS query, but I've validated
this has the intended behavior (if I comment out the fix it fails).

Fixes #1101.