### PR TITLE
Adding some basic tests for handling malformed HTTP/1.1

### DIFF
--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -171,6 +171,7 @@ public:
   void registerPort(const std::string& key, uint32_t port);
   uint32_t lookupPort(const std::string& key);
 
+  void sendRawHttpAndWaitForResponse(const char* http, std::string* response);
   void registerTestServerPorts(const std::vector<std::string>& port_names);
   void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);
 
@@ -197,7 +198,10 @@ protected:
   void testRouterUpstreamResponseBeforeRequestComplete(Network::ClientConnectionPtr&& conn,
                                                        Http::CodecClient::Type type);
   void testTwoRequests(Http::CodecClient::Type type);
-  void testBadHttpRequest();
+  void testBadFirstline();
+  void testMissingDelimiter();
+  void testInvalidCharacterInFirstline();
+  void testLowVersion();
   void testHttp10Request();
   void testNoHost();
   void testUpstreamProtocolError();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -110,7 +110,13 @@ TEST_P(IntegrationTest, Retry) { testRetry(Http::CodecClient::Type::HTTP1); }
 
 TEST_P(IntegrationTest, TwoRequests) { testTwoRequests(Http::CodecClient::Type::HTTP1); }
 
-TEST_P(IntegrationTest, BadHttpRequest) { testBadHttpRequest(); }
+TEST_P(IntegrationTest, BadFirstline) { testBadFirstline(); }
+
+TEST_P(IntegrationTest, MissingDelimiter) { testMissingDelimiter(); }
+
+TEST_P(IntegrationTest, InvalidCharacterInFirstline) { testInvalidCharacterInFirstline(); }
+
+TEST_P(IntegrationTest, LowVersion) { testLowVersion(); }
 
 TEST_P(IntegrationTest, Http10Request) { testHttp10Request(); }
 


### PR DESCRIPTION
Adding tests for blocking requests with missing header delimiter, bad character in the firstline and overly low version of HTTP.