### PR TITLE
Fixes segfault for when initializing Target list. 

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -41,7 +41,11 @@ void InitManagerImpl::initialize(std::function<void()> callback) {
   } else {
     callback_ = callback;
     state_ = State::Initializing;
-    for (auto target : targets_) {
+    // Target::initialize(...) method can modify the list to remove the item currently
+    // being initialized, so we increment the iterator before calling initialize.
+    for (auto iter = targets_.begin(); iter != targets_.end();) {
+      Init::Target* target = *iter;
+      ++iter;
       target->initialize([this, target]() -> void {
         ASSERT(std::find(targets_.begin(), targets_.end(), target) != targets_.end());
         targets_.remove(target);

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -13,6 +13,7 @@
 namespace Envoy {
 using testing::_;
 using testing::InSequence;
+using testing::Invoke;
 
 namespace Server {
 
@@ -35,6 +36,19 @@ TEST(InitManagerImplTest, Targets) {
   manager.initialize([&]() -> void { initialized.ready(); });
   EXPECT_CALL(initialized, ready());
   target.callback_();
+}
+
+TEST(InitManagerImplTest, TargetRemoveWhile) {
+  InSequence s;
+  InitManagerImpl manager;
+  Init::MockTarget target1;
+  ReadyWatcher initialized;
+
+  manager.registerTarget(target1);
+  EXPECT_CALL(target1, initialize(_))
+      .WillOnce(Invoke([this](std::function<void()> callback) -> void { callback(); }));
+  EXPECT_CALL(initialized, ready());
+  manager.initialize([&]() -> void { initialized.ready(); });
 }
 
 // Class creates minimally viable server instance for testing.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -46,7 +46,7 @@ TEST(InitManagerImplTest, TargetRemoveWhile) {
 
   manager.registerTarget(target1);
   EXPECT_CALL(target1, initialize(_))
-      .WillOnce(Invoke([this](std::function<void()> callback) -> void { callback(); }));
+      .WillOnce(Invoke([](std::function<void()> callback) -> void { callback(); }));
   EXPECT_CALL(initialized, ready());
   manager.initialize([&]() -> void { initialized.ready(); });
 }


### PR DESCRIPTION
Fixes #1093 

When initializing the targets, it is possible to remove the current item. The fix is to update the iterator pointer before initializing the target. 