### PR TITLE
Add two components for Log+Stats shipping.

### DIFF
--- a/source/common/log_sink/BUILD
+++ b/source/common/log_sink/BUILD
@@ -1,0 +1,20 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "conveyor_lib",
+    hdrs = ["conveyor.h"],
+)
+
+envoy_cc_library(
+    name = "log_obj_store_lib",
+    hdrs = ["log_obj_store.h"],
+    deps = ["//source/common/common:assert_lib"],
+)

--- a/source/common/log_sink/conveyor.h
+++ b/source/common/log_sink/conveyor.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace Envoy {
+namespace LogTransport {
+
+/**
+ * A Conveyor is a bidirectional thread safe queue.
+ *
+ * Like a conveyor in a mine the Conveyor is meant to transport "loaded"
+ * objects in one direction and "empty" objects back in the other direction.
+ * It is possible for there to be no "empty" objects available if processing
+ * slows down. This makes for a natural backpressure feedback mechanism as data
+ * is dropped instead of being logged.
+ *
+ * There are a few reasons for this approach:
+ *   1) Reduced allocation activity. Most of the allocations will happen once, at
+ *      startup.
+ *   2) Natural upper bound on memory usage. Produced data will be dropped if
+ *      log processing is unable to keep up rather than consuming unbounded amounts
+ *      of memory.
+ *   3) Fastest implementation on the insert-loaded side of the queue. There's
+ *      never any allocation or object construction cost in the fast path, just
+ *      pointer updates and accounting.
+ *
+ * If the producer would like to instead perform an allocation when there are no
+ * "empty" objects available it can do the allocation and move-pass the unique_ptr to
+ * the putLoaded() method.
+ */
+template <typename T> class Conveyor {
+public:
+  /**
+   * Expand the number of objects used in the conveyor by performing
+   * allocations.  Objects will be constructed using the remaining arguments
+   * as constructor params (emplace style), default constructed if only the
+   * count arugment is given.
+   *
+   * @param count The number of objects to allocate and add to the conveyor
+   * @param args Constructor args (variadic).
+   */
+  template <typename... Args> void expand(int count, Args&&... args) {
+    // We do the slower allocation outside of the lock
+    std::vector<std::unique_ptr<T>> allocations(count);
+    for (auto&& p : allocations) {
+      p.reset(new T(std::forward<Args>(args)...));
+    }
+
+    // Then add the newly allocated items into the outbound deque under lock
+    // It doesn't matter which end we add to.
+    std::unique_lock<std::mutex> locked(lock_);
+    for (auto&& p : allocations) {
+      outbound_.push_back(std::move(p));
+    }
+  }
+
+  /**
+   * Contract the number of objects used in the conveyor to free memory.
+   *
+   * If there are not enough objects in the "unloaded" queue the entire unloaded
+   * queue will be emptied.
+   *
+   * @param count The number of objects to try freeing.
+   * @return int The number of objects actually freed.
+   */
+  int contract(int count) {
+    int liberated = 0;
+    while (liberated < count && !outbound_.empty()) {
+      {
+        std::unique_lock<std::mutex> locked(lock_);
+        outbound_.pop_back(); // Implicitly deletes object as reference goes away
+      }
+      liberated++;
+    }
+    return liberated;
+  }
+
+  /**
+   * Try to get an empty T object.
+   *
+   * If no empty objects are available this method will return nullptr.
+   * It will not block.
+   *
+   * @return std::unique_ptr<T> Empty object, or nullptr.
+   */
+  std::unique_ptr<T> getEmpty() {
+    std::unique_lock<std::mutex> locked(lock_);
+    if (outbound_.empty()) {
+      return std::unique_ptr<T>();
+    } else {
+      auto obj = std::move(outbound_.back());
+      outbound_.pop_back();
+      return obj;
+    }
+  }
+
+  /**
+   * Place a loaded object onto the Conveyor for processing.
+   *
+   * @param obj An std::unique_ptr<T> to a loaded object ready for processing
+   */
+  void putLoaded(std::unique_ptr<T>&& obj) {
+    {
+      std::unique_lock<std::mutex> locked(lock_);
+      inbound_.push_front(std::move(obj));
+    }
+    queue_event_.notify_one();
+  }
+
+  /**
+   * Block and wait for one loaded object.
+   *
+   * @return std::unique_ptr<T> A loaded object ready for processing.
+   */
+  std::unique_ptr<T> waitAndGetLoaded() {
+    std::unique_lock<std::mutex> locked(lock_);
+    queue_event_.wait(locked, [this]() -> bool { return !inbound_.empty(); });
+    auto obj = std::move(inbound_.back());
+    inbound_.pop_back();
+    return obj;
+  }
+
+  /**
+   * Return a processed ("empty") object.
+   *
+   * @param obj An std::unique_ptr<T> to an empty object ready for reuse
+   */
+  void putEmpty(std::unique_ptr<T>&& obj) {
+    std::unique_lock<std::mutex> locked(lock_);
+    outbound_.push_front(std::move(obj));
+  }
+
+private:
+  // Mutex protects access to queues and condition variable
+  std::mutex lock_;
+  // Condition variable signals that loaded objects are available
+  std::condition_variable_any queue_event_;
+  // "Inbound" is defined as the direction towards the Conveyor object
+  std::deque<std::unique_ptr<T>> inbound_;
+  // "Outbound" is defined as the direction back towards inserters
+  std::deque<std::unique_ptr<T>> outbound_;
+};
+
+} // LogTransport
+} // Envoy

--- a/source/common/log_sink/log_obj_store.h
+++ b/source/common/log_sink/log_obj_store.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <vector>
+
+#include "common/common/assert.h"
+
+//#include "envoy/access_log/access_log.h"
+
+namespace Envoy {
+namespace LogTransport {
+
+/**
+ * Provide a generic wrapper for a block of multiple log objects (of any type).
+ *
+ * Includes the ability to clear the block back to a newly constructed state
+ * (without redoing allocations). This enables passing LogObjectStorage objects
+ * through a queue to a log processing thread which passes them back cleared out
+ * when it is done processing.
+ */
+template <typename T> class LogObjectStore {
+public:
+  /**
+   * Construct a new store with certain capacity.
+   *
+   * @param capacity The number of items that can be stored
+   */
+  LogObjectStore(const int capacity) : use_count_(0), store_(capacity) {}
+
+  /**
+   * Check if the LogObjectStore is full.
+   *
+   * @return True if the store is full, false if there is still room.
+   */
+  bool isFull() const {
+    ASSERT(use_count_ <= store_.size());
+    return use_count_ == store_.size();
+  }
+
+  /**
+   * Return the number of active entries in the LogObjectStore.
+   *
+   * This should be equal to the number of items found when iterating over the
+   * container using begin() -> end() method.
+   *
+   * @return int Number of entries in the LogObjectStore.
+   */
+  int size() const { return use_count_; }
+
+  /**
+   * Reset the object back to newly constructed state.
+   *
+   * The stored data itself is not altered.
+   */
+  void clear() { use_count_ = 0; }
+
+  /**
+   * Reset the object back to newly constructed state and run clearing
+   * function on all stored objects.
+   *
+   * For example if protos are stored:
+   *   clear([](auto& proto) { proto.Clear(); });
+   *
+   * @param f A function run on all items in the store.
+   */
+  template <typename Func> void clear(Func f) {
+    clear();
+    for (auto& item : store_) {
+      f(item);
+    }
+  }
+
+  /**
+   * Get a mutable reference to the next writable entry.
+   *
+   * Ownership is not passed to the caller.
+   *
+   * You must first check that the LogObjectStore is not full with the isFull()
+   * method.  To do otherwise is a programming error.
+   *
+   * @return T& A reference to object of the template type.
+   */
+  T& getNextWritableEntry() {
+    ASSERT(use_count_ < store_.size());
+    return store_[use_count_++];
+  }
+
+  // To enable using a range-based for loops on this object we mostly
+  // leverage the std::vector iterator implementation.
+  //
+  // The end iterator is the vector begin() + use_count_, so if partially
+  // full iteration will stop at the correct place.
+  //
+  // If use_count_ is 0 begin() will return the same thing as end() giving the
+  // expected result.
+  //
+  // Only const iteration is implemented. If non-const iteration is required
+  // in the future just add the typedef and non-const methods below.
+  typedef typename std::vector<T>::const_iterator const_iterator;
+
+  const_iterator begin() const { return store_.begin(); }
+  const_iterator cbegin() const { return store_.begin(); }
+
+  const_iterator end() const { return store_.begin() + use_count_; }
+  const_iterator cend() const { return store_.begin() + use_count_; }
+
+private:
+  unsigned int use_count_;
+  std::vector<T> store_;
+};
+
+} // LogTransport
+} // Envoy

--- a/test/common/log_sink/BUILD
+++ b/test/common/log_sink/BUILD
@@ -1,0 +1,26 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test(
+    name = "conveyor_test",
+    srcs = ["conveyor_test.cc"],
+    deps = [
+        "//source/common/common:thread_lib",
+        "//source/common/log_sink:conveyor_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "log_obj_store_test",
+    srcs = ["log_obj_store_test.cc"],
+    deps = [
+        "//source/common/log_sink:log_obj_store_lib",
+    ],
+)

--- a/test/common/log_sink/conveyor_test.cc
+++ b/test/common/log_sink/conveyor_test.cc
@@ -1,0 +1,132 @@
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "common/common/thread.h"
+#include "common/log_sink/conveyor.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+namespace LogTransport {
+
+TEST(BasicConveyor, ConveyorExpandContractTest) {
+  Conveyor<int> conveyor;
+  conveyor.expand(1);
+  EXPECT_EQ(conveyor.contract(1), 1);
+}
+
+TEST(Conveyor, ConveyorFullContractTest) {
+  Conveyor<int> conveyor;
+  conveyor.expand(1);
+  EXPECT_EQ(conveyor.contract(20), 1);
+}
+
+TEST(Conveyor, ConveyorGetTest) {
+  Conveyor<int> conveyor;
+  auto should_be_unique_null = conveyor.getEmpty();
+  EXPECT_EQ(should_be_unique_null.get(), nullptr);
+  conveyor.expand(1);
+
+  auto should_be_unique_valid = conveyor.getEmpty();
+  EXPECT_NE(should_be_unique_valid.get(), nullptr);
+
+  should_be_unique_null = conveyor.getEmpty();
+  EXPECT_EQ(should_be_unique_null.get(), nullptr);
+}
+
+TEST(BasicConveyor, BidirectionalConveyorTest) {
+  Conveyor<int> conveyor;
+  conveyor.expand(20);
+
+  for (int i = 0; i < 20; i++) {
+    auto uptr = conveyor.getEmpty();
+    ASSERT_TRUE(uptr);
+    *uptr = i;
+    conveyor.putLoaded(std::move(uptr));
+  }
+  for (int i = 0; i < 20; i++) {
+    auto uptr = conveyor.waitAndGetLoaded();
+    ASSERT_TRUE(uptr);
+    ASSERT_EQ(*uptr, i);
+    conveyor.putEmpty(std::move(uptr));
+  }
+
+  // Now verify that we can reuse the put objects:
+  for (int i = 30; i < 50; i++) {
+    auto uptr = conveyor.getEmpty();
+    ASSERT_TRUE(uptr);
+    *uptr = i;
+    conveyor.putLoaded(std::move(uptr));
+  }
+  for (int i = 30; i < 50; i++) {
+    auto uptr = conveyor.waitAndGetLoaded();
+    ASSERT_TRUE(uptr);
+    ASSERT_EQ(*uptr, i);
+    conveyor.putEmpty(std::move(uptr));
+  }
+
+  // There should be exactly 20 items, even if we try to contract by more:
+  EXPECT_EQ(conveyor.contract(50), 20);
+}
+
+TEST(BasicConveyor, ConstructorArgsTest) {
+  Conveyor<int> conveyor;
+  conveyor.expand(1, 1234);
+  auto item = conveyor.getEmpty();
+  EXPECT_EQ(*item, 1234);
+}
+
+class MultiThreadConveyor : public testing::Test {
+protected:
+  MultiThreadConveyor()
+      : endpoint_thread_([this]() -> void {
+          int expected_item_id = 1;
+          while (auto item = conveyor_.waitAndGetLoaded()) {
+            // Because of thread timing the inserter might not be able to get an
+            // empty item, so we expect that the ID is monotonically increasing but
+            // gaps are OK
+            EXPECT_GE(*item, expected_item_id++);
+            *item = 0;
+            conveyor_.putEmpty(std::move(item));
+          }
+          std::lock_guard<std::mutex> guard(thread_exit_lock_);
+          thread_running_ = false;
+          thread_exit_.notify_one();
+        }) {}
+  Conveyor<int> conveyor_;
+  Thread::Thread endpoint_thread_;
+  std::mutex thread_exit_lock_;
+  std::condition_variable_any thread_exit_;
+  std::atomic<bool> thread_running_{true};
+};
+
+TEST_F(MultiThreadConveyor, ConveyorEchoTest) {
+  conveyor_.expand(100);
+  // Start testing at one, default constructed 0 value is used to verify we
+  // only get true empty values from getEmpty()
+  for (int i = 1; i < 10000; i++) {
+    auto item = conveyor_.getEmpty();
+    if (!item) {
+      continue;
+    }
+    EXPECT_EQ(*item, 0);
+    *item = i;
+    conveyor_.putLoaded(std::move(item));
+  }
+  // We should be able to expand and contract the conveyor while the thread
+  // is still processing:
+  conveyor_.expand(1);
+  for (int contracted = 0; contracted < 101; contracted += conveyor_.contract(1)) {
+  }
+  // End the thread loop with a null object:
+  // Wait for thread to exit before ending test:
+  std::lock_guard<std::mutex> guard(thread_exit_lock_);
+  conveyor_.putLoaded(std::unique_ptr<int>());
+  thread_exit_.wait(thread_exit_lock_, [this]() -> bool { return !thread_running_; });
+}
+
+} // LogTransport
+} // Envoy

--- a/test/common/log_sink/log_obj_store_test.cc
+++ b/test/common/log_sink/log_obj_store_test.cc
@@ -1,0 +1,91 @@
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "common/log_sink/log_obj_store.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+namespace LogTransport {
+
+TEST(LogObjStore, InsertTest) {
+  LogObjectStore<int> los(1);
+
+  EXPECT_FALSE(los.isFull());
+
+  auto& ref = los.getNextWritableEntry();
+  ref = 1;
+
+  EXPECT_EQ(los.size(), 1);
+  EXPECT_TRUE(los.isFull());
+}
+
+TEST(LogObjStore, IterableTest) {
+  LogObjectStore<int> los(100);
+
+  for (int i = 0; i < 100; i++) {
+    EXPECT_FALSE(los.isFull());
+    auto& ref = los.getNextWritableEntry();
+    ref = i;
+  }
+  EXPECT_TRUE(los.isFull());
+
+  int expected = 0;
+  for (const auto& ref : los) {
+    EXPECT_EQ(ref, expected++);
+  }
+}
+
+TEST(LogObjStore, HalfFullIterableTest) {
+  LogObjectStore<int> los(100);
+
+  // Since there's nothing loaded this loop should execute no iterations:
+  for (const auto& ref : los) {
+    EXPECT_TRUE(false);
+    EXPECT_EQ(ref, 1234567);
+  }
+
+  for (int i = 0; i < 50; i++) {
+    EXPECT_FALSE(los.isFull());
+    auto& ref = los.getNextWritableEntry();
+    ref = i;
+  }
+  EXPECT_FALSE(los.isFull());
+  EXPECT_EQ(los.size(), 50);
+
+  int expected = 0;
+  for (const auto& ref : los) {
+    EXPECT_EQ(ref, expected++);
+  }
+  // Range-based for should have made exactly 50 iterations:
+  EXPECT_EQ(expected, 50);
+}
+
+TEST(LogObjStore, ClearTest) {
+  LogObjectStore<std::vector<int>> los(10);
+
+  for (int i = 0; !los.isFull(); i++) {
+    auto& ref = los.getNextWritableEntry();
+    ref.push_back(i);
+  }
+  EXPECT_TRUE(los.isFull());
+
+  int expected = 0;
+  los.clear([&expected](std::vector<int>& v) {
+    EXPECT_EQ(v.size(), 1);
+    EXPECT_EQ(v[0], expected++);
+    v.clear();
+  });
+
+  EXPECT_EQ(los.size(), 0);
+
+  auto& ref = los.getNextWritableEntry();
+  // The entry should have been cleared by the lambda above
+  EXPECT_EQ(ref.size(), 0);
+}
+
+} // LogTransport
+} // Envoy


### PR DESCRIPTION
These components - unit tested but not used yet - are intended for use
when sending blocks of access logs and request statistics from a requst
processing thread to a thread or threads that post-process the logs/stats
and ship them out of Envoy.