### PR TITLE
Adding content length validation

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -411,7 +411,8 @@ int ServerConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
         http_parser_pause(&parser_, 1);
       }
 
-    } else if (headers->Method()->value() == "POST" || headers->Method()->value() == "PUT") {
+    } else if (parser_.method == http_method::HTTP_POST ||
+               parser_.method == http_method::HTTP_PUT) {
       // If there is no body present but a body is expected for this particular method,
       // return an error to the user.
       error_code_ = Http::Code::LengthRequired;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -7,8 +7,8 @@
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
 
+#include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
-#include "common/http/codes.h"
 #include "common/http/exception.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
@@ -411,6 +411,11 @@ int ServerConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
         http_parser_pause(&parser_, 1);
       }
 
+    } else if (headers->Method()->value() == "POST" || headers->Method()->value() == "PUT") {
+      // If there is no body present but a body is expected for this particular method,
+      // return an error to the user.
+      error_code_ = Http::Code::LengthRequired;
+      return -1;
     } else {
       deferred_end_stream_headers_ = std::move(headers);
     }
@@ -471,11 +476,13 @@ void ServerConnectionImpl::onResetStream(StreamResetReason reason) {
 
 void ServerConnectionImpl::sendProtocolError() {
   // We do this here because we may get a protocol error before we have a logical stream. Higher
-  // layers can only operate on streams, so there is no coherent way to allow them to send a 400
+  // layers can only operate on streams, so there is no coherent way to allow them to send an error
   // "out of band." On one hand this is kind of a hack but on the other hand it normalizes HTTP/1.1
   // to look more like HTTP/2 to higher layers.
   if (!active_request_ || !active_request_->response_encoder_.startedResponse()) {
-    Buffer::OwnedImpl bad_request_response("HTTP/1.1 400 Bad Request\r\n"
+    Buffer::OwnedImpl bad_request_response("HTTP/1.1 " + std::to_string(enumToInt(error_code_)) +
+                                           " " + CodeUtility::toString(error_code_) +
+                                           "\r\n"
                                            "content-length: 0\r\n"
                                            "connection: close\r\n\r\n");
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -13,6 +13,7 @@
 #include "common/common/assert.h"
 #include "common/common/to_lower_table.h"
 #include "common/http/codec_helper.h"
+#include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 
 #include "http_parser.h"
@@ -149,6 +150,7 @@ protected:
   Network::Connection& connection_;
   http_parser parser_;
   HeaderMapPtr deferred_end_stream_headers_;
+  Http::Code error_code_{Http::Code::BadRequest};
 
 private:
   enum class HeaderParsingState { Field, Value, Done };

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -414,9 +414,14 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
 }
 
 int ConnectionImpl::onInvalidFrame(int error_code) {
-  UNREFERENCED_PARAMETER(error_code);
-
   ENVOY_CONN_LOG(debug, "invalid frame: {}", connection_, nghttp2_strerror(error_code));
+
+  // The stream is about to be closed due to an invalid header.  Don't kill the
+  // entire connection if one stream has bad headers.
+  if (error_code == NGHTTP2_ERR_HTTP_HEADER) {
+    return 0;
+  }
+
   // Cause dispatch to return with an error code.
   return NGHTTP2_ERR_CALLBACK_FAILURE;
 }

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -29,6 +29,14 @@ TEST_P(Http2IntegrationTest, RouterNotFoundBodyBuffer) {
 
 TEST_P(Http2IntegrationTest, RouterRedirect) { testRouterRedirect(Http::CodecClient::Type::HTTP2); }
 
+TEST_P(Http2IntegrationTest, InvalidContentLength) {
+  testInvalidContentLength(Http::CodecClient::Type::HTTP2);
+}
+
+TEST_P(Http2IntegrationTest, MultipleContentLengths) {
+  testMultipleContentLengths(Http::CodecClient::Type::HTTP2);
+}
+
 TEST_P(Http2IntegrationTest, DrainClose) { testDrainClose(Http::CodecClient::Type::HTTP2); }
 
 TEST_P(Http2IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -87,8 +87,9 @@ void IntegrationStreamDecoder::decodeTrailers(Http::HeaderMapPtr&& trailers) {
   }
 }
 
-void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason) {
+void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason reason) {
   saw_reset_ = true;
+  reset_reason_ = reason;
   if (waiting_for_reset_) {
     dispatcher_.exit();
   }
@@ -865,6 +866,13 @@ void BaseIntegrationTest::testLowVersion() {
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
+void BaseIntegrationTest::testMissingContentLength() {
+  std::string response;
+  sendRawHttpAndWaitForResponse("POST / HTTP/1.1\r\nHost: host\r\n\r\n", &response);
+  EXPECT_EQ("HTTP/1.1 411 Length Required\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            response);
+}
+
 void BaseIntegrationTest::testHttp10Request() {
   Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
   std::string response;
@@ -905,6 +913,64 @@ void BaseIntegrationTest::testBadPath() {
 
   connection.run();
   EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
+}
+
+void BaseIntegrationTest::testInvalidContentLength(Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  executeActions({[&]() -> void { codec_client = makeHttpConnection(lookupPort("http"), type); },
+                  [&]() -> void {
+                    codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                       {":path", "/test/long/url"},
+                                                                       {":authority", "host"},
+                                                                       {"content-length", "-1"}},
+                                               *response);
+                  },
+                  [&]() -> void {
+                    if (type == Http::CodecClient::Type::HTTP1) {
+                      codec_client->waitForDisconnect();
+                    } else {
+                      response->waitForReset();
+                      codec_client->close();
+                    }
+                  }});
+
+  if (type == Http::CodecClient::Type::HTTP1) {
+    ASSERT_TRUE(response->complete());
+    EXPECT_STREQ("400", response->headers().Status()->value().c_str());
+  } else {
+    ASSERT_TRUE(response->reset());
+    EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->reset_reason());
+  }
+}
+
+void BaseIntegrationTest::testMultipleContentLengths(Http::CodecClient::Type type) {
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  executeActions({[&]() -> void { codec_client = makeHttpConnection(lookupPort("http"), type); },
+                  [&]() -> void {
+                    codec_client->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                       {":path", "/test/long/url"},
+                                                                       {":authority", "host"},
+                                                                       {"content-length", "3,2"}},
+                                               *response);
+                  },
+                  [&]() -> void {
+                    if (type == Http::CodecClient::Type::HTTP1) {
+                      codec_client->waitForDisconnect();
+                    } else {
+                      response->waitForReset();
+                      codec_client->close();
+                    }
+                  }});
+
+  if (type == Http::CodecClient::Type::HTTP1) {
+    ASSERT_TRUE(response->complete());
+    EXPECT_STREQ("400", response->headers().Status()->value().c_str());
+  } else {
+    ASSERT_TRUE(response->reset());
+    EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->reset_reason());
+  }
 }
 
 void BaseIntegrationTest::testUpstreamProtocolError() {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -28,6 +28,8 @@ public:
 
   const std::string& body() { return body_; }
   bool complete() { return saw_end_stream_; }
+  bool reset() { return saw_reset_; }
+  Http::StreamResetReason reset_reason() { return reset_reason_; }
   const Http::HeaderMap& headers() { return *headers_; }
   const Http::HeaderMapPtr& trailers() { return trailers_; }
   void waitForBodyData(uint64_t size);
@@ -52,6 +54,7 @@ private:
   uint64_t body_data_waiting_length_{};
   bool waiting_for_reset_{};
   bool saw_reset_{};
+  Http::StreamResetReason reset_reason_{};
 };
 
 typedef std::unique_ptr<IntegrationStreamDecoder> IntegrationStreamDecoderPtr;
@@ -202,10 +205,13 @@ protected:
   void testMissingDelimiter();
   void testInvalidCharacterInFirstline();
   void testLowVersion();
+  void testMissingContentLength();
   void testHttp10Request();
   void testNoHost();
   void testUpstreamProtocolError();
   void testBadPath();
+  void testInvalidContentLength(Http::CodecClient::Type type);
+  void testMultipleContentLengths(Http::CodecClient::Type type);
   void testDrainClose(Http::CodecClient::Type type);
   void testRetry(Http::CodecClient::Type type);
   void testGrpcRetry();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -124,6 +124,15 @@ TEST_P(IntegrationTest, NoHost) { testNoHost(); }
 
 TEST_P(IntegrationTest, BadPath) { testBadPath(); }
 
+TEST_P(IntegrationTest, MissingContentLength) { testMissingContentLength(); }
+
+TEST_P(IntegrationTest, InvalidContentLength) {
+  testInvalidContentLength(Http::CodecClient::Type::HTTP1);
+}
+TEST_P(IntegrationTest, MultipleContentLengths) {
+  testMultipleContentLengths(Http::CodecClient::Type::HTTP1);
+}
+
 TEST_P(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 
 TEST_P(IntegrationTest, TcpProxyUpstreamDisconnect) {


### PR DESCRIPTION
Changing H2 from tearing down the connection on invalid content length (and other HTTP style errors) to sending a reset stream instead.
Rejecting POSTs and PUTs with no body and no chunked encoding with 411 (Length Required)
Adding tests for invalid, duplicate, and missing content lengths.