### PR TITLE
config: throw when json is invalid

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -531,7 +531,7 @@ bool ObjectHandler::StartObject() {
     state_ = expectKeyOrEndObject;
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 
@@ -550,7 +550,7 @@ bool ObjectHandler::EndObject(rapidjson::SizeType) {
     }
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 
@@ -561,7 +561,7 @@ bool ObjectHandler::Key(const char* value, rapidjson::SizeType size, bool) {
     state_ = expectValueOrStartObjectArray;
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 
@@ -585,7 +585,7 @@ bool ObjectHandler::StartArray() {
     state_ = expectArrayValueOrEndArray;
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 
@@ -605,7 +605,7 @@ bool ObjectHandler::EndArray(rapidjson::SizeType) {
 
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 
@@ -650,7 +650,7 @@ bool ObjectHandler::handleValueEvent(FieldSharedPtr ptr) {
     stack_.top()->append(ptr);
     return true;
   default:
-    NOT_REACHED;
+    return false;
   }
 }
 

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -531,7 +531,7 @@ bool ObjectHandler::StartObject() {
     state_ = expectKeyOrEndObject;
     return true;
   default:
-    return false;
+    NOT_REACHED;
   }
 }
 
@@ -550,7 +550,7 @@ bool ObjectHandler::EndObject(rapidjson::SizeType) {
     }
     return true;
   default:
-    return false;
+    NOT_REACHED;
   }
 }
 
@@ -561,7 +561,7 @@ bool ObjectHandler::Key(const char* value, rapidjson::SizeType size, bool) {
     state_ = expectValueOrStartObjectArray;
     return true;
   default:
-    return false;
+    NOT_REACHED;
   }
 }
 
@@ -585,7 +585,7 @@ bool ObjectHandler::StartArray() {
     state_ = expectArrayValueOrEndArray;
     return true;
   default:
-    return false;
+    NOT_REACHED;
   }
 }
 
@@ -605,7 +605,7 @@ bool ObjectHandler::EndArray(rapidjson::SizeType) {
 
     return true;
   default:
-    return false;
+    NOT_REACHED;
   }
 }
 

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -314,6 +314,22 @@ TEST(JsonLoaderTest, NestedSchema) {
                             "key: #/value1");
 }
 
+TEST(JsonLoaderTest, MissingEnclosingDocument) {
+
+  std::string json_string = R"EOF(
+  "listeners" : [
+    {
+      "address": "tcp://127.0.0.1:1234",
+      "filters": []
+    }
+  ]
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(Factory::loadFromString(json_string), Exception,
+                            "JSON supplied is not valid. Error(offset 14, line 2): Terminate "
+                            "parsing due to Handler error.\n");
+}
+
 TEST(JsonLoaderTest, AsString) {
   ObjectSharedPtr json = Factory::loadFromString("{\"name1\": \"value1\", \"name2\": true}");
   json->iterate([&](const std::string& key, const Json::Object& value) {


### PR DESCRIPTION
In certain scenarios where invalid JSON is passed, we would hit `NOT_REACHED`. This changes the behavior to pass `false` back to the parser. This will cause the parser to stop and throw an error message with offset and line number.