### PR TITLE
support for allowing custom variable based request headers

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -114,44 +114,6 @@ you can run the test with `--strategy=TestRunner=standalone`, e.g.:
 ```
 bazel test //test/common/http:async_client_impl_test --strategy=TestRunner=standalone --run_under=/some/path/foobar.sh
 ```
-
-# Code Formatter with Bazel
-Envoy code is formatted based on [`clang-format-3.6`](http://releases.llvm.org/3.6.0/tools/clang/docs/ClangFormatStyleOptions.html). 
-
-On Ubuntu machine, run the following command to install `clang-format-3.6` using apt-get
-
-```
- apt-get install clang-format-3.6
-```
-
-The clang-format file [.clang_format](https://github.com/lyft/envoy/blob/master/.clang-format) outlines the formatting specs. 
-There is a handy tool [check_format.py](https://github.com/lyft/envoy/blob/master/tools/check_format.py) that can be run to check and fix the format on the code base. 
-Before you run the tool, you will need to install [`buildifier`](https://github.com/bazelbuild/buildtools) binary, a bazel-based formatting tool.
-
-```
- go get github.com/bazelbuild/buildtools/buildifier
-```
-
-After installing, set the environment variable `BUILDIFIER` to the absolute path of where the buildifier binary is installed.
-
-```
- export BUILDIFIER=<absolute path to buildifier binary>
-```
-
-Run the following command from the envoy root directory to `check` whether to code base is formatted as per the spec
-
-```
- :~/dev/source/envoy$ tools/check_format.py check
-```
-
-Run the following command to `fix` the format
-
-```
- :~/dev/source/envoy$ tools/check_format.py fix 
-``` 
-
-
-
 # Stack trace symbol resolution
 
 Envoy can produce backtraces on demand and from assertions and other fatal

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -114,6 +114,44 @@ you can run the test with `--strategy=TestRunner=standalone`, e.g.:
 ```
 bazel test //test/common/http:async_client_impl_test --strategy=TestRunner=standalone --run_under=/some/path/foobar.sh
 ```
+
+# Code Formatter with Bazel
+Envoy code is formatted based on [`clang-format-3.6`](http://releases.llvm.org/3.6.0/tools/clang/docs/ClangFormatStyleOptions.html). 
+
+On Ubuntu machine, run the following command to install `clang-format-3.6` using apt-get
+
+```
+ apt-get install clang-format-3.6
+```
+
+The clang-format file [.clang_format](https://github.com/lyft/envoy/blob/master/.clang-format) outlines the formatting specs. 
+There is a handy tool [check_format.py](https://github.com/lyft/envoy/blob/master/tools/check_format.py) that can be run to check and fix the format on the code base. 
+Before you run the tool, you will need to install [`buildifier`](https://github.com/bazelbuild/buildtools) binary, a bazel-based formatting tool.
+
+```
+ go get github.com/bazelbuild/buildtools/buildifier
+```
+
+After installing, set the environment variable `BUILDIFIER` to the absolute path of where the buildifier binary is installed.
+
+```
+ export BUILDIFIER=<absolute path to buildifier binary>
+```
+
+Run the following command from the envoy root directory to `check` whether to code base is formatted as per the spec
+
+```
+ :~/dev/source/envoy$ tools/check_format.py check
+```
+
+Run the following command to `fix` the format
+
+```
+ :~/dev/source/envoy$ tools/check_format.py fix 
+``` 
+
+
+
 # Stack trace symbol resolution
 
 Envoy can produce backtraces on demand and from assertions and other fatal

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -118,13 +118,12 @@ public:
   /**
    * Set the downstream address
    */
-  virtual void downStreamAddress(std::string address) PURE;
+  virtual void setDownstreamAddress(std::string address) PURE;
 
   /**
    * Get the down stream address.
    */
-  virtual std::string downStreamAddress() const PURE;
-
+  virtual const std::string& getDownstreamAddress() const PURE;
 };
 
 /**
@@ -175,7 +174,7 @@ public:
                              const RequestInfo& request_info) const PURE;
 };
 
-typedef std::shared_ptr<Formatter> FormatterPtr;
+typedef std::unique_ptr<Formatter> FormatterPtr;
 
 } // namespace AccessLog
 } // namespace Http

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -118,7 +118,7 @@ public:
   /**
    * Set the downstream address
    */
-  virtual void setDownstreamAddress(std::string address) PURE;
+  virtual void setDownstreamAddress(const std::string& address) PURE;
 
   /**
    * Get the down stream address.

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -114,6 +114,17 @@ public:
    * Set whether the request is a health check request or not.
    */
   virtual void healthCheck(bool is_hc) PURE;
+
+  /**
+   * Set the downstream address
+   */
+  virtual void downStreamAddress(std::string address) PURE;
+
+  /**
+   * Get the down stream address.
+   */
+  virtual std::string downStreamAddress() const PURE;
+
 };
 
 /**
@@ -164,7 +175,7 @@ public:
                              const RequestInfo& request_info) const PURE;
 };
 
-typedef std::unique_ptr<Formatter> FormatterPtr;
+typedef std::shared_ptr<Formatter> FormatterPtr;
 
 } // namespace AccessLog
 } // namespace Http

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -30,7 +30,7 @@ public:
 
   const std::string& get() const { return string_; }
   bool operator==(const LowerCaseString& rhs) const { return string_ == rhs.string_; }
-  bool operator<(const LowerCaseString& rhs) const {return string_ < rhs.string_;}
+  bool operator<(const LowerCaseString& rhs) const { return string_ < rhs.string_; }
 
 private:
   void lower() { std::transform(string_.begin(), string_.end(), string_.begin(), tolower); }

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -30,7 +30,6 @@ public:
 
   const std::string& get() const { return string_; }
   bool operator==(const LowerCaseString& rhs) const { return string_ == rhs.string_; }
-  bool operator<(const LowerCaseString& rhs) const { return string_ < rhs.string_; }
 
 private:
   void lower() { std::transform(string_.begin(), string_.end(), string_.begin(), tolower); }

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -38,6 +38,12 @@ private:
   std::string string_;
 };
 
+struct LowerCaseStringHasher {
+  std::size_t operator()(const LowerCaseString& value) const {
+    return std::hash<std::string>{}(value.get());
+  }
+};
+
 /**
  * This is a string implementation for use in header processing. It is heavily optimized for
  * performance. It supports 3 different types of storage and can switch between them:

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -30,6 +30,7 @@ public:
 
   const std::string& get() const { return string_; }
   bool operator==(const LowerCaseString& rhs) const { return string_ == rhs.string_; }
+  bool operator<(const LowerCaseString& rhs) const {return string_ < rhs.string_;}
 
 private:
   void lower() { std::transform(string_.begin(), string_.end(), string_.begin(), tolower); }

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -12,6 +12,7 @@
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
 #include "envoy/upstream/resource_manager.h"
+#include "envoy/http/access_log.h"
 
 namespace Envoy {
 namespace Router {
@@ -192,7 +193,7 @@ public:
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.
    * @param headers supplies the request headers, which may be modified during this call.
    */
-  virtual void finalizeRequestHeaders(Http::HeaderMap& headers) const PURE;
+  virtual void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.
@@ -322,5 +323,5 @@ public:
 
 typedef std::shared_ptr<const Config> ConfigConstSharedPtr;
 
-} // namespace Router
-} // namespace Envoy
+} // Router
+} // Envoy

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -194,7 +194,7 @@ public:
    * @param headers supplies the request headers, which may be modified during this call.
    */
   virtual void finalizeRequestHeaders(Http::HeaderMap& headers,
-                                      Http::AccessLog::RequestInfo& requestInfo) const PURE;
+                                      const Http::AccessLog::RequestInfo& requestInfo) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.
@@ -324,5 +324,5 @@ public:
 
 typedef std::shared_ptr<const Config> ConfigConstSharedPtr;
 
-} // Router
-} // Envoy
+} // namespace Router
+} // namespace Envoy

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -9,10 +9,10 @@
 #include <string>
 
 #include "envoy/common/optional.h"
+#include "envoy/http/access_log.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
 #include "envoy/upstream/resource_manager.h"
-#include "envoy/http/access_log.h"
 
 namespace Envoy {
 namespace Router {
@@ -193,7 +193,8 @@ public:
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.
    * @param headers supplies the request headers, which may be modified during this call.
    */
-  virtual void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const PURE;
+  virtual void finalizeRequestHeaders(Http::HeaderMap& headers,
+                                      Http::AccessLog::RequestInfo& requestInfo) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,7 +46,7 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  void setDownstreamAddress(std::string address) override { downstream_address_ = address; }
+  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
 
   /**
    * Get the down stream address.

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,12 +46,12 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  void downStreamAddress(std::string address) override {downstream_address_ = address;}
+  void setDownstreamAddress(std::string address) override { downstream_address_ = address; }
 
-    /**
-     * Get the down stream address.
-     */
-   std::string downStreamAddress() const override {return downstream_address_;};
+  /**
+   * Get the down stream address.
+   */
+  const std::string& getDownstreamAddress() const override { return downstream_address_; };
 
   Protocol protocol_;
   const SystemTime start_time_;

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,6 +46,13 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
+  void downStreamAddress(std::string address) override {downstream_address_ = address;}
+
+    /**
+     * Get the down stream address.
+     */
+   std::string downStreamAddress() const override {return downstream_address_;};
+
   Protocol protocol_;
   const SystemTime start_time_;
   uint64_t bytes_received_{};
@@ -54,6 +61,7 @@ struct RequestInfoImpl : public RequestInfo {
   uint64_t response_flags_{};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool hc_request_{};
+  std::string downstream_address_;
 };
 
 } // namespace AccessLog

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -124,7 +124,7 @@ private:
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
-    void finalizeRequestHeaders(Http::HeaderMap&) const override {}
+    void finalizeRequestHeaders(Http::HeaderMap&, Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -124,7 +124,8 @@ private:
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
-    void finalizeRequestHeaders(Http::HeaderMap&, Http::AccessLog::RequestInfo&) const override {}
+    void finalizeRequestHeaders(Http::HeaderMap&,
+                                const Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -481,6 +481,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Set the trusted address for the connection by taking the last address in XFF.
   downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
+  request_info_.setDownstreamAddress(downstream_address_);
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -481,6 +481,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Set the trusted address for the connection by taking the last address in XFF.
   downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
+  log().debug("setting down stream address '{}' on request info",
+		  	  connection_manager_.read_callbacks_->connection().remoteAddress().ip()->addressAsString());
+  request_info_.downStreamAddress(connection_manager_.read_callbacks_->connection().remoteAddress().ip()->addressAsString());
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -481,9 +481,6 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Set the trusted address for the connection by taking the last address in XFF.
   downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
-  log().debug("setting down stream address '{}' on request info",
-		  	  connection_manager_.read_callbacks_->connection().remoteAddress().ip()->addressAsString());
-  request_info_.downStreamAddress(connection_manager_.read_callbacks_->connection().remoteAddress().ip()->addressAsString());
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["config_impl.h"],
     deps = [
         ":config_utility_lib",
+        ":req_header_formatter_lib",
         ":retry_state_lib",
         ":router_ratelimit_lib",
         "//include/envoy/common:optional",
@@ -22,12 +23,12 @@ envoy_cc_library(
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
-        "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/json:config_schemas_lib",
         "//source/common/json:json_loader_lib",
     ],
@@ -145,5 +146,16 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/http:headers_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "req_header_formatter_lib",
+    srcs = ["req_header_formatter.cc"],
+    hdrs = ["req_header_formatter.h"],
+    deps = [
+        "//source/common/http:headers_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
+        "//source/common/json:json_loader_lib",
     ],
 )

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
+        "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:utility_lib",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2,7 +2,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <regex>
@@ -180,8 +179,8 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
 
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
-void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                Http::AccessLog::RequestInfo& requestInfo) const {
+void RouteEntryImplBase::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
 
@@ -355,8 +354,8 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost, const J
                                            Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), prefix_(route.getString("prefix")) {}
 
-void PrefixRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                  Http::AccessLog::RequestInfo& requestInfo) const {
+void PrefixRouteEntryImpl::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, prefix_);
@@ -375,8 +374,8 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost, const Json:
                                        Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), path_(route.getString("path")) {}
 
-void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                Http::AccessLog::RequestInfo& requestInfo) const {
+void PathRouteEntryImpl::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, path_);

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -7,6 +7,7 @@
 #include <regex>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "envoy/http/header_map.h"
 #include "envoy/runtime/runtime.h"
@@ -21,6 +22,7 @@
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
 #include "common/router/retry_state_impl.h"
+#include "common/http/access_log/access_log_formatter.h"
 
 #include "spdlog/spdlog.h"
 
@@ -67,6 +69,82 @@ Optional<uint64_t> HashPolicyImpl::generateHash(const Http::HeaderMap& headers) 
   return hash;
 }
 
+HeaderFormatterSharedPtr RequestHeaderParser::parseInternal(const std::string& format) {
+	std::string variable_name;
+	if (format.find("%") == 0) {
+		size_t last_occ_pos = format.rfind("%");
+		if (last_occ_pos == std::string::npos || last_occ_pos <= 1) {
+			throw EnvoyException(fmt::format("Incorrect configuration: {}. Expected the variable to be of format %<variable_name>%",format));
+		}
+		variable_name = format.substr(1, last_occ_pos - 1);
+
+
+	}else {
+		HeaderFormatterSharedPtr plain_header_formatter_shard_ptr (new PlainHeaderFormatter(format));
+		return plain_header_formatter_shard_ptr;
+	}
+	HeaderFormatterSharedPtr request_header_formatter_shard_ptr(new RequestHeaderFormatter(variable_name));
+	return request_header_formatter_shard_ptr;
+}
+
+RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& config) {
+	RequestHeaderParser* parser = new RequestHeaderParser();
+	if (config.hasObject("request_headers_to_add")) {
+			std::vector<Json::ObjectSharedPtr> request_headers = config.getObjectArray("request_headers_to_add");
+			for (const Json::ObjectSharedPtr& header : request_headers) {
+				if (!header->getString("key").empty() && !header->getString("value").empty()) {
+					log().debug("adding key {} to header formatter map", header->getString("key"));
+					parser->header_formatter_map_.emplace(std::make_pair(Http::LowerCaseString(header->getString("key")),
+																 	    RequestHeaderParser::parseInternal(header->getString("value"))));
+				}
+			}
+	}
+	RequestHeaderParserSharedPtr request_header_parser(parser);
+	return request_header_parser;
+}
+
+void RequestHeaderParser::evaluateRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
+  							  	  	  	  	    const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
+  	for (const std::pair<Http::LowerCaseString, std::string>& to_add : requestHeadersToAdd) {
+
+  		log().debug("request headers key {}", to_add.first.get());
+
+  	  //search if the request has formatters defined
+  	  if (header_formatter_map_.count(to_add.first) == 1) {
+
+  		  auto search = header_formatter_map_.find(to_add.first);
+  		  // access the formatter
+  		  if (search != header_formatter_map_.end()) {
+				std::string formatted_header_value = search->second->format(requestInfo);
+				log().debug("formatted header name: '{}', value: '{}'\n", to_add.first.get(), formatted_header_value);
+				headers.addStatic(to_add.first, formatted_header_value);
+  		  }
+  	  }else {
+  		  headers.addStatic(to_add.first, to_add.second);
+  	  }
+  	}
+}
+
+RequestHeaderFormatter::RequestHeaderFormatter(std::string& field_name) {
+	if (field_name == "PROTOCOL") {
+	    field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+	      return Envoy::Http::AccessLog::AccessLogFormatUtils::protocolToString(request_info.protocol());
+	    };
+	 }else if (field_name == "CLIENT_IP") {
+		 field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+		  log().debug("field extractor invoked");
+		  return request_info.downStreamAddress();
+		};
+	 }else {
+		 throw EnvoyException(fmt::format("field {} not supported as custom request header", field_name));
+	 }
+}
+
+std::string RequestHeaderFormatter::format(const Envoy::Http::AccessLog::RequestInfo& request_info) const {
+	log().debug("request header formatter ");
+	return field_extractor_(request_info);
+}
+
 const uint64_t RouteEntryImplBase::WeightedClusterEntry::MAX_CLUSTER_WEIGHT = 100UL;
 
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json::Object& route,
@@ -82,7 +160,9 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
       host_redirect_(route.getString("host_redirect", "")),
       path_redirect_(route.getString("path_redirect", "")), retry_policy_(route),
       rate_limit_policy_(route), shadow_policy_(route),
-      priority_(ConfigUtility::parsePriority(route)), opaque_config_(parseOpaqueConfig(route)) {
+      priority_(ConfigUtility::parsePriority(route)),
+      request_headers_parser_(RequestHeaderParser::parse(route)),
+      opaque_config_(parseOpaqueConfig(route)) {
 
   route.validateSchema(Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA);
 
@@ -150,10 +230,10 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost, const Json:
 
   if (route.hasObject("request_headers_to_add")) {
     for (const Json::ObjectSharedPtr& header : route.getObjectArray("request_headers_to_add")) {
-      request_headers_to_add_.push_back(
-          {Http::LowerCaseString(header->getString("key")), header->getString("value")});
+      request_headers_to_add_.push_back({Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
   }
+
 
   // Only set include_vh_rate_limits_ to true if the rate limit policy for the route is empty
   // or the route set `include_vh_rate_limits` to true.
@@ -176,19 +256,14 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
 
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
-void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers) const {
+void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add : requestHeadersToAdd()) {
-    headers.addStatic(to_add.first, to_add.second);
-  }
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add : vhost_.requestHeadersToAdd()) {
-    headers.addStatic(to_add.first, to_add.second);
-  }
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add :
-       vhost_.globalRouteConfig().requestHeadersToAdd()) {
-    headers.addStatic(to_add.first, to_add.second);
-  }
+
+  request_headers_parser_->evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
+  vhost_.requestHeaderParser()->evaluateRequestHeaders(headers, requestInfo,vhost_.requestHeadersToAdd());
+  vhost_.globalRouteConfig().requestHeaderParser()->evaluateRequestHeaders(headers, requestInfo,
+		  	  	  	  	  	  	  	  	  	  	  	  	  	  	  	  	   vhost_.globalRouteConfig().requestHeadersToAdd());
 
   if (host_rewrite_.empty()) {
     return;
@@ -353,8 +428,8 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost, const J
                                            Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), prefix_(route.getString("prefix")) {}
 
-void PrefixRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers);
+void PrefixRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, prefix_);
 }
@@ -372,8 +447,8 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost, const Json:
                                        Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), path_(route.getString("path")) {}
 
-void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers);
+void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, path_);
 }
@@ -403,8 +478,10 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
 VirtualHostImpl::VirtualHostImpl(const Json::Object& virtual_host,
                                  const ConfigImpl& global_route_config, Runtime::Loader& runtime,
                                  Upstream::ClusterManager& cm, bool validate_clusters)
-    : name_(virtual_host.getString("name")), rate_limit_policy_(virtual_host),
-      global_route_config_(global_route_config) {
+    : name_(virtual_host.getString("name")),
+      rate_limit_policy_(virtual_host),
+      global_route_config_(global_route_config),
+      request_headers_parser_(RequestHeaderParser::parse(virtual_host)) {
 
   virtual_host.validateSchema(Json::Schema::VIRTUAL_HOST_CONFIGURATION_SCHEMA);
 
@@ -636,6 +713,7 @@ ConfigImpl::ConfigImpl(const Json::Object& config, Runtime::Loader& runtime,
           {Http::LowerCaseString(header->getString("key")), header->getString("value")});
     }
   }
+  request_headers_parser_ = RequestHeaderParser::parse(config);
 }
 
 } // namespace Router

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -2,7 +2,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
@@ -42,7 +41,6 @@ public:
                                       uint64_t random_value) const PURE;
 };
 
-// forward declaration
 class RouteEntryImplBase;
 typedef std::shared_ptr<const RouteEntryImplBase> RouteEntryImplBaseConstSharedPtr;
 
@@ -203,7 +201,7 @@ public:
   // Router::RouteEntry
   const std::string& clusterName() const override;
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
 
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
@@ -253,7 +251,7 @@ private:
     const std::string& clusterName() const override { return cluster_name_; }
 
     void finalizeRequestHeaders(Http::HeaderMap& headers,
-                                Http::AccessLog::RequestInfo& requestInfo) const override {
+                                const Http::AccessLog::RequestInfo& requestInfo) const override {
       return parent_->finalizeRequestHeaders(headers, requestInfo);
     }
 
@@ -354,7 +352,7 @@ public:
 
   // Router::RouteEntry
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -373,7 +371,7 @@ public:
 
   // Router::RouteEntry
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
@@ -9,16 +10,16 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <iostream>
 
 #include "envoy/common/optional.h"
 #include "envoy/router/router.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "common/router/config_utility.h"
-#include "common/router/router_ratelimit.h"
 #include "common/http/access_log/access_log_formatter.h"
+#include "common/router/config_utility.h"
+#include "common/router/req_header_formatter.h"
+#include "common/router/router_ratelimit.h"
 
 namespace Envoy {
 namespace Router {
@@ -41,12 +42,9 @@ public:
                                       uint64_t random_value) const PURE;
 };
 
-//forward declaration
+// forward declaration
 class RouteEntryImplBase;
 typedef std::shared_ptr<const RouteEntryImplBase> RouteEntryImplBaseConstSharedPtr;
-
-class RequestHeaderParser;
-typedef std::shared_ptr <RequestHeaderParser> RequestHeaderParserSharedPtr;
 
 /**
  * Redirect entry that does an SSL redirect.
@@ -89,7 +87,7 @@ public:
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
 
-  RequestHeaderParserSharedPtr requestHeaderParser() const {return request_headers_parser_;};
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -182,89 +180,6 @@ private:
 };
 
 /**
- * Interface for all types of header formatters used for custom request headers.
- */
-class HeaderFormatter {
-
-public:
-	virtual ~HeaderFormatter(){};
-
-	virtual std::string  format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
-};
-
-typedef std::shared_ptr<HeaderFormatter> HeaderFormatterSharedPtr;
-
-/**
- * a formatter that expands the request header variable to a value based on info in RequestInfo.
- */
-class RequestHeaderFormatter: public HeaderFormatter,
-							  Logger::Loggable<Logger::Id::config>  {
-
-public:
-	virtual ~RequestHeaderFormatter(){};
-	RequestHeaderFormatter(std::string& field_name);
-
-	std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const;
-
-private:
-	std::function<std::string(const Envoy::Http::AccessLog::RequestInfo&)> field_extractor_;
-
-};
-
-/**
- * Returns back the same static header value.
- */
-class PlainHeaderFormatter : public HeaderFormatter {
-
-public:
-	virtual ~PlainHeaderFormatter(){};
-
-	PlainHeaderFormatter(const std::string& static_header_value) {
-		std::cout << "static header value: " << static_header_value << "\n";
-		static_value_ = static_header_value;
-	};
-
-	std::string format(const Envoy::Http::AccessLog::RequestInfo&) const {
-		std::cout << "static value: " << static_value_ << "\n";
-		return static_value_;
-	};
-private:
-	std::string static_value_;
-
-};
-
-
-// forward declaring the typedef and class
-class RequestHeaderParser;
-
-typedef std::shared_ptr <RequestHeaderParser> RequestHeaderParserSharedPtr;
-
-/**
-  * This class will hold the parsing logic required during configuration build and
-  * also perform evaluation for the variables at runtime.
-  */
- class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
-
- public:
-	 virtual ~RequestHeaderParser(){};
-
-	 static RequestHeaderParserSharedPtr parse(const Json::Object& config);
-
-	 static HeaderFormatterSharedPtr parseInternal(const std::string& format);
-
-	 void evaluateRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
-	   							  const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
-
-	 std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> headerFormatterMap() {return header_formatter_map_;};
- private:
- 	/**
- 	 * building a map of request header formatters.
- 	 */
- 	std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> header_formatter_map_;
- };
-
-
-/**
  * Base implementation for all route entries.
  */
 class RouteEntryImplBase : public RouteEntry,
@@ -287,7 +202,8 @@ public:
 
   // Router::RouteEntry
   const std::string& clusterName() const override;
-  void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              Http::AccessLog::RequestInfo& requestInfo) const override;
 
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
@@ -320,7 +236,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  RequestHeaderParserSharedPtr requestHeaderParser() const {return request_headers_parser_;};
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -336,7 +252,8 @@ private:
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
 
-    void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const override {
+    void finalizeRequestHeaders(Http::HeaderMap& headers,
+                                Http::AccessLog::RequestInfo& requestInfo) const override {
       return parent_->finalizeRequestHeaders(headers, requestInfo);
     }
 
@@ -369,7 +286,6 @@ private:
     const RouteEntryImplBase* parent_;
     const std::string cluster_name_;
   };
-
 
   /**
    * Route entry implementation for weighted clusters. The RouteEntryImplBase object holds
@@ -437,7 +353,8 @@ public:
                        Runtime::Loader& loader);
 
   // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -455,7 +372,8 @@ public:
                      Runtime::Loader& loader);
 
   // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -528,7 +446,7 @@ public:
 
   bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
-  RequestHeaderParserSharedPtr requestHeaderParser() const {return request_headers_parser_;};
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
@@ -537,7 +455,6 @@ private:
   std::list<Http::LowerCaseString> response_headers_to_remove_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
   RequestHeaderParserSharedPtr request_headers_parser_;
-
 };
 
 /**

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -68,7 +68,7 @@ void RequestHeaderParser::evaluateRequestHeaders(
   }
 }
 
-RequestHeaderFormatter::RequestHeaderFormatter(std::string& field_name) {
+RequestHeaderFormatter::RequestHeaderFormatter(const std::string& field_name) {
   if (field_name == "PROTOCOL") {
     field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
       return Envoy::Http::AccessLog::AccessLogFormatUtils::protocolToString(

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -1,0 +1,99 @@
+#include "common/router/req_header_formatter.h"
+
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/http/headers.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Router {
+
+HeaderFormatterSharedPtr RequestHeaderParser::parseInternal(const std::string& format) {
+  std::string variable_name;
+  if (format.find("%") == 0) {
+    size_t last_occ_pos = format.rfind("%");
+    if (last_occ_pos == std::string::npos || last_occ_pos <= 1) {
+      throw EnvoyException(fmt::format(
+          "Incorrect configuration: {}. Expected the variable to be of format %<variable_name>%",
+          format));
+    }
+    variable_name = format.substr(1, last_occ_pos - 1);
+
+  } else {
+    HeaderFormatterSharedPtr plain_header_formatter_shard_ptr(new PlainHeaderFormatter(format));
+    return plain_header_formatter_shard_ptr;
+  }
+  HeaderFormatterSharedPtr request_header_formatter_shard_ptr(
+      new RequestHeaderFormatter(variable_name));
+  return request_header_formatter_shard_ptr;
+}
+
+RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& config) {
+
+  RequestHeaderParserSharedPtr request_header_parser(new RequestHeaderParser());
+  if (config.hasObject("request_headers_to_add")) {
+    std::vector<Json::ObjectSharedPtr> request_headers =
+        config.getObjectArray("request_headers_to_add");
+    for (const Json::ObjectSharedPtr& header : request_headers) {
+      if (!header->getString("key").empty() && !header->getString("value").empty()) {
+        log().debug("adding key {} to header formatter map", header->getString("key"));
+        request_header_parser->header_formatter_map_.emplace(
+            std::make_pair(Http::LowerCaseString(header->getString("key")),
+                           RequestHeaderParser::parseInternal(header->getString("value"))));
+      }
+    }
+  }
+
+  return request_header_parser;
+}
+
+void RequestHeaderParser::evaluateRequestHeaders(
+    Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
+    const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
+
+  for (const std::pair<Http::LowerCaseString, std::string>& to_add : requestHeadersToAdd) {
+
+    log().debug("request headers key {}", to_add.first.get());
+
+    // search if the request has formatters defined
+    if (header_formatter_map_.count(to_add.first) == 1) {
+
+      auto search = header_formatter_map_.find(to_add.first);
+      // access the formatter
+      if (search != header_formatter_map_.end()) {
+        std::string formatted_header_value = search->second->format(requestInfo);
+        headers.addStaticKey(to_add.first, formatted_header_value);
+      }
+    } else {
+      headers.addStatic(to_add.first, to_add.second);
+    }
+  }
+}
+
+RequestHeaderFormatter::RequestHeaderFormatter(std::string& field_name) {
+  if (field_name == "PROTOCOL") {
+    field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+      return Envoy::Http::AccessLog::AccessLogFormatUtils::protocolToString(
+          request_info.protocol());
+    };
+  } else if (field_name == "CLIENT_IP") {
+    field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+      return request_info.getDownstreamAddress();
+    };
+  } else {
+    throw EnvoyException(
+        fmt::format("field {} not supported as custom request header", field_name));
+  }
+}
+
+std::string
+RequestHeaderFormatter::format(const Envoy::Http::AccessLog::RequestInfo& request_info) const {
+  return field_extractor_(request_info);
+}
+} // Router
+} // Envoy

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 #include <iostream>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/http/access_log/access_log_formatter.h"
@@ -25,12 +25,12 @@ HeaderFormatterSharedPtr RequestHeaderParser::parseInternal(const std::string& f
     variable_name = format.substr(1, last_occ_pos - 1);
 
   } else {
-    HeaderFormatterSharedPtr plain_header_formatter_shard_ptr(new PlainHeaderFormatter(format));
-    return plain_header_formatter_shard_ptr;
+    HeaderFormatterSharedPtr plain_header_formatter_shared_ptr(new PlainHeaderFormatter(format));
+    return plain_header_formatter_shared_ptr;
   }
-  HeaderFormatterSharedPtr request_header_formatter_shard_ptr(
+  HeaderFormatterSharedPtr request_header_formatter_shared_ptr(
       new RequestHeaderFormatter(variable_name));
-  return request_header_formatter_shard_ptr;
+  return request_header_formatter_shared_ptr;
 }
 
 RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& config) {
@@ -41,10 +41,10 @@ RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& conf
         config.getObjectArray("request_headers_to_add");
     for (const Json::ObjectSharedPtr& header : request_headers) {
       if (!header->getString("key").empty() && !header->getString("value").empty()) {
-        log().debug("adding key {} to header formatter map", header->getString("key"));
+        ENVOY_LOG(debug, "adding key {} to header formatter map", header->getString("key"));
         request_header_parser->header_formatter_map_.emplace(
-            std::make_pair(Http::LowerCaseString(header->getString("key")),
-                           RequestHeaderParser::parseInternal(header->getString("value"))));
+            Http::LowerCaseString(header->getString("key")),
+            RequestHeaderParser::parseInternal(header->getString("value")));
       }
     }
   }
@@ -53,22 +53,15 @@ RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& conf
 }
 
 void RequestHeaderParser::evaluateRequestHeaders(
-    Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
     const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
 
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add : requestHeadersToAdd) {
-
-    log().debug("request headers key {}", to_add.first.get());
-
-    // search if the request has formatters defined
-    if (header_formatter_map_.count(to_add.first) == 1) {
-
-      auto search = header_formatter_map_.find(to_add.first);
-      // access the formatter
-      if (search != header_formatter_map_.end()) {
-        std::string formatted_header_value = search->second->format(requestInfo);
-        headers.addStaticKey(to_add.first, formatted_header_value);
-      }
+  for (const auto& to_add : requestHeadersToAdd) {
+    ENVOY_LOG(debug, "request headers key {}", to_add.first.get());
+    auto search = header_formatter_map_.find(to_add.first);
+    if (search != header_formatter_map_.end()) {
+      const std::string formatted_header_value = search->second->format(requestInfo);
+      headers.addStaticKey(to_add.first, formatted_header_value);
     } else {
       headers.addStatic(to_add.first, to_add.second);
     }
@@ -87,7 +80,7 @@ RequestHeaderFormatter::RequestHeaderFormatter(std::string& field_name) {
     };
   } else {
     throw EnvoyException(
-        fmt::format("field {} not supported as custom request header", field_name));
+        fmt::format("field '{}' not supported as custom request header", field_name));
   }
 }
 
@@ -95,5 +88,5 @@ std::string
 RequestHeaderFormatter::format(const Envoy::Http::AccessLog::RequestInfo& request_info) const {
   return field_extractor_(request_info);
 }
-} // Router
-} // Envoy
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 #include <iostream>
-#include <map>
 #include <string>
+#include <unordered_map>
 
 #include "common/common/logger.h"
 #include "common/http/access_log/access_log_formatter.h"
@@ -40,7 +40,6 @@ public:
 private:
   std::function<std::string(const Envoy::Http::AccessLog::RequestInfo&)> field_extractor_;
 };
-
 /**
  * Returns back the same static header value.
  */
@@ -68,9 +67,9 @@ class RequestHeaderParser;
 typedef std::shared_ptr<RequestHeaderParser> RequestHeaderParserSharedPtr;
 
 /**
-  * This class will hold the parsing logic required during configuration build and
-  * also perform evaluation for the variables at runtime.
-  */
+ * This class will hold the parsing logic required during configuration build and
+ * also perform evaluation for the variables at runtime.
+ */
 class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
 
 public:
@@ -81,10 +80,11 @@ public:
   static HeaderFormatterSharedPtr parseInternal(const std::string& format);
 
   void evaluateRequestHeaders(
-      Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
+      Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
 
-  std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> headerFormatterMap() {
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+  headerFormatterMap() {
     return header_formatter_map_;
   };
 
@@ -92,8 +92,9 @@ private:
   /**
    * building a map of request header formatters.
    */
-  std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> header_formatter_map_;
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+      header_formatter_map_;
 };
 
-} // Router
-} // Envoy
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "common/common/logger.h"
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * Interface for all types of header formatters used for custom request headers.
+ */
+class HeaderFormatter {
+
+public:
+  virtual ~HeaderFormatter(){};
+
+  virtual std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
+};
+
+typedef std::shared_ptr<HeaderFormatter> HeaderFormatterSharedPtr;
+
+/**
+ * a formatter that expands the request header variable to a value based on info in RequestInfo.
+ */
+class RequestHeaderFormatter : public HeaderFormatter, Logger::Loggable<Logger::Id::config> {
+
+public:
+  virtual ~RequestHeaderFormatter(){};
+  RequestHeaderFormatter(std::string& field_name);
+
+  // HeaderFormatter::format
+  std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const override;
+
+private:
+  std::function<std::string(const Envoy::Http::AccessLog::RequestInfo&)> field_extractor_;
+};
+
+/**
+ * Returns back the same static header value.
+ */
+class PlainHeaderFormatter : public HeaderFormatter {
+
+public:
+  virtual ~PlainHeaderFormatter(){};
+
+  PlainHeaderFormatter(const std::string& static_header_value) {
+    static_value_ = static_header_value;
+  };
+
+  // HeaderFormatter::format
+  std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
+    return static_value_;
+  };
+
+private:
+  std::string static_value_;
+};
+
+// forward declaring the typedef and class
+class RequestHeaderParser;
+
+typedef std::shared_ptr<RequestHeaderParser> RequestHeaderParserSharedPtr;
+
+/**
+  * This class will hold the parsing logic required during configuration build and
+  * also perform evaluation for the variables at runtime.
+  */
+class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
+
+public:
+  virtual ~RequestHeaderParser(){};
+
+  static RequestHeaderParserSharedPtr parse(const Json::Object& config);
+
+  static HeaderFormatterSharedPtr parseInternal(const std::string& format);
+
+  void evaluateRequestHeaders(
+      Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo,
+      const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
+
+  std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> headerFormatterMap() {
+    return header_formatter_map_;
+  };
+
+private:
+  /**
+   * building a map of request header formatters.
+   */
+  std::map<Http::LowerCaseString, HeaderFormatterSharedPtr> header_formatter_map_;
+};
+
+} // Router
+} // Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -32,7 +32,7 @@ class RequestHeaderFormatter : public HeaderFormatter, Logger::Loggable<Logger::
 
 public:
   virtual ~RequestHeaderFormatter(){};
-  RequestHeaderFormatter(std::string& field_name);
+  RequestHeaderFormatter(const std::string& field_name);
 
   // HeaderFormatter::format
   std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const override;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -236,7 +236,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     timeout_response_code_ = Http::Code::NoContent;
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
-  callbacks_->requestInfo().setDownstreamAddress(callbacks_->downstreamAddress());
   log().debug("downstream address: '{}'\n", callbacks_->downstreamAddress());
   route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -145,7 +145,7 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
 
 void Filter::chargeUpstreamCode(Http::Code code,
                                 Upstream::HostDescriptionConstSharedPtr upstream_host) {
-  Http::HeaderMapImpl 	fake_response_headers{
+  Http::HeaderMapImpl fake_response_headers{
       {Http::Headers::get().Status, std::to_string(enumToInt(code))}};
   chargeUpstreamCode(fake_response_headers, upstream_host);
 }
@@ -236,7 +236,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     timeout_response_code_ = Http::Code::NoContent;
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
-  callbacks_->requestInfo().downStreamAddress(callbacks_->downstreamAddress());
+  callbacks_->requestInfo().setDownstreamAddress(callbacks_->downstreamAddress());
   log().debug("downstream address: '{}'\n", callbacks_->downstreamAddress());
   route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -145,7 +145,7 @@ void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,
 
 void Filter::chargeUpstreamCode(Http::Code code,
                                 Upstream::HostDescriptionConstSharedPtr upstream_host) {
-  Http::HeaderMapImpl fake_response_headers{
+  Http::HeaderMapImpl 	fake_response_headers{
       {Http::Headers::get().Status, std::to_string(enumToInt(code))}};
   chargeUpstreamCode(fake_response_headers, upstream_host);
 }
@@ -159,6 +159,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Determine if there is a route entry or a redirect for the request.
   route_ = callbacks_->route();
+
   if (!route_) {
     config_.stats_.no_route_.inc();
     ENVOY_STREAM_LOG(debug, "no cluster match for URL '{}'", *callbacks_,
@@ -235,8 +236,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     timeout_response_code_ = Http::Code::NoContent;
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
-
-  route_entry_->finalizeRequestHeaders(headers);
+  callbacks_->requestInfo().downStreamAddress(callbacks_->downstreamAddress());
+  log().debug("downstream address: '{}'\n", callbacks_->downstreamAddress());
+  route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);
   retry_state_ = createRetryState(route_entry_->retryPolicy(), headers, *cluster_, config_.runtime_,
                                   config_.random_, callbacks_->dispatcher(), finalPriority());

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -66,8 +66,8 @@ public:
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
   std::string downstream_address_;
-  void downStreamAddress(std::string address) override {downstream_address_= address;}
-  std::string downStreamAddress() const override {return downstream_address_;}
+  void setDownstreamAddress(std::string address) override { downstream_address_ = address; }
+  const std::string& getDownstreamAddress() const override { return downstream_address_; }
 
   SystemTime start_time_;
   Protocol protocol_{Protocol::Http11};

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -65,6 +65,10 @@ public:
   bool healthCheck() const override { return hc_request_; }
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
+  std::string downstream_address_;
+  void downStreamAddress(std::string address) override {downstream_address_= address;}
+  std::string downStreamAddress() const override {return downstream_address_;}
+
   SystemTime start_time_;
   Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -65,7 +65,7 @@ public:
   bool healthCheck() const override { return hc_request_; }
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  void setDownstreamAddress(std::string address) override { downstream_address_ = address; }
+  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
   const std::string& getDownstreamAddress() const override { return downstream_address_; }
 
   SystemTime start_time_;

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -65,7 +65,6 @@ public:
   bool healthCheck() const override { return hc_request_; }
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  std::string downstream_address_;
   void setDownstreamAddress(std::string address) override { downstream_address_ = address; }
   const std::string& getDownstreamAddress() const override { return downstream_address_; }
 
@@ -76,6 +75,7 @@ public:
   uint64_t duration_{3};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool hc_request_{};
+  std::string downstream_address_;
 };
 
 class AccessLogImplTest : public testing::Test {

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -97,3 +97,14 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
     ],
 )
+
+envoy_cc_test(
+    name = "req_header_formatter_test",
+    srcs = ["req_header_formatter_test.cc"],
+    deps = [
+        "//source/common/router:req_header_formatter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6,10 +6,10 @@
 
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
-#include "common/json/json_loader.h"
-#include "common/router/config_impl.h"
 #include "common/http/utility.h"
+#include "common/json/json_loader.h"
 #include "common/network/address_impl.h"
+#include "common/router/config_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -33,7 +33,6 @@ static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::st
                                           const std::string& method) {
   return Http::TestHeaderMapImpl{{":authority", host}, {":path", path}, {":method", method}};
 }
-
 
 TEST(RouteMatcherTest, TestRoutes) {
   std::string json = R"EOF(
@@ -2036,7 +2035,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
 }
 
 TEST(CustomRequestHeadersTest, AddNewHeader) {
-	std::string json = R"EOF(
+  std::string json = R"EOF(
 	{
   "virtual_hosts": [
     {
@@ -2129,28 +2128,26 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
   ]
 }
 	  )EOF";
-	Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-	NiceMock<Runtime::MockLoader> runtime;
-	NiceMock<Upstream::MockClusterManager> cm;
-	NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-	ConfigImpl config(*loader, runtime, cm, true);
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  ConfigImpl config(*loader, runtime, cm, true);
 
-
-	// Request header manipulation testing.
-	{
-		{
-			Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
-			ON_CALL(requestInfo, downStreamAddress()).WillByDefault(Return("127.0.0.1"));
-			const RouteEntry* route = config.route(headers, 0)->routeEntry();
-			route->finalizeRequestHeaders(headers, requestInfo);
-			EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));
-		}
-	}
-
+  // Request header manipulation testing.
+  {
+    {
+      Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
+      ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef("127.0.0.1"));
+      const RouteEntry* route = config.route(headers, 0)->routeEntry();
+      route->finalizeRequestHeaders(headers, requestInfo);
+      EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));
+    }
+  }
 }
 
 TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
-	std::string json = R"EOF(
+  std::string json = R"EOF(
 	{
   "virtual_hosts": [
     {
@@ -2243,12 +2240,11 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
   ]
 }
 	  )EOF";
-	Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-	NiceMock<Runtime::MockLoader> runtime;
-	NiceMock<Upstream::MockClusterManager> cm;
-	NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-	EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
-
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
 }
 
 } // Router

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2035,7 +2035,7 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
 }
 
 TEST(CustomRequestHeadersTest, AddNewHeader) {
-  std::string json = R"EOF(
+  const std::string json = R"EOF(
 	{
   "virtual_hosts": [
     {
@@ -2146,6 +2146,11 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
   }
 }
 
+bool CheckFormatMessage(const std::string errorMessage) {
+  std::size_t found = errorMessage.find("Incorrect configuration");
+  return (found != std::string::npos);
+}
+
 TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
   std::string json = R"EOF(
 	{
@@ -2244,8 +2249,13 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
+  ASSERT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
+  try {
+    ConfigImpl config(*loader, runtime, cm, true);
+  } catch (EnvoyException& ex) {
+    EXPECT_PRED1(CheckFormatMessage, ex.what());
+  }
 }
 
-} // Router
-} // Envoy
+} // namespace Router
+} // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2137,8 +2137,9 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
   // Request header manipulation testing.
   {
     {
+      std::string s1 = ("127.0.0.1");
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
-      ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef("127.0.0.1"));
+      ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
       route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -8,6 +8,8 @@
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
 #include "common/router/config_impl.h"
+#include "common/http/utility.h"
+#include "common/network/address_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -31,6 +33,7 @@ static Http::TestHeaderMapImpl genHeaders(const std::string& host, const std::st
                                           const std::string& method) {
   return Http::TestHeaderMapImpl{{":authority", host}, {":path", path}, {":method", method}};
 }
+
 
 TEST(RouteMatcherTest, TestRoutes) {
   std::string json = R"EOF(
@@ -165,6 +168,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(*loader, runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -219,7 +223,7 @@ TEST(RouteMatcherTest, TestRoutes) {
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     EXPECT_EQ("www2", route->clusterName());
     EXPECT_EQ("www2", route->virtualHost().name());
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/api/new_endpoint/foo", headers.get_(Http::Headers::get().Path));
   }
 
@@ -228,14 +232,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/api/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/foo", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/bar", headers.get_(Http::Headers::get().Path));
   }
 
@@ -243,7 +247,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/host/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -252,14 +256,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/API/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/fooD", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/cAndy", headers.get_(Http::Headers::get().Path));
   }
 
@@ -267,14 +271,14 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/FOO", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/FOO", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/ApPles", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/ApPles", headers.get_(Http::Headers::get().Path));
   }
 
@@ -282,7 +286,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/oLDhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().Host));
   }
 
@@ -290,7 +294,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/Tart", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/Tart", headers.get_(Http::Headers::get().Path));
   }
 
@@ -298,7 +302,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/newhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -446,6 +450,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(*loader, runtime, cm, true);
 
   // Request header manipulation testing.
@@ -453,7 +458,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("route-override", headers.get_("x-global-header1"));
       EXPECT_EQ("route-override", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-new_endpoint", headers.get_("x-route-header"));
@@ -463,7 +468,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("vhost-override", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allpath", headers.get_("x-route-header"));
@@ -473,7 +478,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www-staging.lyft.net", "/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2_staging", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allprefix", headers.get_("x-route-header"));
@@ -483,7 +488,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
     }
   }
@@ -760,6 +765,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(*loader, runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -779,7 +785,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 
     // Make sure things forward and don't crash.
     EXPECT_EQ(std::chrono::milliseconds(0), route->routeEntry()->timeout());
-    route->routeEntry()->finalizeRequestHeaders(headers);
+    route->routeEntry()->finalizeRequestHeaders(headers, requestInfo);
     route->routeEntry()->priority();
     route->routeEntry()->rateLimitPolicy();
     route->routeEntry()->retryPolicy();
@@ -2029,5 +2035,221 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
-} // namespace Router
-} // namespace Envoy
+TEST(CustomRequestHeadersTest, AddNewHeader) {
+	std::string json = R"EOF(
+	{
+  "virtual_hosts": [
+    {
+      "name": "www2",
+      "domains": [
+        "lyft.com",
+        "www.lyft.com",
+        "w.lyft.com",
+        "ww.lyft.com",
+        "wwww.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-client-ip",
+          "value": "%CLIENT_IP%"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        },
+        {
+          "path": "/",
+          "cluster": "root_www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        },
+        {
+          "prefix": "/",
+          "cluster": "www2"
+        }
+      ]
+    },
+    {
+      "name": "www2_staging",
+      "domains": [
+        "www-staging.lyft.net",
+        "www-staging-orca.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-vhost-header1",
+          "value": "vhost1-www2_staging"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "www2_staging",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "default",
+      "domains": [
+        "*"
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "instant-server",
+          "timeout_ms": 30000
+        }
+      ]
+    }
+  ],
+  "request_headers_to_add": [
+    {
+      "key": "x-client-ip",
+      "value": "%CLIENT_IP%"
+    }
+  ]
+}
+	  )EOF";
+	Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+	NiceMock<Runtime::MockLoader> runtime;
+	NiceMock<Upstream::MockClusterManager> cm;
+	NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+	ConfigImpl config(*loader, runtime, cm, true);
+
+
+	// Request header manipulation testing.
+	{
+		{
+			Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
+			ON_CALL(requestInfo, downStreamAddress()).WillByDefault(Return("127.0.0.1"));
+			const RouteEntry* route = config.route(headers, 0)->routeEntry();
+			route->finalizeRequestHeaders(headers, requestInfo);
+			EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));
+		}
+	}
+
+}
+
+TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
+	std::string json = R"EOF(
+	{
+  "virtual_hosts": [
+    {
+      "name": "www2",
+      "domains": [
+        "lyft.com",
+        "www.lyft.com",
+        "w.lyft.com",
+        "ww.lyft.com",
+        "wwww.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-client-ip",
+          "value": "%CLIENT_IP%"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        },
+        {
+          "path": "/",
+          "cluster": "root_www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        },
+        {
+          "prefix": "/",
+          "cluster": "www2"
+        }
+      ]
+    },
+    {
+      "name": "www2_staging",
+      "domains": [
+        "www-staging.lyft.net",
+        "www-staging-orca.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-vhost-header1",
+          "value": "vhost1-www2_staging"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "www2_staging",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "default",
+      "domains": [
+        "*"
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "instant-server",
+          "timeout_ms": 30000
+        }
+      ]
+    }
+  ],
+  "request_headers_to_add": [
+    {
+      "key": "x-client-ip",
+      "value": "%CLIENT_IP"
+    }
+  ]
+}
+	  )EOF";
+	Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+	NiceMock<Runtime::MockLoader> runtime;
+	NiceMock<Upstream::MockClusterManager> cm;
+	NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+	EXPECT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
+
+}
+
+} // Router
+} // Envoy

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -1,0 +1,98 @@
+#include <string>
+
+#include "envoy/http/protocol.h"
+
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/router/req_header_formatter.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Router {
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::_;
+
+TEST(RequestHeaderFormatterTest, TestFormatWithClientIpVariable) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::string variable = "CLIENT_IP";
+  RequestHeaderFormatter requestHeaderFormatter(variable);
+  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  EXPECT_EQ("127.0.0.1", formatted_string);
+}
+
+TEST(RequestHeaderFormatterTest, TestFormatWithProtocolVariable) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  ON_CALL(requestInfo, protocol()).WillByDefault(Return(Envoy::Http::Protocol::Http11));
+  std::string variable = "PROTOCOL";
+  RequestHeaderFormatter requestHeaderFormatter(variable);
+  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  EXPECT_EQ("HTTP/1.1", formatted_string);
+}
+
+TEST(RequestHeaderFormatterTest, WrongVariableToFormat) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::string variable = "INVALID_VARIABLE";
+  ASSERT_THROW(RequestHeaderFormatter requestHeaderFormatter(variable), EnvoyException);
+}
+
+TEST(RequestHeaderParserTest, EvaluateHeaders) {
+  std::string json = R"EOF(
+		{
+	     "request_headers_to_add": [
+	    	{
+	      		"key": "x-client-ip",
+	      		"value": "%CLIENT_IP%"
+	    	}
+	   	]
+	  })EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
+      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::pair<Http::LowerCaseString, std::string> client_ip_req_header(
+      Http::LowerCaseString{"x-client-ip"}, "%CLIENT_IP%");
+  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
+      client_ip_req_header};
+  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  EXPECT_TRUE(headerMap.has("x-client-ip"));
+}
+
+TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
+  std::string json = R"EOF(
+		{
+	     "request_headers_to_add": [
+	    	{
+	      		"key": "static-header",
+	      		"value": "static-value"
+	    	}
+	   	]
+	  })EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
+      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::pair<Http::LowerCaseString, std::string> static_req_header(
+      Http::LowerCaseString{"static-header"}, "static-value");
+  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
+      static_req_header};
+  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  EXPECT_TRUE(headerMap.has("static-header"));
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -59,7 +59,7 @@ public:
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
   MOCK_CONST_METHOD0(getDownstreamAddress, const std::string&());
-  MOCK_METHOD1(setDownstreamAddress, void(std::string downstream_address));
+  MOCK_METHOD1(setDownstreamAddress, void(const std::string& downstream_address));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -58,6 +58,8 @@ public:
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
+  MOCK_CONST_METHOD0(downStreamAddress, std::string());
+  MOCK_METHOD1(downStreamAddress, void(std::string downstream_address));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -58,8 +58,8 @@ public:
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
-  MOCK_CONST_METHOD0(downStreamAddress, std::string());
-  MOCK_METHOD1(downStreamAddress, void(std::string downstream_address));
+  MOCK_CONST_METHOD0(getDownstreamAddress, const std::string&());
+  MOCK_METHOD1(setDownstreamAddress, void(std::string downstream_address));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -149,7 +149,8 @@ public:
 
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD2(finalizeRequestHeaders, void(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo));
+  MOCK_CONST_METHOD2(finalizeRequestHeaders,
+                     void(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -149,7 +149,7 @@ public:
 
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD1(finalizeRequestHeaders, void(Http::HeaderMap& headers));
+  MOCK_CONST_METHOD2(finalizeRequestHeaders, void(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -149,8 +149,8 @@ public:
 
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD2(finalizeRequestHeaders,
-                     void(Http::HeaderMap& headers, Http::AccessLog::RequestInfo& requestInfo));
+  MOCK_CONST_METHOD2(finalizeRequestHeaders, void(Http::HeaderMap& headers,
+                                                  const Http::AccessLog::RequestInfo& requestInfo));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -154,9 +154,9 @@ bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-
+  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
     actual = tool_config.headers_->get_(Http::Headers::get().Path);
   }
   return compareResults(actual, expected, "path_rewrite");
@@ -164,9 +164,9 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-
+  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
     actual = tool_config.headers_->get_(Http::Headers::get().Host);
   }
   return compareResults(actual, expected, "host_rewrite");


### PR DESCRIPTION
This PR is a new feature that allows the user to configure the custom request headers names for certain fields like CLIENT_IP. The feature leverages the "request_headers_to_add" property.

GH Ticket https://github.com/lyft/envoy/issues/1016