### PR TITLE
config: drop ResponseType as a Subscription interface parameter.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -105,7 +105,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = "https://github.com/lyft/envoy-api.git",
-        commit = "7352904532dcfa16965062e481d8e4776707e9da",
+        commit = "ecd521b1acf7e5c1ca3d2b0e9c3ad18a6cc5b530",
     )
     native.bind(
         name = "envoy_base",

--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -27,14 +27,10 @@ public:
 
 /**
  * Common abstraction for subscribing to versioned config updates. This may be implemented via bidi
- * gRPC streams, periodic/long polling REST or inotify filesystem updates. Both ResponseType and
- * ResourceType are expected to be protobuf serializable objects. ResponseType must have two fields:
- * - bytes version_info
- * - repeated ResponseType resources
- * This typing corresponds to the stylized use of protobufs in the xDS subscription response
- * objects.
+ * gRPC streams, periodic/long polling REST or inotify filesystem updates. ResourceType is expected
+ * to be a protobuf serializable object.
  */
-template <class ResponseType, class ResourceType> class Subscription {
+template <class ResourceType> class Subscription {
 public:
   virtual ~Subscription() {}
 

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -15,8 +15,7 @@ public:
       bool(const typename SubscriptionCallbacks<ResourceType>::ResourceVector& resources));
 };
 
-template <class ResponseType, class ResourceType>
-class MockSubscription : public Subscription<ResponseType, ResourceType> {
+template <class ResourceType> class MockSubscription : public Subscription<ResourceType> {
 public:
   MOCK_METHOD2_T(start, void(const std::vector<std::string>& resources,
                              SubscriptionCallbacks<ResourceType>& callbacks));


### PR DESCRIPTION
Bumping lyft/envoy-api to ecd521b allows us to only consider ResourceType in the Subscription
templating.