### PR TITLE
config: REST Subscription implementation.

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -1,0 +1,15 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "utility_lib",
+    hdrs = ["utility.h"],
+    external_deps = ["envoy_base"],
+)

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "api/base.pb.h"
+
+namespace Envoy {
+namespace Config {
+
+/**
+ * General config API utilities.
+ */
+class Utility {
+public:
+  /**
+   * Extract typed resources from a DiscoveryResponse.
+   * @param response reference to DiscoveryResponse.
+   * @return google::protobuf::RepatedPtrField<ResourceType> vector of typed resources in response.
+   */
+  template <class ResourceType>
+  static google::protobuf::RepeatedPtrField<ResourceType>
+  getTypedResources(const envoy::api::v2::DiscoveryResponse& response) {
+    google::protobuf::RepeatedPtrField<ResourceType> typed_resources;
+    for (auto& resource : response.resources()) {
+      auto* typed_resource = typed_resources.Add();
+      resource.UnpackTo(typed_resource);
+    }
+    return typed_resources;
+  }
+};
+
+} // Config
+} // Envoy

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -110,5 +110,6 @@ envoy_cc_library(
     deps = [
         ":async_client_lib",
         "//include/envoy/config:subscription_interface",
+        "//source/common/config:utility_lib",
     ],
 )

--- a/source/common/grpc/subscription_impl.h
+++ b/source/common/grpc/subscription_impl.h
@@ -3,6 +3,7 @@
 #include "envoy/config/subscription.h"
 #include "envoy/event/dispatcher.h"
 
+#include "common/config/utility.h"
 #include "common/grpc/async_client_impl.h"
 
 #include "api/base.pb.h"
@@ -81,11 +82,7 @@ public:
   }
 
   void onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResponse>&& message) override {
-    google::protobuf::RepeatedPtrField<ResourceType> typed_resources;
-    for (auto& resource : message->resources()) {
-      auto* typed_resource = typed_resources.Add();
-      resource.UnpackTo(typed_resource);
-    }
+    const auto typed_resources = Config::Utility::getTypedResources<ResourceType>(*message);
     if (callbacks_->onConfigUpdate(typed_resources)) {
       request_.set_version_info(message->version_info());
       // This effectively ACKs the accepted configuration.

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -204,6 +204,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "subscription_lib",
+    hdrs = ["subscription_impl.h"],
+    external_deps = ["envoy_base"],
+    deps = [
+        ":headers_lib",
+        ":rest_api_fetcher_lib",
+        "//include/envoy/config:subscription_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "user_agent_lib",
     srcs = ["user_agent.cc"],
     hdrs = ["user_agent.h"],

--- a/source/common/http/subscription_impl.h
+++ b/source/common/http/subscription_impl.h
@@ -73,6 +73,8 @@ public:
     const auto typed_resources = Config::Utility::getTypedResources<ResourceType>(message);
     if (callbacks_->onConfigUpdate(typed_resources)) {
       request_.set_version_info(message.version_info());
+    } else {
+      // TODO(htuch): Track stats and log failures.
     }
   }
 

--- a/source/common/http/subscription_impl.h
+++ b/source/common/http/subscription_impl.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "envoy/config/subscription.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/assert.h"
+#include "common/common/macros.h"
+#include "common/config/utility.h"
+#include "common/http/headers.h"
+#include "common/http/rest_api_fetcher.h"
+
+#include "api/base.pb.h"
+#include "google/api/annotations.pb.h"
+#include "google/protobuf/descriptor.pb.h"
+#include "google/protobuf/util/json_util.h"
+
+namespace Envoy {
+namespace Http {
+
+template <class ResourceType>
+class SubscriptionImpl : public RestApiFetcher, Config::Subscription<ResourceType> {
+public:
+  SubscriptionImpl(const envoy::api::v2::Node& node, Upstream::ClusterManager& cm,
+                   const std::string& remote_cluster_name, Event::Dispatcher& dispatcher,
+                   Runtime::RandomGenerator& random, std::chrono::milliseconds refresh_interval,
+                   const google::protobuf::MethodDescriptor& service_method)
+      : RestApiFetcher(cm, remote_cluster_name, dispatcher, random, refresh_interval) {
+    request_.mutable_node()->CopyFrom(node);
+    ASSERT(service_method.options().HasExtension(google::api::http));
+    const auto& http_rule = service_method.options().GetExtension(google::api::http);
+    path_ = http_rule.post();
+    ASSERT(http_rule.body() == "*");
+  }
+
+  // Config::Subscription
+  void start(const std::vector<std::string>& resources,
+             Config::SubscriptionCallbacks<ResourceType>& callbacks) override {
+    ASSERT(callbacks_ == nullptr);
+    google::protobuf::RepeatedPtrField<std::string> resources_vector(resources.begin(),
+                                                                     resources.end());
+    request_.mutable_resource_names()->Swap(&resources_vector);
+    callbacks_ = &callbacks;
+    initialize();
+  }
+
+  void updateResources(const std::vector<std::string>& resources) override {
+    google::protobuf::RepeatedPtrField<std::string> resources_vector(resources.begin(),
+                                                                     resources.end());
+    request_.mutable_resource_names()->Swap(&resources_vector);
+  }
+
+  // Http::RestApiFetcher
+  void createRequest(Message& request) override {
+    google::protobuf::util::JsonOptions json_options;
+    std::string request_json;
+    const auto status =
+        google::protobuf::util::MessageToJsonString(request_, &request_json, json_options);
+    // If the status isn't OK, we just send an empty body.
+    ASSERT(status == google::protobuf::util::Status::OK);
+    request.headers().insertMethod().value(Http::Headers::get().MethodValues.Post);
+    request.headers().insertPath().value(path_);
+    request.body().reset(new Buffer::OwnedImpl(request_json));
+  }
+
+  void parseResponse(const Message& response) override {
+    envoy::api::v2::DiscoveryResponse message;
+    const auto status =
+        google::protobuf::util::JsonStringToMessage(response.bodyAsString(), &message);
+    if (status != google::protobuf::util::Status::OK) {
+      // TODO(htuch): Track stats and log failures.
+      return;
+    }
+    const auto typed_resources = Config::Utility::getTypedResources<ResourceType>(message);
+    if (callbacks_->onConfigUpdate(typed_resources)) {
+      request_.set_version_info(message.version_info());
+    }
+  }
+
+  void onFetchComplete() override {}
+
+  void onFetchFailure(EnvoyException* e) override {
+    // TODO(htuch): Track stats and log failures.
+    UNREFERENCED_PARAMETER(e);
+  }
+
+private:
+  std::string path_;
+  google::protobuf::RepeatedPtrField<std::string> resources_;
+  Config::SubscriptionCallbacks<ResourceType>* callbacks_{};
+  envoy::api::v2::DiscoveryRequest request_;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/subscription_impl.h
+++ b/source/common/http/subscription_impl.h
@@ -17,6 +17,13 @@
 namespace Envoy {
 namespace Http {
 
+/**
+ * REST implementation of the API Subscription interface. This fetches the API via periodic polling
+ * with jitter (based on RestApiFetcher). The REST requests are POSTs of the JSON canonical
+ * representation of the DiscoveryRequest proto and the responses are in the form of the JSON
+ * canonical representation of DiscoveryResponse. This implementation is responsible for translating
+ * between the proto serializable objects in the Subscription API and the REST JSON representation.
+ */
 template <class ResourceType>
 class SubscriptionImpl : public RestApiFetcher, Config::Subscription<ResourceType> {
 public:

--- a/test/common/grpc/subscription_impl_test.cc
+++ b/test/common/grpc/subscription_impl_test.cc
@@ -31,30 +31,6 @@ typedef MockAsyncClient<envoy::api::v2::DiscoveryRequest, envoy::api::v2::Discov
     SubscriptionMockAsyncClient;
 typedef SubscriptionImpl<envoy::api::v2::ClusterLoadAssignment> EdsSubscriptionImpl;
 
-// TODO(htuch): Move this to a common utility for tests that want proto
-// equality.
-
-template <class ProtoType> bool protoEq(ProtoType lhs, ProtoType rhs) {
-  return lhs.GetTypeName() == rhs.GetTypeName() &&
-         lhs.SerializeAsString() == rhs.SerializeAsString();
-}
-
-MATCHER_P(ProtoEq, rhs, "") { return protoEq(arg, rhs); }
-
-MATCHER_P(RepeatedProtoEq, rhs, "") {
-  if (arg.size() != rhs.size()) {
-    return false;
-  }
-
-  for (int i = 0; i < arg.size(); ++i) {
-    if (!protoEq(arg[i], rhs[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 class GrpcSubscriptionImplTest : public testing::Test {
 public:
   GrpcSubscriptionImplTest()

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -148,6 +148,28 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "subscription_impl_test",
+    srcs = ["subscription_impl_test.cc"],
+    external_deps = [
+        "envoy_eds",
+        "protobuf",
+    ],
+    deps = [
+        "//include/envoy/http:async_client_interface",
+        "//source/common/common:base64_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/http:message_lib",
+        "//source/common/http:subscription_lib",
+        "//test/mocks/config:config_mocks",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "user_agent_test",
     srcs = ["user_agent_test.cc"],
     deps = [

--- a/test/common/http/subscription_impl_test.cc
+++ b/test/common/http/subscription_impl_test.cc
@@ -1,0 +1,212 @@
+#include "envoy/http/async_client.h"
+
+#include "common/common/base64.h"
+#include "common/common/utility.h"
+#include "common/config/utility.h"
+#include "common/http/message_impl.h"
+#include "common/http/subscription_impl.h"
+
+#include "test/mocks/config/mocks.h"
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "api/eds.pb.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/util/json_util.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::Return;
+
+namespace Envoy {
+namespace Http {
+namespace {
+
+typedef SubscriptionImpl<envoy::api::v2::ClusterLoadAssignment> EdsSubscriptionImpl;
+
+class HttpSubscriptionImplTest : public testing::Test {
+public:
+  HttpSubscriptionImplTest()
+      : method_descriptor_(envoy::api::v2::EndpointDiscoveryService::descriptor()->FindMethodByName(
+            "FetchEndpoints")),
+        timer_(new Event::MockTimer()), http_request_(&cm_.async_client_) {
+    node_.set_id("fo0");
+    EXPECT_CALL(dispatcher_, createTimer_(_))
+        .WillOnce(Invoke([this](Event::TimerCb timer_cb) {
+          timer_cb_ = timer_cb;
+          return timer_;
+        }));
+    subscription_.reset(new EdsSubscriptionImpl(node_, cm_, "eds_cluster", dispatcher_, random_gen_,
+                                                std::chrono::milliseconds(1), *method_descriptor_));
+  }
+
+  void TearDown() override {
+    // Stop subscribing on the way out.
+    if (request_in_progress_) {
+      EXPECT_CALL(http_request_, cancel());
+    }
+    subscription_ = nullptr;
+  }
+
+  void expectSendMessage() {
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
+    EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+        .WillOnce(Invoke([this](MessagePtr& request, AsyncClient::Callbacks& callbacks,
+                                const Optional<std::chrono::milliseconds>& timeout) {
+          http_callbacks_ = &callbacks;
+          UNREFERENCED_PARAMETER(timeout);
+          EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
+          EXPECT_EQ("eds_cluster", std::string(request->headers().Host()->value().c_str()));
+          EXPECT_EQ("/v2/discovery:endpoints",
+                    std::string(request->headers().Path()->value().c_str()));
+          std::string expected_request = "{";
+          if (!version_.empty()) {
+            expected_request += "\"versionInfo\":\"" + version_ + "\",";
+          }
+          expected_request += "\"node\":{\"id\":\"fo0\"},";
+          if (!cluster_names_.empty()) {
+            expected_request +=
+                "\"resourceNames\":[\"" + StringUtil::join(cluster_names_, "\",\"") + "\"]";
+          }
+          expected_request += "}";
+          EXPECT_EQ(expected_request, request->bodyAsString());
+          request_in_progress_ = true;
+          return &http_request_;
+        }));
+  }
+
+  void startSubscription(const std::vector<std::string>& cluster_names) {
+    version_ = "";
+    cluster_names_ = cluster_names;
+    expectSendMessage();
+    subscription_->start(cluster_names, callbacks_);
+  }
+
+  void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
+                           bool accept) {
+    std::string response_json = "{\"versionInfo\":\"" +
+                                Base64::encode(version.c_str(), version.size()) +
+                                "\",\"resources\":[";
+    for (const auto& cluster : cluster_names) {
+      response_json += "{\"@type\":\"type.googleapis.com/"
+                       "envoy.api.v2.ClusterLoadAssignment\",\"clusterName\":\"" +
+                       cluster + "\"},";
+    }
+    response_json.pop_back();
+    response_json += "]}";
+    envoy::api::v2::DiscoveryResponse response_pb;
+    EXPECT_EQ(google::protobuf::util::Status::OK,
+              google::protobuf::util::JsonStringToMessage(response_json, &response_pb));
+    HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
+    MessagePtr message{new ResponseMessageImpl(std::move(response_headers))};
+    message->body().reset(new Buffer::OwnedImpl(response_json));
+    EXPECT_CALL(callbacks_,
+                onConfigUpdate(RepeatedProtoEq(
+                    Config::Utility::getTypedResources<envoy::api::v2::ClusterLoadAssignment>(
+                        response_pb)))).WillOnce(Return(accept));
+    EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
+    EXPECT_CALL(*timer_, enableTimer(_));
+    http_callbacks_->onSuccess(std::move(message));
+    if (accept) {
+      version_ = Base64::encode(version.c_str(), version.size());
+    }
+    request_in_progress_ = false;
+  }
+
+  void timerTick() {
+    expectSendMessage();
+    timer_cb_();
+  }
+
+  bool request_in_progress_{};
+  std::string version_;
+  std::vector<std::string> cluster_names_;
+  const google::protobuf::MethodDescriptor* method_descriptor_;
+  Upstream::MockClusterManager cm_;
+  Event::MockDispatcher dispatcher_;
+  Event::MockTimer* timer_;
+  Event::TimerCb timer_cb_;
+  envoy::api::v2::Node node_;
+  Runtime::MockRandomGenerator random_gen_;
+  MockAsyncClientRequest http_request_;
+  AsyncClient::Callbacks* http_callbacks_;
+  Config::MockSubscriptionCallbacks<envoy::api::v2::ClusterLoadAssignment> callbacks_;
+  std::unique_ptr<EdsSubscriptionImpl> subscription_;
+};
+
+// Validate basic fetch succeeds.
+TEST_F(HttpSubscriptionImplTest, InitialRequestResponse) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+// Validate that multiple fetches succeed.
+TEST_F(HttpSubscriptionImplTest, ResponseFetches) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+  timerTick();
+  deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
+  timerTick();
+}
+
+// Validate that the client can reject a config.
+TEST_F(HttpSubscriptionImplTest, RejectConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+}
+
+// Validate that the client can reject a config and accept the same config later.
+TEST_F(HttpSubscriptionImplTest, RejectAcceptConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+  timerTick();
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+// Validate that the client can reject a config and accept another config later.
+TEST_F(HttpSubscriptionImplTest, RejectAcceptNextConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+  timerTick();
+  deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
+}
+
+// Validate that subscription updates send a message with the updated resources.
+TEST_F(HttpSubscriptionImplTest, UpdateResources) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+  cluster_names_ = {"cluster2"};
+  subscription_->updateResources({"cluster2"});
+  timerTick();
+}
+
+// Validate that the client can recover from a remote fetch failure.
+TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
+  startSubscription({"cluster0", "cluster1"});
+  EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
+  EXPECT_CALL(*timer_, enableTimer(_));
+  http_callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
+  timerTick();
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+// Validate that the client can recover from bad JSON responses.
+TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
+  startSubscription({"cluster0", "cluster1"});
+  HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
+  MessagePtr message{new ResponseMessageImpl(std::move(response_headers))};
+  message->body().reset(new Buffer::OwnedImpl(";!@#badjso n"));
+  EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
+  EXPECT_CALL(*timer_, enableTimer(_));
+  http_callbacks_->onSuccess(std::move(message));
+  request_in_progress_ = false;
+  timerTick();
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+} // namespace
+} // namespace Http
+} // namespace Envoy

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -13,6 +13,7 @@
 
 #include "test/test_common/printers.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -56,6 +57,19 @@ public:
    * @return std::vector<std::string> filenames
    */
   static std::vector<std::string> listFiles(const std::string& path, bool recursive);
+
+  /**
+   * Compare two protos of the same type for equality.
+   *
+   * @param lhs proto on LHS.
+   * @param rhs proto on RHS.
+   * @return bool indicating whether the protos are equal. Type name and string serialization are
+   *         used for equality testing.
+   */
+  template <class ProtoType> static bool protoEqual(ProtoType lhs, ProtoType rhs) {
+    return lhs.GetTypeName() == rhs.GetTypeName() &&
+           lhs.SerializeAsString() == rhs.SerializeAsString();
+  }
 };
 
 /**
@@ -110,4 +124,21 @@ public:
 };
 
 } // Http
+
+MATCHER_P(ProtoEq, rhs, "") { return TestUtility::protoEqual(arg, rhs); }
+
+MATCHER_P(RepeatedProtoEq, rhs, "") {
+  if (arg.size() != rhs.size()) {
+    return false;
+  }
+
+  for (int i = 0; i < arg.size(); ++i) {
+    if (!TestUtility::protoEqual(arg[i], rhs[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 } // Envoy


### PR DESCRIPTION
REST implementation of the API Subscription interface. This fetches the API via periodic polling with jitter (based on RestApiFetcher). The REST requests are POSTs of the JSON canonical representation of the DiscoveryRequest proto and the responses are in the form of the JSON canonical representation of DiscoveryResponse. This implementation is responsible for translating between the proto serializable objects in the Subscription API and the REST JSON representation.