### PR TITLE
http: Tweaks to the "headers too long" path

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -437,7 +437,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   // here and keep it under 60K. Ultimately it would be nice to bring this to a lower value but
   // unclear if that is possible or not.
   if (request_headers_->byteSize() > (60 * 1024)) {
-    HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::BadRequest))}};
+    HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::RequestHeaderFieldsTooLarge))}};
     encodeHeaders(nullptr, headers, true);
     return;
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -428,16 +428,14 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Check for maximum incoming header size. Both codecs have some amount of checking for maximum
   // header size. For HTTP/1.1 the entire headers data has be less than ~80K (hard coded in
-  // http_parser). For HTTP/2 we currently check if the incoming headers is less than ~63K. 63K
-  // is abritrary and is set because currently nghttp2 does not allow *sending* more than 64K of
-  // headers for reasons I don't understand so 63K is testable. However, since HTTP/1.1 can send us
-  // potentially 80K of headers, we can still die when we try to proxy to HTTP/2. We correctly
-  // handle this but to the rest of the code it looks like an upstream reset which will usually
-  // result in a 503. In order to have generally uniform behavior we also check total header size
-  // here and keep it under 60K. Ultimately it would be nice to bring this to a lower value but
-  // unclear if that is possible or not.
+  // http_parser). For HTTP/2 the default allowed header block length is 64k/
+  // In order to have generally uniform behavior we also check total header size here and keep it
+  // under 60K.  Ultimately it would be nice to have a configuration option ranging from the largest
+  // header size http_parser and nghttp2 will allow, down to 16k or 8k for
+  // envoy users who do not wish to proxy large headers.
   if (request_headers_->byteSize() > (60 * 1024)) {
-    HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::RequestHeaderFieldsTooLarge))}};
+    HeaderMapImpl headers{
+        {Headers::get().Status, std::to_string(enumToInt(Code::RequestHeaderFieldsTooLarge))}};
     encodeHeaders(nullptr, headers, true);
     return;
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -428,7 +428,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Check for maximum incoming header size. Both codecs have some amount of checking for maximum
   // header size. For HTTP/1.1 the entire headers data has be less than ~80K (hard coded in
-  // http_parser). For HTTP/2 the default allowed header block length is 64k/
+  // http_parser). For HTTP/2 the default allowed header block length is 64k.
   // In order to have generally uniform behavior we also check total header size here and keep it
   // under 60K.  Ultimately it would be nice to have a configuration option ranging from the largest
   // header size http_parser and nghttp2 will allow, down to 16k or 8k for

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -118,25 +118,6 @@ TEST_P(Http2IntegrationTest, MaxHeadersInCodec) {
        [&]() -> void { response->waitForReset(); }, [&]() -> void { codec_client->close(); }});
 }
 
-TEST_P(Http2IntegrationTest, MaxHeadersInConnectionManager) {
-  Http::TestHeaderMapImpl big_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
-
-  big_headers.addViaCopy("big", std::string(60 * 1024, 'a'));
-
-  IntegrationCodecClientPtr codec_client;
-  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  executeActions({[&]() -> void {
-    codec_client = makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP2);
-  },
-                  [&]() -> void { codec_client->makeHeaderOnlyRequest(big_headers, *response); },
-                  [&]() -> void { response->waitForEndStream(); },
-                  [&]() -> void { codec_client->close(); }});
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("400", response->headers().Status()->value().c_str());
-}
-
 TEST_P(Http2IntegrationTest, DownstreamResetBeforeResponseComplete) {
   testDownstreamResetBeforeResponseComplete();
 }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -973,6 +973,27 @@ void BaseIntegrationTest::testMultipleContentLengths(Http::CodecClient::Type typ
   }
 }
 
+void BaseIntegrationTest::testOverlyLongHeaders(Http::CodecClient::Type type) {
+  Http::TestHeaderMapImpl big_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+
+  big_headers.addViaCopy("big", std::string(60 * 1024, 'a'));
+  IntegrationCodecClientPtr codec_client;
+  IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
+  executeActions(
+      {[&]() -> void {
+        codec_client = makeHttpConnection(lookupPort("http"), type);
+      },
+       [&]() -> void {
+         std::string long_value(7500, 'x');
+         codec_client->startRequest(big_headers, *response);
+       },
+       [&]() -> void { codec_client->waitForDisconnect(); }});
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("431", response->headers().Status()->value().c_str());
+}
+
 void BaseIntegrationTest::testUpstreamProtocolError() {
   IntegrationCodecClientPtr codec_client;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -980,15 +980,12 @@ void BaseIntegrationTest::testOverlyLongHeaders(Http::CodecClient::Type type) {
   big_headers.addViaCopy("big", std::string(60 * 1024, 'a'));
   IntegrationCodecClientPtr codec_client;
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
-  executeActions(
-      {[&]() -> void {
-        codec_client = makeHttpConnection(lookupPort("http"), type);
-      },
-       [&]() -> void {
-         std::string long_value(7500, 'x');
-         codec_client->startRequest(big_headers, *response);
-       },
-       [&]() -> void { codec_client->waitForDisconnect(); }});
+  executeActions({[&]() -> void { codec_client = makeHttpConnection(lookupPort("http"), type); },
+                  [&]() -> void {
+                    std::string long_value(7500, 'x');
+                    codec_client->startRequest(big_headers, *response);
+                  },
+                  [&]() -> void { codec_client->waitForDisconnect(); }});
 
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("431", response->headers().Status()->value().c_str());

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -208,6 +208,7 @@ protected:
   void testMissingContentLength();
   void testHttp10Request();
   void testNoHost();
+  void testOverlyLongHeaders(Http::CodecClient::Type type);
   void testUpstreamProtocolError();
   void testBadPath();
   void testInvalidContentLength(Http::CodecClient::Type type);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -133,6 +133,10 @@ TEST_P(IntegrationTest, MultipleContentLengths) {
   testMultipleContentLengths(Http::CodecClient::Type::HTTP1);
 }
 
+TEST_P(IntegrationTest, OverlyLongHeaders) {
+  testOverlyLongHeaders(Http::CodecClient::Type::HTTP1);
+}
+
 TEST_P(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 
 TEST_P(IntegrationTest, TcpProxyUpstreamDisconnect) {


### PR DESCRIPTION
Changing it from a generic "bad request" to 431 (Request Header Fields Too Large)
Moving the existing H2 integration test to integration.cc and adding HTTP/1.1 coverage.