### PR TITLE
config: explicit NACK in gRPC Subscription implementation.

### DIFF
--- a/source/common/grpc/subscription_impl.h
+++ b/source/common/grpc/subscription_impl.h
@@ -88,9 +88,9 @@ public:
     }
     if (callbacks_->onConfigUpdate(typed_resources)) {
       request_.set_version_info(message->version_info());
-      // This effectively ACKs the accepted configuration.
-      sendDiscoveryRequest();
     }
+    // This effectively ACK/NACKs the accepted configuration.
+    sendDiscoveryRequest();
   }
 
   void onReceiveTrailingMetadata(Http::HeaderMapPtr&& metadata) override {

--- a/test/common/grpc/subscription_impl_test.cc
+++ b/test/common/grpc/subscription_impl_test.cc
@@ -112,11 +112,15 @@ public:
         .WillOnce(Return(accept));
     if (accept) {
       expectSendMessage(cluster_names, version);
+      version_ = version;
+    } else {
+      expectSendMessage(cluster_names, version_);
     }
     subscription_->onReceiveMessage(std::move(response));
     Mock::VerifyAndClearExpectations(&async_stream_);
   }
 
+  std::string version_;
   const google::protobuf::MethodDescriptor* method_descriptor_;
   SubscriptionMockAsyncClient* async_client_;
   NiceMock<Upstream::MockClusterManager> cm_;


### PR DESCRIPTION
Previously, we only ACKed by reflecting the new version when a config is accepted. In this patch, we
send a NACK message (reflecting the existing version) when a config is not accepted.