### PR TITLE
Fix over increment test flake in guarddog test.

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -87,6 +87,7 @@ envoy_cc_library(
     hdrs = ["guarddog_impl.h"],
     deps = [
         ":watchdog_lib",
+        "//include/envoy/common:optional",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/server:configuration_interface",
         "//include/envoy/server:guarddog_interface",


### PR DESCRIPTION
Whether due to spurious wakeups, actual timeouts, etc, the GuardDog loop
might run several times after a thread ceases responding and the counter
(miss or megamiss) would get incremented multiple times even though the
thread only stopped responding once. This caused a test flake and was
also a departure from the old watchdog stat behavior where the
resolution of a starvation event resulted in a single increment.

With this change the GuardDog will only count one miss and one megamiss
for each starvation event. If the watchdog is touched this resets and we
will increment the stats again if there is another period of
nonresponsiveness.

Fixes #1141