### PR TITLE
config: inotify Subscription implementation.

### DIFF
--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -38,7 +38,8 @@ public:
    * Start a configuration subscription asynchronously. This should be called once and will continue
    * to fetch throughout the lifetime of the Subscription object.
    * @param resources vector of resource names to fetch.
-   * @param callbacks the callbacks to be notified of configuration updates.
+   * @param callbacks the callbacks to be notified of configuration updates. The callback must not
+   *        result in the deletion of the Subscription object.
    */
   virtual void start(const std::vector<std::string>& resources,
                      SubscriptionCallbacks<ResourceType>& callbacks) PURE;

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -21,6 +21,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "subscription_lib",
+    hdrs = ["subscription_impl.h"],
+    external_deps = ["protobuf"],
+    deps = [
+        ":filesystem_lib",
+        "//include/envoy/config:subscription_interface",
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/filesystem:filesystem_interface",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "watcher_lib",
     srcs = ["watcher_impl.cc"],
     hdrs = ["watcher_impl.h"],

--- a/source/common/filesystem/subscription_impl.h
+++ b/source/common/filesystem/subscription_impl.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "envoy/config/subscription.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/filesystem/filesystem.h"
+
+#include "common/common/macros.h"
+#include "common/config/utility.h"
+#include "common/filesystem/filesystem_impl.h"
+
+#include "api/base.pb.h"
+#include "google/protobuf/util/json_util.h"
+
+namespace Envoy {
+namespace Filesystem {
+
+/**
+ * Filesystem inotify implementation of the API Subscription interface. This allows the API to be
+ * consumed on filesystem changes to files containing the JSON canonical representation of
+ * lists of ResourceType.
+ */
+template <class ResourceType> class SubscriptionImpl : public Config::Subscription<ResourceType> {
+public:
+  SubscriptionImpl(Event::Dispatcher& dispatcher, const std::string& path)
+      : path_(path), watcher_(dispatcher.createFilesystemWatcher()) {}
+
+  // Config::Subscription
+  void start(const std::vector<std::string>& resources,
+             Config::SubscriptionCallbacks<ResourceType>& callbacks) override {
+    // We report all discovered resources in the watched file.
+    UNREFERENCED_PARAMETER(resources);
+    callbacks_ = &callbacks;
+    watcher_->addWatch(path_, Watcher::Events::MovedTo, [this](uint32_t events) {
+      UNREFERENCED_PARAMETER(events);
+      refresh();
+    });
+  }
+
+  void updateResources(const std::vector<std::string>& resources) override {
+    // We report all discovered resources in the watched file.
+    UNREFERENCED_PARAMETER(resources);
+  }
+
+private:
+  void refresh() {
+    try {
+      const std::string json = Filesystem::fileReadToEnd(path_);
+      envoy::api::v2::DiscoveryResponse message;
+      const auto status = google::protobuf::util::JsonStringToMessage(json, &message);
+      if (status != google::protobuf::util::Status::OK) {
+        // TODO(htuch): Track stats and log failures.
+        return;
+      }
+      const auto typed_resources = Config::Utility::getTypedResources<ResourceType>(message);
+      if (callbacks_->onConfigUpdate(typed_resources)) {
+        // TODO(htuch): Add some notion of current version for every API in stats/admin.
+      } else {
+        // TODO(htuch): Track stats and log failures.
+      }
+    } catch (const EnvoyException& ex) {
+      // TODO(htuch): Track stats and log failures.
+    }
+  }
+
+  const std::string path_;
+  std::unique_ptr<Watcher> watcher_;
+  Config::SubscriptionCallbacks<ResourceType>* callbacks_{};
+};
+
+} // namespace Filesystem
+} // namespace Envoy

--- a/test/common/filesystem/BUILD
+++ b/test/common/filesystem/BUILD
@@ -9,6 +9,19 @@ load(
 envoy_package()
 
 envoy_cc_test(
+    name = "subscription_impl_test",
+    srcs = ["subscription_impl_test.cc"],
+    external_deps = ["envoy_eds"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//source/common/filesystem:subscription_lib",
+        "//test/mocks/config:config_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "filesystem_impl_test",
     srcs = ["filesystem_impl_test.cc"],
     deps = [

--- a/test/common/filesystem/subscription_impl_test.cc
+++ b/test/common/filesystem/subscription_impl_test.cc
@@ -1,0 +1,119 @@
+#include <fstream>
+
+#include "common/event/dispatcher_impl.h"
+#include "common/filesystem/subscription_impl.h"
+
+#include "test/mocks/config/mocks.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "api/eds.pb.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::Return;
+
+namespace Envoy {
+namespace Filesystem {
+namespace {
+
+typedef SubscriptionImpl<envoy::api::v2::ClusterLoadAssignment> EdsSubscriptionImpl;
+
+class FilesystemSubscriptionImplTest : public testing::Test {
+public:
+  FilesystemSubscriptionImplTest()
+      : path_(TestEnvironment::temporaryPath("eds.pb")), subscription_(dispatcher_, path_) {}
+
+  void startSubscription(const std::vector<std::string>& cluster_names) {
+    subscription_.start(cluster_names, callbacks_);
+  }
+
+  void updateFile(const std::string json) {
+    // Write JSON contents to file, rename to path_ and run dispatcher to catch
+    // inotify.
+    const std::string temp_path = path_ + ".tmp";
+    std::ofstream temp_file(temp_path);
+    temp_file << json;
+    temp_file.close();
+    EXPECT_EQ(0, ::rename(temp_path.c_str(), path_.c_str()));
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
+                           bool accept) {
+    std::string file_json = "{\"versionInfo\":\"" + version + "\",\"resources\":[";
+    for (const auto& cluster : cluster_names) {
+      file_json += "{\"@type\":\"type.googleapis.com/"
+                   "envoy.api.v2.ClusterLoadAssignment\",\"clusterName\":\"" +
+                   cluster + "\"},";
+    }
+    file_json.pop_back();
+    file_json += "]}";
+    envoy::api::v2::DiscoveryResponse response_pb;
+    EXPECT_EQ(google::protobuf::util::Status::OK,
+              google::protobuf::util::JsonStringToMessage(file_json, &response_pb));
+    EXPECT_CALL(callbacks_,
+                onConfigUpdate(RepeatedProtoEq(
+                    Config::Utility::getTypedResources<envoy::api::v2::ClusterLoadAssignment>(
+                        response_pb)))).WillOnce(Return(accept));
+    updateFile(file_json);
+  }
+
+  const std::string path_;
+  Event::DispatcherImpl dispatcher_;
+  Config::MockSubscriptionCallbacks<envoy::api::v2::ClusterLoadAssignment> callbacks_;
+  EdsSubscriptionImpl subscription_;
+};
+
+// Validate basic inotify succeeds.
+TEST_F(FilesystemSubscriptionImplTest, Basic) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+// Validate that the client can reject a config.
+TEST_F(FilesystemSubscriptionImplTest, RejectConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+}
+
+// Validate that multiple updates succeed.
+TEST_F(FilesystemSubscriptionImplTest, MultipleUpdates) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+  deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
+}
+
+// Validate that the client can reject a config and accept the same config later.
+TEST_F(FilesystemSubscriptionImplTest, RejectAcceptConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+// Validate that the client can reject a config and accept another config later.
+TEST_F(FilesystemSubscriptionImplTest, RejectAcceptNextConfig) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+  deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
+}
+
+// Validate that updateResources is a nop in the inotify implementation.
+TEST_F(FilesystemSubscriptionImplTest, UpdateResources) {
+  startSubscription({"cluster0", "cluster1"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+  subscription_.updateResources({"cluster2"});
+  deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
+}
+
+// Validate that the client can recover from bad JSON responses.
+TEST_F(FilesystemSubscriptionImplTest, BadJsonRecovery) {
+  startSubscription({"cluster0", "cluster1"});
+  updateFile(";!@#badjso n");
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+}
+
+} // namespace
+} // namespace Grpc
+} // namespace Envoy

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -156,7 +156,6 @@ envoy_cc_test(
     ],
     deps = [
         "//include/envoy/http:async_client_interface",
-        "//source/common/common:base64_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:utility_lib",
         "//source/common/http:message_lib",

--- a/test/common/http/subscription_impl_test.cc
+++ b/test/common/http/subscription_impl_test.cc
@@ -1,6 +1,5 @@
 #include "envoy/http/async_client.h"
 
-#include "common/common/base64.h"
 #include "common/common/utility.h"
 #include "common/config/utility.h"
 #include "common/http/message_impl.h"
@@ -87,9 +86,7 @@ public:
 
   void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
                            bool accept) {
-    std::string response_json = "{\"versionInfo\":\"" +
-                                Base64::encode(version.c_str(), version.size()) +
-                                "\",\"resources\":[";
+    std::string response_json = "{\"versionInfo\":\"" + version + "\",\"resources\":[";
     for (const auto& cluster : cluster_names) {
       response_json += "{\"@type\":\"type.googleapis.com/"
                        "envoy.api.v2.ClusterLoadAssignment\",\"clusterName\":\"" +
@@ -111,7 +108,7 @@ public:
     EXPECT_CALL(*timer_, enableTimer(_));
     http_callbacks_->onSuccess(std::move(message));
     if (accept) {
-      version_ = Base64::encode(version.c_str(), version.size());
+      version_ = version;
     }
     request_in_progress_ = false;
   }


### PR DESCRIPTION
Filesystem inotify implementation of the API Subscription interface. This allows the API to be consumed on filesystem changes to files containing the JSON canonical representation of lists of ResourceType.