### PR TITLE
Upgrade to c-ares 1.13.0.

### DIFF
--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=cares-1_12_0
+VERSION=cares-1_13_0
 
 wget -O c-ares-$VERSION.tar.gz https://github.com/c-ares/c-ares/archive/$VERSION.tar.gz
 tar xf c-ares-$VERSION.tar.gz

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -19,7 +19,7 @@ Envoy has the following requirements:
 * `protobuf <https://github.com/google/protobuf>`_ (last tested with 3.0.0)
 * `lightstep-tracer-cpp <https://github.com/lightstep/lightstep-tracer-cpp/>`_ (last tested with 0.36)
 * `rapidjson <https://github.com/miloyip/rapidjson/>`_ (last tested with 1.1.0)
-* `c-ares <https://github.com/c-ares/c-ares>`_ (last tested with 1.12.0)
+* `c-ares <https://github.com/c-ares/c-ares>`_ (last tested with 1.13.0)
 * `backward <https://github.com/bombela/backward-cpp>`_ (last tested with 1.3)
 
 In order to compile and run the tests the following is required:


### PR DESCRIPTION
Latest c-ares release 1.13.0 provides bug fixes and resolution of [CVE-2017-1000381](https://c-ares.haxx.se/adv_20170620.html). [Announcement](https://daniel.haxx.se/blog/2017/06/20/c-ares-1-13-0/) & [changelog](https://c-ares.haxx.se/changelog.html).