### PR TITLE
http/2: add upstream GOAWAY stat

### DIFF
--- a/docs/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/configuration/cluster_manager/cluster_stats.rst
@@ -30,7 +30,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_cx_destroy_with_active_rq, Counter, Total connections destroyed with 1+ active request
   upstream_cx_destroy_local_with_active_rq, Counter, Total connections destroyed locally with 1+ active request
   upstream_cx_destroy_remote_with_active_rq, Counter, Total connections destroyed remotely with 1+ active request
-  upstream_cx_close_header, Counter, Total connections closed via HTTP/1.1 connection close header
+  upstream_cx_close_notify, Counter, Total connections closed via HTTP/1.1 connection close header or HTTP/2 GOAWAY
   upstream_cx_rx_bytes_total, Counter, Total received connection bytes
   upstream_cx_rx_bytes_buffered, Gauge, Received connection bytes currently buffered
   upstream_cx_tx_bytes_total, Counter, Total sent connection bytes

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -177,7 +177,7 @@ public:
   COUNTER(upstream_cx_destroy_with_active_rq)                                                      \
   COUNTER(upstream_cx_destroy_local_with_active_rq)                                                \
   COUNTER(upstream_cx_destroy_remote_with_active_rq)                                               \
-  COUNTER(upstream_cx_close_header)                                                                \
+  COUNTER(upstream_cx_close_notify)                                                                \
   COUNTER(upstream_cx_rx_bytes_total)                                                              \
   GAUGE  (upstream_cx_rx_bytes_buffered)                                                           \
   COUNTER(upstream_cx_tx_bytes_total)                                                              \

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -236,7 +236,7 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end
       0 == StringUtil::caseInsensitiveCompare(headers->Connection()->value().c_str(),
                                               Headers::get().ConnectionValues.Close.c_str())) {
     saw_close_header_ = true;
-    parent_.parent_.host_->cluster().stats().upstream_cx_close_header_.inc();
+    parent_.parent_.host_->cluster().stats().upstream_cx_close_notify_.inc();
   }
 
   StreamDecoderWrapper::decodeHeaders(std::move(headers), end_stream);

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -171,6 +171,7 @@ void ConnPoolImpl::onConnectTimeout(ActiveClient& client) {
 
 void ConnPoolImpl::onGoAway(ActiveClient& client) {
   ENVOY_CONN_LOG(debug, "remote goaway", *client.client_);
+  host_->cluster().stats().upstream_cx_close_notify_.inc();
   if (&client == primary_client_.get()) {
     movePrimaryClientToDraining();
   }

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -400,6 +400,8 @@ TEST_F(Http2ConnPoolImplTest, GoAway) {
   test_clients_[0].connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
   EXPECT_CALL(*this, onClientDestroy()).Times(2);
   dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_close_notify_.value());
 }
 
 } // Http2


### PR DESCRIPTION
Unify the stat for http/1 connection close and http/2 GOAWAY.