### PR TITLE
Fix ZeroCopyInputStreamImpl::BackUp

### DIFF
--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -47,8 +47,8 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
 bool ZeroCopyInputStreamImpl::Skip(int) { NOT_IMPLEMENTED; }
 
 void ZeroCopyInputStreamImpl::BackUp(int count) {
-  ASSERT(count > 0);
-  ASSERT(uint64_t(count) < position_);
+  ASSERT(count >= 0);
+  ASSERT(uint64_t(count) <= position_);
 
   // Preconditions for BackUp:
   // - The last method called must have been Next().

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -60,6 +60,17 @@ TEST_F(ZeroCopyInputStreamTest, BackUp) {
   EXPECT_EQ(4, stream_.ByteCount());
 }
 
+TEST_F(ZeroCopyInputStreamTest, BackUpFull) {
+  EXPECT_TRUE(stream_.Next(&data_, &size_));
+  EXPECT_EQ(4, size_);
+
+  stream_.BackUp(4);
+  EXPECT_TRUE(stream_.Next(&data_, &size_));
+  EXPECT_EQ(4, size_);
+  EXPECT_EQ(0, memcmp("abcd", data_, size_));
+  EXPECT_EQ(4, stream_.ByteCount());
+}
+
 TEST_F(ZeroCopyInputStreamTest, ByteCount) {
   EXPECT_EQ(0, stream_.ByteCount());
   EXPECT_TRUE(stream_.Next(&data_, &size_));


### PR DESCRIPTION
Fixed wrong boundary assertion on `count` and `position_`. Allow to `BackUp` full length `Next()` just returned.