### PR TITLE
init: handle new target after initializing starts

### DIFF
--- a/source/server/init_manager_impl.cc
+++ b/source/server/init_manager_impl.cc
@@ -18,21 +18,28 @@ void InitManagerImpl::initialize(std::function<void()> callback) {
     for (auto iter = targets_.begin(); iter != targets_.end();) {
       Init::Target* target = *iter;
       ++iter;
-      target->initialize([this, target]() -> void {
-        ASSERT(std::find(targets_.begin(), targets_.end(), target) != targets_.end());
-        targets_.remove(target);
-        if (targets_.empty()) {
-          state_ = State::Initialized;
-          callback_();
-        }
-      });
+      initializeTarget(*target);
     }
   }
 }
 
+void InitManagerImpl::initializeTarget(Init::Target& target) {
+  target.initialize([this, &target]() -> void {
+    ASSERT(std::find(targets_.begin(), targets_.end(), &target) != targets_.end());
+    targets_.remove(&target);
+    if (targets_.empty()) {
+      state_ = State::Initialized;
+      callback_();
+    }
+  });
+}
+
 void InitManagerImpl::registerTarget(Init::Target& target) {
-  ASSERT(state_ == State::NotInitialized);
+  ASSERT(state_ != State::Initialized);
   targets_.push_back(&target);
+  if (state_ == State::Initializing) {
+    initializeTarget(target);
+  }
 }
 
 } // Server

--- a/source/server/init_manager_impl.h
+++ b/source/server/init_manager_impl.h
@@ -20,6 +20,8 @@ public:
 private:
   enum class State { NotInitialized, Initializing, Initialized };
 
+  void initializeTarget(Init::Target& target);
+
   std::list<Init::Target*> targets_;
   State state_{State::NotInitialized};
   std::function<void()> callback_;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -53,6 +53,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "init_manager_impl_test",
+    srcs = ["init_manager_impl_test.cc"],
+    deps = [
+        "//source/server:init_manager_lib",
+        "//test/mocks:common_lib",
+        "//test/mocks/init:init_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "guarddog_impl_test",
     srcs = ["guarddog_impl_test.cc"],
     deps = [
@@ -96,8 +106,6 @@ envoy_cc_test(
     deps = [
         "//source/server:server_lib",
         "//test/integration:integration_lib",
-        "//test/mocks:common_lib",
-        "//test/mocks/init:init_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
     ],

--- a/test/server/init_manager_impl_test.cc
+++ b/test/server/init_manager_impl_test.cc
@@ -1,0 +1,66 @@
+#include "server/init_manager_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/init/mocks.h"
+
+#include "gmock/gmock.h"
+
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+
+namespace Envoy {
+namespace Server {
+
+class InitManagerImplTest : public testing::Test {
+public:
+  InitManagerImpl manager_;
+  ReadyWatcher initialized_;
+};
+
+TEST_F(InitManagerImplTest, NoTargets) {
+  EXPECT_CALL(initialized_, ready());
+  manager_.initialize([&]() -> void { initialized_.ready(); });
+}
+
+TEST_F(InitManagerImplTest, Targets) {
+  InSequence s;
+  Init::MockTarget target;
+
+  manager_.registerTarget(target);
+  EXPECT_CALL(target, initialize(_));
+  manager_.initialize([&]() -> void { initialized_.ready(); });
+  EXPECT_CALL(initialized_, ready());
+  target.callback_();
+}
+
+TEST_F(InitManagerImplTest, TargetRemoveWhileInitializing) {
+  InSequence s;
+  Init::MockTarget target;
+
+  manager_.registerTarget(target);
+  EXPECT_CALL(target, initialize(_))
+      .WillOnce(Invoke([](std::function<void()> callback) -> void { callback(); }));
+  EXPECT_CALL(initialized_, ready());
+  manager_.initialize([&]() -> void { initialized_.ready(); });
+}
+
+TEST_F(InitManagerImplTest, TargetAfterInitializing) {
+  InSequence s;
+  Init::MockTarget target1;
+  Init::MockTarget target2;
+
+  manager_.registerTarget(target1);
+  EXPECT_CALL(target1, initialize(_));
+  manager_.initialize([&]() -> void { initialized_.ready(); });
+
+  EXPECT_CALL(target2, initialize(_));
+  manager_.registerTarget(target2);
+
+  target2.callback_();
+  EXPECT_CALL(initialized_, ready());
+  target1.callback_();
+}
+
+} // Server
+} // Envoy

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1,55 +1,14 @@
 #include "server/server.h"
 
 #include "test/integration/server.h"
-#include "test/mocks/common.h"
-#include "test/mocks/init/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
-using testing::_;
-using testing::InSequence;
-using testing::Invoke;
-
 namespace Server {
-
-TEST(InitManagerImplTest, NoTargets) {
-  InitManagerImpl manager;
-  ReadyWatcher initialized;
-
-  EXPECT_CALL(initialized, ready());
-  manager.initialize([&]() -> void { initialized.ready(); });
-}
-
-TEST(InitManagerImplTest, Targets) {
-  InSequence s;
-  InitManagerImpl manager;
-  Init::MockTarget target;
-  ReadyWatcher initialized;
-
-  manager.registerTarget(target);
-  EXPECT_CALL(target, initialize(_));
-  manager.initialize([&]() -> void { initialized.ready(); });
-  EXPECT_CALL(initialized, ready());
-  target.callback_();
-}
-
-TEST(InitManagerImplTest, TargetRemoveWhile) {
-  InSequence s;
-  InitManagerImpl manager;
-  Init::MockTarget target1;
-  ReadyWatcher initialized;
-
-  manager.registerTarget(target1);
-  EXPECT_CALL(target1, initialize(_))
-      .WillOnce(Invoke([](std::function<void()> callback) -> void { callback(); }));
-  EXPECT_CALL(initialized, ready());
-  manager.initialize([&]() -> void { initialized.ready(); });
-}
 
 // Class creates minimally viable server instance for testing.
 class ServerInstanceImplTest : public testing::TestWithParam<Network::Address::IpVersion> {


### PR DESCRIPTION
This is needed for LDS. Also move the tests into a dedicated file which
I forgot to do in the previous move commit.