### PR TITLE
listener component refactor

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -90,7 +90,6 @@ envoy_cc_library(
     hdrs = ["filter_config.h"],
     deps = [
         ":drain_manager_interface",
-        ":instance_interface",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/init:init_interface",
@@ -107,6 +106,7 @@ envoy_cc_library(
     name = "listener_manager_interface",
     hdrs = ["listener_manager.h"],
     deps = [
+        ":filter_config_interface",
         "//include/envoy/json:json_object_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/network:listen_socket_interface",

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -10,12 +10,15 @@
 #include "envoy/ratelimit/ratelimit.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/drain_manager.h"
-#include "envoy/server/instance.h" // TODO(mattklein123): Remove post 1.4.0
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
 namespace Envoy {
 namespace Server {
+
+class Instance; // TODO(mattklein123): Remove post 1.4.0. Forward declare to avoid circular
+                // includes.
+
 namespace Configuration {
 
 /**

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -29,9 +29,9 @@ public:
    * Creates a list of filter factories.
    * @param filters supplies the JSON configuration.
    * @param context supplies the factory creation context.
-   * @return std::list<Configuration::NetworkFilterFactoryCb> the list of filter factories.
+   * @return std::vector<Configuration::NetworkFilterFactoryCb> the list of filter factories.
    */
-  virtual std::list<Configuration::NetworkFilterFactoryCb>
+  virtual std::vector<Configuration::NetworkFilterFactoryCb>
   createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
                           Configuration::FactoryContext& context) PURE;
 };

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -3,17 +3,18 @@
 #include "envoy/json/json_object.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listen_socket.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/ssl/context.h"
 
 namespace Envoy {
 namespace Server {
 
 /**
- * Factory for creating listen sockets.
+ * Factory for creating listener components.
  */
-class ListenSocketFactory {
+class ListenerComponentFactory {
 public:
-  virtual ~ListenSocketFactory() {}
+  virtual ~ListenerComponentFactory() {}
 
   /**
    * Creates a socket.
@@ -21,8 +22,18 @@ public:
    * @param bind_to_port supplies whether to actually bind the socket.
    * @return Network::ListenSocketPtr an initialized and potentially bound socket.
    */
-  virtual Network::ListenSocketPtr create(Network::Address::InstanceConstSharedPtr address,
-                                          bool bind_to_port) PURE;
+  virtual Network::ListenSocketPtr
+  createListenSocket(Network::Address::InstanceConstSharedPtr address, bool bind_to_port) PURE;
+
+  /**
+   * Creates a list of filter factories.
+   * @param filters supplies the JSON configuration.
+   * @param context supplies the factory creation context.
+   * @return std::list<Configuration::NetworkFilterFactoryCb> the list of filter factories.
+   */
+  virtual std::list<Configuration::NetworkFilterFactoryCb>
+  createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
+                          Configuration::FactoryContext& context) PURE;
 };
 
 /**

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -8,7 +8,6 @@
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/network/connection.h"
 #include "envoy/registry/registry.h"
-#include "envoy/server/instance.h"
 #include "envoy/server/options.h"
 #include "envoy/stats/stats.h"
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -88,7 +88,7 @@ public:
   const LocalInfo::LocalInfo& localInfo() override { return local_info_; }
 
   // Server::ListenerComponentFactory
-  std::list<Configuration::NetworkFilterFactoryCb>
+  std::vector<Configuration::NetworkFilterFactoryCb>
   createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
                           Configuration::FactoryContext& context) override {
     return ProdListenerComponentFactory::createFilterFactoryList_(filters, *this, context);

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -48,7 +48,7 @@ bool validateConfig(Options& options, ComponentFactory& component_factory,
  */
 class ValidationInstance : Logger::Loggable<Logger::Id::main>,
                            public Instance,
-                           public ListenSocketFactory {
+                           public ListenerComponentFactory {
 public:
   ValidationInstance(Options& options, Stats::IsolatedStoreImpl& store,
                      Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory,
@@ -87,8 +87,14 @@ public:
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() override { return local_info_; }
 
-  // Server::ListenSocketFactory
-  Network::ListenSocketPtr create(Network::Address::InstanceConstSharedPtr, bool) override {
+  // Server::ListenerComponentFactory
+  std::list<Configuration::NetworkFilterFactoryCb>
+  createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
+                          Configuration::FactoryContext& context) override {
+    return ProdListenerComponentFactory::createFilterFactoryList_(filters, *this, context);
+  }
+  Network::ListenSocketPtr createListenSocket(Network::Address::InstanceConstSharedPtr,
+                                              bool) override {
     // Returned sockets are not currently used so we can return nothing here safely vs. a
     // validation mock.
     return nullptr;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -25,7 +25,7 @@ namespace Server {
 namespace Configuration {
 
 bool FilterChainUtility::buildFilterChain(Network::FilterManager& filter_manager,
-                                          const std::list<NetworkFilterFactoryCb>& factories) {
+                                          const std::vector<NetworkFilterFactoryCb>& factories) {
   for (const NetworkFilterFactoryCb& factory : factories) {
     factory(filter_manager);
   }

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -75,7 +75,7 @@ public:
    * exit early if any filters immediately close the connection.
    */
   static bool buildFilterChain(Network::FilterManager& filter_manager,
-                               const std::list<NetworkFilterFactoryCb>& factories);
+                               const std::vector<NetworkFilterFactoryCb>& factories);
 };
 
 /**

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -13,48 +13,11 @@
 namespace Envoy {
 namespace Server {
 
-Network::ListenSocketPtr
-ProdListenSocketFactory::create(Network::Address::InstanceConstSharedPtr address,
-                                bool bind_to_port) {
-  // For each listener config we share a single TcpListenSocket among all threaded listeners.
-  // UdsListenerSockets are not managed and do not participate in hot restart as they are only
-  // used for testing. First we try to get the socket from our parent if applicable.
-  ASSERT(address->type() == Network::Address::Type::Ip);
-  std::string addr = fmt::format("tcp://{}", address->asString());
-  const int fd = restarter_.duplicateParentListenSocket(addr);
-  if (fd != -1) {
-    ENVOY_LOG(info, "obtained socket for address {} from parent", addr);
-    return Network::ListenSocketPtr{new Network::TcpListenSocket(fd, address)};
-  } else {
-    return Network::ListenSocketPtr{new Network::TcpListenSocket(address, bind_to_port)};
-  }
-}
-
-ListenerImpl::ListenerImpl(Instance& server, ListenSocketFactory& factory, const Json::Object& json)
-    : Json::Validator(json, Json::Schema::LISTENER_SCHEMA), server_(server),
-      address_(Network::Utility::resolveUrl(json.getString("address"))),
-      global_scope_(server.stats().createScope("")),
-      bind_to_port_(json.getBoolean("bind_to_port", true)),
-      use_proxy_proto_(json.getBoolean("use_proxy_proto", false)),
-      use_original_dst_(json.getBoolean("use_original_dst", false)),
-      per_connection_buffer_limit_bytes_(
-          json.getInteger("per_connection_buffer_limit_bytes", 1024 * 1024)) {
-
-  // ':' is a reserved char in statsd. Do the translation here to avoid costly inline translations
-  // later.
-  std::string final_stat_name = fmt::format("listener.{}.", address_->asString());
-  std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
-
-  listener_scope_ = server.stats().createScope(final_stat_name);
-  ENVOY_LOG(info, "  address={}", address_->asString());
-
-  if (json.hasObject("ssl_context")) {
-    Ssl::ContextConfigImpl context_config(*json.getObject("ssl_context"));
-    ssl_context_ =
-        server.sslContextManager().createSslServerContext(*listener_scope_, context_config);
-  }
-
-  std::vector<Json::ObjectSharedPtr> filters = json.getObjectArray("filters");
+std::list<Configuration::NetworkFilterFactoryCb>
+ProdListenerComponentFactory::createFilterFactoryList_(
+    const std::vector<Json::ObjectSharedPtr>& filters, Server::Instance& server,
+    Configuration::FactoryContext& context) {
+  std::list<Configuration::NetworkFilterFactoryCb> ret;
   for (size_t i = 0; i < filters.size(); i++) {
     std::string string_type = filters[i]->getString("type");
     std::string string_name = filters[i]->getString("name");
@@ -79,8 +42,9 @@ ListenerImpl::ListenerImpl(Instance& server, ListenSocketFactory& factory, const
         Registry::FactoryRegistry<Configuration::NamedNetworkFilterConfigFactory>::getFactory(
             string_name);
     if (factory != nullptr && factory->type() == type) {
-      Configuration::NetworkFilterFactoryCb callback = factory->createFilterFactory(*config, *this);
-      filter_factories_.push_back(callback);
+      Configuration::NetworkFilterFactoryCb callback =
+          factory->createFilterFactory(*config, context);
+      ret.push_back(callback);
     } else {
       // DEPRECATED
       // This name wasn't found in the named map, so search in the deprecated list registry.
@@ -90,7 +54,7 @@ ListenerImpl::ListenerImpl(Instance& server, ListenSocketFactory& factory, const
         Configuration::NetworkFilterFactoryCb callback =
             config_factory->tryCreateFilterFactory(type, string_name, *config, server);
         if (callback) {
-          filter_factories_.push_back(callback);
+          ret.push_back(callback);
           found_filter = true;
           break;
         }
@@ -102,8 +66,53 @@ ListenerImpl::ListenerImpl(Instance& server, ListenSocketFactory& factory, const
       }
     }
   }
+  return ret;
+}
 
-  socket_ = factory.create(address_, bind_to_port_);
+Network::ListenSocketPtr
+ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConstSharedPtr address,
+                                                 bool bind_to_port) {
+  // For each listener config we share a single TcpListenSocket among all threaded listeners.
+  // UdsListenerSockets are not managed and do not participate in hot restart as they are only
+  // used for testing. First we try to get the socket from our parent if applicable.
+  ASSERT(address->type() == Network::Address::Type::Ip);
+  std::string addr = fmt::format("tcp://{}", address->asString());
+  const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
+  if (fd != -1) {
+    ENVOY_LOG(info, "obtained socket for address {} from parent", addr);
+    return Network::ListenSocketPtr{new Network::TcpListenSocket(fd, address)};
+  } else {
+    return Network::ListenSocketPtr{new Network::TcpListenSocket(address, bind_to_port)};
+  }
+}
+
+ListenerImpl::ListenerImpl(Instance& server, ListenerComponentFactory& factory,
+                           const Json::Object& json)
+    : Json::Validator(json, Json::Schema::LISTENER_SCHEMA), server_(server),
+      address_(Network::Utility::resolveUrl(json.getString("address"))),
+      global_scope_(server.stats().createScope("")),
+      bind_to_port_(json.getBoolean("bind_to_port", true)),
+      use_proxy_proto_(json.getBoolean("use_proxy_proto", false)),
+      use_original_dst_(json.getBoolean("use_original_dst", false)),
+      per_connection_buffer_limit_bytes_(
+          json.getInteger("per_connection_buffer_limit_bytes", 1024 * 1024)) {
+
+  // ':' is a reserved char in statsd. Do the translation here to avoid costly inline translations
+  // later.
+  std::string final_stat_name = fmt::format("listener.{}.", address_->asString());
+  std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
+
+  listener_scope_ = server.stats().createScope(final_stat_name);
+  ENVOY_LOG(info, "  address={}", address_->asString());
+
+  if (json.hasObject("ssl_context")) {
+    Ssl::ContextConfigImpl context_config(*json.getObject("ssl_context"));
+    ssl_context_ =
+        server.sslContextManager().createSslServerContext(*listener_scope_, context_config);
+  }
+
+  filter_factories_ = factory.createFilterFactoryList(json.getObjectArray("filters"), *this);
+  socket_ = factory.createListenSocket(address_, bind_to_port_);
 }
 
 bool ListenerImpl::createFilterChain(Network::Connection& connection) {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -13,14 +13,14 @@
 namespace Envoy {
 namespace Server {
 
-std::list<Configuration::NetworkFilterFactoryCb>
+std::vector<Configuration::NetworkFilterFactoryCb>
 ProdListenerComponentFactory::createFilterFactoryList_(
     const std::vector<Json::ObjectSharedPtr>& filters, Server::Instance& server,
     Configuration::FactoryContext& context) {
-  std::list<Configuration::NetworkFilterFactoryCb> ret;
+  std::vector<Configuration::NetworkFilterFactoryCb> ret;
   for (size_t i = 0; i < filters.size(); i++) {
-    std::string string_type = filters[i]->getString("type");
-    std::string string_name = filters[i]->getString("name");
+    const std::string string_type = filters[i]->getString("type");
+    const std::string string_name = filters[i]->getString("name");
     Json::ObjectSharedPtr config = filters[i]->getObject("config");
     ENVOY_LOG(info, "  filter #{}:", i);
     ENVOY_LOG(info, "    type: {}", string_type);
@@ -76,7 +76,7 @@ ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConst
   // UdsListenerSockets are not managed and do not participate in hot restart as they are only
   // used for testing. First we try to get the socket from our parent if applicable.
   ASSERT(address->type() == Network::Address::Type::Ip);
-  std::string addr = fmt::format("tcp://{}", address->asString());
+  const std::string addr = fmt::format("tcp://{}", address->asString());
   const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
   if (fd != -1) {
     ENVOY_LOG(info, "obtained socket for address {} from parent", addr);

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -23,12 +23,12 @@ public:
   /**
    * Static worker for createFilterFactoryList() that can be used directly in tests.
    */
-  static std::list<Configuration::NetworkFilterFactoryCb>
+  static std::vector<Configuration::NetworkFilterFactoryCb>
   createFilterFactoryList_(const std::vector<Json::ObjectSharedPtr>& filters,
                            Server::Instance& server, Configuration::FactoryContext& context);
 
   // Server::ListenSocketFactory
-  std::list<Configuration::NetworkFilterFactoryCb>
+  std::vector<Configuration::NetworkFilterFactoryCb>
   createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
                           Configuration::FactoryContext& context) override {
     return createFilterFactoryList_(filters, server_, context);
@@ -95,7 +95,7 @@ private:
   const bool use_proxy_proto_{};
   const bool use_original_dst_{};
   const uint32_t per_connection_buffer_limit_bytes_{};
-  std::list<Configuration::NetworkFilterFactoryCb> filter_factories_;
+  std::vector<Configuration::NetworkFilterFactoryCb> filter_factories_;
 };
 
 /**

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/server/filter_config.h"
+#include "envoy/server/instance.h"
 #include "envoy/server/listener_manager.h"
 
 #include "common/common/logger.h"
@@ -10,19 +11,33 @@ namespace Envoy {
 namespace Server {
 
 /**
- * Prod implementation of ListenSocketFactory that creates real sockets and attempts to fetch
- * sockets from the parent process via the hot restarter.
+ * Prod implementation of ListenerComponentFactory that creates real sockets and attempts to fetch
+ * sockets from the parent process via the hot restarter. The filter factory list is created from
+ * statically registered filters.
  */
-class ProdListenSocketFactory : public ListenSocketFactory, Logger::Loggable<Logger::Id::config> {
+class ProdListenerComponentFactory : public ListenerComponentFactory,
+                                     Logger::Loggable<Logger::Id::config> {
 public:
-  ProdListenSocketFactory(HotRestart& restarter) : restarter_(restarter) {}
+  ProdListenerComponentFactory(Instance& server) : server_(server) {}
+
+  /**
+   * Static worker for createFilterFactoryList() that can be used directly in tests.
+   */
+  static std::list<Configuration::NetworkFilterFactoryCb>
+  createFilterFactoryList_(const std::vector<Json::ObjectSharedPtr>& filters,
+                           Server::Instance& server, Configuration::FactoryContext& context);
 
   // Server::ListenSocketFactory
-  Network::ListenSocketPtr create(Network::Address::InstanceConstSharedPtr address,
-                                  bool bind_to_port) override;
+  std::list<Configuration::NetworkFilterFactoryCb>
+  createFilterFactoryList(const std::vector<Json::ObjectSharedPtr>& filters,
+                          Configuration::FactoryContext& context) override {
+    return createFilterFactoryList_(filters, server_, context);
+  }
+  Network::ListenSocketPtr createListenSocket(Network::Address::InstanceConstSharedPtr address,
+                                              bool bind_to_port) override;
 
 private:
-  HotRestart& restarter_;
+  Instance& server_;
 };
 
 /**
@@ -34,7 +49,7 @@ class ListenerImpl : public Listener,
                      Json::Validator,
                      Logger::Loggable<Logger::Id::config> {
 public:
-  ListenerImpl(Instance& server, ListenSocketFactory& factory, const Json::Object& json);
+  ListenerImpl(Instance& server, ListenerComponentFactory& factory, const Json::Object& json);
 
   // Server::Listener
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
@@ -88,7 +103,7 @@ private:
  */
 class ListenerManagerImpl : public ListenerManager {
 public:
-  ListenerManagerImpl(Instance& server, ListenSocketFactory& factory)
+  ListenerManagerImpl(Instance& server, ListenerComponentFactory& factory)
       : server_(server), factory_(factory) {}
 
   // Server::ListenerManager
@@ -97,7 +112,7 @@ public:
 
 private:
   Instance& server_;
-  ListenSocketFactory& factory_;
+  ListenerComponentFactory& factory_;
   std::list<ListenerPtr> listeners_;
 };
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -40,7 +40,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
       original_start_time_(start_time_), stats_store_(store),
       server_stats_{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))},
       handler_(log(), Api::ApiPtr{new Api::Impl(options.fileFlushIntervalMsec())}),
-      listen_socket_factory_(restarter_), listener_manager_(*this, listen_socket_factory_),
+      listen_socket_factory_(*this), listener_manager_(*this, listen_socket_factory_),
       dns_resolver_(handler_.dispatcher().createDnsResolver({})), local_info_(local_info),
       access_log_manager_(handler_.api(), handler_.dispatcher(), access_log_lock, store) {
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -40,7 +40,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
       original_start_time_(start_time_), stats_store_(store),
       server_stats_{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))},
       handler_(log(), Api::ApiPtr{new Api::Impl(options.fileFlushIntervalMsec())}),
-      listen_socket_factory_(*this), listener_manager_(*this, listen_socket_factory_),
+      listen_component_factory_(*this), listener_manager_(*this, listen_component_factory_),
       dns_resolver_(handler_.dispatcher().createDnsResolver({})), local_info_(local_info),
       access_log_manager_(handler_.api(), handler_.dispatcher(), access_log_lock, store) {
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -146,7 +146,7 @@ private:
   Runtime::RandomGeneratorImpl random_generator_;
   Runtime::LoaderPtr runtime_loader_;
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
-  ProdListenSocketFactory listen_socket_factory_;
+  ProdListenerComponentFactory listen_socket_factory_;
   ListenerManagerImpl listener_manager_;
   std::unique_ptr<Configuration::Main> config_;
   std::list<WorkerPtr> workers_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -146,7 +146,7 @@ private:
   Runtime::RandomGeneratorImpl random_generator_;
   Runtime::LoaderPtr runtime_loader_;
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
-  ProdListenerComponentFactory listen_socket_factory_;
+  ProdListenerComponentFactory listen_component_factory_;
   ListenerManagerImpl listener_manager_;
   std::unique_ptr<Configuration::Main> config_;
   std::list<WorkerPtr> workers_;

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -12,7 +12,6 @@
 namespace Envoy {
 
 class TestFilterLog : public Logger::Loggable<Logger::Id::filter> {
-
 public:
   void deprecatedLogMessage() {
     log_trace("fake message");
@@ -29,8 +28,8 @@ public:
   }
 
 private:
-  Envoy::Network::MockConnection connection_;
-  Envoy::Http::MockStreamDecoderFilterCallbacks stream_;
+  NiceMock<Network::MockConnection> connection_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> stream_;
 };
 
 TEST(Logger, All) {

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -45,7 +45,7 @@ public:
         .WillByDefault(
             Invoke([&](const std::vector<Json::ObjectSharedPtr>& filters,
                        Server::Configuration::FactoryContext& context)
-                       -> std::list<Server::Configuration::NetworkFilterFactoryCb> {
+                       -> std::vector<Server::Configuration::NetworkFilterFactoryCb> {
                          return Server::ProdListenerComponentFactory::createFilterFactoryList_(
                              filters, server_, context);
                        }));

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -41,6 +41,14 @@ public:
         .WillByDefault(
             Invoke([&]() -> Upstream::ClusterManager& { return main_config.clusterManager(); }));
     ON_CALL(server_, listenerManager()).WillByDefault(ReturnRef(listener_manager_));
+    ON_CALL(component_factory_, createFilterFactoryList(_, _))
+        .WillByDefault(
+            Invoke([&](const std::vector<Json::ObjectSharedPtr>& filters,
+                       Server::Configuration::FactoryContext& context)
+                       -> std::list<Server::Configuration::NetworkFilterFactoryCb> {
+                         return Server::ProdListenerComponentFactory::createFilterFactoryList_(
+                             filters, server_, context);
+                       }));
 
     try {
       main_config.initialize(*config_json, server_, cluster_manager_factory_);
@@ -55,8 +63,8 @@ public:
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   Server::TestOptionsImpl options_;
   Upstream::ProdClusterManagerFactory cluster_manager_factory_;
-  NiceMock<Server::MockListenSocketFactory> socket_factory_;
-  Server::ListenerManagerImpl listener_manager_{server_, socket_factory_};
+  NiceMock<Server::MockListenerComponentFactory> component_factory_;
+  Server::ListenerManagerImpl listener_manager_{server_, component_factory_};
 };
 
 uint32_t run(const std::string& directory) {

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -30,8 +30,8 @@ MockDrainManager::~MockDrainManager() {}
 MockHotRestart::MockHotRestart() {}
 MockHotRestart::~MockHotRestart() {}
 
-MockListenSocketFactory::MockListenSocketFactory() {}
-MockListenSocketFactory::~MockListenSocketFactory() {}
+MockListenerComponentFactory::MockListenerComponentFactory() {}
+MockListenerComponentFactory::~MockListenerComponentFactory() {}
 
 MockListenerManager::MockListenerManager() {}
 MockListenerManager::~MockListenerManager() {}

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -96,18 +96,22 @@ public:
   MOCK_METHOD0(version, std::string());
 };
 
-class MockListenSocketFactory : public ListenSocketFactory {
+class MockListenerComponentFactory : public ListenerComponentFactory {
 public:
-  MockListenSocketFactory();
-  ~MockListenSocketFactory();
+  MockListenerComponentFactory();
+  ~MockListenerComponentFactory();
 
-  Network::ListenSocketPtr create(Network::Address::InstanceConstSharedPtr address,
-                                  bool bind_to_port) override {
-    return Network::ListenSocketPtr{create_(address, bind_to_port)};
+  Network::ListenSocketPtr createListenSocket(Network::Address::InstanceConstSharedPtr address,
+                                              bool bind_to_port) override {
+    return Network::ListenSocketPtr{createListenSocket_(address, bind_to_port)};
   }
 
-  MOCK_METHOD2(create_, Network::ListenSocket*(Network::Address::InstanceConstSharedPtr address,
-                                               bool bind_to_port));
+  MOCK_METHOD2(createFilterFactoryList, std::list<Configuration::NetworkFilterFactoryCb>(
+                                            const std::vector<Json::ObjectSharedPtr>& filters,
+                                            Configuration::FactoryContext& context));
+  MOCK_METHOD2(createListenSocket_,
+               Network::ListenSocket*(Network::Address::InstanceConstSharedPtr address,
+                                      bool bind_to_port));
 };
 
 class MockListenerManager : public ListenerManager {
@@ -189,7 +193,6 @@ public:
 
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
-  MOCK_METHOD0(listeners, std::list<ListenerPtr>&());
   MOCK_METHOD0(rateLimitClientFactory, RateLimit::ClientFactory&());
   MOCK_METHOD0(statsdTcpClusterName, Optional<std::string>());
   MOCK_METHOD0(statsdUdpPort, Optional<uint32_t>());

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -106,7 +106,7 @@ public:
     return Network::ListenSocketPtr{createListenSocket_(address, bind_to_port)};
   }
 
-  MOCK_METHOD2(createFilterFactoryList, std::list<Configuration::NetworkFilterFactoryCb>(
+  MOCK_METHOD2(createFilterFactoryList, std::vector<Configuration::NetworkFilterFactoryCb>(
                                             const std::vector<Json::ObjectSharedPtr>& filters,
                                             Configuration::FactoryContext& context));
   MOCK_METHOD2(createListenSocket_,

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -24,7 +24,7 @@ namespace Configuration {
 
 TEST(FilterChainUtility, buildFilterChain) {
   Network::MockConnection connection;
-  std::list<NetworkFilterFactoryCb> factories;
+  std::vector<NetworkFilterFactoryCb> factories;
   ReadyWatcher watcher;
   NetworkFilterFactoryCb factory = [&](Network::FilterManager&) -> void { watcher.ready(); };
   factories.push_back(factory);
@@ -37,7 +37,7 @@ TEST(FilterChainUtility, buildFilterChain) {
 
 TEST(FilterChainUtility, buildFilterChainFailWithBadFilters) {
   Network::MockConnection connection;
-  std::list<NetworkFilterFactoryCb> factories;
+  std::vector<NetworkFilterFactoryCb> factories;
   EXPECT_CALL(connection, initializeReadFilters()).WillOnce(Return(false));
   EXPECT_EQ(FilterChainUtility::buildFilterChain(connection, factories), false);
 }

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -24,7 +24,7 @@ public:
         .WillByDefault(
             Invoke([&](const std::vector<Json::ObjectSharedPtr>& filters,
                        Server::Configuration::FactoryContext& context)
-                       -> std::list<Server::Configuration::NetworkFilterFactoryCb> {
+                       -> std::vector<Server::Configuration::NetworkFilterFactoryCb> {
                          return Server::ProdListenerComponentFactory::createFilterFactoryList_(
                              filters, server_, context);
                        }));


### PR DESCRIPTION
Add another factory that is used to create the list of filter chain
factory callbacks. This will make LDS tests simpler to write.