### PR TITLE
Removed namespace alias to prevent collisions

### DIFF
--- a/include/envoy/grpc/rpc_channel.h
+++ b/include/envoy/grpc/rpc_channel.h
@@ -11,8 +11,6 @@
 
 #include "google/protobuf/service.h"
 
-namespace proto = ::google::protobuf;
-
 namespace Envoy {
 namespace Grpc {
 
@@ -43,14 +41,14 @@ public:
 };
 
 /**
- * A single active grpc request arbiter. This interface derives from proto::RpcChannel. When
+ * A single active grpc request arbiter. This interface derives from ::google::protobuf::RpcChannel. When
  * mocking, CallMethod() can be overriden to accept the response message and the mock constructor
  * can accept a RequestCallbacks object. An RpcChannel should be passed to the constructor of an RPC
  * stub generated via protoc using the "option cc_generic_services = true;" option. It can be used
  * for multiple service calls, but not concurrently.
  * DEPRECATED: See https://github.com/lyft/envoy/issues/1102
  */
-class RpcChannel : public proto::RpcChannel {
+class RpcChannel : public ::google::protobuf::RpcChannel {
 public:
   virtual ~RpcChannel() {}
 

--- a/include/envoy/grpc/rpc_channel.h
+++ b/include/envoy/grpc/rpc_channel.h
@@ -41,11 +41,12 @@ public:
 };
 
 /**
- * A single active grpc request arbiter. This interface derives from ::google::protobuf::RpcChannel. When
- * mocking, CallMethod() can be overriden to accept the response message and the mock constructor
- * can accept a RequestCallbacks object. An RpcChannel should be passed to the constructor of an RPC
- * stub generated via protoc using the "option cc_generic_services = true;" option. It can be used
- * for multiple service calls, but not concurrently.
+ * A single active grpc request arbiter. This interface derives from
+ * ::google::protobuf::RpcChannel. When mocking, CallMethod() can be overriden to accept the
+ * response message and the mock constructor can accept a RequestCallbacks object. An RpcChannel
+ * should be passed to the constructor of an RPC stub generated via protoc using the "option
+ * cc_generic_services = true;" option. It can be used for multiple service calls, but not
+ * concurrently.
  * DEPRECATED: See https://github.com/lyft/envoy/issues/1102
  */
 class RpcChannel : public ::google::protobuf::RpcChannel {

--- a/source/common/grpc/rpc_channel_impl.cc
+++ b/source/common/grpc/rpc_channel_impl.cc
@@ -21,9 +21,9 @@ void RpcChannelImpl::cancel() {
   onComplete();
 }
 
-void RpcChannelImpl::CallMethod(const proto::MethodDescriptor* method, proto::RpcController*,
-                                const proto::Message* grpc_request, proto::Message* grpc_response,
-                                proto::Closure*) {
+void RpcChannelImpl::CallMethod(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController*,
+                                const ::google::protobuf::Message* grpc_request, ::google::protobuf::Message* grpc_response,
+                                ::google::protobuf::Closure*) {
   ASSERT(!http_request_ && !grpc_method_ && !grpc_response_);
   grpc_method_ = method;
   grpc_response_ = grpc_response;

--- a/source/common/grpc/rpc_channel_impl.cc
+++ b/source/common/grpc/rpc_channel_impl.cc
@@ -21,8 +21,10 @@ void RpcChannelImpl::cancel() {
   onComplete();
 }
 
-void RpcChannelImpl::CallMethod(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController*,
-                                const ::google::protobuf::Message* grpc_request, ::google::protobuf::Message* grpc_response,
+void RpcChannelImpl::CallMethod(const ::google::protobuf::MethodDescriptor* method,
+                                ::google::protobuf::RpcController*,
+                                const ::google::protobuf::Message* grpc_request,
+                                ::google::protobuf::Message* grpc_response,
                                 ::google::protobuf::Closure*) {
   ASSERT(!http_request_ && !grpc_method_ && !grpc_response_);
   grpc_method_ = method;

--- a/source/common/grpc/rpc_channel_impl.h
+++ b/source/common/grpc/rpc_channel_impl.h
@@ -35,15 +35,15 @@ public:
 
   ~RpcChannelImpl() { ASSERT(!http_request_ && !grpc_method_ && !grpc_response_); }
 
-  static Buffer::InstancePtr serializeBody(const proto::Message& message);
+  static Buffer::InstancePtr serializeBody(const ::google::protobuf::Message& message);
 
   // Grpc::RpcChannel
   void cancel() override;
 
-  // proto::RpcChannel
-  void CallMethod(const proto::MethodDescriptor* method, proto::RpcController* controller,
-                  const proto::Message* grpc_request, proto::Message* grpc_response,
-                  proto::Closure* done_callback) override;
+  // ::google::protobuf::RpcChannel
+  void CallMethod(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController* controller,
+                  const ::google::protobuf::Message* grpc_request, ::google::protobuf::Message* grpc_response,
+                  ::google::protobuf::Closure* done_callback) override;
 
 private:
   void incStat(bool success);
@@ -58,8 +58,8 @@ private:
   Upstream::ClusterManager& cm_;
   Upstream::ClusterInfoConstSharedPtr cluster_;
   Http::AsyncClient::Request* http_request_{};
-  const proto::MethodDescriptor* grpc_method_{};
-  proto::Message* grpc_response_{};
+  const ::google::protobuf::MethodDescriptor* grpc_method_{};
+  ::google::protobuf::Message* grpc_response_{};
   RpcChannelCallbacks& callbacks_;
   Optional<std::chrono::milliseconds> timeout_;
 };

--- a/source/common/grpc/rpc_channel_impl.h
+++ b/source/common/grpc/rpc_channel_impl.h
@@ -41,8 +41,10 @@ public:
   void cancel() override;
 
   // ::google::protobuf::RpcChannel
-  void CallMethod(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController* controller,
-                  const ::google::protobuf::Message* grpc_request, ::google::protobuf::Message* grpc_response,
+  void CallMethod(const ::google::protobuf::MethodDescriptor* method,
+                  ::google::protobuf::RpcController* controller,
+                  const ::google::protobuf::Message* grpc_request,
+                  ::google::protobuf::Message* grpc_response,
                   ::google::protobuf::Closure* done_callback) override;
 
 private:

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -54,7 +54,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     Http::HeaderMapImpl headers;
     GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}}}});
     EXPECT_CALL(*channel_, CallMethod(_, _, ProtoMessageEqual(&request), _, nullptr))
-        .WillOnce(WithArg<3>(Invoke([&](proto::Message* raw_response) -> void {
+        .WillOnce(WithArg<3>(Invoke([&](::google::protobuf::Message* raw_response) -> void {
           response = dynamic_cast<pb::lyft::ratelimit::RateLimitResponse*>(raw_response);
         })));
 
@@ -74,7 +74,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     Http::HeaderMapImpl headers;
     GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}, {"bar", "baz"}}}});
     EXPECT_CALL(*channel_, CallMethod(_, _, ProtoMessageEqual(&request), _, nullptr))
-        .WillOnce(WithArg<3>(Invoke([&](proto::Message* raw_response) -> void {
+        .WillOnce(WithArg<3>(Invoke([&](::google::protobuf::Message* raw_response) -> void {
           response = dynamic_cast<pb::lyft::ratelimit::RateLimitResponse*>(raw_response);
         })));
 
@@ -96,7 +96,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}, {"bar", "baz"}}},
                                                    {{{"foo2", "bar2"}, {"bar2", "baz2"}}}});
     EXPECT_CALL(*channel_, CallMethod(_, _, ProtoMessageEqual(&request), _, nullptr))
-        .WillOnce(WithArg<3>(Invoke([&](proto::Message* raw_response) -> void {
+        .WillOnce(WithArg<3>(Invoke([&](::google::protobuf::Message* raw_response) -> void {
           response = dynamic_cast<pb::lyft::ratelimit::RateLimitResponse*>(raw_response);
         })));
 
@@ -114,7 +114,7 @@ TEST_F(RateLimitGrpcClientTest, Cancel) {
   pb::lyft::ratelimit::RateLimitResponse* response;
 
   EXPECT_CALL(*channel_, CallMethod(_, _, _, _, nullptr))
-      .WillOnce(WithArg<3>(Invoke([&](proto::Message* raw_response) -> void {
+      .WillOnce(WithArg<3>(Invoke([&](::google::protobuf::Message* raw_response) -> void {
         response = dynamic_cast<pb::lyft::ratelimit::RateLimitResponse*>(raw_response);
       })));
 

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -64,8 +64,8 @@ public:
 
   MOCK_METHOD0(cancel, void());
   MOCK_METHOD5(CallMethod,
-               void(const proto::MethodDescriptor* method, proto::RpcController* controller,
-                    const proto::Message* request, proto::Message* response, proto::Closure* done));
+               void(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController* controller,
+                    const ::google::protobuf::Message* request, ::google::protobuf::Message* response, ::google::protobuf::Closure* done));
 };
 
 } // Grpc

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -64,8 +64,10 @@ public:
 
   MOCK_METHOD0(cancel, void());
   MOCK_METHOD5(CallMethod,
-               void(const ::google::protobuf::MethodDescriptor* method, ::google::protobuf::RpcController* controller,
-                    const ::google::protobuf::Message* request, ::google::protobuf::Message* response, ::google::protobuf::Closure* done));
+               void(const ::google::protobuf::MethodDescriptor* method,
+                    ::google::protobuf::RpcController* controller,
+                    const ::google::protobuf::Message* request,
+                    ::google::protobuf::Message* response, ::google::protobuf::Closure* done));
 };
 
 } // Grpc


### PR DESCRIPTION
We're having issues with internal namespace collisions due to the proto namespace alias, so we would prefer removing it.