### PR TITLE
Tracing: Make missing response as an error on a span.

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -152,7 +152,7 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
   span.setTag("response_size", std::to_string(request_info_.bytesSent()));
   span.setTag("response_flags", Http::AccessLog::ResponseFlagUtils::toShortString(request_info_));
 
-  if (request_info_.responseCode().valid() &&
+  if (!request_info_.responseCode().valid() ||
       Http::CodeUtility::is5xx(request_info_.responseCode().value())) {
     span.setTag("error", "true");
   }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -268,6 +268,7 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
 
   EXPECT_CALL(*span, setTag("response_code", "0"));
+  EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "11"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
@@ -302,6 +303,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(100));
 
   EXPECT_CALL(*span, setTag("response_code", "0"));
+  EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "100"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
 


### PR DESCRIPTION
@lyft/network-team 