### PR TITLE
Update CI for envoy-filter-example.

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -78,7 +78,7 @@ then
 fi
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 29981ca67a9ac9a28e688f69f21c1ed65b8b7592)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 8442ed70a5fc55662ca1a6d45fde2d23a4cb4adf)
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -59,7 +59,7 @@ elif [[ "$1" == "bazel.asan" ]]; then
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan @envoy//test/... \
-    //:echo2_integration_test
+    //...
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
   setup_clang_toolchain
@@ -67,7 +67,7 @@ elif [[ "$1" == "bazel.tsan" ]]; then
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan @envoy//test/... \
-    //:echo2_integration_test
+    //...
   exit 0
 elif [[ "$1" == "bazel.dev" ]]; then
   setup_clang_toolchain

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -59,7 +59,7 @@ elif [[ "$1" == "bazel.asan" ]]; then
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan @envoy//test/... \
-    //...
+    //:echo2_integration_test //:envoy_binary_test
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
   setup_clang_toolchain
@@ -67,7 +67,7 @@ elif [[ "$1" == "bazel.tsan" ]]; then
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan @envoy//test/... \
-    //...
+    //:echo2_integration_test //:envoy_binary_test
   exit 0
 elif [[ "$1" == "bazel.dev" ]]; then
   setup_clang_toolchain


### PR DESCRIPTION
The envoy-filter-example has a new test to verify the Envoy binary is
created correctly. This change updates the envoy-filter-example commit
hash to the latest and changes do_ci.sh to run all tests in
envoy-filter-example.