### PR TITLE
admin: fix clusters output bug

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -113,9 +113,9 @@ void AdminImpl::addOutlierInfo(const std::string& cluster_name,
                                const Upstream::Outlier::Detector* outlier_detector,
                                Buffer::Instance& response) {
   if (outlier_detector) {
-    response.add(fmt::format("{}::outlier::success_rate_average::{}", cluster_name,
+    response.add(fmt::format("{}::outlier::success_rate_average::{}\n", cluster_name,
                              outlier_detector->successRateAverage()));
-    response.add(fmt::format("{}::outlier::success_rate_ejection_threshold::{}", cluster_name,
+    response.add(fmt::format("{}::outlier::success_rate_ejection_threshold::{}\n", cluster_name,
                              outlier_detector->successRateEjectionThreshold()));
   }
 }


### PR DESCRIPTION
pre-bugfix output:
```
$ curl -s 0:9901/clusters
my_service::outlier::success_rate_average::-1my_service::outlier::success_rate_ejection_threshold::-1my_service::default_priority::max_connections::1024
my_service::default_priority::max_pending_requests::1024
my_service::default_priority::max_requests::1024
my_service::default_priority::max_retries::3
...
```