### PR TITLE
BUILD: build ip_tagging filter into envoy and integration test.

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "//source/server/config/http:grpc_http1_bridge_lib",
         "//source/server/config/http:grpc_json_transcoder_lib",
         "//source/server/config/http:grpc_web_lib",
+        "//source/server/config/http:ip_tagging_lib",
         "//source/server/config/http:ratelimit_lib",
         "//source/server/config/http:router_lib",
         "//source/server/config/network:client_ssl_auth_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -147,6 +147,7 @@ envoy_cc_test_library(
         "//source/server/config/http:fault_lib",
         "//source/server/config/http:grpc_http1_bridge_lib",
         "//source/server/config/http:grpc_json_transcoder_lib",
+        "//source/server/config/http:ip_tagging_lib",
         "//source/server/config/http:lightstep_lib",
         "//source/server/config/http:ratelimit_lib",
         "//source/server/config/http:router_lib",


### PR DESCRIPTION
Current documentation states that ip_tagging filter is under
development and is currently doing nothing.  However, envoy startup
fails if ip_tagging filter is included in configuration due to
ip_tagging filter not being included in the envoy build at all.  This
change allows the (currently no-op) ip_tagging filter to be
configured.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>