### PR TITLE
Revert "ci: add clang-format-5.0"

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -5,12 +5,12 @@ set -e
 # Setup basic requirements and install them.
 apt-get update
 apt-get install -y wget software-properties-common make cmake git python python-pip \
-  bc libtool automake zip time golang g++ gdb strace
+  clang-format-3.6 bc libtool automake zip time golang g++ gdb strace
 # clang head (currently 5.0)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main"
 apt-get update
-apt-get install -y clang-5.0 clang-format-5.0
+apt-get install -y clang-5.0
 # Bazel and related dependencies.
 apt-get install -y openjdk-8-jdk curl
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list


### PR DESCRIPTION
Reverts lyft/envoy#1205. This broke fix_format etc., since it removes clang-format-3.6. We should probably add a CI with the changes to the various scripts and format changes.