### PR TITLE
run_envoy_docker: don't pull latest when working with explicit image ID.

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -11,10 +11,15 @@ else
 	USER_GROUP=$(id -g)
 fi
 
+# The IMAGE_ID can be set to an arbitrary image ID (found with 'docker images').
 [[ -z "${IMAGE_ID}" ]] && IMAGE_ID="latest"
 [[ -z "${ENVOY_DOCKER_BUILD_DIR}" ]] && ENVOY_DOCKER_BUILD_DIR=/tmp/envoy-docker-build
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
-docker pull lyft/envoy-build:"${IMAGE_ID}"
+# When not operating on an existing image ID, fetch latest.
+if [[ "${IMAGE_ID}" == "latest" ]]
+then
+  docker pull lyft/envoy-build:latest
+fi
 docker run -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source lyft/envoy-build:"${IMAGE_ID}" /bin/bash -c "cd source && $*"


### PR DESCRIPTION
docker pull takes a tag, not an image ID. Plus, the point of the IMAGE_ID override is to work with
an image ID found in 'docker images', not to remote fetch.