### PR TITLE
listener manager: implement dynamic add/remove

### DIFF
--- a/docs/configuration/listeners/listeners.rst
+++ b/docs/configuration/listeners/listeners.rst
@@ -9,6 +9,7 @@ Each individual listener configuration has the following format:
 .. code-block:: json
 
   {
+    "name": "...",
     "address": "...",
     "filters": [],
     "ssl_context": "{...}",
@@ -17,6 +18,11 @@ Each individual listener configuration has the following format:
     "use_original_dst": "...",
     "per_connection_buffer_limit_bytes": "..."
   }
+
+name
+  *(optional, string)* The unique name by which this listener is known. If no name is provided,
+  Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
+  updated or removed via LDS a unique name must be provided.
 
 address
   *(required, string)* The address that the listener should listen on. Currently only TCP

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -92,6 +92,7 @@ public:
   virtual ~Instance() {}
 
   virtual bool operator==(const Instance& rhs) const PURE;
+  bool operator!=(const Instance& rhs) const { return !operator==(rhs); }
 
   /**
    * @return a human readable string for the address.

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -32,6 +32,7 @@ public:
 };
 
 typedef std::unique_ptr<ListenSocket> ListenSocketPtr;
+typedef std::shared_ptr<ListenSocket> ListenSocketSharedPtr;
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -43,6 +43,7 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
     },
     "type" : "object",
     "properties": {
+       "name": {"type": "string"},
        "address": {"type": "string"},
        "filters" : {
          "type" : "array",

--- a/source/exe/hot_restart.cc
+++ b/source/exe/hot_restart.cc
@@ -176,7 +176,7 @@ void HotRestartImpl::drainParentListeners() {
 }
 
 int HotRestartImpl::duplicateParentListenSocket(const std::string& address) {
-  if (options_.restartEpoch() == 0) {
+  if (options_.restartEpoch() == 0 || parent_terminated_) {
     return -1;
   }
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -34,12 +34,9 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/json:config_schemas_lib",
-        "//source/common/json:json_loader_lib",
         "//source/common/network:utility_lib",
         "//source/common/ratelimit:ratelimit_lib",
         "//source/common/tracing:http_tracer_lib",
-        "//source/common/tracing/zipkin:zipkin_lib",
-        "//source/common/upstream:cluster_manager_lib",
     ],
 )
 
@@ -125,6 +122,7 @@ envoy_cc_library(
     hdrs = ["listener_manager_impl.h"],
     deps = [
         ":configuration_lib",
+        ":init_manager_lib",
         "//include/envoy/registry",
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/server:listener_manager_interface",
@@ -159,7 +157,6 @@ envoy_cc_library(
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:listener_manager_interface",
         "//include/envoy/server:options_interface",
-        "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -171,6 +168,7 @@ envoy_cc_library(
         "//source/common/runtime:runtime_lib",
         "//source/common/stats:statsd_lib",
         "//source/common/thread_local:thread_local_lib",
+        "//source/common/upstream:cluster_manager_lib",
         "//source/server/http:admin_lib",
     ],
 )
@@ -198,6 +196,7 @@ envoy_cc_library(
     hdrs = ["worker_impl.h"],
     deps = [
         ":connection_handler_lib",
+        ":test_hooks_lib",
         "//include/envoy/api:api_interface",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:timer_interface",

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -92,8 +92,8 @@ public:
                           Configuration::FactoryContext& context) override {
     return ProdListenerComponentFactory::createFilterFactoryList_(filters, *this, context);
   }
-  Network::ListenSocketPtr createListenSocket(Network::Address::InstanceConstSharedPtr,
-                                              bool) override {
+  Network::ListenSocketSharedPtr createListenSocket(Network::Address::InstanceConstSharedPtr,
+                                                    bool) override {
     // Returned sockets are not currently used so we can return nothing here safely vs. a
     // validation mock.
     return nullptr;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -16,7 +16,7 @@
 #include "common/common/utility.h"
 #include "common/json/config_schemas.h"
 #include "common/ratelimit/ratelimit_impl.h"
-#include "common/upstream/cluster_manager_impl.h"
+#include "common/tracing/http_tracer_impl.h"
 
 #include "spdlog/spdlog.h"
 
@@ -43,7 +43,7 @@ void MainImpl::initialize(const Json::Object& json, Instance& server,
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
   for (size_t i = 0; i < listeners.size(); i++) {
     ENVOY_LOG(info, "listener #{}:", i);
-    server.listenerManager().addListener(*listeners[i]);
+    server.listenerManager().addOrUpdateListener(*listeners[i]);
   }
 
   if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -185,12 +185,11 @@ bool ListenerManagerImpl::addOrUpdateListener(const Json::Object& json) {
        (*existing_warming_listener)->hash() == hash) ||
       (existing_active_listener != active_listeners_.end() &&
        (*existing_active_listener)->hash() == hash)) {
-    ENVOY_LOG(debug, "duplicate listener. no add/update");
+    ENVOY_LOG(debug, "duplicate listener '{}'. no add/update", name);
     return false;
   }
 
-  std::unique_ptr<ListenerImpl> new_listener(
-      new ListenerImpl(json, *this, name, workers_started_, hash));
+  ListenerImplPtr new_listener(new ListenerImpl(json, *this, name, workers_started_, hash));
   ListenerImpl& new_listener_ref = *new_listener;
 
   // We mandate that a listener with the same name must have the same configured address. This
@@ -340,7 +339,7 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
   auto existing_warming_listener = getListenerByName(warming_listeners_, name);
   if (existing_warming_listener == warming_listeners_.end() &&
       existing_active_listener == active_listeners_.end()) {
-    ENVOY_LOG(debug, "unknown listener. no remove", name);
+    ENVOY_LOG(debug, "unknown listener '{}'. no remove", name);
     return false;
   }
 

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -8,7 +8,7 @@
 #include "common/network/utility.h"
 #include "common/ssl/context_config_impl.h"
 
-#include "server/configuration_impl.h"
+#include "server/configuration_impl.h" // TODO(mattklein123): Remove post 1.4.0
 
 namespace Envoy {
 namespace Server {
@@ -69,55 +69,96 @@ ProdListenerComponentFactory::createFilterFactoryList_(
   return ret;
 }
 
-Network::ListenSocketPtr
+Network::ListenSocketSharedPtr
 ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConstSharedPtr address,
                                                  bool bind_to_port) {
   // For each listener config we share a single TcpListenSocket among all threaded listeners.
   // UdsListenerSockets are not managed and do not participate in hot restart as they are only
   // used for testing. First we try to get the socket from our parent if applicable.
+  // TODO(mattklein123): UDS support.
   ASSERT(address->type() == Network::Address::Type::Ip);
   const std::string addr = fmt::format("tcp://{}", address->asString());
   const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
   if (fd != -1) {
     ENVOY_LOG(info, "obtained socket for address {} from parent", addr);
-    return Network::ListenSocketPtr{new Network::TcpListenSocket(fd, address)};
+    return std::make_shared<Network::TcpListenSocket>(fd, address);
   } else {
-    return Network::ListenSocketPtr{new Network::TcpListenSocket(address, bind_to_port)};
+    return std::make_shared<Network::TcpListenSocket>(address, bind_to_port);
   }
 }
 
-ListenerImpl::ListenerImpl(Instance& server, ListenerComponentFactory& factory,
-                           const Json::Object& json)
-    : Json::Validator(json, Json::Schema::LISTENER_SCHEMA), server_(server),
+ListenerImpl::ListenerImpl(const Json::Object& json, ListenerManagerImpl& parent,
+                           const std::string& name, bool workers_started, uint64_t hash)
+    : Json::Validator(json, Json::Schema::LISTENER_SCHEMA), parent_(parent),
       address_(Network::Utility::resolveUrl(json.getString("address"))),
-      global_scope_(server.stats().createScope("")),
+      global_scope_(parent_.server_.stats().createScope("")),
       bind_to_port_(json.getBoolean("bind_to_port", true)),
       use_proxy_proto_(json.getBoolean("use_proxy_proto", false)),
       use_original_dst_(json.getBoolean("use_original_dst", false)),
       per_connection_buffer_limit_bytes_(
           json.getInteger("per_connection_buffer_limit_bytes", 1024 * 1024)),
-      listener_tag_(factory.nextListenerTag()) {
+      listener_tag_(parent_.factory_.nextListenerTag()), name_(name),
+      workers_started_(workers_started), hash_(hash) {
 
   // ':' is a reserved char in statsd. Do the translation here to avoid costly inline translations
   // later.
   std::string final_stat_name = fmt::format("listener.{}.", address_->asString());
   std::replace(final_stat_name.begin(), final_stat_name.end(), ':', '_');
-
-  listener_scope_ = server.stats().createScope(final_stat_name);
-  ENVOY_LOG(info, "  address={}", address_->asString());
+  listener_scope_ = parent_.server_.stats().createScope(final_stat_name);
 
   if (json.hasObject("ssl_context")) {
     Ssl::ContextConfigImpl context_config(*json.getObject("ssl_context"));
-    ssl_context_ =
-        server.sslContextManager().createSslServerContext(*listener_scope_, context_config);
+    ssl_context_ = parent_.server_.sslContextManager().createSslServerContext(*listener_scope_,
+                                                                              context_config);
   }
 
-  filter_factories_ = factory.createFilterFactoryList(json.getObjectArray("filters"), *this);
-  socket_ = factory.createListenSocket(address_, bind_to_port_);
+  filter_factories_ =
+      parent_.factory_.createFilterFactoryList(json.getObjectArray("filters"), *this);
+}
+
+ListenerImpl::~ListenerImpl() {
+  // The filter factories may have pending initialize actions (like in the case of RDS). Those
+  // actions will fire in the destructor to avoid blocking initial server startup. If we are using
+  // a local init manager we should block the notification from trying to move us from warming to
+  // active. This is done here explicitly by setting a boolean and then clearing the factory
+  // vector for clarity.
+  initialize_canceled_ = true;
+  filter_factories_.clear();
 }
 
 bool ListenerImpl::createFilterChain(Network::Connection& connection) {
   return Configuration::FilterChainUtility::buildFilterChain(connection, filter_factories_);
+}
+
+void ListenerImpl::infoLog(const std::string& message) {
+  ENVOY_LOG(info, "{}: name={}, hash={}, address={}", message, name_, hash_, address_->asString());
+}
+
+void ListenerImpl::initialize() {
+  // If workers have already started, we shift from using the global init manager to using a local
+  // per listener init manager. See ~ListenerImpl() for why we gate the onListenerWarmed() call
+  // with initialize_canceled_.
+  if (workers_started_) {
+    dynamic_init_manager_.initialize([this]() -> void {
+      if (!initialize_canceled_) {
+        parent_.onListenerWarmed(*this);
+      }
+    });
+  }
+}
+
+Init::Manager& ListenerImpl::initManager() {
+  // See initialize() for why we choose different init managers to return.
+  if (workers_started_) {
+    return dynamic_init_manager_;
+  } else {
+    return parent_.server_.initManager();
+  }
+}
+
+void ListenerImpl::setSocket(const Network::ListenSocketSharedPtr& socket) {
+  ASSERT(!socket_);
+  socket_ = socket;
 }
 
 ListenerManagerImpl::ListenerManagerImpl(Instance& server,
@@ -129,16 +170,158 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
   }
 }
 
-void ListenerManagerImpl::addListener(const Json::Object& json) {
-  listeners_.emplace_back(new ListenerImpl(server_, factory_, json));
+bool ListenerManagerImpl::addOrUpdateListener(const Json::Object& json) {
+  const std::string name = json.getString("name", server_.random().uuid());
+  const uint64_t hash = json.hash();
+  ENVOY_LOG(debug, "begin add/update listener: name={} hash={}", name, hash);
+
+  auto existing_active_listener = getListenerByName(active_listeners_, name);
+  auto existing_warming_listener = getListenerByName(warming_listeners_, name);
+
+  // Do a quick hash check to see if we have a duplicate before going further. This check needs
+  // to be done against both warming and active.
+  // TODO(mattklein123): In v2 move away from hashes and just do an explicit proto equality check.
+  if ((existing_warming_listener != warming_listeners_.end() &&
+       (*existing_warming_listener)->hash() == hash) ||
+      (existing_active_listener != active_listeners_.end() &&
+       (*existing_active_listener)->hash() == hash)) {
+    ENVOY_LOG(debug, "duplicate listener. no add/update");
+    return false;
+  }
+
+  std::unique_ptr<ListenerImpl> new_listener(
+      new ListenerImpl(json, *this, name, workers_started_, hash));
+  ListenerImpl& new_listener_ref = *new_listener;
+
+  // We mandate that a listener with the same name must have the same configured address. This
+  // avoids confusion during updates and allows us to use the same bound address. Note that in
+  // the case of port 0 binding, the new listener will implicitly use the same bound port from
+  // the existing listener.
+  if ((existing_warming_listener != warming_listeners_.end() &&
+       *(*existing_warming_listener)->address() != *new_listener->address()) ||
+      (existing_active_listener != active_listeners_.end() &&
+       *(*existing_active_listener)->address() != *new_listener->address())) {
+    const std::string message = fmt::format(
+        "error updating listener: '{}' has a different address '{}' from existing listener", name,
+        new_listener->address()->asString());
+    ENVOY_LOG(warn, "{}", message);
+    throw EnvoyException(message);
+  }
+
+  if (existing_warming_listener != warming_listeners_.end()) {
+    // In this case we can just replace inline.
+    ASSERT(workers_started_);
+    new_listener->infoLog("update warming listener");
+    new_listener->setSocket((*existing_warming_listener)->getSocket());
+    *existing_warming_listener = std::move(new_listener);
+  } else if (existing_active_listener != active_listeners_.end()) {
+    // In this case we have no warming listener, so what we do depends on whether workers
+    // have been started or not. Either way we get the socket from the existing listener.
+    new_listener->setSocket((*existing_active_listener)->getSocket());
+    if (workers_started_) {
+      new_listener->infoLog("add warming listener");
+      warming_listeners_.emplace_back(std::move(new_listener));
+    } else {
+      new_listener->infoLog("update active listener");
+      *existing_active_listener = std::move(new_listener);
+    }
+  } else {
+    // We have no warming or active listener so we need to make a new one. What we do depends on
+    // whether workers have been started or not. Additionally, search through draining listeners
+    // to see if there is a listener that has a socket bound to the address we are configured for.
+    // This is an edge case, but may happen if a listener is removed and then added back with a same
+    // or different name and intended to listen on the same address. This should work and not fail.
+    Network::ListenSocketSharedPtr draining_listener_socket;
+    {
+      std::lock_guard<std::mutex> guard(draining_listeners_lock_);
+      auto existing_draining_listener = std::find_if(
+          draining_listeners_.cbegin(), draining_listeners_.cend(),
+          [&new_listener](const DrainingListener& listener) {
+            return *new_listener->address() == *listener.listener_->socket().localAddress();
+          });
+      if (existing_draining_listener != draining_listeners_.cend()) {
+        draining_listener_socket = existing_draining_listener->listener_->getSocket();
+      }
+    }
+
+    new_listener->setSocket(
+        draining_listener_socket
+            ? draining_listener_socket
+            : factory_.createListenSocket(new_listener->address(), new_listener->bindToPort()));
+    if (workers_started_) {
+      new_listener->infoLog("add warming listener");
+      warming_listeners_.emplace_back(std::move(new_listener));
+    } else {
+      new_listener->infoLog("add active listener");
+      active_listeners_.emplace_back(std::move(new_listener));
+    }
+  }
+
+  new_listener_ref.initialize();
+  return true;
 }
 
-std::list<std::reference_wrapper<Listener>> ListenerManagerImpl::listeners() {
-  std::list<std::reference_wrapper<Listener>> ret;
-  for (const auto& listener : listeners_) {
-    ret.emplace_back(*listener);
+void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
+  // TODO(mattklein123): Actually implement timed draining in a follow up. Currently we just
+  // correctly synchronize removal across all workers.
+  std::list<DrainingListener>::iterator draining_it;
+  {
+    std::lock_guard<std::mutex> guard(draining_listeners_lock_);
+    draining_it = draining_listeners_.emplace(draining_listeners_.begin(), std::move(listener),
+                                              workers_.size());
+  }
+
+  draining_it->listener_->infoLog("removing listener");
+  for (const auto& worker : workers_) {
+    worker->removeListener(*draining_it->listener_, [this, draining_it]() -> void {
+      std::lock_guard<std::mutex> guard(draining_listeners_lock_);
+      if (--draining_it->workers_pending_removal_ == 0) {
+        draining_it->listener_->infoLog("listener removal complete");
+        draining_listeners_.erase(draining_it);
+      }
+    });
+  }
+}
+
+ListenerManagerImpl::ListenerList::iterator
+ListenerManagerImpl::getListenerByName(ListenerList& listeners, const std::string& name) {
+  auto ret = listeners.end();
+  for (auto it = listeners.begin(); it != listeners.end(); ++it) {
+    if ((*it)->name() == name) {
+      // There should only ever be a single listener per name in the list. We could return faster
+      // but take the opportunity to assert that fact.
+      ASSERT(ret == listeners.end());
+      ret = it;
+    }
   }
   return ret;
+}
+
+std::vector<std::reference_wrapper<Listener>> ListenerManagerImpl::listeners() {
+  std::vector<std::reference_wrapper<Listener>> ret;
+  ret.reserve(active_listeners_.size());
+  for (const auto& listener : active_listeners_) {
+    ret.push_back(*listener);
+  }
+  return ret;
+}
+
+void ListenerManagerImpl::onListenerWarmed(ListenerImpl& listener) {
+  auto existing_active_listener = getListenerByName(active_listeners_, listener.name());
+  auto existing_warming_listener = getListenerByName(warming_listeners_, listener.name());
+  (*existing_warming_listener)->infoLog("warm complete. updating active listener");
+  if (existing_active_listener != active_listeners_.end()) {
+    drainListener(std::move(*existing_active_listener));
+    *existing_active_listener = std::move(*existing_warming_listener);
+  } else {
+    active_listeners_.emplace_back(std::move(*existing_warming_listener));
+  }
+
+  warming_listeners_.erase(existing_warming_listener);
+
+  for (const auto& worker : workers_) {
+    worker->addListener(listener);
+  }
 }
 
 uint64_t ListenerManagerImpl::numConnections() {
@@ -150,9 +333,39 @@ uint64_t ListenerManagerImpl::numConnections() {
   return num_connections;
 }
 
+bool ListenerManagerImpl::removeListener(const std::string& name) {
+  ENVOY_LOG(debug, "begin remove listener: name={}", name);
+
+  auto existing_active_listener = getListenerByName(active_listeners_, name);
+  auto existing_warming_listener = getListenerByName(warming_listeners_, name);
+  if (existing_warming_listener == warming_listeners_.end() &&
+      existing_active_listener == active_listeners_.end()) {
+    ENVOY_LOG(debug, "unknown listener. no remove", name);
+    return false;
+  }
+
+  // Destroy a warming listener directly.
+  if (existing_warming_listener != warming_listeners_.end()) {
+    (*existing_warming_listener)->infoLog("removing warming listener");
+    warming_listeners_.erase(existing_warming_listener);
+  }
+
+  // If there is an active listener
+  if (existing_active_listener != active_listeners_.end()) {
+    drainListener(std::move(*existing_active_listener));
+    active_listeners_.erase(existing_active_listener);
+  }
+
+  return true;
+}
+
 void ListenerManagerImpl::startWorkers(GuardDog& guard_dog) {
+  ENVOY_LOG(warn, "all dependencies initialized. starting workers");
+  ASSERT(!workers_started_);
+  workers_started_ = true;
   for (const auto& worker : workers_) {
-    for (const auto& listener : listeners_) {
+    ASSERT(warming_listeners_.empty());
+    for (const auto& listener : active_listeners_) {
       worker->addListener(*listener);
     }
     worker->start(guard_dog);
@@ -166,6 +379,7 @@ void ListenerManagerImpl::stopListeners() {
 }
 
 void ListenerManagerImpl::stopWorkers() {
+  ASSERT(workers_started_);
   for (const auto& worker : workers_) {
     worker->stop();
   }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -8,6 +8,8 @@
 #include "common/common/logger.h"
 #include "common/json/json_validator.h"
 
+#include "server/init_manager_impl.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -34,14 +36,78 @@ public:
                           Configuration::FactoryContext& context) override {
     return createFilterFactoryList_(filters, server_, context);
   }
-  Network::ListenSocketPtr createListenSocket(Network::Address::InstanceConstSharedPtr address,
-                                              bool bind_to_port) override;
+  Network::ListenSocketSharedPtr
+  createListenSocket(Network::Address::InstanceConstSharedPtr address, bool bind_to_port) override;
   uint64_t nextListenerTag() override { return next_listener_tag_++; }
 
 private:
   Instance& server_;
   uint64_t next_listener_tag_{1};
 };
+
+class ListenerImpl;
+typedef std::unique_ptr<ListenerImpl> ListenerImplPtr;
+
+/**
+ * Implementation of ListenerManager.
+ */
+class ListenerManagerImpl : public ListenerManager, Logger::Loggable<Logger::Id::config> {
+public:
+  ListenerManagerImpl(Instance& server, ListenerComponentFactory& listener_factory,
+                      WorkerFactory& worker_factory);
+
+  void onListenerWarmed(ListenerImpl& listener);
+
+  // Server::ListenerManager
+  bool addOrUpdateListener(const Json::Object& json) override;
+  std::vector<std::reference_wrapper<Listener>> listeners() override;
+  uint64_t numConnections() override;
+  bool removeListener(const std::string& listener_name) override;
+  void startWorkers(GuardDog& guard_dog) override;
+  void stopListeners() override;
+  void stopWorkers() override;
+
+  Instance& server_;
+  ListenerComponentFactory& factory_;
+
+private:
+  typedef std::list<ListenerImplPtr> ListenerList;
+
+  struct DrainingListener {
+    DrainingListener(ListenerImplPtr&& listener, uint64_t workers_pending_removal)
+        : listener_(std::move(listener)), workers_pending_removal_(workers_pending_removal) {}
+
+    ListenerImplPtr listener_;
+    uint64_t workers_pending_removal_;
+  };
+
+  /**
+   * Mark a listener for draining. The listener will no longer be considered active but will remain
+   * present to allow connection draining.
+   * @param listener supplies the listener to drain.
+   */
+  void drainListener(ListenerImplPtr&& listener);
+
+  /**
+   * Get a listener by name. This routine is used because listeners have inherent order in static
+   * configuration and especially for tests. Thus, we can't use a map.
+   * @param listeners supplies the listener list to look in.
+   * @param name supplies the name to search for.
+   */
+  ListenerList::iterator getListenerByName(ListenerList& listeners, const std::string& name);
+
+  ListenerList active_listeners_;
+  ListenerList warming_listeners_;
+  std::list<DrainingListener> draining_listeners_;
+  std::list<WorkerPtr> workers_;
+  bool workers_started_{};
+  std::mutex draining_listeners_lock_;
+};
+
+// TODO(mattklein123): Listener manager stats.
+// TODO(mattklein123): Check that addresses for unbound listeners are unique.
+// TODO(mattklein123): Real listener draining with a per listener drain manager.
+// TODO(mattklein123): Detect runtime worker listener addition failure and handle.
 
 /**
  * Maps JSON config to runtime config for a listener with a network filter chain.
@@ -52,11 +118,29 @@ class ListenerImpl : public Listener,
                      Json::Validator,
                      Logger::Loggable<Logger::Id::config> {
 public:
-  ListenerImpl(Instance& server, ListenerComponentFactory& factory, const Json::Object& json);
+  /**
+   * Create a new listener.
+   * @param json supplies the configuration JSON.
+   * @param parent supplies the owning manager.
+   * @param name supplies the listener name.
+   * @param workers_started supplies whether the listener is being added before or after workers
+   *        have been started. This controls various behavior related to init management.
+   * @param hash supplies the hash to use for duplicate checking.
+   */
+  ListenerImpl(const Json::Object& json, ListenerManagerImpl& parent, const std::string& name,
+               bool workers_started, uint64_t hash);
+  ~ListenerImpl();
+
+  Network::Address::InstanceConstSharedPtr address() { return address_; }
+  const Network::ListenSocketSharedPtr& getSocket() { return socket_; }
+  uint64_t hash() { return hash_; }
+  void infoLog(const std::string& message);
+  void initialize();
+  const std::string& name() { return name_; }
+  void setSocket(const Network::ListenSocketSharedPtr& socket);
 
   // Server::Listener
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
-  Network::Address::InstanceConstSharedPtr address() override { return address_; }
   Network::ListenSocket& socket() override { return *socket_; }
   bool bindToPort() override { return bind_to_port_; }
   Ssl::ServerContext* sslContext() override { return ssl_context_.get(); }
@@ -67,63 +151,47 @@ public:
   uint64_t listenerTag() override { return listener_tag_; }
 
   // Server::Configuration::FactoryContext
-  AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
-  Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
-  Event::Dispatcher& dispatcher() override { return server_.dispatcher(); }
-  DrainManager& drainManager() override { return server_.drainManager(); }
-  bool healthCheckFailed() override { return server_.healthCheckFailed(); }
-  Tracing::HttpTracer& httpTracer() override { return server_.httpTracer(); }
-  Init::Manager& initManager() override { return server_.initManager(); }
-  const LocalInfo::LocalInfo& localInfo() override { return server_.localInfo(); }
-  Envoy::Runtime::RandomGenerator& random() override { return server_.random(); }
+  AccessLog::AccessLogManager& accessLogManager() override {
+    return parent_.server_.accessLogManager();
+  }
+  Upstream::ClusterManager& clusterManager() override { return parent_.server_.clusterManager(); }
+  Event::Dispatcher& dispatcher() override { return parent_.server_.dispatcher(); }
+  DrainManager& drainManager() override { return parent_.server_.drainManager(); }
+  bool healthCheckFailed() override { return parent_.server_.healthCheckFailed(); }
+  Tracing::HttpTracer& httpTracer() override { return parent_.server_.httpTracer(); }
+  Init::Manager& initManager() override;
+  const LocalInfo::LocalInfo& localInfo() override { return parent_.server_.localInfo(); }
+  Envoy::Runtime::RandomGenerator& random() override { return parent_.server_.random(); }
   RateLimit::ClientPtr
   rateLimitClient(const Optional<std::chrono::milliseconds>& timeout) override {
-    return server_.rateLimitClient(timeout);
+    return parent_.server_.rateLimitClient(timeout);
   }
-  Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
-  Instance& server() override { return server_; }
+  Envoy::Runtime::Loader& runtime() override { return parent_.server_.runtime(); }
+  Instance& server() override { return parent_.server_; }
   Stats::Scope& scope() override { return *global_scope_; }
-  ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
+  ThreadLocal::Instance& threadLocal() override { return parent_.server_.threadLocal(); }
 
   // Network::FilterChainFactory
   bool createFilterChain(Network::Connection& connection) override;
 
 private:
-  Instance& server_;
+  ListenerManagerImpl& parent_;
   Network::Address::InstanceConstSharedPtr address_;
-  Network::ListenSocketPtr socket_;
+  Network::ListenSocketSharedPtr socket_;
   Stats::ScopePtr global_scope_;   // Stats with global named scope, but needed for LDS cleanup.
   Stats::ScopePtr listener_scope_; // Stats with listener named scope.
   Ssl::ServerContextPtr ssl_context_;
-  const bool bind_to_port_{};
-  const bool use_proxy_proto_{};
-  const bool use_original_dst_{};
-  const uint32_t per_connection_buffer_limit_bytes_{};
-  std::vector<Configuration::NetworkFilterFactoryCb> filter_factories_;
+  const bool bind_to_port_;
+  const bool use_proxy_proto_;
+  const bool use_original_dst_;
+  const uint32_t per_connection_buffer_limit_bytes_;
   const uint64_t listener_tag_;
-};
-
-/**
- * Implementation of ListenerManager.
- */
-class ListenerManagerImpl : public ListenerManager {
-public:
-  ListenerManagerImpl(Instance& server, ListenerComponentFactory& listener_factory,
-                      WorkerFactory& worker_factory);
-
-  // Server::ListenerManager
-  void addListener(const Json::Object& json) override;
-  std::list<std::reference_wrapper<Listener>> listeners() override;
-  uint64_t numConnections() override;
-  void startWorkers(GuardDog& guard_dog) override;
-  void stopListeners() override;
-  void stopWorkers() override;
-
-private:
-  Instance& server_;
-  ListenerComponentFactory& factory_;
-  std::list<ListenerPtr> listeners_;
-  std::list<WorkerPtr> workers_;
+  const std::string name_;
+  const bool workers_started_;
+  const uint64_t hash_;
+  InitManagerImpl dynamic_init_manager_;
+  bool initialize_canceled_{};
+  std::vector<Configuration::NetworkFilterFactoryCb> filter_factories_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -20,7 +20,6 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/ssl/context_manager_impl.h"
 #include "common/thread_local/thread_local_impl.h"
-#include "common/upstream/cluster_manager_impl.h"
 
 #include "server/http/admin.h"
 #include "server/init_manager_impl.h"
@@ -162,7 +161,7 @@ private:
   const LocalInfo::LocalInfo& local_info_;
   DrainManagerPtr drain_manager_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
-  std::unique_ptr<Upstream::ProdClusterManagerFactory> cluster_manager_factory_;
+  std::unique_ptr<Upstream::ClusterManagerFactory> cluster_manager_factory_;
   InitManagerImpl init_manager_;
   std::unique_ptr<Server::GuardDog> guard_dog_;
 };

--- a/source/server/test_hooks.h
+++ b/source/server/test_hooks.h
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace Envoy {
+
 /**
  * Hooks in the server to allow for integration testing. The real server just uses an empty
  * implementation defined below.
@@ -13,6 +14,16 @@ public:
    * Called when the server is initialized and about to start event loops.
    */
   virtual void onServerInitialized() PURE;
+
+  /**
+   * Called when a worker has added a listener and it is listening.
+   */
+  virtual void onWorkerListenerAdded() PURE;
+
+  /**
+   * Called when a worker has removed a listener and it is no longer listening.
+   */
+  virtual void onWorkerListenerRemoved() PURE;
 };
 
 /**
@@ -22,5 +33,8 @@ class DefaultTestHooks : public TestHooks {
 public:
   // TestHooks
   void onServerInitialized() override {}
+  void onWorkerListenerAdded() override {}
+  void onWorkerListenerRemoved() override {}
 };
+
 } // namespace Envoy

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -12,12 +12,15 @@
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 
+#include "server/test_hooks.h"
+
 namespace Envoy {
 namespace Server {
 
 class ProdWorkerFactory : public WorkerFactory, Logger::Loggable<Logger::Id::main> {
 public:
-  ProdWorkerFactory(ThreadLocal::Instance& tls, Api::Api& api) : tls_(tls), api_(api) {}
+  ProdWorkerFactory(ThreadLocal::Instance& tls, Api::Api& api, TestHooks& hooks)
+      : tls_(tls), api_(api), hooks_(hooks) {}
 
   // Server::WorkerFactory
   WorkerPtr createWorker() override;
@@ -25,6 +28,7 @@ public:
 private:
   ThreadLocal::Instance& tls_;
   Api::Api& api_;
+  TestHooks& hooks_;
 };
 
 /**
@@ -32,7 +36,7 @@ private:
  */
 class WorkerImpl : public Worker, Logger::Loggable<Logger::Id::main> {
 public:
-  WorkerImpl(ThreadLocal::Instance& tls, Event::DispatcherPtr&& dispatcher,
+  WorkerImpl(ThreadLocal::Instance& tls, TestHooks& hooks, Event::DispatcherPtr&& dispatcher,
              Network::ConnectionHandlerPtr handler);
 
   // Server::Worker
@@ -49,6 +53,7 @@ private:
   void threadRoutine(GuardDog& guard_dog);
 
   ThreadLocal::Instance& tls_;
+  TestHooks& hooks_;
   Event::DispatcherPtr dispatcher_;
   Network::ConnectionHandlerPtr handler_;
   Thread::ThreadPtr thread_;

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -43,4 +43,64 @@ TEST_P(EchoIntegrationTest, Hello) {
   connection.run();
   EXPECT_EQ("hello", response);
 }
+
+TEST_P(EchoIntegrationTest, AddRemoveListener) {
+  std::string json = R"EOF(
+  {
+    "name": "new_listener",
+    "address": "tcp://{{ ip_loopback_address }}:0",
+    "filters": [
+      { "type": "read", "name": "echo", "config": {} }
+    ]
+  }
+  )EOF";
+
+  // Add the listener.
+  ConditionalInitializer listener_added;
+  test_server_->setOnWorkerListenerAddedCb(
+      [&listener_added]() -> void { listener_added.setReady(); });
+  Json::ObjectSharedPtr loader = TestEnvironment::jsonLoadFromString(json, GetParam());
+  test_server_->server().dispatcher().post([this, loader]() -> void {
+    EXPECT_TRUE(test_server_->server().listenerManager().addOrUpdateListener(*loader));
+  });
+  listener_added.waitReady();
+
+  EXPECT_EQ(2UL, test_server_->server().listenerManager().listeners().size());
+  uint32_t new_listener_port = test_server_->server()
+                                   .listenerManager()
+                                   .listeners()[1]
+                                   .get()
+                                   .socket()
+                                   .localAddress()
+                                   ->ip()
+                                   ->port();
+
+  Buffer::OwnedImpl buffer("hello");
+  std::string response;
+  RawConnectionDriver connection(
+      new_listener_port, buffer,
+      [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        connection.close();
+      },
+      version_);
+  connection.run();
+  EXPECT_EQ("hello", response);
+
+  // Remove the listener.
+  ConditionalInitializer listener_removed;
+  test_server_->setOnWorkerListenerRemovedCb(
+      [&listener_removed]() -> void { listener_removed.setReady(); });
+  test_server_->server().dispatcher().post([this, loader]() -> void {
+    EXPECT_TRUE(test_server_->server().listenerManager().removeListener("new_listener"));
+  });
+  listener_removed.waitReady();
+
+  // Now connect. This should fail.
+  RawConnectionDriver connection2(
+      new_listener_port, buffer,
+      [&](Network::ClientConnection&, const Buffer::Instance&) -> void { FAIL(); }, version_);
+  connection2.run();
+}
+
 } // namespace Envoy

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -184,12 +184,28 @@ public:
     RELEASE_ASSERT(server_ != nullptr);
     return *server_;
   }
+  void setOnWorkerListenerAddedCb(std::function<void()> on_worker_listener_added) {
+    on_worker_listener_added_cb_ = on_worker_listener_added;
+  }
+  void setOnWorkerListenerRemovedCb(std::function<void()> on_worker_listener_removed) {
+    on_worker_listener_removed_cb_ = on_worker_listener_removed;
+  }
   void start(const Network::Address::IpVersion version);
   void start();
   Stats::Store& store() { return stats_store_; }
 
   // TestHooks
   void onServerInitialized() override { server_initialized_.setReady(); }
+  void onWorkerListenerAdded() override {
+    if (on_worker_listener_added_cb_) {
+      on_worker_listener_added_cb_();
+    }
+  }
+  void onWorkerListenerRemoved() override {
+    if (on_worker_listener_removed_cb_) {
+      on_worker_listener_removed_cb_();
+    }
+  }
 
   // Server::ComponentFactory
   Server::DrainManagerPtr createDrainManager(Server::Instance&) override {
@@ -217,5 +233,8 @@ private:
   std::unique_ptr<Server::InstanceImpl> server_;
   Server::TestDrainManager* drain_manager_{};
   Stats::TestIsolatedStoreImpl stats_store_;
+  std::function<void()> on_worker_listener_added_cb_;
+  std::function<void()> on_worker_listener_removed_cb_;
 };
+
 } // namespace Envoy

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test(
     srcs = ["configuration_impl_test.cc"],
     deps = [
         "//source/common/event:dispatcher_lib",
+        "//source/common/upstream:cluster_manager_lib",
         "//source/server:configuration_lib",
         "//test/mocks:common_lib",
         "//test/mocks/network:network_mocks",

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/registry/registry.h"
 
+#include "common/network/address_impl.h"
+
 #include "server/configuration_impl.h"
 #include "server/listener_manager_impl.h"
 
@@ -9,33 +11,76 @@
 
 #include "gtest/gtest.h"
 
+using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Return;
+using testing::Throw;
 using testing::_;
 
 namespace Envoy {
 namespace Server {
 
+class ListenerHandle {
+public:
+  ~ListenerHandle() { onDestroy(); }
+
+  MOCK_METHOD0(onDestroy, void());
+
+  Init::MockTarget target_;
+};
+
 class ListenerManagerImplTest : public testing::Test {
 public:
   ListenerManagerImplTest() {
+    EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
+    manager_.reset(new ListenerManagerImpl(server_, listener_factory_, worker_factory_));
+  }
+
+  /**
+   * This routing sets up an expectation that does two things:
+   * 1) Allows us to track listener destruction via filter factory destruction.
+   * 2) Allows us to register for init manager handling much like RDS, etc. would do.
+   */
+  ListenerHandle* expectFilterFactoryCreate(bool need_init) {
+    ListenerHandle* raw_listener = new ListenerHandle();
+    EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _))
+        .WillOnce(Invoke([raw_listener, need_init](const std::vector<Json::ObjectSharedPtr>&,
+                                                   Server::Configuration::FactoryContext& context)
+                             -> std::vector<Server::Configuration::NetworkFilterFactoryCb> {
+          std::shared_ptr<ListenerHandle> notifier(raw_listener);
+          if (need_init) {
+            context.initManager().registerTarget(notifier->target_);
+          }
+          return {[notifier](Network::FilterManager&) -> void {}};
+        }));
+
+    return raw_listener;
+  }
+
+  NiceMock<MockInstance> server_;
+  NiceMock<MockListenerComponentFactory> listener_factory_;
+  MockWorker* worker_ = new MockWorker();
+  NiceMock<MockWorkerFactory> worker_factory_;
+  std::unique_ptr<ListenerManagerImpl> manager_;
+  NiceMock<MockGuardDog> guard_dog_;
+};
+
+class ListenerManagerImplWithRealFiltersTest : public ListenerManagerImplTest {
+public:
+  ListenerManagerImplWithRealFiltersTest() {
     // Use real filter loading by default.
     ON_CALL(listener_factory_, createFilterFactoryList(_, _))
-        .WillByDefault(Invoke([&](const std::vector<Json::ObjectSharedPtr>& filters,
-                                  Server::Configuration::FactoryContext& context)
+        .WillByDefault(Invoke([this](const std::vector<Json::ObjectSharedPtr>& filters,
+                                     Server::Configuration::FactoryContext& context)
                                   -> std::vector<Server::Configuration::NetworkFilterFactoryCb> {
           return Server::ProdListenerComponentFactory::createFilterFactoryList_(filters, server_,
                                                                                 context);
         }));
   }
-
-  NiceMock<MockInstance> server_;
-  MockListenerComponentFactory listener_factory_;
-  NiceMock<MockWorkerFactory> worker_factory_;
-  ListenerManagerImpl manager_{server_, listener_factory_, worker_factory_};
 };
 
-TEST_F(ListenerManagerImplTest, EmptyFilter) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, EmptyFilter) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -44,14 +89,13 @@ TEST_F(ListenerManagerImplTest, EmptyFilter) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, true));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
-  EXPECT_EQ(1U, manager_.listeners().size());
+  EXPECT_CALL(server_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  manager_->addOrUpdateListener(*loader);
+  EXPECT_EQ(1U, manager_->listeners().size());
 }
 
-TEST_F(ListenerManagerImplTest, DefaultListenerPerConnectionBufferLimit) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, DefaultListenerPerConnectionBufferLimit) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -60,14 +104,12 @@ TEST_F(ListenerManagerImplTest, DefaultListenerPerConnectionBufferLimit) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, true));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
-  EXPECT_EQ(1024 * 1024U, manager_.listeners().back().get().perConnectionBufferLimitBytes());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  manager_->addOrUpdateListener(*loader);
+  EXPECT_EQ(1024 * 1024U, manager_->listeners().back().get().perConnectionBufferLimitBytes());
 }
 
-TEST_F(ListenerManagerImplTest, SetListenerPerConnectionBufferLimit) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, SetListenerPerConnectionBufferLimit) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -77,14 +119,12 @@ TEST_F(ListenerManagerImplTest, SetListenerPerConnectionBufferLimit) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, true));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
-  EXPECT_EQ(8192U, manager_.listeners().back().get().perConnectionBufferLimitBytes());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  manager_->addOrUpdateListener(*loader);
+  EXPECT_EQ(8192U, manager_->listeners().back().get().perConnectionBufferLimitBytes());
 }
 
-TEST_F(ListenerManagerImplTest, SslContext) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, SslContext) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -101,14 +141,12 @@ TEST_F(ListenerManagerImplTest, SslContext) {
   )EOF";
 
   Json::ObjectSharedPtr loader = TestEnvironment::jsonLoadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, true));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
-  EXPECT_NE(nullptr, manager_.listeners().back().get().sslContext());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  manager_->addOrUpdateListener(*loader);
+  EXPECT_NE(nullptr, manager_->listeners().back().get().sslContext());
 }
 
-TEST_F(ListenerManagerImplTest, BadListenerConfig) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, BadListenerConfig) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -118,10 +156,10 @@ TEST_F(ListenerManagerImplTest, BadListenerConfig) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_THROW(manager_.addListener(*loader), Json::Exception);
+  EXPECT_THROW(manager_->addOrUpdateListener(*loader), Json::Exception);
 }
 
-TEST_F(ListenerManagerImplTest, BadFilterConfig) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterConfig) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -136,10 +174,10 @@ TEST_F(ListenerManagerImplTest, BadFilterConfig) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_THROW(manager_.addListener(*loader), Json::Exception);
+  EXPECT_THROW(manager_->addOrUpdateListener(*loader), Json::Exception);
 }
 
-TEST_F(ListenerManagerImplTest, BadFilterName) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterName) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -154,12 +192,11 @@ TEST_F(ListenerManagerImplTest, BadFilterName) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  EXPECT_THROW_WITH_MESSAGE(manager_.addListener(*loader), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(*loader), EnvoyException,
                             "unable to create filter factory for 'invalid'/'write'");
 }
 
-TEST_F(ListenerManagerImplTest, BadFilterType) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterType) {
   std::string json = R"EOF(
   {
     "address": "tcp://127.0.0.1:1234",
@@ -174,8 +211,7 @@ TEST_F(ListenerManagerImplTest, BadFilterType) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  EXPECT_THROW_WITH_MESSAGE(manager_.addListener(*loader), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(*loader), EnvoyException,
                             "unable to create filter factory for 'echo'/'write'");
 }
 
@@ -193,7 +229,7 @@ public:
   }
 };
 
-TEST_F(ListenerManagerImplTest, StatsScopeTest) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {
   Registry::RegisterFactory<TestStatsConfigFactory, Configuration::NamedNetworkFilterConfigFactory>
       registered;
 
@@ -212,11 +248,9 @@ TEST_F(ListenerManagerImplTest, StatsScopeTest) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, false));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
-  manager_.listeners().front().get().listenerScope().counter("foo").inc();
+  EXPECT_CALL(listener_factory_, createListenSocket(_, false));
+  manager_->addOrUpdateListener(*loader);
+  manager_->listeners().front().get().listenerScope().counter("foo").inc();
 
   EXPECT_EQ(1UL, server_.stats_store_.counter("bar").value());
   EXPECT_EQ(1UL, server_.stats_store_.counter("listener.127.0.0.1_1234.foo").value());
@@ -239,7 +273,7 @@ public:
   }
 };
 
-TEST_F(ListenerManagerImplTest, DeprecatedFilterConfigFactoryRegistrationTest) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, DeprecatedFilterConfigFactoryRegistrationTest) {
   // Test ensures that the deprecated network filter registration still works without error.
 
   // Register the config factory
@@ -259,10 +293,292 @@ TEST_F(ListenerManagerImplTest, DeprecatedFilterConfigFactoryRegistrationTest) {
   )EOF";
 
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  EXPECT_CALL(listener_factory_, createFilterFactoryList(_, _));
-  EXPECT_CALL(listener_factory_, createListenSocket_(_, true));
-  EXPECT_CALL(listener_factory_, nextListenerTag());
-  manager_.addListener(*loader);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  manager_->addOrUpdateListener(*loader);
+}
+
+TEST_F(ListenerManagerImplTest, AddListenerAddressNotMatching) {
+  InSequence s;
+
+  // Add foo listener.
+  std::string listener_foo_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": []
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo = expectFilterFactoryCreate(false);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+
+  // Update foo listener, but with a different address. Should throw.
+  std::string listener_foo_different_address_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1235",
+    "filters": []
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_foo_different_address_json);
+  ListenerHandle* listener_foo_different_address = expectFilterFactoryCreate(false);
+  EXPECT_CALL(*listener_foo_different_address, onDestroy());
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(*loader), EnvoyException,
+                            "error updating listener: 'foo' has a different address "
+                            "'127.0.0.1:1235' from existing listener");
+
+  EXPECT_CALL(*listener_foo, onDestroy());
+}
+
+TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
+  InSequence s;
+
+  // Add foo listener.
+  std::string listener_foo_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": []
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo = expectFilterFactoryCreate(false);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+
+  // Update duplicate should be a NOP.
+  EXPECT_FALSE(manager_->addOrUpdateListener(*loader));
+
+  // Update foo listener. Should share socket.
+  std::string listener_foo_update1_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": [
+      { "type" : "read", "name" : "fake", "config" : {} }
+    ]
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_foo_update1_json);
+  ListenerHandle* listener_foo_update1 = expectFilterFactoryCreate(false);
+  EXPECT_CALL(*listener_foo, onDestroy());
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+
+  // Start workers.
+  EXPECT_CALL(*worker_, addListener(_));
+  EXPECT_CALL(*worker_, start(_));
+  manager_->startWorkers(guard_dog_);
+
+  // Update duplicate should be a NOP.
+  EXPECT_FALSE(manager_->addOrUpdateListener(*loader));
+
+  // Update foo. Should go into warming, have an immediate warming callback, and start immediate
+  // removal.
+  loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo_update2 = expectFilterFactoryCreate(false);
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  EXPECT_CALL(*worker_, addListener(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_CALL(*listener_foo_update1, onDestroy());
+  worker_->callRemovalCompletion();
+
+  // Add bar listener.
+  std::string listener_bar_json = R"EOF(
+  {
+    "name": "bar",
+    "address": "tcp://127.0.0.1:1235",
+    "filters": []
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_bar_json);
+  ListenerHandle* listener_bar = expectFilterFactoryCreate(false);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_CALL(*worker_, addListener(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_EQ(2UL, manager_->listeners().size());
+
+  // Add baz listener, this time requiring initializing.
+  std::string listener_baz_json = R"EOF(
+  {
+    "name": "baz",
+    "address": "tcp://127.0.0.1:1236",
+    "filters": []
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_baz_json);
+  ListenerHandle* listener_baz = expectFilterFactoryCreate(true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_CALL(listener_baz->target_, initialize(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_EQ(2UL, manager_->listeners().size());
+
+  // Update a duplicate baz that is currently warming.
+  EXPECT_FALSE(manager_->addOrUpdateListener(*loader));
+
+  // Update baz while it is warming.
+  std::string listener_baz_update1_json = R"EOF(
+  {
+    "name": "baz",
+    "address": "tcp://127.0.0.1:1236",
+    "filters": [
+      { "type" : "read", "name" : "fake", "config" : {} }
+    ]
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_baz_update1_json);
+  ListenerHandle* listener_baz_update1 = expectFilterFactoryCreate(true);
+  EXPECT_CALL(*listener_baz, onDestroy()).WillOnce(Invoke([listener_baz]() -> void {
+    // Call the initialize callback during destruction like RDS will.
+    listener_baz->target_.callback_();
+  }));
+  EXPECT_CALL(listener_baz_update1->target_, initialize(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_EQ(2UL, manager_->listeners().size());
+
+  // Finish initialization for baz which should make it active.
+  EXPECT_CALL(*worker_, addListener(_));
+  listener_baz_update1->target_.callback_();
+  EXPECT_EQ(3UL, manager_->listeners().size());
+
+  EXPECT_CALL(*listener_foo_update2, onDestroy());
+  EXPECT_CALL(*listener_bar, onDestroy());
+  EXPECT_CALL(*listener_baz_update1, onDestroy());
+}
+
+TEST_F(ListenerManagerImplTest, AddDrainingListener) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_));
+  manager_->startWorkers(guard_dog_);
+
+  // Add foo listener directly into active.
+  std::string listener_foo_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": []
+  }
+  )EOF";
+
+  Network::Address::InstanceConstSharedPtr local_address(
+      new Network::Address::Ipv4Instance("127.0.0.1", 1234));
+  ON_CALL(*listener_factory_.socket_, localAddress()).WillByDefault(Return(local_address));
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo = expectFilterFactoryCreate(false);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_CALL(*worker_, addListener(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+
+  // Remove foo into draining.
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  EXPECT_TRUE(manager_->removeListener("foo"));
+
+  // Add foo again. We should use the socket from draining.
+  loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo2 = expectFilterFactoryCreate(false);
+  EXPECT_CALL(*worker_, addListener(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callRemovalCompletion();
+
+  EXPECT_CALL(*listener_foo2, onDestroy());
+}
+
+TEST_F(ListenerManagerImplTest, CantBindSocket) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_));
+  manager_->startWorkers(guard_dog_);
+
+  std::string listener_foo_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": []
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo = expectFilterFactoryCreate(true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true))
+      .WillOnce(Throw(EnvoyException("can't bind")));
+  EXPECT_CALL(*listener_foo, onDestroy());
+  EXPECT_THROW(manager_->addOrUpdateListener(*loader), EnvoyException);
+}
+
+TEST_F(ListenerManagerImplTest, RemoveListener) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_));
+  manager_->startWorkers(guard_dog_);
+
+  // Remove an unknown listener.
+  EXPECT_FALSE(manager_->removeListener("unknown"));
+
+  // Add foo listener into warming.
+  std::string listener_foo_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": []
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(listener_foo_json);
+  ListenerHandle* listener_foo = expectFilterFactoryCreate(true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_CALL(listener_foo->target_, initialize(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_EQ(0UL, manager_->listeners().size());
+
+  // Remove foo.
+  EXPECT_CALL(*listener_foo, onDestroy());
+  EXPECT_TRUE(manager_->removeListener("foo"));
+  EXPECT_EQ(0UL, manager_->listeners().size());
+
+  // Add foo again and initialize it.
+  listener_foo = expectFilterFactoryCreate(true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, true));
+  EXPECT_CALL(listener_foo->target_, initialize(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_CALL(*worker_, addListener(_));
+  listener_foo->target_.callback_();
+  EXPECT_EQ(1UL, manager_->listeners().size());
+
+  // Update foo into warming.
+  std::string listener_foo_update1_json = R"EOF(
+  {
+    "name": "foo",
+    "address": "tcp://127.0.0.1:1234",
+    "filters": [
+      { "type" : "read", "name" : "fake", "config" : {} }
+    ]
+  }
+  )EOF";
+
+  loader = Json::Factory::loadFromString(listener_foo_update1_json);
+  ListenerHandle* listener_foo_update1 = expectFilterFactoryCreate(true);
+  EXPECT_CALL(listener_foo_update1->target_, initialize(_));
+  EXPECT_TRUE(manager_->addOrUpdateListener(*loader));
+  EXPECT_EQ(1UL, manager_->listeners().size());
+
+  // Remove foo which should remove both warming and active.
+  EXPECT_CALL(*listener_foo_update1, onDestroy());
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  EXPECT_TRUE(manager_->removeListener("foo"));
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callRemovalCompletion();
+  EXPECT_EQ(0UL, manager_->listeners().size());
 }
 
 } // namespace Server

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -29,7 +29,8 @@ public:
   Event::DispatcherImpl* dispatcher_ = new Event::DispatcherImpl();
   Network::MockConnectionHandler* handler_ = new Network::MockConnectionHandler();
   NiceMock<MockGuardDog> guard_dog_;
-  WorkerImpl worker_{tls_, Event::DispatcherPtr{dispatcher_},
+  DefaultTestHooks hooks_;
+  WorkerImpl worker_{tls_, hooks_, Event::DispatcherPtr{dispatcher_},
                      Network::ConnectionHandlerPtr{handler_}};
   Event::TimerPtr no_exit_timer_ = dispatcher_->createTimer([]() -> void {});
 };

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -100,14 +100,17 @@ public:
   }
 
   /**
-   * String environment path substitution.
+   * String environment path, loopback, and DNS resolver type substitution.
    * @param str string with template patterns including {{ test_tmpdir }}.
+   * @param version supplies the IP version to substitute for relevant templates.
    * @return std::string with patterns replaced with environment values.
    */
-  static std::string substitute(const std::string str);
+  static std::string
+  substitute(const std::string& str,
+             Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   /**
-   * Substitue ports, paths, and IP loopback addressses in a JSON file in the
+   * Substitute ports, paths, and IP loopback addressses in a JSON file in the
    * private writable test temporary directory.
    * @param path path prefix for the input file with port and path templates.
    * @param port_map map from port name to port number.
@@ -117,7 +120,7 @@ public:
   static std::string temporaryFileSubstitute(const std::string& path, const PortMap& port_map,
                                              Network::Address::IpVersion version);
   /**
-   * Substitue ports, paths, and IP loopback addressses in a JSON file in the
+   * Substitute ports, paths, and IP loopback addressses in a JSON file in the
    * private writable test temporary directory.
    * @param path path prefix for the input file with port and path templates.
    * @param param_map map from parameter name to values.
@@ -130,11 +133,15 @@ public:
                                              Network::Address::IpVersion version);
 
   /**
-   * Build JSON object from a string subject to environment path substitution.
+   * Build JSON object from a string subject to environment path, loopback, and DNS resolver type
+   * substitution.
    * @param json JSON with template patterns including {{ test_certs }}.
+   * @param version supplies the IP version to substitute for relevant templates.
    * @return Json::ObjectSharedPtr with built JSON object.
    */
-  static Json::ObjectSharedPtr jsonLoadFromString(const std::string& json);
+  static Json::ObjectSharedPtr
+  jsonLoadFromString(const std::string& json,
+                     Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
   /**
    * Execute a program under ::system. Any failure is fatal.


### PR DESCRIPTION
This is the main heavy lifting PR to add dynamic add/removal of
listeners at runtime. There are various things still to do (see
TODOs in code) which will be added in follow up changes. The
actual v1 LDS API using RestApiFetcher will also be added in a follow
up.

This commit contains both unit tests as well as a full end to end
integration test that demonstrates adding and removing a listener
in the running server. In the future we should extend this
integration test to also cover dynamic cluster add/remove.