### PR TITLE
ci: build thirdparty for both opt/dbg.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -37,8 +37,18 @@ fi
 
 export THIRDPARTY_DEPS=/tmp
 export THIRDPARTY_SRC=/thirdparty
-export THIRDPARTY_BUILD=/thirdparty_build
 DEPS=$(python <(cat target_recipes.bzl; \
   echo "print ' '.join(\"${THIRDPARTY_DEPS}/%s.dep\" % r for r in set(TARGET_RECIPES.values()))"))
-echo "Building deps ${DEPS}"
+
+# TODO(htuch): We build twice as a workaround for https://github.com/google/protobuf/issues/3322.
+# Fix this.
+export THIRDPARTY_BUILD=/thirdparty_build_opt
+export CPPFLAGS="-DNDEBUG"
+echo "Building opt deps ${DEPS}"
+"$(dirname "$0")"/build_and_install_deps.sh ${DEPS}
+
+export THIRDPARTY_BUILD=/thirdparty_build_dbg
+export CPPFLAGS=""
+echo "Building dbg deps ${DEPS}"
+rm -f /tmp/*.dep
 "$(dirname "$0")"/build_and_install_deps.sh ${DEPS}


### PR DESCRIPTION
Needed as a workaround for https://github.com/google/protobuf/issues/3322. I'm going to work on an
upstream fix once I unblock current dependencies on the merge of
https://github.com/lyft/envoy/pull/1202.

This increases image size from 2.3GB to 2.9GB. While it might be possible to only rebuild
protobuf/lightstep, it's significantly more complicated throwaway build hacking to get there.