### PR TITLE
Make Bazel more verbose in CI builds.

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -64,7 +64,7 @@ BAZEL_OPTIONS="--package_path %workspace%:/source"
 export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS}"
 export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone \
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
-  --jobs=${NUM_CPUS}"
+  --jobs=${NUM_CPUS} --show_task_finish"
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
   --cache_test_results=no --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge


### PR DESCRIPTION
Travis has complained about extended periods of no output, especially on
the coverage build. This should make Bazel print something after every
step finishes which will mitigate this issue or help debug if there is a
real build stall.