### PR TITLE
Refactoring the connection class to create buffers via factory

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -64,7 +64,7 @@ BAZEL_OPTIONS="--package_path %workspace%:/source"
 export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS}"
 export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone \
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
-  --jobs=${NUM_CPUS}"
+  --jobs=${NUM_CPUS} --show_task_finish"
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
   --cache_test_results=no --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -134,14 +134,14 @@ public:
 typedef std::unique_ptr<Instance> InstancePtr;
 
 /**
- * A factory for creating buffer instances.
+ * A factory for creating buffers.
  */
 class Factory {
 public:
   virtual ~Factory() {}
 
   /**
-   * Creates and returns a unique pointer to a new buffer instance.
+   * Creates and returns a unique pointer to a new buffer.
    */
   virtual InstancePtr create() PURE;
 };

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -133,5 +133,20 @@ public:
 
 typedef std::unique_ptr<Instance> InstancePtr;
 
+/**
+ * A factory for creating buffer instances.
+ */
+class Factory {
+public:
+  virtual ~Factory() {}
+
+  /**
+   * Creates and returns a unique pointer to a new buffer instance.
+   */
+  virtual InstancePtr create() PURE;
+};
+
+typedef std::unique_ptr<Factory> FactoryPtr;
+
 } // namespace Buffer
 } // namespace Envoy

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -142,6 +142,7 @@ public:
 
   /**
    * Creates and returns a unique pointer to a new buffer.
+   * @return a newly created InstancePtr.
    */
   virtual InstancePtr create() PURE;
 };

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -158,7 +158,7 @@ public:
    * Optionally sets a custom buffer factory for the dispatcher.  This factory may be used by new
    * connections on connection creation.
    */
-  virtual void setBufferFactory(Buffer::FactoryPtr factory) PURE;
+  virtual void setBufferFactory(Buffer::FactoryPtr&& factory) PURE;
 
   /**
    * Returns the buffer factory for this dispatcher.

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -153,6 +153,17 @@ public:
    */
   enum class RunType { Block, NonBlock };
   virtual void run(RunType type) PURE;
+
+  /**
+   * Optionally sets a custom buffer factory for the dispatcher.  This factory may be used by new
+   * connections on connection creation.
+   */
+  virtual void setBufferFactory(Buffer::FactoryPtr factory) PURE;
+
+  /**
+   * Returns the buffer factory for this dispatcher.
+   */
+  virtual Buffer::Factory& getBufferFactory() PURE;
 };
 
 typedef std::unique_ptr<Dispatcher> DispatcherPtr;

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -155,13 +155,8 @@ public:
   virtual void run(RunType type) PURE;
 
   /**
-   * Optionally sets a custom buffer factory for the dispatcher.  This factory may be used by new
-   * connections on connection creation.
-   */
-  virtual void setBufferFactory(Buffer::FactoryPtr&& factory) PURE;
-
-  /**
-   * Returns the buffer factory for this dispatcher.
+   * Returns a factory which connections may use for buffer creation.
+   * @return the buffer factory for this dispatcher.
    */
   virtual Buffer::Factory& getBufferFactory() PURE;
 };

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -10,6 +10,8 @@
 namespace Envoy {
 namespace Buffer {
 
+InstancePtr OwnedImplFactory::create() { return InstancePtr{new OwnedImpl()}; }
+
 // RawSlice is the same structure as evbuffer_iovec. This was put into place to avoid leaking
 // libevent into most code since we will likely replace evbuffer with our own implementation at
 // some point. However, we can avoid a bunch of copies since the structure is the same.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -12,6 +12,7 @@ namespace Buffer {
 
 class OwnedImplFactory : public Factory {
 public:
+  // Buffer::Factory
   InstancePtr create() override;
 };
 

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -10,6 +10,11 @@
 namespace Envoy {
 namespace Buffer {
 
+class OwnedImplFactory : public Factory {
+public:
+  InstancePtr create() override;
+};
+
 /**
  * Wraps an allocated and owned evbuffer.
  */

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -25,7 +25,7 @@ namespace Envoy {
 namespace Event {
 
 DispatcherImpl::DispatcherImpl()
-    : base_(event_base_new()),
+    : buffer_factory_(new Buffer::OwnedImplFactory), base_(event_base_new()),
       deferred_delete_timer_(createTimer([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimer([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {}
@@ -143,6 +143,10 @@ void DispatcherImpl::run(RunType type) {
   runPostCallbacks();
 
   event_base_loop(base_.get(), type == RunType::NonBlock ? EVLOOP_NONBLOCK : 0);
+}
+
+void DispatcherImpl::setBufferFactory(Buffer::FactoryPtr factory) {
+  buffer_factory_ = std::move(factory);
 }
 
 void DispatcherImpl::runPostCallbacks() {

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -145,7 +145,7 @@ void DispatcherImpl::run(RunType type) {
   event_base_loop(base_.get(), type == RunType::NonBlock ? EVLOOP_NONBLOCK : 0);
 }
 
-void DispatcherImpl::setBufferFactory(Buffer::FactoryPtr factory) {
+void DispatcherImpl::setBufferFactory(Buffer::FactoryPtr&& factory) {
   buffer_factory_ = std::move(factory);
 }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -25,7 +25,10 @@ namespace Envoy {
 namespace Event {
 
 DispatcherImpl::DispatcherImpl()
-    : buffer_factory_(new Buffer::OwnedImplFactory), base_(event_base_new()),
+    : DispatcherImpl(Buffer::FactoryPtr{new Buffer::OwnedImplFactory}) {}
+
+DispatcherImpl::DispatcherImpl(Buffer::FactoryPtr&& factory)
+    : buffer_factory_(std::move(factory)), base_(event_base_new()),
       deferred_delete_timer_(createTimer([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimer([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {}
@@ -143,10 +146,6 @@ void DispatcherImpl::run(RunType type) {
   runPostCallbacks();
 
   event_base_loop(base_.get(), type == RunType::NonBlock ? EVLOOP_NONBLOCK : 0);
-}
-
-void DispatcherImpl::setBufferFactory(Buffer::FactoryPtr&& factory) {
-  buffer_factory_ = std::move(factory);
 }
 
 void DispatcherImpl::runPostCallbacks() {

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -55,7 +55,7 @@ public:
   SignalEventPtr listenForSignal(int signal_num, SignalCb cb) override;
   void post(std::function<void()> callback) override;
   void run(RunType type) override;
-  void setBufferFactory(Buffer::FactoryPtr factory) override;
+  void setBufferFactory(Buffer::FactoryPtr&& factory) override;
   Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
 
 private:

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -55,10 +55,13 @@ public:
   SignalEventPtr listenForSignal(int signal_num, SignalCb cb) override;
   void post(std::function<void()> callback) override;
   void run(RunType type) override;
+  void setBufferFactory(Buffer::FactoryPtr factory) override;
+  Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
 
 private:
   void runPostCallbacks();
 
+  Buffer::FactoryPtr buffer_factory_;
   Libevent::BasePtr base_;
   TimerPtr deferred_delete_timer_;
   TimerPtr post_timer_;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -22,6 +22,7 @@ namespace Event {
 class DispatcherImpl : Logger::Loggable<Logger::Id::main>, public Dispatcher {
 public:
   DispatcherImpl();
+  DispatcherImpl(Buffer::FactoryPtr&& factory);
   ~DispatcherImpl();
 
   /**
@@ -55,7 +56,6 @@ public:
   SignalEventPtr listenForSignal(int signal_num, SignalCb cb) override;
   void post(std::function<void()> callback) override;
   void run(RunType type) override;
-  void setBufferFactory(Buffer::FactoryPtr&& factory) override;
   Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
 
 private:

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -77,10 +77,6 @@ public:
   Buffer::Instance& getReadBuffer() override { return *read_buffer_; }
   Buffer::Instance& getWriteBuffer() override { return *current_write_buffer_; }
 
-  void replaceWriteBufferForTest(std::unique_ptr<Buffer::OwnedImpl> new_buffer) {
-    write_buffer_ = std::move(new_buffer);
-  }
-
 protected:
   enum class PostIoAction { Close, KeepOpen };
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -77,6 +77,10 @@ public:
   Buffer::Instance& getReadBuffer() override { return read_buffer_; }
   Buffer::Instance& getWriteBuffer() override { return *current_write_buffer_; }
 
+  void replaceWriteBufferForTest(std::unique_ptr<Buffer::OwnedImpl> new_buffer) {
+    write_buffer_ = std::move(new_buffer);
+  }
+
 protected:
   enum class PostIoAction { Close, KeepOpen };
 
@@ -103,7 +107,7 @@ protected:
   Address::InstanceConstSharedPtr remote_address_;
   Address::InstanceConstSharedPtr local_address_;
   Buffer::OwnedImpl read_buffer_;
-  Buffer::OwnedImpl write_buffer_;
+  Buffer::InstancePtr write_buffer_;
   uint32_t read_buffer_limit_ = 0;
 
 private:

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -74,7 +74,7 @@ public:
   uint32_t readBufferLimit() const override { return read_buffer_limit_; }
 
   // Network::BufferSource
-  Buffer::Instance& getReadBuffer() override { return read_buffer_; }
+  Buffer::Instance& getReadBuffer() override { return *read_buffer_; }
   Buffer::Instance& getWriteBuffer() override { return *current_write_buffer_; }
 
   void replaceWriteBufferForTest(std::unique_ptr<Buffer::OwnedImpl> new_buffer) {
@@ -94,7 +94,7 @@ protected:
   void raiseEvents(uint32_t events);
   // Should the read buffer be drained?
   bool shouldDrainReadBuffer() {
-    return read_buffer_limit_ > 0 && read_buffer_.length() >= read_buffer_limit_;
+    return read_buffer_limit_ > 0 && read_buffer_->length() >= read_buffer_limit_;
   }
   // Mark read buffer ready to read in the event loop. This is used when yielding following
   // shouldDrainReadBuffer().
@@ -106,7 +106,7 @@ protected:
   FilterManagerImpl filter_manager_;
   Address::InstanceConstSharedPtr remote_address_;
   Address::InstanceConstSharedPtr local_address_;
-  Buffer::OwnedImpl read_buffer_;
+  Buffer::InstancePtr read_buffer_;
   Buffer::InstancePtr write_buffer_;
   uint32_t read_buffer_limit_ = 0;
 

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -70,7 +70,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     // if there is extra space. 16K read is arbitrary and can be tuned later.
     Buffer::RawSlice slices[2];
     uint64_t slices_to_commit = 0;
-    uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);
+    uint64_t num_slices = read_buffer_->reserve(16384, slices, 2);
     for (uint64_t i = 0; i < num_slices; i++) {
       int rc = SSL_read(ssl_.get(), slices[i].mem_, slices[i].len_);
       ENVOY_CONN_LOG(trace, "ssl read returns: {}", *this, rc);
@@ -97,7 +97,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     }
 
     if (slices_to_commit > 0) {
-      read_buffer_.commit(slices, slices_to_commit);
+      read_buffer_->commit(slices, slices_to_commit);
       if (shouldDrainReadBuffer()) {
         setReadBufferReady();
         keep_reading = false;

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -159,7 +159,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     }
   }
 
-  uint64_t original_buffer_length = write_buffer_.length();
+  uint64_t original_buffer_length = write_buffer_->length();
   uint64_t total_bytes_written = 0;
   bool keep_writing = true;
   while ((original_buffer_length != total_bytes_written) && keep_writing) {
@@ -170,7 +170,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     // of iterations of this loop, either by pure iterations, bytes written, etc.
     const uint64_t MAX_SLICES = 32;
     Buffer::RawSlice slices[MAX_SLICES];
-    uint64_t num_slices = write_buffer_.getRawSlices(slices, MAX_SLICES);
+    uint64_t num_slices = write_buffer_->getRawSlices(slices, MAX_SLICES);
 
     uint64_t inner_bytes_written = 0;
     for (uint64_t i = 0; (i < num_slices) && (original_buffer_length != total_bytes_written); i++) {
@@ -205,7 +205,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     // Draining must be done within the inner loop, otherwise we will keep getting the same slices
     // at the beginning of the buffer.
     if (inner_bytes_written > 0) {
-      write_buffer_.drain(inner_bytes_written);
+      write_buffer_->drain(inner_bytes_written);
     }
   }
 

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -42,6 +42,7 @@ envoy_cc_test(
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:stats_lib",
+        "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -9,8 +9,10 @@
 #include "common/network/connection_impl.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
+#include "common/runtime/runtime_impl.h"
 #include "common/stats/stats_impl.h"
 
+#include "test/mocks/buffer/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
@@ -22,6 +24,8 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
+using testing::AnyNumber;
+using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;
 using testing::Return;
@@ -67,47 +71,95 @@ TEST_P(ConnectionImplDeathTest, BadFd) {
                ".*assert failure: fd_ != -1.*");
 }
 
-class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {};
+class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
+public:
+  void setUpBasicConnection() {
+    listener_ =
+        dispatcher_.createListener(connection_handler_, socket_, listener_callbacks_, stats_store_,
+                                   Network::ListenerOptions::listenerOptionsWithBindToPort());
+
+    client_connection_ = dispatcher_.createClientConnection(socket_.localAddress());
+    client_connection_->addConnectionCallbacks(client_callbacks_);
+  }
+
+  void connect() {
+    client_connection_->connect();
+    read_filter_.reset(new NiceMock<MockReadFilter>());
+    EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
+        .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
+          server_connection_ = std::move(conn);
+          server_connection_->addConnectionCallbacks(server_callbacks_);
+          server_connection_->addReadFilter(read_filter_);
+        }));
+    EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::Connected));
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  void disconnect() {
+    EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
+    client_connection_->close(ConnectionCloseType::NoFlush);
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  void useMockBuffer() {
+    ASSERT(client_connection_.get() == nullptr);
+
+    MockBufferFactory* factory = new MockBufferFactory;
+    dispatcher_.setBufferFactory(Buffer::FactoryPtr{factory});
+    // The first call to create a client session will get a MockBuffer.
+    // Expect one other call to create a server session which will by default
+    // get a normal OwnedImpl.
+    ON_CALL(*factory, create_()).WillByDefault(Invoke([&]() -> Buffer::Instance* {
+      return new Buffer::OwnedImpl;
+    }));
+    EXPECT_CALL(*factory, create_()).Times(2).WillOnce(Invoke([&]() -> Buffer::Instance* {
+      buffer_ = new MockBuffer;
+      return buffer_;
+    }));
+  }
+
+protected:
+  Event::DispatcherImpl dispatcher_;
+  Stats::IsolatedStoreImpl stats_store_;
+  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), true};
+  Network::MockListenerCallbacks listener_callbacks_;
+  Network::MockConnectionHandler connection_handler_;
+  Network::ListenerPtr listener_;
+  Network::ClientConnectionPtr client_connection_;
+  MockConnectionCallbacks client_callbacks_;
+  Network::ConnectionPtr server_connection_;
+  Network::MockConnectionCallbacks server_callbacks_;
+  std::shared_ptr<MockReadFilter> read_filter_;
+  MockBuffer* buffer_ = nullptr;
+};
+
 INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
-  Stats::IsolatedStoreImpl stats_store;
-  Event::DispatcherImpl dispatcher;
-  Network::TcpListenSocket socket(Network::Test::getAnyAddress(GetParam()), true);
-  Network::MockListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener =
-      dispatcher.createListener(connection_handler, socket, listener_callbacks, stats_store,
-                                Network::ListenerOptions::listenerOptionsWithBindToPort());
+  setUpBasicConnection();
 
-  Network::ClientConnectionPtr client_connection =
-      dispatcher.createClientConnection(socket.localAddress());
-  MockConnectionCallbacks client_callbacks;
-  client_connection->addConnectionCallbacks(client_callbacks);
   Buffer::OwnedImpl buffer("hello world");
-  client_connection->write(buffer);
-  client_connection->connect();
+  client_connection_->write(buffer);
+  client_connection_->connect();
 
-  EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::Connected))
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::Connected))
       .WillOnce(Invoke(
-          [&](uint32_t) -> void { client_connection->close(ConnectionCloseType::NoFlush); }));
-  EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::LocalClose));
+          [&](uint32_t) -> void { client_connection_->close(ConnectionCloseType::NoFlush); }));
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
 
-  Network::ConnectionPtr server_connection;
-  Network::MockConnectionCallbacks server_callbacks;
-  std::shared_ptr<MockReadFilter> read_filter(new NiceMock<MockReadFilter>());
-  EXPECT_CALL(listener_callbacks, onNewConnection_(_))
+  read_filter_.reset(new NiceMock<MockReadFilter>());
+  EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        server_connection = std::move(conn);
-        server_connection->addConnectionCallbacks(server_callbacks);
-        server_connection->addReadFilter(read_filter);
+        server_connection_ = std::move(conn);
+        server_connection_->addConnectionCallbacks(server_callbacks_);
+        server_connection_->addReadFilter(read_filter_);
       }));
 
-  EXPECT_CALL(server_callbacks, onEvent(ConnectionEvent::RemoteClose))
-      .WillOnce(Invoke([&](uint32_t) -> void { dispatcher.exit(); }));
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::RemoteClose))
+      .WillOnce(Invoke([&](uint32_t) -> void { dispatcher_.exit(); }));
 
-  dispatcher.run(Event::Dispatcher::RunType::Block);
+  dispatcher_.run(Event::Dispatcher::RunType::Block);
 }
 
 struct MockBufferStats {
@@ -122,27 +174,16 @@ struct MockBufferStats {
 };
 
 TEST_P(ConnectionImplTest, BufferStats) {
-  Stats::IsolatedStoreImpl stats_store;
-  Event::DispatcherImpl dispatcher;
-  Network::TcpListenSocket socket(Network::Test::getAnyAddress(GetParam()), true);
-  Network::MockListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener =
-      dispatcher.createListener(connection_handler, socket, listener_callbacks, stats_store,
-                                Network::ListenerOptions::listenerOptionsWithBindToPort());
+  setUpBasicConnection();
 
-  Network::ClientConnectionPtr client_connection =
-      dispatcher.createClientConnection(socket.localAddress());
-  MockConnectionCallbacks client_callbacks;
-  client_connection->addConnectionCallbacks(client_callbacks);
   MockBufferStats client_buffer_stats;
-  client_connection->setBufferStats(client_buffer_stats.toBufferStats());
-  client_connection->connect();
+  client_connection_->setBufferStats(client_buffer_stats.toBufferStats());
+  client_connection_->connect();
 
   std::shared_ptr<MockWriteFilter> write_filter(new MockWriteFilter());
   std::shared_ptr<MockFilter> filter(new MockFilter());
-  client_connection->addWriteFilter(write_filter);
-  client_connection->addFilter(filter);
+  client_connection_->addWriteFilter(write_filter);
+  client_connection_->addFilter(filter);
 
   Sequence s1;
   EXPECT_CALL(*write_filter, onWrite(_))
@@ -150,101 +191,116 @@ TEST_P(ConnectionImplTest, BufferStats) {
       .WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_CALL(*write_filter, onWrite(_)).InSequence(s1).WillOnce(Return(FilterStatus::Continue));
   EXPECT_CALL(*filter, onWrite(_)).InSequence(s1).WillOnce(Return(FilterStatus::Continue));
-  EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::Connected)).InSequence(s1);
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::Connected)).InSequence(s1);
   EXPECT_CALL(client_buffer_stats.tx_total_, add(4)).InSequence(s1);
 
-  Network::ConnectionPtr server_connection;
-  Network::MockConnectionCallbacks server_callbacks;
+  read_filter_.reset(new NiceMock<MockReadFilter>());
   MockBufferStats server_buffer_stats;
-  std::shared_ptr<MockReadFilter> read_filter(new MockReadFilter());
-  EXPECT_CALL(listener_callbacks, onNewConnection_(_))
+  EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        server_connection = std::move(conn);
-        server_connection->addConnectionCallbacks(server_callbacks);
-        server_connection->setBufferStats(server_buffer_stats.toBufferStats());
-        server_connection->addReadFilter(read_filter);
-        EXPECT_EQ("", server_connection->nextProtocol());
+        server_connection_ = std::move(conn);
+        server_connection_->addConnectionCallbacks(server_callbacks_);
+        server_connection_->setBufferStats(server_buffer_stats.toBufferStats());
+        server_connection_->addReadFilter(read_filter_);
+        EXPECT_EQ("", server_connection_->nextProtocol());
       }));
 
   Sequence s2;
   EXPECT_CALL(server_buffer_stats.rx_total_, add(4)).InSequence(s2);
   EXPECT_CALL(server_buffer_stats.rx_current_, add(4)).InSequence(s2);
   EXPECT_CALL(server_buffer_stats.rx_current_, sub(4)).InSequence(s2);
-  EXPECT_CALL(server_callbacks, onEvent(ConnectionEvent::LocalClose)).InSequence(s2);
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).InSequence(s2);
 
-  EXPECT_CALL(*read_filter, onNewConnection());
-  EXPECT_CALL(*read_filter, onData(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> FilterStatus {
-    data.drain(data.length());
-    server_connection->close(ConnectionCloseType::FlushWrite);
-    return FilterStatus::StopIteration;
-  }));
+  EXPECT_CALL(*read_filter_, onNewConnection());
+  EXPECT_CALL(*read_filter_, onData(_))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> FilterStatus {
+        data.drain(data.length());
+        server_connection_->close(ConnectionCloseType::FlushWrite);
+        return FilterStatus::StopIteration;
+      }));
 
-  EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::RemoteClose))
-      .WillOnce(Invoke([&](uint32_t) -> void { dispatcher.exit(); }));
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
+      .WillOnce(Invoke([&](uint32_t) -> void { dispatcher_.exit(); }));
 
   Buffer::OwnedImpl data("1234");
-  client_connection->write(data);
-  client_connection->write(data);
-  dispatcher.run(Event::Dispatcher::RunType::Block);
+  client_connection_->write(data);
+  client_connection_->write(data);
+  dispatcher_.run(Event::Dispatcher::RunType::Block);
 }
 
-class ReadBufferLimitTest : public testing::TestWithParam<Network::Address::IpVersion> {
+// Write some data to the connection.  It will automatically attempt to flush
+// it to the upstream file descriptor via a write() call to buffer_, which is
+// configured to succeed and accept all bytes read.
+TEST_P(ConnectionImplTest, BasicWrite) {
+  useMockBuffer();
+
+  setUpBasicConnection();
+
+  connect();
+
+  // Send the data to the connection and verify it is sent upstream.
+  std::string data_to_write = "hello world";
+  Buffer::OwnedImpl buffer_to_write(data_to_write);
+  std::string data_written;
+  EXPECT_CALL(*buffer_, move(_))
+      .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
+                            Invoke(buffer_, &MockBuffer::BaseMove)));
+  EXPECT_CALL(*buffer_, write(_)).WillOnce(Invoke(buffer_, &MockBuffer::TrackWrites));
+  client_connection_->write(buffer_to_write);
+  dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  EXPECT_EQ(data_to_write, data_written);
+
+  disconnect();
+}
+
+class ReadBufferLimitTest : public ConnectionImplTest {
 public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size) {
     const uint32_t buffer_size = 256 * 1024;
+    listener_ =
+        dispatcher_.createListener(connection_handler_, socket_, listener_callbacks_, stats_store_,
+                                   {.bind_to_port_ = true,
+                                    .use_proxy_proto_ = false,
+                                    .use_original_dst_ = false,
+                                    .per_connection_buffer_limit_bytes_ = read_buffer_limit});
 
-    Stats::IsolatedStoreImpl stats_store;
-    Event::DispatcherImpl dispatcher;
-    Network::TcpListenSocket socket(Network::Test::getAnyAddress(GetParam()), true);
-    Network::MockListenerCallbacks listener_callbacks;
-    Network::MockConnectionHandler connection_handler;
-    Network::ListenerPtr listener =
-        dispatcher.createListener(connection_handler, socket, listener_callbacks, stats_store,
-                                  {.bind_to_port_ = true,
-                                   .use_proxy_proto_ = false,
-                                   .use_original_dst_ = false,
-                                   .per_connection_buffer_limit_bytes_ = read_buffer_limit});
+    client_connection_ = dispatcher_.createClientConnection(socket_.localAddress());
+    client_connection_->connect();
 
-    Network::ClientConnectionPtr client_connection =
-        dispatcher.createClientConnection(socket.localAddress());
-    client_connection->connect();
-
-    Network::ConnectionPtr server_connection;
-    std::shared_ptr<MockReadFilter> read_filter(new MockReadFilter());
-    EXPECT_CALL(listener_callbacks, onNewConnection_(_))
+    read_filter_.reset(new NiceMock<MockReadFilter>());
+    EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
         .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-          server_connection = std::move(conn);
-          server_connection->addReadFilter(read_filter);
-          EXPECT_EQ("", server_connection->nextProtocol());
-          EXPECT_EQ(read_buffer_limit, server_connection->readBufferLimit());
+          server_connection_ = std::move(conn);
+          server_connection_->addReadFilter(read_filter_);
+          EXPECT_EQ("", server_connection_->nextProtocol());
+          EXPECT_EQ(read_buffer_limit, server_connection_->readBufferLimit());
         }));
 
     uint32_t filter_seen = 0;
 
-    EXPECT_CALL(*read_filter, onNewConnection());
-    EXPECT_CALL(*read_filter, onData(_))
+    EXPECT_CALL(*read_filter_, onNewConnection());
+    EXPECT_CALL(*read_filter_, onData(_))
         .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> FilterStatus {
           EXPECT_EQ(expected_chunk_size, data.length());
           filter_seen += data.length();
           data.drain(data.length());
           if (filter_seen == buffer_size) {
-            server_connection->close(ConnectionCloseType::FlushWrite);
+            server_connection_->close(ConnectionCloseType::FlushWrite);
           }
           return FilterStatus::StopIteration;
         }));
 
-    MockConnectionCallbacks client_callbacks;
-    client_connection->addConnectionCallbacks(client_callbacks);
-    EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::Connected));
-    EXPECT_CALL(client_callbacks, onEvent(ConnectionEvent::RemoteClose))
+    client_connection_->addConnectionCallbacks(client_callbacks_);
+    EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::Connected));
+    EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
         .WillOnce(Invoke([&](uint32_t) -> void {
           EXPECT_EQ(buffer_size, filter_seen);
-          dispatcher.exit();
+          dispatcher_.exit();
         }));
 
     Buffer::OwnedImpl data(std::string(buffer_size, 'a'));
-    client_connection->write(data);
-    dispatcher.run(Event::Dispatcher::RunType::Block);
+    client_connection_->write(data);
+    dispatcher_.run(Event::Dispatcher::RunType::Block);
   }
 };
 

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -29,6 +29,7 @@ envoy_cc_test(
         "//source/common/ssl:context_config_lib",
         "//source/common/ssl:context_lib",
         "//source/common/stats:stats_lib",
+        "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -13,6 +13,7 @@
 #include "common/stats/stats_impl.h"
 
 #include "test/common/ssl/ssl_certs_test.h"
+#include "test/mocks/buffer/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/mocks.h"
@@ -278,80 +279,61 @@ TEST_P(SslConnectionImplTest, SslError) {
 class SslReadBufferLimitTest : public SslCertsTest,
                                public testing::WithParamInterface<Network::Address::IpVersion> {
 public:
-  void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size,
-                           uint32_t write_size, uint32_t num_writes, bool reserve_write_space) {
-    Stats::IsolatedStoreImpl stats_store;
-    Event::DispatcherImpl dispatcher;
-    Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), true);
-    Network::MockListenerCallbacks listener_callbacks;
-    Network::MockConnectionHandler connection_handler;
+  void Initialize(uint32_t read_buffer_limit) {
+    server_ctx_loader_ = TestEnvironment::jsonLoadFromString(server_ctx_json_);
+    server_ctx_config_.reset(new ContextConfigImpl(*server_ctx_loader_));
+    manager_.reset(new ContextManagerImpl(runtime_));
+    server_ctx_ = manager_->createSslServerContext(stats_store_, *server_ctx_config_);
 
-    std::string server_ctx_json = R"EOF(
-    {
-      "cert_chain_file": "{{ test_tmpdir }}/unittestcert.pem",
-      "private_key_file": "{{ test_tmpdir }}/unittestkey.pem",
-      "ca_cert_file": "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem"
-    }
-    )EOF";
-    Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-    ContextConfigImpl server_ctx_config(*server_ctx_loader);
-    Runtime::MockLoader runtime;
-    ContextManagerImpl manager(runtime);
-    ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
-
-    Network::ListenerPtr listener = dispatcher.createSslListener(
-        connection_handler, *server_ctx, socket, listener_callbacks, stats_store,
+    listener_ = dispatcher_.createSslListener(
+        connection_handler_, *server_ctx_, socket_, listener_callbacks_, stats_store_,
         {.bind_to_port_ = true,
          .use_proxy_proto_ = false,
          .use_original_dst_ = false,
          .per_connection_buffer_limit_bytes_ = read_buffer_limit});
 
-    std::string client_ctx_json = R"EOF(
-    {
-      "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/no_san_cert.pem",
-      "private_key_file": "{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"
-    }
-    )EOF";
+    client_ctx_loader_ = TestEnvironment::jsonLoadFromString(client_ctx_json_);
+    client_ctx_config_.reset(new ContextConfigImpl(*client_ctx_loader_));
+    client_ctx_ = manager_->createSslClientContext(stats_store_, *client_ctx_config_);
 
-    Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-    ContextConfigImpl client_ctx_config(*client_ctx_loader);
-    ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
+    client_connection_ =
+        dispatcher_.createSslClientConnection(*client_ctx_, socket_.localAddress());
+    client_connection_->connect();
+    read_filter_.reset(new Network::MockReadFilter());
+    client_connection_->addConnectionCallbacks(client_callbacks_);
+    EXPECT_CALL(client_callbacks_, onEvent(Network::ConnectionEvent::Connected));
+  }
 
-    Network::ClientConnectionPtr client_connection =
-        dispatcher.createSslClientConnection(*client_ctx, socket.localAddress());
-    client_connection->connect();
+  void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size,
+                           uint32_t write_size, uint32_t num_writes, bool reserve_write_space) {
+    Initialize(read_buffer_limit);
 
-    Network::ConnectionPtr server_connection;
-    std::shared_ptr<Network::MockReadFilter> read_filter(new Network::MockReadFilter());
-    EXPECT_CALL(listener_callbacks, onNewConnection_(_))
+    EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
         .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-          server_connection = std::move(conn);
-          server_connection->addReadFilter(read_filter);
-          EXPECT_EQ("", server_connection->nextProtocol());
-          EXPECT_EQ(read_buffer_limit, server_connection->readBufferLimit());
+          server_connection_ = std::move(conn);
+          server_connection_->addReadFilter(read_filter_);
+          EXPECT_EQ("", server_connection_->nextProtocol());
+          EXPECT_EQ(read_buffer_limit, server_connection_->readBufferLimit());
         }));
 
     uint32_t filter_seen = 0;
 
-    EXPECT_CALL(*read_filter, onNewConnection());
-    EXPECT_CALL(*read_filter, onData(_))
+    EXPECT_CALL(*read_filter_, onNewConnection());
+    EXPECT_CALL(*read_filter_, onData(_))
         .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Network::FilterStatus {
           EXPECT_GE(expected_chunk_size, data.length());
           filter_seen += data.length();
           data.drain(data.length());
           if (filter_seen == (write_size * num_writes)) {
-            server_connection->close(Network::ConnectionCloseType::FlushWrite);
+            server_connection_->close(Network::ConnectionCloseType::FlushWrite);
           }
           return Network::FilterStatus::StopIteration;
         }));
 
-    Network::MockConnectionCallbacks client_callbacks;
-    client_connection->addConnectionCallbacks(client_callbacks);
-    EXPECT_CALL(client_callbacks, onEvent(Network::ConnectionEvent::Connected));
-    EXPECT_CALL(client_callbacks, onEvent(Network::ConnectionEvent::RemoteClose))
+    EXPECT_CALL(client_callbacks_, onEvent(Network::ConnectionEvent::RemoteClose))
         .WillOnce(Invoke([&](uint32_t) -> void {
           EXPECT_EQ((write_size * num_writes), filter_seen);
-          dispatcher.exit();
+          dispatcher_.exit();
         }));
 
     for (uint32_t i = 0; i < num_writes; i++) {
@@ -366,13 +348,80 @@ public:
         data.commit(iovecs, 2);
       }
 
-      client_connection->write(data);
+      client_connection_->write(data);
     }
 
-    dispatcher.run(Event::Dispatcher::RunType::Block);
+    dispatcher_.run(Event::Dispatcher::RunType::Block);
 
-    EXPECT_EQ(0UL, stats_store.counter("ssl.connection_error").value());
+    EXPECT_EQ(0UL, stats_store_.counter("ssl.connection_error").value());
   }
+
+  void singleWriteTest(uint32_t read_buffer_limit, uint32_t bytes_to_write) {
+    Initialize(read_buffer_limit);
+
+    EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
+        .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
+          server_connection_ = std::move(conn);
+          server_connection_->addReadFilter(read_filter_);
+          EXPECT_EQ("", server_connection_->nextProtocol());
+          EXPECT_EQ(read_buffer_limit, server_connection_->readBufferLimit());
+        }));
+
+    std::unique_ptr<MockBuffer> buffer_ptr_{new MockBuffer()};
+    MockBuffer& buffer_{*buffer_ptr_};
+    dynamic_cast<ConnectionImpl*>(client_connection_.get())
+        ->replaceWriteBufferForTest(std::move(buffer_ptr_));
+
+    EXPECT_CALL(*read_filter_, onNewConnection());
+    EXPECT_CALL(*read_filter_, onData(_)).Times(testing::AnyNumber());
+
+    std::string data_to_write(bytes_to_write, 'a');
+    Buffer::OwnedImpl buffer_to_write(data_to_write);
+    std::string data_written;
+    EXPECT_CALL(buffer_, move(_))
+        .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
+                              Invoke(&buffer_, &MockBuffer::BaseMove)));
+    EXPECT_CALL(buffer_, drain(_)).WillOnce(Invoke(&buffer_, &MockBuffer::BaseDrain));
+    client_connection_->write(buffer_to_write);
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+    EXPECT_EQ(data_to_write, data_written);
+
+    EXPECT_CALL(client_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+    client_connection_->close(Network::ConnectionCloseType::NoFlush);
+    dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  Stats::IsolatedStoreImpl stats_store_;
+  Event::DispatcherImpl dispatcher_;
+  Network::TcpListenSocket socket_{Network::Test::getCanonicalLoopbackAddress(GetParam()), true};
+  Network::MockListenerCallbacks listener_callbacks_;
+  Network::MockConnectionHandler connection_handler_;
+  std::string server_ctx_json_ = R"EOF(
+    {
+      "cert_chain_file": "{{ test_tmpdir }}/unittestcert.pem",
+      "private_key_file": "{{ test_tmpdir }}/unittestkey.pem",
+      "ca_cert_file": "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem"
+    }
+    )EOF";
+  std::string client_ctx_json_ = R"EOF(
+    {
+      "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/no_san_cert.pem",
+      "private_key_file": "{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"
+    }
+  )EOF";
+  Runtime::MockLoader runtime_;
+  Json::ObjectSharedPtr server_ctx_loader_;
+  std::unique_ptr<ContextConfigImpl> server_ctx_config_;
+  std::unique_ptr<ContextManagerImpl> manager_;
+  ServerContextPtr server_ctx_;
+  Network::ListenerPtr listener_;
+  Json::ObjectSharedPtr client_ctx_loader_;
+  std::unique_ptr<ContextConfigImpl> client_ctx_config_;
+  ClientContextPtr client_ctx_;
+  Network::ClientConnectionPtr client_connection_;
+  Network::ConnectionPtr server_connection_;
+  std::shared_ptr<Network::MockReadFilter> read_filter_;
+  Network::MockConnectionCallbacks client_callbacks_;
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, SslReadBufferLimitTest,
@@ -391,6 +440,10 @@ TEST_P(SslReadBufferLimitTest, NoLimitSmallWrites) {
 TEST_P(SslReadBufferLimitTest, SomeLimit) {
   readBufferLimitTest(32 * 1024, 32 * 1024, 256 * 1024, 1, false);
 }
+
+TEST_P(SslReadBufferLimitTest, WritesSmallerThanBufferLimit) { singleWriteTest(5 * 1024, 1024); }
+
+TEST_P(SslReadBufferLimitTest, WritesLargerThanBufferLimit) { singleWriteTest(1024, 5 * 1024); }
 
 } // namespace Ssl
 } // namespace Envoy

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -8,6 +8,49 @@
 #include "gmock/gmock.h"
 
 namespace Envoy {
+
+class MockBuffer : public Buffer::OwnedImpl {
+public:
+  MockBuffer() {
+    ON_CALL(*this, write(testing::_))
+        .WillByDefault(testing::Invoke(this, &MockBuffer::TrackWrites));
+    ON_CALL(*this, move(testing::_)).WillByDefault(testing::Invoke(this, &MockBuffer::BaseMove));
+  }
+
+  MOCK_METHOD1(write, int(int fd));
+  MOCK_METHOD1(move, void(Instance& rhs));
+  MOCK_METHOD2(move, void(Instance& rhs, uint64_t length));
+  MOCK_METHOD1(drain, void(uint64_t size));
+
+  void BaseMove(Instance& rhs) { Buffer::OwnedImpl::move(rhs); }
+  void BaseDrain(uint64_t size) { Buffer::OwnedImpl::drain(size); }
+
+  int TrackWrites(int fd) {
+    int bytes_written = Buffer::OwnedImpl::write(fd);
+    if (bytes_written > 0) {
+      bytes_written_ += bytes_written;
+    }
+    return bytes_written;
+  }
+
+  int FailWrite(int) {
+    errno = EAGAIN;
+    return -1;
+  }
+
+  int bytes_written() const { return bytes_written_; }
+
+private:
+  int bytes_written_{0};
+};
+
+class MockBufferFactory : public Buffer::Factory {
+public:
+  Buffer::InstancePtr create() override { return Buffer::InstancePtr{create_()}; }
+
+  MOCK_METHOD0(create_, Buffer::Instance*());
+};
+
 MATCHER_P(BufferEqual, rhs, testing::PrintToString(*rhs)) {
   return TestUtility::buffersEqual(arg, *rhs);
 }
@@ -23,4 +66,9 @@ ACTION_P(AddBufferToString, target_string) {
   target_string->append(TestUtility::bufferToString(arg0));
   arg0.drain(arg0.length());
 }
+
+ACTION_P(AddBufferToStringWithoutDraining, target_string) {
+  target_string->append(TestUtility::bufferToString(arg0));
+}
+
 } // namespace Envoy

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -33,11 +33,6 @@ public:
     return bytes_written;
   }
 
-  int FailWrite(int) {
-    errno = EAGAIN;
-    return -1;
-  }
-
   int bytes_written() const { return bytes_written_; }
 
 private:

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -13,8 +13,8 @@ class MockBuffer : public Buffer::OwnedImpl {
 public:
   MockBuffer() {
     ON_CALL(*this, write(testing::_))
-        .WillByDefault(testing::Invoke(this, &MockBuffer::TrackWrites));
-    ON_CALL(*this, move(testing::_)).WillByDefault(testing::Invoke(this, &MockBuffer::BaseMove));
+        .WillByDefault(testing::Invoke(this, &MockBuffer::trackWrites));
+    ON_CALL(*this, move(testing::_)).WillByDefault(testing::Invoke(this, &MockBuffer::baseMove));
   }
 
   MOCK_METHOD1(write, int(int fd));
@@ -22,10 +22,10 @@ public:
   MOCK_METHOD2(move, void(Instance& rhs, uint64_t length));
   MOCK_METHOD1(drain, void(uint64_t size));
 
-  void BaseMove(Instance& rhs) { Buffer::OwnedImpl::move(rhs); }
-  void BaseDrain(uint64_t size) { Buffer::OwnedImpl::drain(size); }
+  void baseMove(Instance& rhs) { Buffer::OwnedImpl::move(rhs); }
+  void baseDrain(uint64_t size) { Buffer::OwnedImpl::drain(size); }
 
-  int TrackWrites(int fd) {
+  int trackWrites(int fd) {
     int bytes_written = Buffer::OwnedImpl::write(fd);
     if (bytes_written > 0) {
       bytes_written_ += bytes_written;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -105,7 +105,7 @@ public:
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
   Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
-  void setBufferFactory(Buffer::FactoryPtr factory) override {
+  void setBufferFactory(Buffer::FactoryPtr&& factory) override {
     buffer_factory_ = std::move(factory);
   }
 

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -105,9 +105,6 @@ public:
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
   Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
-  void setBufferFactory(Buffer::FactoryPtr&& factory) override {
-    buffer_factory_ = std::move(factory);
-  }
 
 private:
   std::list<DeferredDeletablePtr> to_delete_;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -104,9 +104,14 @@ public:
   MOCK_METHOD2(listenForSignal_, SignalEvent*(int signal_num, SignalCb cb));
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
+  Buffer::Factory& getBufferFactory() override { return *buffer_factory_; }
+  void setBufferFactory(Buffer::FactoryPtr factory) override {
+    buffer_factory_ = std::move(factory);
+  }
 
 private:
   std::list<DeferredDeletablePtr> to_delete_;
+  Buffer::FactoryPtr buffer_factory_;
 };
 
 class MockTimer : public Timer {


### PR DESCRIPTION
This plus substantial refactors to the connection tests for code reuse, and some new tests using the new factories.

pulling this out from https://github.com/lyft/envoy/pull/1217 since it's well over 700 lines on its own.

Also did the read buffer along with the write buffer for consistency.  Someone may need it some day and they shouldn't have to rewrite all the existing connection tests when they do.