### PR TITLE
lds: implement the the v1 API

### DIFF
--- a/docs/configuration/listeners/lds.rst
+++ b/docs/configuration/listeners/lds.rst
@@ -15,6 +15,9 @@ The semantics of listener updates are as follows:
 * When a listener is added, it will be "warmed" before taking traffic. For example, if the listener
   references an :ref:`RDS <config_http_conn_man_rds>` configuration, that configuration will be
   resolved and fetched before the listener is moved to "active."
+* Listeners are effectively constant once created. Thus, when a listener is updated, an entirely
+  new listener is created (with the same listen socket). This listener goes through the same
+  warming process described above for a newly added listener.
 * When a listener is updated or removed, the old listener will be placed into a "draining" state
   much like when the entire server is drained for restart. Connections owned by the listener will
   be gracefully closed (if possible) for some period of time before the listener is removed and any
@@ -60,8 +63,10 @@ JSON schema:
 
 listeners
   *(Required, array)* A list of :ref:`listeners <config_listeners>` that will be
-  dynamically added/modified within the listener manager. Envoy will reconcile this list with the
-  listeners that are currently loaded and either add/modify/remove listeners as necessary.
+  dynamically added/modified within the listener manager. The management server is expected to
+  respond with the complete set of listeners that Envoy should configure during each polling cycle.
+  Envoy will reconcile this list with the listeners that are currently loaded and either
+  add/modify/remove listeners as necessary.
 
 Statistics
 ----------

--- a/docs/configuration/listeners/lds.rst
+++ b/docs/configuration/listeners/lds.rst
@@ -1,0 +1,77 @@
+.. _config_listeners_lds:
+
+Listener discovery service
+==========================
+
+The listener discovery service (LDS) is an optional API that Envoy will call to dynamically fetch
+listeners. Envoy will reconcile the API response and add, modify, or remove known listeners
+depending on what is required.
+
+The semantics of listener updates are as follows:
+
+* Every listener must have a unique :ref:`name <config_listeners_name>`. If a name is not
+  provided, Envoy will create a UUID. Listeners that are to be dynamically updated should have a
+  unique name supplied by the management server.
+* When a listener is added, it will be "warmed" before taking traffic. For example, if the listener
+  references an :ref:`RDS <config_http_conn_man_rds>` configuration, that configuration will be
+  resolved and fetched before the listener is moved to "active."
+* When a listener is updated or removed, the old listener will be placed into a "draining" state
+  much like when the entire server is drained for restart. Connections owned by the listener will
+  be gracefully closed (if possible) for some period of time before the listener is removed and any
+  remaining connections are closed. The drain time is set via the :option:`--drain-time-s` option.
+
+.. code-block:: json
+
+  {
+    "cluster": "{...}",
+    "refresh_delay_ms": "..."
+  }
+
+cluster
+  *(required, object)* The name of an upstream :ref:`cluster <config_cluster_manager_cluster>` that
+  hosts the listener discovery service. The cluster must run a REST service that implements the
+  :ref:`LDS HTTP API <config_listeners_lds_api>`. NOTE: This is the *name* of a cluster defined
+  in the :ref:`cluster manager <config_cluster_manager>` configuration, not the full definition of
+  a cluster as in the case of SDS and CDS.
+
+refresh_delay_ms
+  *(optional, integer)* The delay, in milliseconds, between fetches to the LDS API. Envoy will add
+  an additional random jitter to the delay that is between zero and *refresh_delay_ms*
+  milliseconds. Thus the longest possible refresh delay is 2 \* *refresh_delay_ms*. Default value
+  is 30000ms (30 seconds).
+
+.. _config_listeners_lds_api:
+
+REST API
+--------
+
+.. http:get:: /v1/listeners/(string: service_cluster)/(string: service_node)
+
+Asks the discovery service to return all listeners for a particular `service_cluster` and
+`service_node`. `service_cluster` corresponds to the :option:`--service-cluster` CLI option.
+`service_node` corresponds to the :option:`--service-node` CLI option. Responses use the following
+JSON schema:
+
+.. code-block:: json
+
+  {
+    "listeners": []
+  }
+
+listeners
+  *(Required, array)* A list of :ref:`listeners <config_listeners>` that will be
+  dynamically added/modified within the listener manager. Envoy will reconcile this list with the
+  listeners that are currently loaded and either add/modify/remove listeners as necessary.
+
+Statistics
+----------
+
+LDS has a statistics tree rooted at *listener_manager.lds.* with the following statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  update_attempt, Counter, Total API fetches attempted
+  update_success, Counter, Total API fetches completed successfully
+  update_failure, Counter, Total API fetches that failed (either network or schema errors)

--- a/docs/configuration/listeners/listeners.rst
+++ b/docs/configuration/listeners/listeners.rst
@@ -19,10 +19,12 @@ Each individual listener configuration has the following format:
     "per_connection_buffer_limit_bytes": "..."
   }
 
+.. _config_listeners_name:
+
 name
   *(optional, string)* The unique name by which this listener is known. If no name is provided,
   Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
-  updated or removed via LDS a unique name must be provided.
+  updated or removed via :ref:`LDS <config_listeners_lds>` a unique name must be provided.
 
 address
   *(required, string)* The address that the listener should listen on. Currently only TCP
@@ -73,3 +75,4 @@ per_connection_buffer_limit_bytes
   ssl
   stats
   runtime
+  lds

--- a/docs/intro/arch_overview/arch_overview.rst
+++ b/docs/intro/arch_overview/arch_overview.rst
@@ -29,3 +29,4 @@ Architecture overview
   dynamo
   hot_restart
   dynamic_configuration
+  init

--- a/docs/intro/arch_overview/dynamic_configuration.rst
+++ b/docs/intro/arch_overview/dynamic_configuration.rst
@@ -62,5 +62,12 @@ when used alongside SDS and CDS, allows implementors to build a complex routing 
 (:ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting>`, blue/green
 deployment, etc.) that will not require any Envoy restarts other than to obtain a new Envoy binary.
 
-Note that currently, there is no dynamic mechanism by which Envoy can add, update, and remove
-listeners. In the future it likely that a listener discovery service (LDS) API will be added.
+SDS, CDS, RDS, and LDS
+----------------------
+
+The :ref:`listener discovery service (LDS) <config_listeners_lds>` layers on a mechanism by which
+Envoy can discover entire listeners at runtime. This includes all filter stacks, up to and including
+HTTP filters with embedded references to :ref:`RDS <config_http_conn_man_rds>`. Adding LDS into
+the mix allows almost every aspect of Envoy to be dynamically configured. Hot restart should
+only be required for very rare configuration changes (admin, tracing driver, etc.) or binary
+updates.

--- a/docs/intro/arch_overview/dynamic_configuration.rst
+++ b/docs/intro/arch_overview/dynamic_configuration.rst
@@ -26,6 +26,8 @@ via the built in :ref:`hot restart <arch_overview_hot_restart>` mechanism.
 Though simplistic, fairly complicated deployments can be created using static configurations and
 graceful hot restarts.
 
+.. _arch_overview_dynamic_config_sds:
+
 SDS only
 --------
 
@@ -35,6 +37,8 @@ configuration, SDS allows an Envoy deployment to circumvent the limitations of D
 in a response, etc.) as well as consume more information used in load balancing and routing (e.g.,
 canary status, zone, etc.).
 
+.. _arch_overview_dynamic_config_cds:
+
 SDS and CDS
 -----------
 
@@ -42,15 +46,17 @@ The :ref:`cluster discovery service (CDS) API <config_cluster_manager_cds>` laye
 which Envoy can discover upstream clusters used during routing. Envoy will gracefully add, update,
 and remove clusters as specified by the API. This API allows implementors to build a topology in
 which Envoy does not need to be aware of all upstream clusters at initial configuration time.
-Typically, when doing HTTP routing along with CDS (but without route discovery service), implementors will make use of
-the router's ability to forward requests to a cluster specified in an :ref:`HTTP request header
-<config_http_conn_man_route_table_route_cluster_header>`.
+Typically, when doing HTTP routing along with CDS (but without route discovery service),
+implementors will make use of the router's ability to forward requests to a cluster specified in an
+:ref:`HTTP request header <config_http_conn_man_route_table_route_cluster_header>`.
 
 Although it is possible to use CDS without SDS by specifying fully static clusters, we recommend
 still using the SDS API for clusters specified via CDS. Internally, when a cluster definition is
 updated, the operation is graceful. However, all existing connection pools will be drained and
 reconnected. SDS does not suffer from this limitation. When hosts are added and removed via SDS,
 the existing hosts in the cluster are unaffected.
+
+.. _arch_overview_dynamic_config_rds:
 
 SDS, CDS, and RDS
 -----------------
@@ -61,6 +67,8 @@ The route configuration will be gracefully swapped in without affecting existing
 when used alongside SDS and CDS, allows implementors to build a complex routing topology
 (:ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting>`, blue/green
 deployment, etc.) that will not require any Envoy restarts other than to obtain a new Envoy binary.
+
+.. _arch_overview_dynamic_config_lds:
 
 SDS, CDS, RDS, and LDS
 ----------------------

--- a/docs/intro/arch_overview/init.rst
+++ b/docs/intro/arch_overview/init.rst
@@ -10,14 +10,15 @@ accepting new connections.
   :ref:`SDS <arch_overview_dynamic_config_sds>` clusters. Then it initializes
   :ref:`CDS <arch_overview_dynamic_config_cds>` if applicable, waits for one response (or failure),
   and does the same primary/secondary initialization of CDS provided clusters.
-* If clusters use :ref:`active health checking <arch_overview_health_checking>`, Envoy also do a
+* If clusters use :ref:`active health checking <arch_overview_health_checking>`, Envoy also does a
   single active HC round.
 * Once cluster manager initialization is done, :ref:`RDS <arch_overview_dynamic_config_rds>` and
   :ref:`LDS <arch_overview_dynamic_config_lds>` initialize (if applicable). The server
   doesn't start accepting connections until there has been at least one response (or failure) for
   LDS/RDS requests.
 * If LDS itself returns a listener that needs an RDS response, Envoy further waits until an RDS
-  response (or failure) is received.
+  response (or failure) is received. Note that this process takes place on every future listener
+  addition via LDS and is known as :ref:`listener warming <config_listeners_lds>`.
 * After all of the previous steps have taken place, the listeners start accepting new connections.
   This flow ensures that during hot restart the new process is fully capable of accepting and
   processing new connections before the draining of the old process begins.

--- a/docs/intro/arch_overview/init.rst
+++ b/docs/intro/arch_overview/init.rst
@@ -1,0 +1,23 @@
+Initialization
+==============
+
+How Envoy initializes itself when it starts up is complex. This section explains at a high level
+how the process works. All of the following happens before any listeners start listening and
+accepting new connections.
+
+* During startup, the :ref:`cluster manager <arch_overview_cluster_manager>` goes through a
+  multi-phase initialization where it first initializes static/DNS clusters, then predefined
+  :ref:`SDS <arch_overview_dynamic_config_sds>` clusters. Then it initializes
+  :ref:`CDS <arch_overview_dynamic_config_cds>` if applicable, waits for one response (or failure),
+  and does the same primary/secondary initialization of CDS provided clusters.
+* If clusters use :ref:`active health checking <arch_overview_health_checking>`, Envoy also do a
+  single active HC round.
+* Once cluster manager initialization is done, :ref:`RDS <arch_overview_dynamic_config_rds>` and
+  :ref:`LDS <arch_overview_dynamic_config_lds>` initialize (if applicable). The server
+  doesn't start accepting connections until there has been at least one response (or failure) for
+  LDS/RDS requests.
+* If LDS itself returns a listener that needs an RDS response, Envoy further waits until an RDS
+  response (or failure) is received.
+* After all of the previous steps have taken place, the listeners start accepting new connections.
+  This flow ensures that during hot restart the new process is fully capable of accepting and
+  processing new connections before the draining of the old process begins.

--- a/docs/intro/arch_overview/listeners.rst
+++ b/docs/intro/arch_overview/listeners.rst
@@ -17,4 +17,7 @@ used for (e.g., :ref:`rate limiting <arch_overview_rate_limit>`, :ref:`TLS clien
 MongoDB :ref:`sniffing <arch_overview_mongo>`, raw :ref:`TCP proxy <arch_overview_tcp_proxy>`,
 etc.).
 
+Listeners can also be fetched dynamically via the :ref:`listener discovery service (LDS)
+<config_listeners_lds>`.
+
 Listener :ref:`configuration <config_listeners>`.

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -106,6 +106,11 @@ public:
    * @return uint64_t the tag the listener should use for connection handler tracking.
    */
   virtual uint64_t listenerTag() PURE;
+
+  /**
+   * @return const std::string& the listener's name.
+   */
+  virtual const std::string& name() const PURE;
 };
 
 /**

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1016,6 +1016,40 @@ const std::string Json::Schema::CLUSTER_MANAGER_SCHEMA(R"EOF(
   }
   )EOF");
 
+const std::string Json::Schema::LDS_SCHEMA(R"EOF(
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
+    "properties" : {
+      "listeners" : {
+        "type" : "array",
+        "items" : {"type" : "object"}
+      }
+    },
+    "required" : ["listeners"],
+    "additionalProperties" : false
+  }
+  )EOF");
+
+const std::string Json::Schema::LDS_CONFIG_SCHEMA(R"EOF(
+  {
+    "$schema": "http://json-schema.org/schema#",
+    "type" : "object",
+    "properties" : {
+      "cluster" : {
+        "type" : "string"
+      },
+      "refresh_delay_ms" : {
+        "type" : "integer",
+        "minimum" : 0,
+        "exclusiveMinimum" : true
+      }
+    },
+    "required" : ["cluster"],
+    "additionalProperties" : false
+  }
+  )EOF");
+
 const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
   {
     "$schema": "http://json-schema.org/schema#",
@@ -1086,6 +1120,7 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
         "type" : "array",
         "items" : {"type" : "object"}
       },
+      "lds" : {"type" : "object"},
       "admin" : {
         "type" : "object",
         "properties" : {

--- a/source/common/json/config_schemas.h
+++ b/source/common/json/config_schemas.h
@@ -12,6 +12,8 @@ public:
 
   // Listener Schema
   static const std::string LISTENER_SCHEMA;
+  static const std::string LDS_SCHEMA;
+  static const std::string LDS_CONFIG_SCHEMA;
 
   // Network Filter Schemas
   static const std::string CLIENT_SSL_NETWORK_FILTER_SCHEMA;

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -54,7 +54,7 @@ void CdsApiImpl::parseResponse(const Http::Message& response) {
   // We need to keep track of which clusters we might need to remove.
   ClusterManager::ClusterInfoMap clusters_to_remove = cm_.clusters();
   for (auto& cluster : clusters) {
-    std::string cluster_name = cluster->getString("name");
+    const std::string cluster_name = cluster->getString("name");
     clusters_to_remove.erase(cluster_name);
     if (cm_.addOrUpdatePrimaryCluster(*cluster)) {
       ENVOY_LOG(info, "cds: add/update cluster '{}'", cluster_name);

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
     srcs = ["configuration_impl.cc"],
     hdrs = ["configuration_impl.h"],
     deps = [
+        ":lds_api_lib",
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
@@ -113,6 +114,20 @@ envoy_cc_library(
         "//include/envoy/server:options_interface",
         "//source/common/common:macros",
         "//source/common/common:version_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "lds_api_lib",
+    srcs = ["lds_api.cc"],
+    hdrs = ["lds_api.h"],
+    deps = [
+        "//include/envoy/init:init_interface",
+        "//include/envoy/server:listener_manager_interface",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/http:rest_api_fetcher_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/json:json_validator_lib",
     ],
 )
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -46,6 +46,12 @@ void MainImpl::initialize(const Json::Object& json, Instance& server,
     server.listenerManager().addOrUpdateListener(*listeners[i]);
   }
 
+  if (json.hasObject("lds")) {
+    lds_api_.reset(new LdsApi(*json.getObject("lds"), *cluster_manager_, server.dispatcher(),
+                              server.random(), server.initManager(), server.localInfo(),
+                              server.stats(), server.listenerManager()));
+  }
+
   if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {
     throw EnvoyException("statsd_local_udp_port and statsd_udp_ip_address "
                          "are mutually exclusive.");

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -20,6 +20,8 @@
 #include "common/json/json_loader.h"
 #include "common/network/utility.h"
 
+#include "server/lds_api.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
@@ -144,6 +146,7 @@ private:
   }
 
   std::unique_ptr<Upstream::ClusterManager> cluster_manager_;
+  std::unique_ptr<LdsApi> lds_api_;
   Tracing::HttpTracerPtr http_tracer_;
   Optional<std::string> statsd_tcp_cluster_name_;
   Optional<uint32_t> statsd_udp_port_;

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -1,0 +1,81 @@
+#include "server/lds_api.h"
+
+#include "common/http/headers.h"
+#include "common/json/config_schemas.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Server {
+
+LdsApi::LdsApi(const Json::Object& config, Upstream::ClusterManager& cm,
+               Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+               Init::Manager& init_manager, const LocalInfo::LocalInfo& local_info,
+               Stats::Scope& scope, ListenerManager& lm)
+    : Json::Validator(config, Json::Schema::LDS_CONFIG_SCHEMA),
+      RestApiFetcher(cm, config.getString("cluster"), dispatcher, random,
+                     std::chrono::milliseconds(config.getInteger("refresh_delay_ms", 30000))),
+      local_info_(local_info), lm_(lm),
+      stats_({ALL_LDS_STATS(POOL_COUNTER_PREFIX(scope, "listener_manager.lds."))}) {
+  init_manager.registerTarget(*this);
+}
+
+void LdsApi::initialize(std::function<void()> callback) {
+  initialize_callback_ = callback;
+  RestApiFetcher::initialize();
+}
+
+void LdsApi::createRequest(Http::Message& request) {
+  ENVOY_LOG(debug, "lds: starting request");
+  stats_.update_attempt_.inc();
+  request.headers().insertMethod().value(Http::Headers::get().MethodValues.Get);
+  request.headers().insertPath().value(
+      fmt::format("/v1/listeners/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
+}
+
+void LdsApi::parseResponse(const Http::Message& response) {
+  ENVOY_LOG(debug, "lds: parsing response");
+  Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
+  response_json->validateSchema(Json::Schema::LDS_SCHEMA);
+  std::vector<Json::ObjectSharedPtr> json_listeners = response_json->getObjectArray("listeners");
+
+  // We need to keep track of which listeners we might need to remove.
+  std::unordered_map<std::string, std::reference_wrapper<Listener>> listeners_to_remove;
+  for (const auto& listener : lm_.listeners()) {
+    listeners_to_remove.emplace(listener.get().name(), listener);
+  }
+
+  for (const auto& listener : json_listeners) {
+    const std::string listener_name = listener->getString("name");
+    listeners_to_remove.erase(listener_name);
+    if (lm_.addOrUpdateListener(*listener)) {
+      ENVOY_LOG(info, "lds: add/update listener '{}'", listener_name);
+    }
+  }
+
+  for (const auto& listener : listeners_to_remove) {
+    if (lm_.removeListener(listener.first)) {
+      ENVOY_LOG(info, "lds: remove listener '{}'", listener.first);
+    }
+  }
+
+  stats_.update_success_.inc();
+}
+
+void LdsApi::onFetchComplete() {
+  if (initialize_callback_) {
+    initialize_callback_();
+    initialize_callback_ = nullptr;
+  }
+}
+
+void LdsApi::onFetchFailure(const EnvoyException* e) {
+  stats_.update_failure_.inc();
+  if (e) {
+    ENVOY_LOG(warn, "lds: fetch failure: {}", e->what());
+  } else {
+    ENVOY_LOG(info, "lds: fetch failure: network error");
+  }
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -51,7 +51,7 @@ private:
   void onFetchFailure(const EnvoyException* e) override;
 
   const LocalInfo::LocalInfo& local_info_;
-  ListenerManager& lm_;
+  ListenerManager& listener_manager_;
   LdsStats stats_;
   std::function<void()> initialize_callback_;
 };

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "envoy/init/init.h"
+#include "envoy/server/listener_manager.h"
+#include "envoy/stats/stats_macros.h"
+
+#include "common/common/logger.h"
+#include "common/http/rest_api_fetcher.h"
+#include "common/json/json_validator.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * All LDS stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_LDS_STATS(COUNTER)                                                                     \
+  COUNTER(update_attempt)                                                                          \
+  COUNTER(update_success)                                                                          \
+  COUNTER(update_failure)
+// clang-format on
+
+/**
+ * Struct definition for all LDS stats. @see stats_macros.h
+ */
+struct LdsStats {
+  ALL_LDS_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * v1 implementation of the LDS REST API.
+ */
+class LdsApi : Json::Validator,
+               public Init::Target,
+               public Http::RestApiFetcher,
+               Logger::Loggable<Logger::Id::upstream> {
+public:
+  LdsApi(const Json::Object& config, Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+         Runtime::RandomGenerator& random, Init::Manager& init_manager,
+         const LocalInfo::LocalInfo& local_info, Stats::Scope& scope, ListenerManager& lm);
+
+  // Init::Target
+  void initialize(std::function<void()> callback) override;
+
+private:
+  // Http::RestApiFetcher
+  void createRequest(Http::Message& request) override;
+  void parseResponse(const Http::Message& response) override;
+  void onFetchComplete() override;
+  void onFetchFailure(const EnvoyException* e) override;
+
+  const LocalInfo::LocalInfo& local_info_;
+  ListenerManager& lm_;
+  LdsStats stats_;
+  std::function<void()> initialize_callback_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -150,7 +150,6 @@ public:
   void infoLog(const std::string& message);
   void initialize();
   DrainManager& localDrainManager() const { return *local_drain_manager_; }
-  const std::string& name() const { return name_; }
   void setSocket(const Network::ListenSocketSharedPtr& socket);
 
   // Server::Listener
@@ -163,6 +162,7 @@ public:
   uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
   Stats::Scope& listenerScope() override { return *listener_scope_; }
   uint64_t listenerTag() override { return listener_tag_; }
+  const std::string& name() const override { return name_; }
 
   // Server::Configuration::FactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -14,13 +14,13 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 using testing::InSequence;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnRef;
 using testing::_;
 
+namespace Envoy {
 namespace Upstream {
 
 class CdsApiImplTest : public testing::Test {

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -248,6 +248,10 @@
     }
   },
 
+  "lds": {
+    "cluster": "lds"
+  },
+
   "runtime": {
     "symlink_root": "{{ test_rundir }}/test/common/runtime/test_data/current",
     "subdirectory": "envoy",
@@ -267,6 +271,13 @@
     "clusters": [
     {
       "name": "rds",
+      "connect_timeout_ms": 5000,
+      "type": "static",
+      "lb_type": "round_robin",
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
+    },
+    {
+      "name": "lds",
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -54,6 +54,7 @@ MockListener::MockListener() {
   ON_CALL(*this, filterChainFactory()).WillByDefault(ReturnRef(filter_chain_factory_));
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
   ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(scope_));
+  ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
 }
 MockListener::~MockListener() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -169,10 +169,12 @@ public:
   MOCK_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_METHOD0(listenerTag, uint64_t());
+  MOCK_CONST_METHOD0(name, const std::string&());
 
   testing::NiceMock<Network::MockFilterChainFactory> filter_chain_factory_;
   testing::NiceMock<Network::MockListenSocket> socket_;
   Stats::IsolatedStoreImpl scope_;
+  std::string name_;
 };
 
 class MockWorkerFactory : public WorkerFactory {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -85,6 +85,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "lds_api_test",
+    srcs = ["lds_api_test.cc"],
+    deps = [
+        "//source/server:lds_api_lib",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "listener_manager_impl_test",
     srcs = ["listener_manager_impl_test.cc"],
     data = ["//test/common/ssl/test_data:certs"],

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -1,0 +1,178 @@
+#include "common/http/message_impl.h"
+
+#include "server/lds_api.h"
+
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+
+using testing::InSequence;
+using testing::Invoke;
+using testing::Return;
+using testing::_;
+
+namespace Envoy {
+namespace Server {
+
+class LdsApiTest : public testing::Test {
+public:
+  LdsApiTest() : request_(&cm_.async_client_) {}
+
+  void setup() {
+    std::string config_json = R"EOF(
+    {
+      "cluster": "foo_cluster",
+      "refresh_delay_ms": 1000
+    }
+    )EOF";
+
+    Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+    EXPECT_CALL(init_, registerTarget(_));
+    lds_.reset(new LdsApi(*config, cm_, dispatcher_, random_, init_, local_info_, store_, lm_));
+
+    expectRequest();
+    init_.initialize();
+  }
+
+  void expectAdd(const std::string& listener_name) {
+    EXPECT_CALL(lm_, addOrUpdateListener(_))
+        .WillOnce(Invoke([listener_name](const Json::Object& config) -> bool {
+          EXPECT_EQ(listener_name, config.getString("name"));
+          return true;
+        }));
+  }
+
+  void expectRequest() {
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("foo_cluster"));
+    EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+                       const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              EXPECT_EQ((Http::TestHeaderMapImpl{{":method", "GET"},
+                                                 {":path", "/v1/listeners/cluster_name/node_name"},
+                                                 {":authority", "foo_cluster"}}),
+                        request->headers());
+              callbacks_ = &callbacks;
+              return &request_;
+            }));
+  }
+
+  void makeListenersAndExpectCall(const std::vector<std::string>& listener_names) {
+    std::vector<std::reference_wrapper<Listener>> refs;
+    listeners_.clear();
+    for (const auto& name : listener_names) {
+      listeners_.emplace_back();
+      listeners_.back().name_ = name;
+      refs.push_back(listeners_.back());
+    }
+    EXPECT_CALL(lm_, listeners()).WillOnce(Return(refs));
+  }
+
+  Upstream::MockClusterManager cm_;
+  Event::MockDispatcher dispatcher_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  Init::MockManager init_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  Stats::IsolatedStoreImpl store_;
+  MockListenerManager lm_;
+  Http::MockAsyncClientRequest request_;
+  std::unique_ptr<LdsApi> lds_;
+  Event::MockTimer* interval_timer_{new Event::MockTimer(&dispatcher_)};
+  Http::AsyncClient::Callbacks* callbacks_{};
+
+private:
+  std::list<NiceMock<MockListener>> listeners_;
+};
+
+TEST_F(LdsApiTest, Basic) {
+  InSequence s;
+
+  setup();
+
+  std::string response1_json = R"EOF(
+  {
+    "listeners": [
+    {
+      "name": "listener1"
+    },
+    {
+      "name": "listener2"
+    }
+    ]
+  }
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body().reset(new Buffer::OwnedImpl(response1_json));
+
+  makeListenersAndExpectCall({});
+  expectAdd("listener1");
+  expectAdd("listener2");
+  EXPECT_CALL(init_.initialized_, ready());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  expectRequest();
+  interval_timer_->callback_();
+
+  std::string response2_json = R"EOF(
+  {
+    "listeners": [
+    {
+      "name": "listener1"
+    },
+    {
+      "name": "listener3"
+    }
+    ]
+  }
+  )EOF";
+
+  message.reset(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body().reset(new Buffer::OwnedImpl(response2_json));
+
+  makeListenersAndExpectCall({"listener1", "listener2"});
+  expectAdd("listener1");
+  expectAdd("listener3");
+  EXPECT_CALL(lm_, removeListener("listener2"));
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_success").value());
+}
+
+TEST_F(LdsApiTest, Failure) {
+  InSequence s;
+
+  setup();
+
+  std::string response_json = R"EOF(
+  {
+    "listeners" : {}
+  }
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body().reset(new Buffer::OwnedImpl(response_json));
+
+  EXPECT_CALL(init_.initialized_, ready());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  expectRequest();
+  interval_timer_->callback_();
+
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
+
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
+  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_failure").value());
+}
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
This is a v1 (in the API sense) implementation of LDS. The work to get
the v2 API running is substantial and I don't want to block initial users
from testing out the API since the plumbing is the hard part that won't
change between API versions. There are still some follow up TODOs but
this should be fully functional for beta use.