### PR TITLE
build: add missing export for example_configs_test_setup.sh. 

### DIFF
--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -9,6 +9,8 @@ load(
 
 envoy_package()
 
+exports_files(["example_configs_test_setup.sh"])
+
 envoy_cc_test(
     name = "example_configs_test",
     srcs = [


### PR DESCRIPTION
Turns out that //test/server/config_validation:server_test has a dependency on this, surprised Bazel didn't complain before.