### PR TITLE
listener manager: handle listener creation failures on workers

### DIFF
--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -13,10 +13,20 @@ public:
   virtual ~Worker() {}
 
   /**
+   * Completion called when a listener has been added on a worker and is listening for new
+   * connections.
+   * @param success supplies whether the addition was successful or not. FALSE can be returned
+   *                when there is a race condition between bind() and listen().
+   */
+  typedef std::function<void(bool success)> AddListenerCompletion;
+
+  /**
    * Add a listener to the worker.
    * @param listener supplies the listener to add.
+   * @param completion supplies the completion to call when the listener has been added (or not) on
+   *                   the worker.
    */
-  virtual void addListener(Listener& listener) PURE;
+  virtual void addListener(Listener& listener, AddListenerCompletion completion) PURE;
 
   /**
    * @return uint64_t the number of connections across all listeners that the worker owns.

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -168,7 +168,6 @@ envoy_cc_library(
         "//include/envoy/event:signal_interface",
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:dns_interface",
-        "//include/envoy/network:listener_interface",
         "//include/envoy/server:drain_manager_interface",
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:listener_manager_interface",

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -380,9 +380,10 @@ void ListenerManagerImpl::addListenerToWorker(Worker& worker, ListenerImpl& list
     // avoid locking.
     server_.dispatcher().post([this, success, &listener]() -> void {
       // It is theoretically possible for a listener to get added on 1 worker but not the others.
-      // The following code will yield 1 critical log and 1 stat. It will also cause listener
-      // removal a single time. Note also that that drain/removal can race with addition. It's
-      // guaranteed that workers process remove after add so this should be fine.
+      // The below check with onListenerCreateFailure() is there to ensure we execute the
+      // removal/logging/stats at most once on failure. Note also that that drain/removal can race
+      // with addition. It's guaranteed that workers process remove after add so this should be
+      // fine.
       if (!success && !listener.onListenerCreateFailure()) {
         // TODO(mattklein123): In addition to a critical log and a stat, we should consider adding
         //                     a startup option here to cause the server to exit. I think we

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -173,7 +173,7 @@ public:
 
   /**
    * Called when a listener failed to be actually created on a worker.
-   * @return TRUE if this is not the first create failure (via multiple workers).
+   * @return TRUE if we have seen more than one worker failure.
    */
   bool onListenerCreateFailure() {
     bool ret = saw_listener_create_failure_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -126,11 +126,11 @@ public:
 
 private:
   void flushStats();
-  void initialize(Options& options, TestHooks& hooks, ComponentFactory& component_factory);
+  void initialize(Options& options, ComponentFactory& component_factory);
   void initializeStatSinks();
   void loadServerFlags(const Optional<std::string>& flags_path);
   uint64_t numConnections();
-  void startWorkers(TestHooks& hooks);
+  void startWorkers();
 
   Options& options_;
   HotRestart& restarter_;

--- a/source/server/test_hooks.h
+++ b/source/server/test_hooks.h
@@ -11,11 +11,6 @@ public:
   virtual ~TestHooks() {}
 
   /**
-   * Called when the server is initialized and about to start event loops.
-   */
-  virtual void onServerInitialized() PURE;
-
-  /**
    * Called when a worker has added a listener and it is listening.
    */
   virtual void onWorkerListenerAdded() PURE;
@@ -32,7 +27,6 @@ public:
 class DefaultTestHooks : public TestHooks {
 public:
   // TestHooks
-  void onServerInitialized() override {}
   void onWorkerListenerAdded() override {}
   void onWorkerListenerRemoved() override {}
 };

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -40,7 +40,7 @@ public:
              Network::ConnectionHandlerPtr handler);
 
   // Server::Worker
-  void addListener(Listener& listener) override;
+  void addListener(Listener& listener, AddListenerCompletion completion) override;
   uint64_t numConnections() override;
   void removeListener(Listener& listener, std::function<void()> completion) override;
   void start(GuardDog& guard_dog) override;

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -254,7 +254,7 @@
         "connect_timeout_ms": 5000,
         "type": "static",
         "lb_type": "round_robin",
-        "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
+        "hosts": [{"url": "tcp://{{ ip_loopback_address }}:4"}]
       }
     },
     "clusters": [
@@ -263,14 +263,14 @@
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:4"}]
     },
     {
       "name": "lds",
       "connect_timeout_ms": 5000,
       "type": "static",
       "lb_type": "round_robin",
-      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:12000"}]
+      "hosts": [{"url": "tcp://{{ ip_loopback_address }}:4"}]
     },
     {
       "name": "cluster_1",
@@ -293,7 +293,7 @@
       "type": "strict_dns",
       "lb_type": "round_robin",
       "dns_lookup_family": "{{ dns_lookup_family }}",
-      "hosts": [{"url": "tcp://localhost:10009"}]
+      "hosts": [{"url": "tcp://localhost:4"}]
     }]
   }
 }

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -226,7 +226,7 @@
       "type": "strict_dns",
       "lb_type": "round_robin",
       "dns_lookup_family": "{{ dns_lookup_family }}",
-      "hosts": [{"url": "tcp://localhost:10009"}]
+      "hosts": [{"url": "tcp://localhost:4"}]
     }]
   }
 }

--- a/test/config/integration/server_proxy_proto.json
+++ b/test/config/integration/server_proxy_proto.json
@@ -61,10 +61,6 @@
                 {
                   "prefix": "/test/long/url",
                   "cluster": "cluster_1"
-                },
-                {
-                  "prefix": "/test/",
-                  "cluster": "cluster_2"
                 }
               ]
             }
@@ -93,14 +89,6 @@
       "type": "static",
       "lb_type": "round_robin",
       "hosts": [{"url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"}]
-    },
-    {
-      "name": "cluster_2",
-      "connect_timeout_ms": 5000,
-      "type": "strict_dns",
-      "lb_type": "round_robin",
-      "dns_lookup_family": "{{ dns_lookup_family }}",
-      "hosts": [{"url": "tcp://localhost:11001"}]
     }]
   }
 }

--- a/test/config/integration/tcp_proxy.json
+++ b/test/config/integration/tcp_proxy.json
@@ -68,7 +68,7 @@
       "type": "strict_dns",
       "lb_type": "round_robin",
       "dns_lookup_family": "{{ dns_lookup_family }}",
-      "hosts": [{"url": "tcp://localhost:{{ upstream_1 }}"}]
+      "hosts": [{"url": "tcp://localhost:4"}]
     }]
   }
 }

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -73,7 +73,7 @@ void IntegrationTestServer::onWorkerListenerAdded() {
     on_worker_listener_added_cb_();
   }
 
-  std::unique_lock<std::mutex> gaurd(listeners_mutex_);
+  std::unique_lock<std::mutex> guard(listeners_mutex_);
   if (pending_listeners_ > 0) {
     pending_listeners_--;
     listeners_cv_.notify_one();

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -43,13 +43,17 @@ void IntegrationTestServer::start(const Network::Address::IpVersion version) {
   ENVOY_LOG(info, "starting integration test server");
   ASSERT(!thread_);
   thread_.reset(new Thread::Thread([version, this]() -> void { threadRoutine(version); }));
-  // First, we want to wait until we know the server's worker threads are all
-  // started.
-  server_initialized_.waitReady();
-  // Then we need to make sure the thread with
-  // IntegrationTestServer::threadRoutine has set server_, since integration
-  // tests might rely on the value of server().
+
+  // Wait for the server to be created and the number of initial listeners to wait for to be set.
   server_set_.waitReady();
+
+  // Now wait for the initial listeners to actually be listening on the worker. At this point
+  // the server is up and ready for testing.
+  std::unique_lock<std::mutex> guard(listeners_mutex_);
+  while (pending_listeners_ != 0) {
+    listeners_cv_.wait(guard);
+  }
+  ENVOY_LOG(info, "listener wait complete");
 }
 
 IntegrationTestServer::~IntegrationTestServer() {
@@ -64,6 +68,24 @@ IntegrationTestServer::~IntegrationTestServer() {
   thread_->join();
 }
 
+void IntegrationTestServer::onWorkerListenerAdded() {
+  if (on_worker_listener_added_cb_) {
+    on_worker_listener_added_cb_();
+  }
+
+  std::unique_lock<std::mutex> gaurd(listeners_mutex_);
+  if (pending_listeners_ > 0) {
+    pending_listeners_--;
+    listeners_cv_.notify_one();
+  }
+}
+
+void IntegrationTestServer::onWorkerListenerRemoved() {
+  if (on_worker_listener_removed_cb_) {
+    on_worker_listener_removed_cb_();
+  }
+}
+
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version) {
   Server::TestOptionsImpl options(config_path_);
   Server::TestHotRestart restarter;
@@ -72,6 +94,8 @@ void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion vers
                                       "cluster_name", "node_name");
   server_.reset(
       new Server::InstanceImpl(options, *this, restarter, stats_store_, lock, *this, local_info));
+  pending_listeners_ = server_->listenerManager().listeners().size();
+  ENVOY_LOG(info, "waiting for {} test server listeners", pending_listeners_);
   server_set_.setReady();
   server_->run();
   server_.reset();

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -194,17 +194,8 @@ public:
   Stats::Store& store() { return stats_store_; }
 
   // TestHooks
-  void onServerInitialized() override { server_initialized_.setReady(); }
-  void onWorkerListenerAdded() override {
-    if (on_worker_listener_added_cb_) {
-      on_worker_listener_added_cb_();
-    }
-  }
-  void onWorkerListenerRemoved() override {
-    if (on_worker_listener_removed_cb_) {
-      on_worker_listener_removed_cb_();
-    }
-  }
+  void onWorkerListenerAdded() override;
+  void onWorkerListenerRemoved() override;
 
   // Server::ComponentFactory
   Server::DrainManagerPtr createDrainManager(Server::Instance&) override {
@@ -227,7 +218,9 @@ private:
 
   const std::string config_path_;
   Thread::ThreadPtr thread_;
-  ConditionalInitializer server_initialized_;
+  std::condition_variable listeners_cv_;
+  std::mutex listeners_mutex_;
+  uint64_t pending_listeners_;
   ConditionalInitializer server_set_;
   std::unique_ptr<Server::InstanceImpl> server_;
   Server::TestDrainManager* drain_manager_{};

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -16,8 +16,6 @@ public:
   void SetUp() override {
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/tcp_proxy.json",
                      {"tcp_proxy", "tcp_proxy_with_tls_termination"});
   }

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -62,6 +62,12 @@ MockWorkerFactory::MockWorkerFactory() {}
 MockWorkerFactory::~MockWorkerFactory() {}
 
 MockWorker::MockWorker() {
+  ON_CALL(*this, addListener(_, _))
+      .WillByDefault(Invoke([this](Listener&, AddListenerCompletion completion) -> void {
+        EXPECT_EQ(nullptr, add_listener_completion_);
+        add_listener_completion_ = completion;
+      }));
+
   ON_CALL(*this, removeListener(_, _))
       .WillByDefault(Invoke([this](Listener&, std::function<void()> completion) -> void {
         EXPECT_EQ(nullptr, remove_listener_completion_);

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -193,6 +193,12 @@ public:
   MockWorker();
   ~MockWorker();
 
+  void callAddCompletion(bool success) {
+    EXPECT_NE(nullptr, add_listener_completion_);
+    add_listener_completion_(success);
+    add_listener_completion_ = nullptr;
+  }
+
   void callRemovalCompletion() {
     EXPECT_NE(nullptr, remove_listener_completion_);
     remove_listener_completion_();
@@ -200,7 +206,7 @@ public:
   }
 
   // Server::Worker
-  MOCK_METHOD1(addListener, void(Listener& listener));
+  MOCK_METHOD2(addListener, void(Listener& listener, AddListenerCompletion completion));
   MOCK_METHOD0(numConnections, uint64_t());
   MOCK_METHOD2(removeListener, void(Listener& listener, std::function<void()> completion));
   MOCK_METHOD1(start, void(GuardDog& guard_dog));
@@ -208,6 +214,7 @@ public:
   MOCK_METHOD1(stopListener, void(Listener& listener));
   MOCK_METHOD0(stopListeners, void());
 
+  AddListenerCompletion add_listener_completion_;
   std::function<void()> remove_listener_completion_;
 };
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -129,5 +129,6 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -5,6 +5,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -39,6 +40,7 @@ public:
 TEST_F(WorkerImplTest, BasicFlow) {
   InSequence s;
   std::thread::id current_thread_id = std::this_thread::get_id();
+  ConditionalInitializer ci;
 
   // Before a worker is started adding a listener will be posted and will get added when the
   // thread starts running.
@@ -48,9 +50,13 @@ TEST_F(WorkerImplTest, BasicFlow) {
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
       }));
-  worker_.addListener(listener, [](bool success) -> void { EXPECT_TRUE(success); });
+  worker_.addListener(listener, [&ci](bool success) -> void {
+    EXPECT_TRUE(success);
+    ci.setReady();
+  });
 
   worker_.start(guard_dog_);
+  ci.waitReady();
 
   // After a worker is started adding/stopping/removing a listener happens on the worker thread.
   NiceMock<MockListener> listener2;
@@ -59,23 +65,29 @@ TEST_F(WorkerImplTest, BasicFlow) {
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
       }));
-  worker_.addListener(listener2, [](bool success) -> void { EXPECT_TRUE(success); });
+  worker_.addListener(listener2, [&ci](bool success) -> void {
+    EXPECT_TRUE(success);
+    ci.setReady();
+  });
+  ci.waitReady();
 
   EXPECT_CALL(*handler_, stopListeners(2))
-      .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
+      .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
+        ci.setReady();
       }));
   worker_.stopListener(listener2);
+  ci.waitReady();
 
-  ReadyWatcher ready;
   EXPECT_CALL(*handler_, removeListeners(2))
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
       }));
-  EXPECT_CALL(ready, ready()).WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
+  worker_.removeListener(listener2, [current_thread_id, &ci]() -> void {
     EXPECT_NE(current_thread_id, std::this_thread::get_id());
-  }));
-  worker_.removeListener(listener2, [&ready]() -> void { ready.ready(); });
+    ci.setReady();
+  });
+  ci.waitReady();
 
   // Now test adding and removing a listener without stopping it first.
   NiceMock<MockListener> listener3;
@@ -84,16 +96,19 @@ TEST_F(WorkerImplTest, BasicFlow) {
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
       }));
-  worker_.addListener(listener3, [](bool success) -> void { EXPECT_TRUE(success); });
+  worker_.addListener(listener3, [&ci](bool success) -> void {
+    EXPECT_TRUE(success);
+    ci.setReady();
+  });
+  ci.waitReady();
 
   EXPECT_CALL(*handler_, removeListeners(3))
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
       }));
-  EXPECT_CALL(ready, ready()).WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
+  worker_.removeListener(listener3, [current_thread_id]() -> void {
     EXPECT_NE(current_thread_id, std::this_thread::get_id());
-  }));
-  worker_.removeListener(listener3, [&ready]() -> void { ready.ready(); });
+  });
 
   worker_.stop();
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -127,11 +127,13 @@ void ConditionalInitializer::setReady() {
 void ConditionalInitializer::waitReady() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (ready_) {
+    ready_ = false;
     return;
   }
 
   cv_.wait(lock);
   EXPECT_TRUE(ready_);
+  ready_ = false;
 }
 
 ScopedFdCloser::ScopedFdCloser(int fd) : fd_(fd) {}

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -100,8 +100,9 @@ public:
   void setReady();
 
   /**
-   * Block until the conditional is ready, will return immediately if it is already ready.
-   *
+   * Block until the conditional is ready, will return immediately if it is already ready. This
+   * routine will also reset ready_ so that the initializer can be used again. setReady() should
+   * only be called once in between a call to waitReady().
    */
   void waitReady();
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -95,7 +95,7 @@ public:
 class ConditionalInitializer {
 public:
   /**
-   * Set the conditional to ready, should only be called once.
+   * Set the conditional to ready.
    */
   void setReady();
 


### PR DESCRIPTION
This commit properly handles listener creation failures on worker threads.
Specifically, the race condition that can happen between bind() and
listen(). (To be perfectly honest I don't understand how this can happen
at the OS level but we have seen it in practice).

This turned into somewhat of a complicated change. It does the following
things:
1) Add an add listener completion which can tell the listener manager
   if a creation failed. As part of this work, locking was replaced with
   posts inside the listener manager which makes synchronization simpler.
2) The failed listener is removed, in the hope that a future addition
   it might succeed at that point.
3) Listeners are now always added to workers via post.
4) Because of (3), this caused race conditions in the integration tests.
   The integration startup code needed to be refactored so that we now
   wait for all listeners to be up before starting to run the tests.
5) Because of (4) it exposed an issue in the TCP proxy integration test
   with trying to handle a response from the client SSL auth filter which
   happens before the listeners are actually up. To fix this, I removed
   the code in the tests trying to handle client SSL auth filter calls.
   I also replaced all "random" upstream clusters with a host pointing
   at reserved port 4 which should always fail in any reasonable case.
   This still has value in testing startup with failure, but won't block
   startup. If we want to bring back testing of initial startup things
   like SDS, RDS, etc. we will need to revisit how this works but IMO
   this is fine for now.