### PR TITLE
Be specific about format of peer subjects, and use non-deprecated print.

### DIFF
--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -32,8 +32,8 @@ public:
   virtual std::string sha256PeerCertificateDigest() PURE;
 
   /**
-   * @return the subject field of the peer certificate. Returns "" if there is no peer certificate,
-   *         or no subject.
+   * @return the subject field of the peer certificate in RFC 2253 format. Returns "" if there is
+   *         no peer certificate, or no subject.
    **/
   virtual std::string subjectPeerCertificate() PURE;
 

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -263,6 +263,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   int mem_content_rc = BIO_mem_contents(buf.get(), &buf_data, &buf_data_len);
   // It should be impossible for BIO_mem_contents to fail when called with a BIO
   // created using BIO_s_mem().
+  (void) mem_content_rc;
   ASSERT(mem_content_rc == 1);
   return std::string(reinterpret_cast<const char*>(buf_data), buf_data_len);
 }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -263,7 +263,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   int mem_content_rc = BIO_mem_contents(buf.get(), &buf_data, &buf_data_len);
   // It should be impossible for BIO_mem_contents to fail when called with a BIO
   // created using BIO_s_mem().
-  (void) mem_content_rc;
+  (void)mem_content_rc;
   ASSERT(mem_content_rc == 1);
   return std::string(reinterpret_cast<const char*>(buf_data), buf_data_len);
 }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -263,7 +263,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   int mem_content_rc = BIO_mem_contents(buf.get(), &buf_data, &buf_data_len);
   // It should be impossible for BIO_mem_contents to fail when called with a BIO
   // created using BIO_s_mem().
-  (void)mem_content_rc;
+  UNREFERENCED_PARAMETER(mem_content_rc);
   ASSERT(mem_content_rc == 1);
   return std::string(reinterpret_cast<const char*>(buf_data), buf_data_len);
 }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -258,7 +258,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
 
   bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
   X509_NAME_print_ex(buf.get(), X509_get_subject_name(cert.get()), indent, flags);
-  char *buf_data;
+  char* buf_data;
   long buf_data_len = BIO_get_mem_data(buf.get(), &buf_data);
   return std::string(buf_data, buf_data_len);
 }

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -251,8 +251,16 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   if (!cert) {
     return "";
   }
-  bssl::UniquePtr<char> buf(X509_NAME_oneline(X509_get_subject_name(cert.get()), nullptr, 0));
-  return std::string(buf.get());
+
+  // Format settings for a single line in RFC 2253 format.
+  constexpr int indent = 0;
+  constexpr unsigned long flags = XN_FLAG_RFC2253;
+
+  bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
+  X509_NAME_print_ex(buf.get(), X509_get_subject_name(cert.get()), indent, flags);
+  char *buf_data;
+  long buf_data_len = BIO_get_mem_data(buf.get(), &buf_data);
+  return std::string(buf_data, buf_data_len);
 }
 
 std::string ConnectionImpl::uriSanPeerCertificate() {

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -252,7 +252,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
     return "";
   }
 
-  bssl::UniquePtr<BIO> buf(IO_new(BIO_s_mem()));
+  bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
   RELEASE_ASSERT(buf != nullptr);
 
   // [indent=0 flags=XN_FLAG_RFC2253] is the documented set of parameters for

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -264,8 +264,8 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   int rc = BIO_mem_contents(buf.get(), &data, &data_len);
   // It should be impossible for BIO_mem_contents to fail when called with a BIO
   // created using BIO_s_mem().
-  UNREFERENCED_PARAMETER(rc);
   ASSERT(rc == 1);
+  UNREFERENCED_PARAMETER(rc);
   return std::string(reinterpret_cast<const char*>(data), data_len);
 }
 

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -255,15 +255,12 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
   RELEASE_ASSERT(buf != nullptr);
 
-  // [indent=0 flags=XN_FLAG_RFC2253] is the documented set of parameters for
-  // single-line in RFC 2253 format.
+  // flags=XN_FLAG_RFC2253 is the documented parameter for single-line output in RFC 2253 format.
   X509_NAME_print_ex(buf.get(), X509_get_subject_name(cert.get()), 0 /* indent */, XN_FLAG_RFC2253);
 
   const uint8_t* data;
   size_t data_len;
   int rc = BIO_mem_contents(buf.get(), &data, &data_len);
-  // It should be impossible for BIO_mem_contents to fail when called with a BIO
-  // created using BIO_s_mem().
   ASSERT(rc == 1);
   UNREFERENCED_PARAMETER(rc);
   return std::string(reinterpret_cast<const char*>(data), data_len);

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -23,9 +23,9 @@ public:
   const std::string current_xfcc_by_hash_ =
       "By=spiffe://lyft.com/"
       "backend-team;Hash=9ed6533649269c694f717e8729a1c8b55006fd51013c0e0d4294916e00d7ea04";
-  const std::string client_subject_ = "Subject=\"/C=US/ST=California/L=San Francisco/"
-                                      "O=Lyft/OU=Lyft Engineering/CN=Test Frontend Team/"
-                                      "emailAddress=frontend-team@lyft.com\"";
+  const std::string client_subject_ = "Subject=\""
+      "emailAddress=frontend-team@lyft.com,CN=Test Frontend Team,"
+      "OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US\"";
   const std::string client_san_ = "SAN=spiffe://lyft.com/frontend-team";
 
   XfccIntegrationTest() : BaseIntegrationTest(GetParam()) {}

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -23,7 +23,8 @@ public:
   const std::string current_xfcc_by_hash_ =
       "By=spiffe://lyft.com/"
       "backend-team;Hash=9ed6533649269c694f717e8729a1c8b55006fd51013c0e0d4294916e00d7ea04";
-  const std::string client_subject_ = "Subject=\""
+  const std::string client_subject_ =
+      "Subject=\""
       "emailAddress=frontend-team@lyft.com,CN=Test Frontend Team,"
       "OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US\"";
   const std::string client_san_ = "SAN=spiffe://lyft.com/frontend-team";


### PR DESCRIPTION
The previous code was using `X509_NAME_oneline()` to format the peer
certificate's distinguished name. This function is documented as being
deprecated and having no well-specified output format.

This commit uses `X509_NAME_print_ex` instead, and sets the
`XN_FLAG_RFC2253` format flag.