### PR TITLE
redis command splitter refactor

### DIFF
--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -31,6 +31,7 @@ SplitRequestPtr SimpleRequest::create(ConnPool::Instance& conn_pool,
                                                incoming_request, *request_ptr);
   if (!request_ptr->handle_) {
     request_ptr->callbacks_.onResponse(Utility::makeError("no upstream host"));
+    return nullptr;
   }
 
   return std::move(request_ptr);

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -86,6 +86,7 @@ SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
     PendingRequest& pending_request = request_ptr->pending_requests_.back();
 
     single_mget.asArray()[1].asString() = incoming_request.asArray()[i].asString();
+    ENVOY_LOG(debug, "redis: parallel get: '{}'", single_mget.toString());
     pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
                                                     single_mget, pending_request);
     if (!pending_request.handle_) {

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -20,7 +20,7 @@ RespValuePtr Utility::makeError(const std::string& error) {
   response->asString() = error;
   return response;
 }
-  
+
 InstanceImpl::InstanceImpl(ConnPool::InstancePtr&& conn_pool, Stats::Scope& scope,
                            const std::string& stat_prefix)
     : conn_pool_(std::move(conn_pool)), simple_command_handler_(*conn_pool_),

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -20,135 +20,15 @@ RespValuePtr Utility::makeError(const std::string& error) {
   response->asString() = error;
   return response;
 }
-
-SplitRequestPtr AllParamsToOneServerCommandHandler::startRequest(const RespValue& request,
-                                                                 SplitCallbacks& callbacks) {
-  std::unique_ptr<SplitRequestImpl> request_handle(new SplitRequestImpl(callbacks));
-  request_handle->handle_ =
-      conn_pool_.makeRequest(request.asArray()[1].asString(), request, *request_handle);
-  if (!request_handle->handle_) {
-    callbacks.onResponse(Utility::makeError("no upstream host"));
-    return nullptr;
-  }
-
-  return std::move(request_handle);
-}
-
-AllParamsToOneServerCommandHandler::SplitRequestImpl::~SplitRequestImpl() { ASSERT(!handle_); }
-
-void AllParamsToOneServerCommandHandler::SplitRequestImpl::cancel() {
-  handle_->cancel();
-  handle_ = nullptr;
-}
-
-void AllParamsToOneServerCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& response) {
-  handle_ = nullptr;
-  ENVOY_LOG(debug, "redis: response: '{}'", response->toString());
-  callbacks_.onResponse(std::move(response));
-}
-
-void AllParamsToOneServerCommandHandler::SplitRequestImpl::onFailure() {
-  handle_ = nullptr;
-  callbacks_.onResponse(Utility::makeError("upstream failure"));
-}
-
-SplitRequestPtr MGETCommandHandler::startRequest(const RespValue& request,
-                                                 SplitCallbacks& callbacks) {
-  std::unique_ptr<SplitRequestImpl> request_handle(
-      new SplitRequestImpl(callbacks, request.asArray().size() - 1));
-
-  // Create the get request that we will use for each split get below.
-  std::vector<RespValue> values(2);
-  values[0].type(RespType::BulkString);
-  values[0].asString() = "get";
-  values[1].type(RespType::BulkString);
-  RespValue single_mget;
-  single_mget.type(RespType::Array);
-  single_mget.asArray().swap(values);
-
-  for (uint64_t i = 1; i < request.asArray().size(); i++) {
-    request_handle->pending_requests_.emplace_back(*request_handle, i - 1);
-    SplitRequestImpl::PendingRequest& pending_request = request_handle->pending_requests_.back();
-
-    single_mget.asArray()[1].asString() = request.asArray()[i].asString();
-    ENVOY_LOG(debug, "redis: parallel get: '{}'", single_mget.toString());
-    pending_request.handle_ =
-        conn_pool_.makeRequest(request.asArray()[i].asString(), single_mget, pending_request);
-    if (!pending_request.handle_) {
-      pending_request.onResponse(Utility::makeError("no upstream host"));
-    }
-  }
-
-  return request_handle->pending_responses_ > 0 ? std::move(request_handle) : nullptr;
-}
-
-MGETCommandHandler::SplitRequestImpl::SplitRequestImpl(SplitCallbacks& callbacks,
-                                                       uint32_t num_responses)
-    : callbacks_(callbacks), pending_responses_(num_responses) {
-  pending_response_.reset(new RespValue());
-  pending_response_->type(RespType::Array);
-  std::vector<RespValue> responses(num_responses);
-  pending_response_->asArray().swap(responses);
-  pending_requests_.reserve(num_responses);
-}
-
-MGETCommandHandler::SplitRequestImpl::~SplitRequestImpl() {
-#ifndef NDEBUG
-  for (const PendingRequest& request : pending_requests_) {
-    ASSERT(!request.handle_);
-  }
-#endif
-}
-
-void MGETCommandHandler::SplitRequestImpl::cancel() {
-  for (PendingRequest& request : pending_requests_) {
-    if (request.handle_) {
-      request.handle_->cancel();
-      request.handle_ = nullptr;
-    }
-  }
-}
-
-void MGETCommandHandler::SplitRequestImpl::onResponse(RespValuePtr&& value, uint32_t index) {
-  pending_requests_[index].handle_ = nullptr;
-
-  pending_response_->asArray()[index].type(value->type());
-  switch (value->type()) {
-  case RespType::Array:
-  case RespType::Integer: {
-    pending_response_->asArray()[index].type(RespType::Error);
-    pending_response_->asArray()[index].asString() = "upstream protocol error";
-    break;
-  }
-  case RespType::SimpleString:
-  case RespType::BulkString:
-  case RespType::Error: {
-    pending_response_->asArray()[index].asString().swap(value->asString());
-    break;
-  }
-  case RespType::Null:
-    break;
-  }
-
-  ASSERT(pending_responses_ > 0);
-  if (--pending_responses_ == 0) {
-    ENVOY_LOG(debug, "redis: response: '{}'", pending_response_->toString());
-    callbacks_.onResponse(std::move(pending_response_));
-  }
-}
-
-void MGETCommandHandler::SplitRequestImpl::onFailure(uint32_t index) {
-  onResponse(Utility::makeError("upstream failure"), index);
-}
-
+  
 InstanceImpl::InstanceImpl(ConnPool::InstancePtr&& conn_pool, Stats::Scope& scope,
                            const std::string& stat_prefix)
-    : conn_pool_(std::move(conn_pool)), all_to_one_handler_(*conn_pool_),
+    : conn_pool_(std::move(conn_pool)), simple_command_handler_(*conn_pool_),
       mget_handler_(*conn_pool_), stats_{ALL_COMMAND_SPLITTER_STATS(
                                       POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))} {
   // TODO(mattklein123) PERF: Make this a trie (like in header_map_impl).
   for (const std::string& command : SupportedCommands::allToOneCommands()) {
-    addHandler(scope, stat_prefix, command, all_to_one_handler_);
+    addHandler(scope, stat_prefix, command, simple_command_handler_);
   }
 
   // TODO(danielhochman): support for other multi-shard operations (del, mset)
@@ -170,6 +50,7 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
 
   std::string to_lower_string(request.asArray()[0].asString());
   to_lower_table_.toLowerCase(to_lower_string);
+
   auto handler = command_map_.find(to_lower_string);
   if (handler == command_map_.end()) {
     stats_.unsupported_command_.inc();

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -34,6 +34,9 @@ protected:
   ConnPool::Instance& conn_pool_;
 };
 
+/**
+ * SimpleRequest hashes the first argument as the key and sends the request to a single Redis.
+ */
 class SimpleRequest : public SplitRequest, public ConnPool::PoolCallbacks {
 public:
   static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -69,9 +69,6 @@ public:
   static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
                                 SplitCallbacks& callbacks);
 
-  void onChildResponse(RespValuePtr&& value, uint32_t index);
-  void onChildFailure(uint32_t index);
-
   // Redis::CommandSplitter::SplitRequest
   void cancel() override;
 
@@ -91,6 +88,9 @@ private:
     const uint32_t index_;
     ConnPool::PoolRequest* handle_{};
   };
+
+  void onChildResponse(RespValuePtr&& value, uint32_t index);
+  void onChildFailure(uint32_t index);
 
   SplitCallbacks& callbacks_;
   RespValuePtr pending_response_;

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -35,135 +35,138 @@ protected:
 };
 
 class SimpleRequest : public SplitRequest, public ConnPool::PoolCallbacks {
-  public:
-    SimpleRequest(ConnPool::Instance& conn_pool, const RespValue& request, SplitCallbacks& callbacks) : callbacks_(callbacks) {
-      handle_ = conn_pool.makeRequest(request.asArray()[1].asString(), request, *this);
+public:
+  SimpleRequest(ConnPool::Instance& conn_pool, const RespValue& request, SplitCallbacks& callbacks)
+      : callbacks_(callbacks) {
+    handle_ = conn_pool.makeRequest(request.asArray()[1].asString(), request, *this);
 
-      if (!handle_) {
-        callbacks_.onResponse(Utility::makeError("no upstream host"));
-      }
+    if (!handle_) {
+      callbacks_.onResponse(Utility::makeError("no upstream host"));
     }
+  }
 
-    void onResponse(RespValuePtr&& response) {
-      handle_ = nullptr;
-      callbacks_.onResponse(std::move(response));
-    }
+  void onResponse(RespValuePtr&& response) {
+    handle_ = nullptr;
+    callbacks_.onResponse(std::move(response));
+  }
 
-    void onFailure() {
-      handle_ = nullptr;
-      callbacks_.onResponse(Utility::makeError("upstream failure"));
-    }
+  void onFailure() {
+    handle_ = nullptr;
+    callbacks_.onResponse(Utility::makeError("upstream failure"));
+  }
 
-    void cancel() {
-      handle_->cancel();
-      handle_ = nullptr;
-    }
+  void cancel() {
+    handle_->cancel();
+    handle_ = nullptr;
+  }
 
-  private:
-    SplitCallbacks& callbacks_;
-    ConnPool::PoolRequest* handle_{};
+private:
+  SplitCallbacks& callbacks_;
+  ConnPool::PoolRequest* handle_{};
 };
 
 class MGETRequest : public SplitRequest {
-  public:
-    MGETRequest(ConnPool::Instance& conn_pool, const RespValue& request, SplitCallbacks& callbacks) : callbacks_(callbacks) {
-      num_pending_responses_ = request.asArray().size() - 1;
+public:
+  MGETRequest(ConnPool::Instance& conn_pool, const RespValue& request, SplitCallbacks& callbacks)
+      : callbacks_(callbacks) {
+    num_pending_responses_ = request.asArray().size() - 1;
 
-      pending_response_.reset(new RespValue());
-      pending_response_->type(RespType::Array);
-      std::vector<RespValue> responses(num_pending_responses_);
-      pending_response_->asArray().swap(responses);
-      pending_requests_.reserve(num_pending_responses_);
+    pending_response_.reset(new RespValue());
+    pending_response_->type(RespType::Array);
+    std::vector<RespValue> responses(num_pending_responses_);
+    pending_response_->asArray().swap(responses);
+    pending_requests_.reserve(num_pending_responses_);
 
-      std::vector<RespValue> values(2);
-      values[0].type(RespType::BulkString);
-      values[0].asString() = "get";
-      values[1].type(RespType::BulkString);
-      RespValue single_mget;
-      single_mget.type(RespType::Array);
-      single_mget.asArray().swap(values);
+    std::vector<RespValue> values(2);
+    values[0].type(RespType::BulkString);
+    values[0].asString() = "get";
+    values[1].type(RespType::BulkString);
+    RespValue single_mget;
+    single_mget.type(RespType::Array);
+    single_mget.asArray().swap(values);
 
-      for (uint64_t i = 1; i < request.asArray().size(); i++) {
-        pending_requests_.emplace_back(*this, i - 1);
-        PendingRequest& pending_request = pending_requests_.back();
+    for (uint64_t i = 1; i < request.asArray().size(); i++) {
+      pending_requests_.emplace_back(*this, i - 1);
+      PendingRequest& pending_request = pending_requests_.back();
 
-        single_mget.asArray()[1].asString() = request.asArray()[i].asString();
-        pending_request.handle_ = conn_pool.makeRequest(request.asArray()[i].asString(), single_mget, pending_request);
-        if (!pending_request.handle_) {
-           pending_request.onResponse(Utility::makeError("no upstream host"));
-        }
+      single_mget.asArray()[1].asString() = request.asArray()[i].asString();
+      pending_request.handle_ =
+          conn_pool.makeRequest(request.asArray()[i].asString(), single_mget, pending_request);
+      if (!pending_request.handle_) {
+        pending_request.onResponse(Utility::makeError("no upstream host"));
       }
     }
+  }
 
-    void onChildResponse(RespValuePtr&& value, uint32_t index) {
-      pending_requests_[index].handle_ = nullptr;
+  void onChildResponse(RespValuePtr&& value, uint32_t index) {
+    pending_requests_[index].handle_ = nullptr;
 
-      pending_response_->asArray()[index].type(value->type());
-      switch (value->type()) {
-      case RespType::Array:
-      case RespType::Integer: {
-        pending_response_->asArray()[index].type(RespType::Error);
-        pending_response_->asArray()[index].asString() = "upstream protocol error";
-        break;
-      }
-      case RespType::SimpleString:
-      case RespType::BulkString:
-      case RespType::Error: {
-        pending_response_->asArray()[index].asString().swap(value->asString());
-        break;
-      }
-      case RespType::Null:
-        break;
-      }
-
-      // ASSERT(num_pending_responses_ > 0);
-      if (--num_pending_responses_ == 0) {
-        // ENVOY_LOG(debug, "redis: response: '{}'", pending_response_->toString());
-        callbacks_.onResponse(std::move(pending_response_));
-      }
+    pending_response_->asArray()[index].type(value->type());
+    switch (value->type()) {
+    case RespType::Array:
+    case RespType::Integer: {
+      pending_response_->asArray()[index].type(RespType::Error);
+      pending_response_->asArray()[index].asString() = "upstream protocol error";
+      break;
+    }
+    case RespType::SimpleString:
+    case RespType::BulkString:
+    case RespType::Error: {
+      pending_response_->asArray()[index].asString().swap(value->asString());
+      break;
+    }
+    case RespType::Null:
+      break;
     }
 
-    void onChildFailure(uint32_t index) {
-      onChildResponse(Utility::makeError("upstream failure"), index);
+    // ASSERT(num_pending_responses_ > 0);
+    if (--num_pending_responses_ == 0) {
+      // ENVOY_LOG(debug, "redis: response: '{}'", pending_response_->toString());
+      callbacks_.onResponse(std::move(pending_response_));
     }
+  }
 
-    void cancel() override {
-      for (PendingRequest& request : pending_requests_) {
-        if (request.handle_) {
-          request.handle_->cancel();
-          request.handle_ = nullptr;
-        }
+  void onChildFailure(uint32_t index) {
+    onChildResponse(Utility::makeError("upstream failure"), index);
+  }
+
+  void cancel() override {
+    for (PendingRequest& request : pending_requests_) {
+      if (request.handle_) {
+        request.handle_->cancel();
+        request.handle_ = nullptr;
       }
     }
+  }
 
-  private:
-    struct PendingRequest : public ConnPool::PoolCallbacks {
-      PendingRequest(MGETRequest& parent, uint32_t index) : parent_(parent), index_(index) {}
+private:
+  struct PendingRequest : public ConnPool::PoolCallbacks {
+    PendingRequest(MGETRequest& parent, uint32_t index) : parent_(parent), index_(index) {}
 
-      void onResponse(RespValuePtr&& value) override {
-        parent_.onChildResponse(std::move(value), index_);
-      }
-      void onFailure() override { parent_.onChildFailure(index_); }
+    void onResponse(RespValuePtr&& value) override {
+      parent_.onChildResponse(std::move(value), index_);
+    }
+    void onFailure() override { parent_.onChildFailure(index_); }
 
-      MGETRequest& parent_;
-      const uint32_t index_;
-      ConnPool::PoolRequest* handle_{};
-    };
+    MGETRequest& parent_;
+    const uint32_t index_;
+    ConnPool::PoolRequest* handle_{};
+  };
 
-    SplitCallbacks& callbacks_;
-    RespValuePtr pending_response_;
-    std::vector<PendingRequest> pending_requests_;
-    uint32_t num_pending_responses_;
+  SplitCallbacks& callbacks_;
+  RespValuePtr pending_response_;
+  std::vector<PendingRequest> pending_requests_;
+  uint32_t num_pending_responses_;
 };
 
 template <class RequestClass>
 class CommandHandlerFactory : public CommandHandler, CommandHandlerBase {
-  public:
-    CommandHandlerFactory(ConnPool::Instance& conn_pool) : CommandHandlerBase(conn_pool) {}
-    SplitRequestPtr startRequest(const RespValue& request, SplitCallbacks& callbacks) {
-      return SplitRequestPtr{new RequestClass(conn_pool_, request, callbacks)};
-      // return RequestClass::create(conn_pool_, request, callbacks); 
-    }
+public:
+  CommandHandlerFactory(ConnPool::Instance& conn_pool) : CommandHandlerBase(conn_pool) {}
+  SplitRequestPtr startRequest(const RespValue& request, SplitCallbacks& callbacks) {
+    return SplitRequestPtr{new RequestClass(conn_pool_, request, callbacks)};
+    // return RequestClass::create(conn_pool_, request, callbacks);
+  }
 };
 
 /**

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -45,6 +45,13 @@ public:
     }
   }
 
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+                                SplitCallbacks& callbacks) {
+    SplitRequestPtr request_ptr =
+        SplitRequestPtr{new SimpleRequest(conn_pool, incoming_request, callbacks)};
+    return request_ptr;
+  }
+
   void onResponse(RespValuePtr&& response) {
     handle_ = nullptr;
     callbacks_.onResponse(std::move(response));
@@ -96,6 +103,13 @@ public:
         pending_request.onResponse(Utility::makeError("no upstream host"));
       }
     }
+  }
+
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+                                SplitCallbacks& callbacks) {
+    SplitRequestPtr request_ptr =
+        SplitRequestPtr{new MGETRequest(conn_pool, incoming_request, callbacks)};
+    return request_ptr;
   }
 
   void onChildResponse(RespValuePtr&& value, uint32_t index) {
@@ -164,8 +178,7 @@ class CommandHandlerFactory : public CommandHandler, CommandHandlerBase {
 public:
   CommandHandlerFactory(ConnPool::Instance& conn_pool) : CommandHandlerBase(conn_pool) {}
   SplitRequestPtr startRequest(const RespValue& request, SplitCallbacks& callbacks) {
-    return SplitRequestPtr{new RequestClass(conn_pool_, request, callbacks)};
-    // return RequestClass::create(conn_pool_, request, callbacks);
+    return RequestClass::create(conn_pool_, request, callbacks);
   }
 };
 

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -95,9 +95,8 @@ TEST_F(RedisCommandSplitterImplTest, UnsupportedCommand) {
   EXPECT_EQ(1UL, store_.counter("redis.foo.splitter.unsupported_command").value());
 }
 
-class RedisAllParamsToOneServerCommandHandlerTest
-    : public RedisCommandSplitterImplTest,
-      public testing::WithParamInterface<std::string> {
+class RedisSimpleRequestCommandHandlerTest : public RedisCommandSplitterImplTest,
+                                             public testing::WithParamInterface<std::string> {
 public:
   void makeRequest(const std::string& hash_key, const RespValue& request) {
     EXPECT_CALL(*conn_pool_, makeRequest(hash_key, Ref(request), _))
@@ -124,7 +123,7 @@ public:
   ConnPool::MockPoolRequest pool_request_;
 };
 
-TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Success) {
+TEST_P(RedisSimpleRequestCommandHandlerTest, Success) {
   InSequence s;
 
   RespValue request;
@@ -141,7 +140,7 @@ TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Success) {
   EXPECT_EQ(1UL, store_.counter(fmt::format("redis.foo.command.{}.total", lower_command)).value());
 };
 
-TEST_P(RedisAllParamsToOneServerCommandHandlerTest, SuccessMultipleArgs) {
+TEST_P(RedisSimpleRequestCommandHandlerTest, SuccessMultipleArgs) {
   InSequence s;
 
   RespValue request;
@@ -158,7 +157,7 @@ TEST_P(RedisAllParamsToOneServerCommandHandlerTest, SuccessMultipleArgs) {
   EXPECT_EQ(1UL, store_.counter(fmt::format("redis.foo.command.{}.total", lower_command)).value());
 };
 
-TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Fail) {
+TEST_P(RedisSimpleRequestCommandHandlerTest, Fail) {
   InSequence s;
 
   RespValue request;
@@ -169,7 +168,7 @@ TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Fail) {
   fail();
 };
 
-TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Cancel) {
+TEST_P(RedisSimpleRequestCommandHandlerTest, Cancel) {
   InSequence s;
 
   RespValue request;
@@ -181,7 +180,7 @@ TEST_P(RedisAllParamsToOneServerCommandHandlerTest, Cancel) {
   handle_->cancel();
 };
 
-TEST_P(RedisAllParamsToOneServerCommandHandlerTest, NoUpstream) {
+TEST_P(RedisSimpleRequestCommandHandlerTest, NoUpstream) {
   InSequence s;
 
   RespValue request;
@@ -195,13 +194,11 @@ TEST_P(RedisAllParamsToOneServerCommandHandlerTest, NoUpstream) {
   EXPECT_EQ(nullptr, handle_);
 };
 
-INSTANTIATE_TEST_CASE_P(RedisAllParamsToOneServerCommandHandlerTest,
-                        RedisAllParamsToOneServerCommandHandlerTest,
+INSTANTIATE_TEST_CASE_P(RedisSimpleRequestCommandHandlerTest, RedisSimpleRequestCommandHandlerTest,
                         testing::ValuesIn(SupportedCommands::allToOneCommands()));
 
-INSTANTIATE_TEST_CASE_P(RedisAllParamsToOneServerCommandHandlerMixedCaseTests,
-                        RedisAllParamsToOneServerCommandHandlerTest,
-                        testing::Values("INCR", "inCrBY"));
+INSTANTIATE_TEST_CASE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
+                        RedisSimpleRequestCommandHandlerTest, testing::Values("INCR", "inCrBY"));
 
 class RedisMGETCommandHandlerTest : public RedisCommandSplitterImplTest {
 public:


### PR DESCRIPTION
This is a refactor to move logic from the handler into the request. This will make it possible to create an abstract base class for fragmented commands (`MGET` + `MSET`, `DEL`, `EXISTS`, `TOUCH`, etc) to share some of the splitting logic.