### PR TITLE
http: fix segfault discovered during Lyft's smoketest of #1267.

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -206,7 +206,8 @@ public:
    * sure that any async events are cleaned up in the context of this routine. This includes timers,
    * network calls, etc. The reason there is an onDestroy() method vs. doing this type of cleanup
    * in the destructor is due to the deferred deletion model that Envoy uses to avoid stack unwind
-   * complications.
+   * complications. Filters must not invoke either encoder or decoder filter callbacks after having
+   * onDestroy() invoked.
    */
   virtual void onDestroy() PURE;
 };
@@ -240,7 +241,7 @@ public:
 
   /**
    * Called by the filter manager once to initialize the filter decoder callbacks that the
-   * filter should use.
+   * filter should use. Callbacks will not be invoked by the filter after onDestroy() is called.
    */
   virtual void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) PURE;
 };
@@ -320,7 +321,7 @@ public:
 
   /**
    * Called by the filter manager once to initialize the filter callbacks that the filter should
-   * use.
+   * use. Callbacks will not be invoked by the filter after onDestroy() is called.
    */
   virtual void setEncoderFilterCallbacks(StreamEncoderFilterCallbacks& callbacks) PURE;
 };

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -214,7 +214,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::HeaderMap& h
     if (!request_status.ok()) {
       ENVOY_LOG(debug, "Transcoding request error " + request_status.ToString());
       error_ = true;
-      Http::Utility::sendLocalReply(*decoder_callbacks_, Http::Code::BadRequest,
+      Http::Utility::sendLocalReply(*decoder_callbacks_, stream_reset_, Http::Code::BadRequest,
                                     request_status.error_message().ToString());
 
       return Http::FilterHeadersStatus::StopIteration;
@@ -250,7 +250,7 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
   if (!request_status.ok()) {
     ENVOY_LOG(debug, "Transcoding request error " + request_status.ToString());
     error_ = true;
-    Http::Utility::sendLocalReply(*decoder_callbacks_, Http::Code::BadRequest,
+    Http::Utility::sendLocalReply(*decoder_callbacks_, stream_reset_, Http::Code::BadRequest,
                                   request_status.error_message().ToString());
 
     return Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/common/grpc/json_transcoder_filter.h
+++ b/source/common/grpc/json_transcoder_filter.h
@@ -96,7 +96,7 @@ public:
   void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override;
 
   // Http::StreamFilterBase
-  void onDestroy() override {}
+  void onDestroy() override { stream_reset_ = true; }
 
 private:
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
@@ -111,6 +111,7 @@ private:
   Http::HeaderMap* response_headers_{nullptr};
 
   bool error_{false};
+  bool stream_reset_{false};
 };
 
 } // namespace Grpc

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -79,7 +79,7 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
       },
       nullptr);
 #endif
-
+  ASSERT(!remote_closed_);
   stream_callbacks_.onHeaders(std::move(headers), end_stream);
   closeRemote(end_stream);
 }
@@ -87,18 +87,7 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
   ENVOY_LOG(trace, "async http request response data (length={} end_stream={})", data.length(),
             end_stream);
-  // It's possible we have been reset by the client but the router is still
-  // sending data on its way out. This happens for example when
-  // Utility::sendLocalReply() tells the gRPC async client that it has a non-200
-  // via encodeHeaders(), gRPC async client resets the HTTP async stream but on
-  // return to Utility::sendLocalReply() it unconditionally sends a body with
-  // encodeData().
-  // TODO(htuch): This is the only case we catch today, but conceivably we could
-  // see encodeTrailers() as well (or encodeHeaders()?) from router on its way
-  // out.
-  if (remote_closed_) {
-    return;
-  }
+  ASSERT(!remote_closed_);
   stream_callbacks_.onData(data, end_stream);
   closeRemote(end_stream);
 }
@@ -112,7 +101,7 @@ void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
       },
       nullptr);
 #endif
-
+  ASSERT(!remote_closed_);
   stream_callbacks_.onTrailers(std::move(trailers));
   closeRemote(true);
 }
@@ -156,9 +145,6 @@ void AsyncStreamImpl::reset() {
 }
 
 void AsyncStreamImpl::cleanup() {
-  // While deletion may be deferred below, the caller may have decided that its contract with the
-  // HTTP async stream is over and not expect further callbacks. We need to make sure that the
-  // stream is closed if we continue to receive callbacks.
   local_closed_ = remote_closed_ = true;
   // This will destroy us, but only do so if we are actually in a list. This does not happen in
   // the immediate failure case.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -79,9 +79,6 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
       },
       nullptr);
 #endif
-  if (remote_closed_) {
-    return;
-  }
 
   stream_callbacks_.onHeaders(std::move(headers), end_stream);
   closeRemote(end_stream);

--- a/source/common/http/filter/buffer_filter.cc
+++ b/source/common/http/filter/buffer_filter.cc
@@ -38,6 +38,7 @@ FilterDataStatus BufferFilter::decodeData(Buffer::Instance&, bool end_stream) {
     return FilterDataStatus::Continue;
   } else if (callbacks_->decodingBuffer() &&
              callbacks_->decodingBuffer()->length() > config_->max_request_bytes_) {
+    // TODO(htuch): Switch this to Utility::sendLocalReply().
     Http::HeaderMapPtr response_headers{new HeaderMapImpl{
         {Headers::get().Status, std::to_string(enumToInt(Http::Code::PayloadTooLarge))}}};
     callbacks_->encodeHeaders(std::move(response_headers), true);
@@ -60,6 +61,7 @@ BufferFilterStats BufferFilter::generateStats(const std::string& prefix, Stats::
 void BufferFilter::onDestroy() { resetInternalState(); }
 
 void BufferFilter::onRequestTimeout() {
+  // TODO(htuch): Switch this to Utility::sendLocalReply().
   Http::HeaderMapPtr response_headers{new HeaderMapImpl{
       {Headers::get().Status, std::to_string(enumToInt(Http::Code::RequestTimeout))}}};
   callbacks_->encodeHeaders(std::move(response_headers), true);

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -238,6 +238,7 @@ void FaultFilter::postDelayInjection() {
 }
 
 void FaultFilter::abortWithHTTPStatus() {
+  // TODO(htuch): Switch this to Utility::sendLocalReply().
   Http::HeaderMapPtr response_headers{
       new HeaderMapImpl{{Headers::get().Status, abortHttpStatus()}}};
   callbacks_->encodeHeaders(std::move(response_headers), true);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -196,6 +196,8 @@ void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, Code respo
   callbacks.encodeHeaders(std::move(response_headers), body_text.empty());
   if (!body_text.empty()) {
     Buffer::OwnedImpl buffer(body_text);
+    // TODO(htuch): We shouldn't encodeData() if the stream is reset in the encodeHeaders() above,
+    // see https://github.com/lyft/envoy/issues/1283.
     callbacks.encodeData(buffer, true);
   }
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -184,8 +184,8 @@ Http2Settings Utility::parseHttp2Settings(const Json::Object& config) {
   return ret;
 }
 
-void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, Code response_code,
-                             const std::string& body_text) {
+void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, bool& is_reset,
+                             Code response_code, const std::string& body_text) {
   HeaderMapPtr response_headers{
       new HeaderMapImpl{{Headers::get().Status, std::to_string(enumToInt(response_code))}}};
   if (!body_text.empty()) {
@@ -194,7 +194,7 @@ void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, Code respo
   }
 
   callbacks.encodeHeaders(std::move(response_headers), body_text.empty());
-  if (!body_text.empty()) {
+  if (!body_text.empty() && !is_reset) {
     Buffer::OwnedImpl buffer(body_text);
     // TODO(htuch): We shouldn't encodeData() if the stream is reset in the encodeHeaders() above,
     // see https://github.com/lyft/envoy/issues/1283.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -184,7 +184,7 @@ Http2Settings Utility::parseHttp2Settings(const Json::Object& config) {
   return ret;
 }
 
-void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, bool& is_reset,
+void Utility::sendLocalReply(StreamDecoderFilterCallbacks& callbacks, const bool& is_reset,
                              Code response_code, const std::string& body_text) {
   HeaderMapPtr response_headers{
       new HeaderMapImpl{{Headers::get().Status, std::to_string(enumToInt(response_code))}}};

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -87,7 +87,7 @@ public:
    * @param body_text supplies the optional body text which is sent using the text/plain content
    *                  type.
    */
-  static void sendLocalReply(StreamDecoderFilterCallbacks& callbacks, bool& is_reset,
+  static void sendLocalReply(StreamDecoderFilterCallbacks& callbacks, const bool& is_reset,
                              Code response_code, const std::string& body_text);
 
   /**

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -80,12 +80,15 @@ public:
   /**
    * Create a locally generated response using filter callbacks.
    * @param callbacks supplies the filter callbacks to use.
+   * @param is_reset boolean reference that indicates whether a stream has been reset. It is the
+   *                 responsibility of the caller to ensure that this is set to false if onDestroy()
+   *                 is invoked in the context of sendLocalReply().
    * @param response_code supplies the HTTP response code.
    * @param body_text supplies the optional body text which is sent using the text/plain content
    *                  type.
    */
-  static void sendLocalReply(StreamDecoderFilterCallbacks& callbacks, Code response_code,
-                             const std::string& body_text);
+  static void sendLocalReply(StreamDecoderFilterCallbacks& callbacks, bool& is_reset,
+                             Code response_code, const std::string& body_text);
 
   /**
    * Send a redirect response (301).

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -232,6 +232,7 @@ private:
   Http::HeaderMap* downstream_trailers_{};
   MonotonicTime downstream_request_complete_time_;
   std::unique_ptr<LoadBalancerContextImpl> lb_context_;
+  bool stream_destroyed_{};
 
   bool downstream_response_started_ : 1;
   bool downstream_end_stream_ : 1;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -532,13 +532,9 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
-  // This is similar to what Http::Utility::sendLocalReply() does, we don't need
-  // this behavior when https://github.com/lyft/envoy/issues/1283 is resolved.
-  // TODO(htuch): Remove the encodeData() below when #1283 is resolved.
   Http::StreamDecoderFilterCallbacks* filter_callbacks =
       static_cast<Http::AsyncStreamImpl*>(stream);
   filter_callbacks->encodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
-  filter_callbacks->encodeData(*body, false);
 }
 
 TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -499,6 +499,48 @@ TEST_F(AsyncClientImplTest, LocalResetAfterStreamStart) {
   stream->reset();
 }
 
+// Validate behavior when the stream's onHeaders() callback performs a stream
+// reset.
+TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
+
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](StreamDecoder&,
+                           ConnectionPool::Callbacks& callbacks) -> ConnectionPool::Cancellable* {
+        callbacks.onPoolReady(stream_encoder_, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+
+  TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.addViaCopy("x-envoy-internal", "true");
+  headers.addViaCopy("x-forwarded-for", "127.0.0.1");
+  headers.addViaCopy(":scheme", "http");
+
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), false));
+
+  AsyncClient::Stream* stream =
+      client_.start(stream_callbacks_, Optional<std::chrono::milliseconds>());
+
+  TestHeaderMapImpl expected_headers{{":status", "200"}};
+  EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_headers), false))
+      .WillOnce(Invoke([&stream](HeaderMap&, bool) { stream->reset(); }));
+  EXPECT_CALL(stream_callbacks_, onData(_, _)).Times(0);
+  EXPECT_CALL(stream_callbacks_, onReset());
+
+  stream->sendHeaders(headers, false);
+  stream->sendData(*body, false);
+
+  // This is similar to what Http::Utility::sendLocalReply() does, we don't need
+  // this behavior when https://github.com/lyft/envoy/issues/1283 is resolved.
+  // TODO(htuch): Remove the encodeData() below when #1283 is resolved.
+  Http::StreamDecoderFilterCallbacks* filter_callbacks =
+      static_cast<Http::AsyncStreamImpl*>(stream);
+  filter_callbacks->encodeHeaders(HeaderMapPtr(new TestHeaderMapImpl{{":status", "200"}}), false);
+  filter_callbacks->encodeData(*body, false);
+}
+
 TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {
   Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
 


### PR DESCRIPTION
Turns out that a sendLocalReply() will unconditionally send a body after errors such as 504, gRPC
client performs a reset before this and had self-destructed already.