### PR TITLE
http/grpc: fix deferred delete race.

### DIFF
--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
     deps = [
         ":message_interface",
         "//include/envoy/common:optional",
+        "//include/envoy/event:dispatcher_interface",
     ],
 )
 

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "envoy/common/optional.h"
+#include "envoy/event/dispatcher.h"
 #include "envoy/http/message.h"
 
 namespace Envoy {
@@ -152,6 +153,11 @@ public:
    */
   virtual Stream* start(StreamCallbacks& callbacks,
                         const Optional<std::chrono::milliseconds>& timeout) PURE;
+
+  /**
+   * @return Event::Dispatcher& the dispatcher backing this client.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
 };
 
 typedef std::unique_ptr<AsyncClient> AsyncClientPtr;

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -9,6 +9,8 @@
 namespace Envoy {
 namespace Thread {
 
+typedef int32_t ThreadId;
+
 /**
  * Wrapper for a pthread thread. We don't use std::thread because it eats exceptions and leads to
  * unusable stack traces.
@@ -20,7 +22,7 @@ public:
   /**
    * Get current thread id.
    */
-  static int32_t currentThreadId();
+  static ThreadId currentThreadId();
 
   /**
    * Join on thread exit.

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -26,7 +26,7 @@ public:
             std::unique_ptr<Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
                                                   envoy::api::v2::DiscoveryResponse>>(
                 new Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
-                                          envoy::api::v2::DiscoveryResponse>(cm, dispatcher,
+                                          envoy::api::v2::DiscoveryResponse>(cm,
                                                                              remote_cluster_name)),
             dispatcher, service_method, stats) {}
 

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -50,6 +50,7 @@ envoy_cc_library(
         "//include/envoy/event:file_event_interface",
         "//include/envoy/network:connection_handler_interface",
         "//source/common/common:logger_lib",
+        "//source/common/common:thread_lib",
     ],
 )
 

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -61,6 +61,14 @@ public:
 
 private:
   void runPostCallbacks();
+#ifndef NDEBUG
+  // Validate that an operation is thread safe, i.e. it's invoked on the same thread that the
+  // dispatcher run loop is executing on. We allow run_tid_ == 0 for tests where we don't invoke
+  // run().
+  bool isThreadSafe() const {
+    return run_tid_ == 0 || run_tid_ == Thread::Thread::currentThreadId();
+  }
+#endif
 
   Buffer::FactoryPtr buffer_factory_;
   Libevent::BasePtr base_;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/network/connection_handler.h"
 
 #include "common/common/logger.h"
+#include "common/common/thread.h"
 #include "common/event/libevent.h"
 
 namespace Envoy {
@@ -71,6 +72,7 @@ private:
   std::mutex post_lock_;
   std::list<std::function<void()>> post_callbacks_;
   bool deferred_deleting_{};
+  Thread::ThreadId run_tid_{};
 };
 
 } // namespace Event

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -48,6 +48,8 @@ public:
   Stream* start(StreamCallbacks& callbacks,
                 const Optional<std::chrono::milliseconds>& timeout) override;
 
+  Event::Dispatcher& dispatcher() override { return dispatcher_; }
+
 private:
   const Upstream::ClusterInfo& cluster_;
   Router::FilterConfig config_;

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -85,9 +85,8 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status) {
   callbacks_ = nullptr;
 }
 
-GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm,
-                                 Event::Dispatcher& dispatcher)
-    : cluster_name_(config.getString("cluster_name")), cm_(cm), dispatcher_(dispatcher) {
+GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm)
+    : cluster_name_(config.getString("cluster_name")), cm_(cm) {
   if (!cm_.get(cluster_name_)) {
     throw EnvoyException(fmt::format("unknown rate limit service cluster '{}'", cluster_name_));
   }
@@ -95,9 +94,9 @@ GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterMa
 
 ClientPtr GrpcFactoryImpl::create(const Optional<std::chrono::milliseconds>& timeout) {
   return ClientPtr{new GrpcClientImpl(
-      RateLimitAsyncClientPtr{new Grpc::AsyncClientImpl<pb::lyft::ratelimit::RateLimitRequest,
-                                                        pb::lyft::ratelimit::RateLimitResponse>(
-          cm_, dispatcher_, cluster_name_)},
+      RateLimitAsyncClientPtr{
+          new Grpc::AsyncClientImpl<pb::lyft::ratelimit::RateLimitRequest,
+                                    pb::lyft::ratelimit::RateLimitResponse>(cm_, cluster_name_)},
       timeout)};
 }
 

--- a/source/common/ratelimit/ratelimit_impl.h
+++ b/source/common/ratelimit/ratelimit_impl.h
@@ -57,8 +57,7 @@ private:
 
 class GrpcFactoryImpl : public ClientFactory {
 public:
-  GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm,
-                  Event::Dispatcher& dispatcher);
+  GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm);
 
   // RateLimit::ClientFactory
   ClientPtr create(const Optional<std::chrono::milliseconds>& timeout) override;
@@ -66,7 +65,6 @@ public:
 private:
   const std::string cluster_name_;
   Upstream::ClusterManager& cm_;
-  Event::Dispatcher& dispatcher_;
 };
 
 class NullClientImpl : public Client {

--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:async_client_interface",
         "//include/envoy/http:message_interface",
+        "//source/common/common:assert_lib",
     ],
 )
 

--- a/source/server/config_validation/async_client.h
+++ b/source/server/config_validation/async_client.h
@@ -5,6 +5,8 @@
 #include "envoy/http/async_client.h"
 #include "envoy/http/message.h"
 
+#include "common/common/assert.h"
+
 namespace Envoy {
 namespace Http {
 
@@ -19,6 +21,7 @@ public:
   AsyncClient::Request* send(MessagePtr&&, Callbacks&,
                              const Optional<std::chrono::milliseconds>&) override;
   AsyncClient::Stream* start(StreamCallbacks&, const Optional<std::chrono::milliseconds>&) override;
+  Event::Dispatcher& dispatcher() override { NOT_IMPLEMENTED; }
 };
 
 } // namespace Http

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -90,7 +90,7 @@ void MainImpl::initialize(const Json::Object& json, Instance& server,
     ASSERT(type == "grpc_service");
     UNREFERENCED_PARAMETER(type);
     ratelimit_client_factory_.reset(new RateLimit::GrpcFactoryImpl(
-        *rate_limit_service_config->getObject("config"), *cluster_manager_, server.dispatcher()));
+        *rate_limit_service_config->getObject("config"), *cluster_manager_));
   } else {
     ratelimit_client_factory_.reset(new RateLimit::NullFactoryImpl());
   }

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -113,7 +113,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   api_config_source->set_api_type(envoy::api::v2::ApiConfigSource::GRPC);
   api_config_source->add_cluster_name("eds_cluster");
   EXPECT_CALL(dispatcher_, createTimer_(_));
-  EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster")).Times(2);
+  EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
   NiceMock<Http::MockAsyncClientStream> stream;
   EXPECT_CALL(cm_.async_client_, start(_, _)).WillOnce(Return(&stream));
   Http::TestHeaderMapImpl headers{

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -113,7 +113,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   api_config_source->set_api_type(envoy::api::v2::ApiConfigSource::GRPC);
   api_config_source->add_cluster_name("eds_cluster");
   EXPECT_CALL(dispatcher_, createTimer_(_));
-  EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
+  EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster")).Times(2);
   NiceMock<Http::MockAsyncClientStream> stream;
   EXPECT_CALL(cm_.async_client_, start(_, _)).WillOnce(Return(&stream));
   Http::TestHeaderMapImpl headers{
@@ -122,7 +122,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
       {":authority", "eds_cluster"},
       {"content-type", "application/grpc"}};
   EXPECT_CALL(stream, sendHeaders(HeaderMapEqualRef(&headers), _));
-  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  EXPECT_CALL(cm_.async_client_.dispatcher_, deferredDelete_(_));
   subscriptionFromConfigSource(config)->start({"foo"}, callbacks_);
 }
 

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -14,7 +14,6 @@ envoy_cc_test(
     deps = [
         "//source/common/grpc:async_client_lib",
         "//test/mocks/buffer:buffer_mocks",
-        "//test/mocks/event:event_mocks",
         "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -1,7 +1,6 @@
 #include "common/grpc/async_client_impl.h"
 
 #include "test/mocks/buffer/mocks.h"
-#include "test/mocks/event/mocks.h"
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -157,7 +156,7 @@ public:
   GrpcAsyncClientImplTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
         grpc_client_(new AsyncClientImpl<helloworld::HelloRequest, helloworld::HelloReply>(
-            cm_, dispatcher_, "test_cluster")) {
+            cm_, "test_cluster")) {
     ON_CALL(cm_, httpAsyncClientForCluster("test_cluster")).WillByDefault(ReturnRef(http_client_));
   }
 
@@ -255,7 +254,6 @@ public:
   const Protobuf::MethodDescriptor* method_descriptor_;
   NiceMock<Http::MockAsyncClient> http_client_;
   NiceMock<Upstream::MockClusterManager> cm_;
-  NiceMock<Event::MockDispatcher> dispatcher_;
   std::unique_ptr<AsyncClientImpl<helloworld::HelloRequest, helloworld::HelloReply>> grpc_client_;
 };
 

--- a/test/common/ratelimit/BUILD
+++ b/test/common/ratelimit/BUILD
@@ -15,7 +15,6 @@ envoy_cc_test(
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/ratelimit:ratelimit_lib",
-        "//test/mocks/event:event_mocks",
         "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -6,7 +6,6 @@
 #include "common/http/headers.h"
 #include "common/ratelimit/ratelimit_impl.h"
 
-#include "test/mocks/event/mocks.h"
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/printers.h"
@@ -129,10 +128,9 @@ TEST(RateLimitGrpcFactoryTest, NoCluster) {
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
   Upstream::MockClusterManager cm;
-  Event::MockDispatcher dispatcher;
 
   EXPECT_CALL(cm, get("foo")).WillOnce(Return(nullptr));
-  EXPECT_THROW(GrpcFactoryImpl(*config, cm, dispatcher), EnvoyException);
+  EXPECT_THROW(GrpcFactoryImpl(*config, cm), EnvoyException);
 }
 
 TEST(RateLimitGrpcFactoryTest, Create) {
@@ -144,10 +142,9 @@ TEST(RateLimitGrpcFactoryTest, Create) {
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
   Upstream::MockClusterManager cm;
-  Event::MockDispatcher dispatcher;
 
   EXPECT_CALL(cm, get("foo")).Times(AtLeast(1));
-  GrpcFactoryImpl factory(*config, cm, dispatcher);
+  GrpcFactoryImpl factory(*config, cm);
   factory.create(Optional<std::chrono::milliseconds>());
 }
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -120,7 +120,9 @@ MockStreamFilter::MockStreamFilter() {
 
 MockStreamFilter::~MockStreamFilter() {}
 
-MockAsyncClient::MockAsyncClient() {}
+MockAsyncClient::MockAsyncClient() {
+  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
+}
 MockAsyncClient::~MockAsyncClient() {}
 
 MockAsyncClientCallbacks::MockAsyncClientCallbacks() {}

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -351,6 +351,10 @@ public:
 
   MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks,
                               const Optional<std::chrono::milliseconds>& timeout));
+
+  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+
+  NiceMock<Event::MockDispatcher> dispatcher_;
 };
 
 class MockAsyncClientCallbacks : public AsyncClient::Callbacks {


### PR DESCRIPTION
Turns out that the gRPC client factory for RateLimit was using the main serverd thread dispatcher,
not the worker thread dispatcher (my bad). Switched to using the same dispatcher as the HTTP async
client, assertions added to catch this in Event::Dispatcher for the future as suggested by
@mattklein123.