### PR TITLE
build: undo some protobuf hacks, put some new ones in.

### DIFF
--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -5,12 +5,6 @@ load("//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies(
     path = "//ci/prebuilt",
-    skip_protobuf_bzl = True,
-)
-
-local_repository(
-    name = "protobuf_bzl",
-    path = "/thirdparty/protobuf",
 )
 
 cc_configure()

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -10,12 +10,6 @@ load("//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies(
     path = "@envoy//ci/prebuilt",
-    skip_protobuf_bzl = True,
-)
-
-local_repository(
-    name = "protobuf_bzl",
-    path = "/thirdparty/protobuf",
 )
 
 cc_configure()

--- a/ci/build_container/build_recipes/protobuf.sh
+++ b/ci/build_container/build_recipes/protobuf.sh
@@ -2,12 +2,16 @@
 
 set -e
 
-VERSION=3.3.0
+# Unless overriden with an explicit release tag, e.g. v3.2.0rc2, we use a pinned
+# HEAD commit. This is only until we get a release with
+# https://github.com/google/protobuf/pull/3327, i.e. v3.4.0.
+[ -z "$ENVOY_PROTOBUF_COMMIT" ] && ENVOY_PROTOBUF_COMMIT=062df3d0724d9ae5e3c65d481dc1d3aca811152e  # 2017-07-20
 
-wget -O protobuf-$VERSION.tar.gz https://github.com/google/protobuf/releases/download/v$VERSION/protobuf-cpp-$VERSION.tar.gz
-tar xf protobuf-$VERSION.tar.gz
-rsync -av protobuf-$VERSION/* $THIRDPARTY_SRC/protobuf
-cd protobuf-$VERSION
+git clone https://github.com/google/protobuf.git
+rsync -av protobuf/* $THIRDPARTY_SRC/protobuf
+cd protobuf
+git reset --hard "$ENVOY_PROTOBUF_COMMIT"
+./autogen.sh
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no
 make V=1 install
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,7 +9,6 @@ echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {
   echo "Building..."
-  BUILD_TYPE=opt protobuf_3322_workaround
   cd "${ENVOY_CI_DIR}"
   bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //source/exe:envoy-static.stamped
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -21,7 +20,6 @@ function bazel_release_binary_build() {
 
 function bazel_debug_binary_build() {
   echo "Building..."
-  BUILD_TYPE=dbg protobuf_3322_workaround
   cd "${ENVOY_CI_DIR}"
   bazel --batch build ${BAZEL_BUILD_OPTIONS} -c dbg //source/exe:envoy-static.stamped
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -29,11 +27,6 @@ function bazel_debug_binary_build() {
   cp -f \
     "${ENVOY_CI_DIR}"/bazel-genfiles/source/exe/envoy-static.stamped \
     "${ENVOY_DELIVERY_DIR}"/envoy-debug
-}
-
-# See https://github.com/google/protobuf/issues/3322
-function protobuf_3322_workaround() {
-  ln -sf /thirdparty_build_"${BUILD_TYPE}" "${ENVOY_SRCDIR}"/ci/prebuilt/thirdparty_build
 }
 
 if [[ "$1" == "bazel.release" ]]; then
@@ -62,7 +55,6 @@ elif [[ "$1" == "bazel.debug.server_only" ]]; then
   exit 0
 elif [[ "$1" == "bazel.asan" ]]; then
   setup_clang_toolchain
-  BUILD_TYPE=dbg protobuf_3322_workaround
   echo "bazel ASAN/UBSAN debug build with tests..."
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
@@ -71,7 +63,6 @@ elif [[ "$1" == "bazel.asan" ]]; then
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
   setup_clang_toolchain
-  BUILD_TYPE=dbg protobuf_3322_workaround
   echo "bazel TSAN debug build with tests..."
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
@@ -80,7 +71,6 @@ elif [[ "$1" == "bazel.tsan" ]]; then
   exit 0
 elif [[ "$1" == "bazel.dev" ]]; then
   setup_clang_toolchain
-  BUILD_TYPE=dbg protobuf_3322_workaround
   # This doesn't go into CI but is available for developer convenience.
   echo "bazel fastbuild build with tests..."
   cd "${ENVOY_CI_DIR}"
@@ -96,10 +86,6 @@ elif [[ "$1" == "bazel.dev" ]]; then
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   setup_gcc_toolchain
-  # Technically test/run_envoy_bazel_coverage.sh is doing a -c dbg build, but it
-  # also sets -DNDEBUG, so for protobuf #3322 purposes, we need to setup for
-  # opt.
-  BUILD_TYPE=opt protobuf_3322_workaround
   echo "bazel coverage build with tests..."
   export GCOVR="/thirdparty/gcovr/scripts/gcovr"
   export GCOVR_DIR="${ENVOY_BUILD_DIR}/bazel-envoy"


### PR DESCRIPTION
* Use protobuf from HEAD to ensure we have the
  https://github.com/google/protobuf/pull/3327 fix for CI and local
  builds. Users can opt to use a specific release tag with the
  ENVOY_PROTOBUF_COMMIT env var.

* Remove the workaround for https://github.com/google/protobuf/pull/3327
  in do_ci.sh.

* Remove the multiple protobuf versions that existed because
  https://github.com/google/protobuf/pull/2508 wasn't merged.

* Add some evil symlink stuff to get @protobuf_bzl inferred from
  wherever WORKSPACE points the envoy_dependencies path at.

As a bonus, enabled more verbose build of external deps so we don't sit
around for minutes on initial checkout with no activity indicator. This
can be done safely now as everyone should be at Bazel 0.5.2.