### PR TITLE
load_balancer: Compute hash on-demand.

### DIFF
--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -18,9 +18,9 @@ public:
   virtual ~LoadBalancerContext() {}
 
   /**
-   * @return const Optional<uint64_t>& the optional hash key to use during load balancing.
+   * @return Optional<uint64_t> the optional hash key to use during load balancing.
    */
-  virtual const Optional<uint64_t>& hashKey() const PURE;
+  virtual Optional<uint64_t> hashKey() const PURE;
 };
 
 /**

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -158,7 +158,7 @@ private:
     LbContextImpl(const std::string& hash_key) : hash_key_(std::hash<std::string>()(hash_key)) {}
 
     // Upstream::LoadBalancerContext
-    const Optional<uint64_t>& hashKey() const override { return hash_key_; }
+    Optional<uint64_t> hashKey() const override { return hash_key_; }
 
     const Optional<uint64_t> hash_key_;
   };

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -214,14 +214,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  // See if we need to set up for hashing.
-  if (route_entry_->hashPolicy()) {
-    Optional<uint64_t> hash = route_entry_->hashPolicy()->generateHash(headers);
-    if (hash.valid()) {
-      lb_context_.reset(new LoadBalancerContextImpl(hash));
-    }
-  }
-
   // Fetch a connection pool for the upstream cluster.
   Http::ConnectionPool::Instance* conn_pool = getConnPool();
   if (!conn_pool) {
@@ -271,8 +263,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 }
 
 Http::ConnectionPool::Instance* Filter::getConnPool() {
-  return config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), finalPriority(),
-                                            lb_context_.get());
+  return config_.cm_.httpConnPoolForCluster(route_entry_->clusterName(), finalPriority(), this);
 }
 
 void Filter::sendNoHealthyUpstreamResponse() {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -104,7 +104,9 @@ typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
 /**
  * Service routing filter.
  */
-class Filter : Logger::Loggable<Logger::Id::router>, public Http::StreamDecoderFilter {
+class Filter : Logger::Loggable<Logger::Id::router>,
+               public Http::StreamDecoderFilter,
+               public Upstream::LoadBalancerContext {
 public:
   Filter(FilterConfig& config)
       : config_(config), downstream_response_started_(false), downstream_end_stream_(false),
@@ -121,6 +123,17 @@ public:
   Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap& trailers) override;
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
     callbacks_ = &callbacks;
+  }
+
+  // Upstream::LoadBalancerContext
+  Optional<uint64_t> hashKey() const override {
+    if (route_entry_ && downstream_headers_) {
+      auto hash_policy = route_entry_->hashPolicy();
+      if (hash_policy) {
+        return hash_policy->generateHash(*downstream_headers_);
+      }
+    }
+    return {};
   }
 
 private:
@@ -176,15 +189,6 @@ private:
 
   typedef std::unique_ptr<UpstreamRequest> UpstreamRequestPtr;
 
-  struct LoadBalancerContextImpl : public Upstream::LoadBalancerContext {
-    LoadBalancerContextImpl(const Optional<uint64_t>& hash) : hash_(hash) {}
-
-    // Upstream::LoadBalancerContext
-    const Optional<uint64_t>& hashKey() const override { return hash_; }
-
-    const Optional<uint64_t> hash_;
-  };
-
   enum class UpstreamResetType { Reset, GlobalTimeout, PerTryTimeout };
 
   Http::AccessLog::ResponseFlag
@@ -231,7 +235,6 @@ private:
   Http::HeaderMap* downstream_headers_{};
   Http::HeaderMap* downstream_trailers_{};
   MonotonicTime downstream_request_complete_time_;
-  std::unique_ptr<LoadBalancerContextImpl> lb_context_;
   bool stream_destroyed_{};
 
   bool downstream_response_started_ : 1;

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -41,7 +41,7 @@ HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerCont
   if (context) {
     hash = context->hashKey();
   }
-  uint64_t h = hash.valid() ? hash.value() : random.random();
+  const uint64_t h = hash.valid() ? hash.value() : random.random();
 
   // Ported from https://github.com/RJ/ketama/blob/master/libketama/ketama.c (ketama_get_server)
   // I've generally kept the variable names to make the code easier to compare.

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -36,12 +36,12 @@ HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(const LoadBalancerCont
 
   // If there is no hash in the context, just choose a random value (this effectively becomes
   // the random LB but it won't crash if someone configures it this way).
-  uint64_t h;
-  if (!context || !context->hashKey().valid()) {
-    h = random.random();
-  } else {
-    h = context->hashKey().value();
+  // hashKey() may be computed on demand, so get it only once.
+  Optional<uint64_t> hash;
+  if (context) {
+    hash = context->hashKey();
   }
+  uint64_t h = hash.valid() ? hash.value() : random.random();
 
   // Ported from https://github.com/RJ/ketama/blob/master/libketama/ketama.c (ketama_get_server)
   // I've generally kept the variable names to make the code easier to compare.

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -28,7 +28,7 @@ public:
   TestLoadBalancerContext(uint64_t hash_key) : hash_key_(hash_key) {}
 
   // Upstream::LoadBalancerContext
-  const Optional<uint64_t>& hashKey() const override { return hash_key_; }
+  Optional<uint64_t> hashKey() const override { return hash_key_; }
 
   Optional<uint64_t> hash_key_;
 };


### PR DESCRIPTION
The load balancer context is specified as a pure virtual class, but
the return type of the hashKey() member implies that there is a value
stored inside the implementation, since a const reference is returned.
Change the return type to a non-const non-reference, allowing a
stateless implementation.  Enhance the one call site that called
hashKey() twice to call it only once to avoid overhead in case each
hashKey() call recomputes the hash.

Change the router Filter class to inherit from the LoadBalancerContext
interface, allowing for simpler, on-demand implementation of the load
balancer context.

With this change a load balancer context never needs to be dynamically
allocated.  This will make exteonsions to load balancer context also
simpler and cheaper.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>