### PR TITLE
build: switch protobuf version to pinned HEAD commit.

### DIFF
--- a/ci/build_container/build_container.sh
+++ b/ci/build_container/build_container.sh
@@ -41,11 +41,13 @@ DEPS=$(python <(cat target_recipes.bzl; \
   echo "print ' '.join(\"${THIRDPARTY_DEPS}/%s.dep\" % r for r in set(TARGET_RECIPES.values()))"))
 
 # TODO(htuch): We build twice as a workaround for https://github.com/google/protobuf/issues/3322.
-# Fix this.
-export THIRDPARTY_BUILD=/thirdparty_build_opt
+# Fix this. This will be gone real soon now.
+export THIRDPARTY_BUILD=/thirdparty_build
 export CPPFLAGS="-DNDEBUG"
 echo "Building opt deps ${DEPS}"
 "$(dirname "$0")"/build_and_install_deps.sh ${DEPS}
+
+ln -sf /thirdparty_build /thirdparty_build_opt
 
 export THIRDPARTY_BUILD=/thirdparty_build_dbg
 export CPPFLAGS=""

--- a/ci/build_container/build_recipes/protobuf.sh
+++ b/ci/build_container/build_recipes/protobuf.sh
@@ -2,12 +2,16 @@
 
 set -e
 
-VERSION=3.3.0
+# Unless overriden with an explicit release tag, e.g. v3.2.0rc2, we use a pinned
+# HEAD commit. This is only until we get a release with
+# https://github.com/google/protobuf/pull/3327, i.e. v3.4.0.
+[ -z "$ENVOY_PROTOBUF_COMMIT" ] && ENVOY_PROTOBUF_COMMIT=062df3d0724d9ae5e3c65d481dc1d3aca811152e  # 2017-07-20
 
-wget -O protobuf-$VERSION.tar.gz https://github.com/google/protobuf/releases/download/v$VERSION/protobuf-cpp-$VERSION.tar.gz
-tar xf protobuf-$VERSION.tar.gz
-rsync -av protobuf-$VERSION/* $THIRDPARTY_SRC/protobuf
-cd protobuf-$VERSION
+git clone https://github.com/google/protobuf.git
+rsync -av protobuf/* $THIRDPARTY_SRC/protobuf
+cd protobuf
+git reset --hard "$ENVOY_PROTOBUF_COMMIT"
+./autogen.sh
 ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no
 make V=1 install
 


### PR DESCRIPTION
Use protobuf from HEAD to ensure we have the
https://github.com/google/protobuf/pull/3327 fix for CI and local
builds. Users can opt to use a specific release tag with the
ENVOY_PROTOBUF_COMMIT env var.