### PR TITLE
Fixing tsan "Data race on vptr" failures in the ssl integration test

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -281,6 +281,7 @@ FakeHttpConnectionPtr FakeUpstream::waitForHttpConnection(Event::Dispatcher& cli
   ASSERT(!new_connections_.empty());
   FakeHttpConnectionPtr connection(
       new FakeHttpConnection(std::move(new_connections_.front()), stats_store_, http_type_));
+  connection->initialize();
   new_connections_.pop_front();
   connection->readDisable(false);
   return connection;
@@ -295,6 +296,7 @@ FakeRawConnectionPtr FakeUpstream::waitForRawConnection() {
 
   ASSERT(!new_connections_.empty());
   FakeRawConnectionPtr connection(new FakeRawConnection(std::move(new_connections_.front())));
+  connection->initialize();
   new_connections_.pop_front();
   connection->readDisable(false);
   return connection;


### PR DESCRIPTION
Deferring registration of the (virtual) connection callbacks from the constructor to a new initialize() function

Also protecting the parented_ bool behind a lock since that flake showed up once in a while while I was doing loads of tsan runs.

This brings the test from failing roughly 1:100 to passing 1:1000 cleanly in my local build.