### PR TITLE
build_container: add link to Docker Hub for tags.

### DIFF
--- a/ci/build_container/README.md
+++ b/ci/build_container/README.md
@@ -1,6 +1,6 @@
 Envoy's CI has a build run called `build_image`. On a commit to master, `ci/build_container/docker_push.sh`
 checks if the commit has changed the `ci/build_container` directory. If there are changes, CI builds a new `lyft/envoy-build`
-image. The image is pushed to dockerhub under `latest` and under the commit sha.
+image. The image is pushed to [dockerhub](https://hub.docker.com/r/lyft/envoy-build/tags/) under `latest` and under the commit sha.
 
 After the PR that changes `ci/build_container` has been merged, and the new image gets pushed,
 a second PR is needed to update `ci/envoy_build_sha.sh`. In order to pull the new tagged version of


### PR DESCRIPTION
Avoid having to look this up when bumping envoy_build_sha.sh.