### PR TITLE
upstream: New original_dst cluster type.

### DIFF
--- a/configs/original_dst_proxy.json
+++ b/configs/original_dst_proxy.json
@@ -1,0 +1,44 @@
+{
+    "listeners": [{
+        "address": "tcp://0.0.0.0:10000",
+        "use_original_dst": true,
+        "filters": [{
+            "type": "read",
+            "name": "http_connection_manager",
+            "config": {
+                "codec_type": "auto",
+                "stat_prefix": "ingress_http",
+                "route_config": {
+                    "virtual_hosts": [{
+                        "name": "local_service",
+                        "domains": [
+                            "*"
+                        ],
+                        "routes": [{
+                            "timeout_ms": 0,
+                            "prefix": "/",
+                            "cluster": "cluster1"
+                        }]
+                    }]
+                },
+                "filters": [{
+                    "type": "decoder",
+                    "name": "router",
+                    "config": {}
+                }]
+            }
+        }]
+    }],
+    "admin": {
+        "access_log_path": "/tmp/admin_access.log",
+        "address": "tcp://127.0.0.1:9901"
+    },
+    "cluster_manager": {
+        "clusters": [{
+            "name": "cluster1",
+            "connect_timeout_ms": 1250,
+            "type": "original_dst",
+            "lb_type": "original_dst_lb"
+        }]
+    }
+}

--- a/configs/original_dst_proxy_cleanup.sh
+++ b/configs/original_dst_proxy_cleanup.sh
@@ -1,0 +1,16 @@
+#
+# Cleanup network namespace after testing Envoy original_dst cluster
+#
+
+NETNS=$1
+TARGET_IP=$2
+ENVOY_PORT=10000
+
+# remove iptables rule
+iptables -t nat -D PREROUTING --src 0/0 --dst "$TARGET_IP" -p tcp --dport 80 -j REDIRECT --to-ports "$ENVOY_PORT"
+
+# delete network namespace
+ip netns delete "$NETNS"
+
+# delete veth pair
+ip link del "$NETNS-veth0" type veth peer name "$NETNS-veth1"

--- a/configs/original_dst_proxy_setup.sh
+++ b/configs/original_dst_proxy_setup.sh
@@ -1,0 +1,34 @@
+#
+# Example setup network namespace for testing Envoy original_dst cluster
+# Clean up with the cleanup script with the same arguments.
+#
+# Test with:
+# $sudo ip netns exec ${NETNS} curl -v ${TARGET_IP}:80
+#
+set -e
+
+# name of the network namespace
+NETNS=$1 
+
+# IP address or prefix that will be redirected
+TARGET_IP=$2
+
+# Local Envoy Listener port number
+ENVOY_PORT=10000
+
+# Create veth pair
+ip link add "$NETNS-veth0" type veth peer name "$NETNS-veth1"
+ifconfig "$NETNS-veth0" 10.0.200.2/24 up
+
+# Create network namespace
+ip netns add "$NETNS"
+# Move veth peer to the namespace
+ip link set "$NETNS-veth1" netns "$NETNS"
+
+# Configure network namespace
+ip netns exec "$NETNS" ifconfig lo 127.0.0.1 up
+ip netns exec "$NETNS" ifconfig "$NETNS-veth1" 10.0.200.1/24 up
+ip netns exec "$NETNS" ip route add default via 10.0.200.2
+
+#configure iptables REDIRECT in the PREROUTING hook of the root name space nat table.
+iptables -t nat -I PREROUTING --src 0/0 --dst "$TARGET_IP" -p tcp --dport 80 -j REDIRECT --to-ports "$ENVOY_PORT"

--- a/docs/configuration/cluster_manager/cluster.rst
+++ b/docs/configuration/cluster_manager/cluster.rst
@@ -37,8 +37,8 @@ name
 
 type
   *(required, string)* The :ref:`service discovery type <arch_overview_service_discovery_types>` to
-  use for resolving the cluster. Possible options are *static*, *strict_dns*, *logical_dns*, and
-  *sds*.
+  use for resolving the cluster. Possible options are *static*, *strict_dns*, *logical_dns*,
+  *original_dst*, and *sds*.
 
 connect_timeout_ms
   *(required, integer)* The timeout for new network connections to hosts in the cluster specified
@@ -53,12 +53,13 @@ per_connection_buffer_limit_bytes
 lb_type
   *(required, string)* The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   when picking a host in the cluster. Possible options are *round_robin*, *least_request*,
-  *ring_hash*, and *random*.
+  *ring_hash*, *random*, and *original_dst_lb*.  Note that *original_dst_lb* must be used with
+  clusters of type *original_dst*, and may not be used with any other cluster type.
 
 hosts
   *(sometimes required, array)* If the service discovery type is *static*, *strict_dns*, or
-  *logical_dns* the hosts array is required. How it is specified depends on the type of service
-  discovery:
+  *logical_dns* the hosts array is required. Hosts array is not allowed with cluster type
+  *original_dst*. How it is specified depends on the type of service discovery:
 
   static
     Static clusters must use fully resolved hosts that require no DNS lookups. Both TCP and unix
@@ -145,6 +146,13 @@ http2_settings
   *(optional, object)* Additional HTTP/2 settings that are passed directly to the HTTP/2 codec when
   initiating HTTP connection pool connections. These are the same options supported in the HTTP connection
   manager :ref:`http2_settings <config_http_conn_man_http2_settings>` option.
+
+.. _config_cluster_manager_cluster_cleanup_interval_ms:
+
+cleanup_interval_ms
+  *(optional, integer)* The interval for removing stale hosts from the cluster. If this setting is
+  not specified, the value defaults to 5000. For cluster types other than *original_dst* this
+  setting is ignored.
 
 .. _config_cluster_manager_cluster_dns_refresh_rate_ms:
 

--- a/docs/intro/arch_overview/load_balancing.rst
+++ b/docs/intro/arch_overview/load_balancing.rst
@@ -54,6 +54,15 @@ The random load balancer selects a random healthy host. The random load balancer
 better than round robin if no health checking policy is configured. Random selection avoids bias
 towards the host in the set that comes after a failed host.
 
+Original destination
+^^^^^^^^^^^^^^^^^^^^
+
+This is a special purpose load balancer that can only be used with an original destination
+cluster. Upstream host is selected based on the downstream connection metadata, i.e., connections
+are opened to the same address as the destination address of the incoming connection was before the
+connection was redirected to Envoy. No other load balancing type can be used with original
+destination clusters.
+
 .. _arch_overview_load_balancing_panic_threshold:
 
 Panic threshold

--- a/docs/intro/arch_overview/service_discovery.rst
+++ b/docs/intro/arch_overview/service_discovery.rst
@@ -45,6 +45,17 @@ When interacting with large scale web services, this is the best of all possible
 asynchronous/eventually consistent DNS resolution, long lived connections, and zero blocking in the
 forwarding path.
 
+Original destination
+^^^^^^^^^^^^^^^^^^^^
+
+Original destination cluster can be used when incoming connections are redirected to Envoy either
+via an iptables REDIRECT rule or with Proxy Protocol.  In these cases requests routed to an original
+destination cluster are forwarded to upstream hosts as addressed by the redirection metadata,
+without any explicit host configuration or upstream host discovery.  Connections to upstream hosts
+are pooled and unused hosts are flushed out when they have been idle longer than
+*cleanup_interval_ms*, which defaults to 5000ms.  If the original destination address is is not
+available, no upstream connection is opened.
+
 .. _arch_overview_service_discovery_sds:
 
 Service discovery service (SDS)

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -184,6 +184,12 @@ public:
    * Get the value set with setBufferLimits.
    */
   virtual uint32_t bufferLimit() const PURE;
+
+  /**
+   * @return boolean telling if the connection's local address is an original destination address,
+   * rather than the listener's address.
+   */
+  virtual bool usingOriginalDst() const PURE;
 };
 
 typedef std::unique_ptr<Connection> ConnectionPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -82,7 +82,8 @@ public:
    * Returns both a connection and the host that backs the connection. Both can be nullptr if there
    * is no host available in the cluster.
    */
-  virtual Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) PURE;
+  virtual Host::CreateConnectionData tcpConnForCluster(const std::string& cluster,
+                                                       LoadBalancerContext* context) PURE;
 
   /**
    * Returns a client that can be used to make async HTTP calls against the given cluster. The

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -21,6 +21,12 @@ public:
    * @return Optional<uint64_t> the optional hash key to use during load balancing.
    */
   virtual Optional<uint64_t> hashKey() const PURE;
+
+  /**
+   * @return const Network::Connection* the incoming connection or nullptr to use during load
+   * balancing.
+   */
+  virtual const Network::Connection* downstreamConnection() const PURE;
 };
 
 /**

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -6,7 +6,7 @@ namespace Upstream {
 /**
  * Type of load balancing to perform.
  */
-enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash };
+enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash, OriginalDst };
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -351,6 +351,7 @@ public:
 };
 
 typedef std::unique_ptr<Cluster> ClusterPtr;
+typedef std::shared_ptr<Cluster> ClusterSharedPtr;
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -95,6 +95,11 @@ public:
    * Set the current load balancing weight of the host, in the range 1-100.
    */
   virtual void weight(uint32_t new_weight) PURE;
+
+  /**
+   * @return the old value of host being in use and set the value to 'new_used'.
+   */
+  virtual bool used(bool new_used) PURE;
 };
 
 typedef std::shared_ptr<const Host> HostConstSharedPtr;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -195,7 +195,8 @@ Network::FilterStatus TcpProxy::initializeUpstreamConnection() {
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return Network::FilterStatus::StopIteration;
   }
-  Upstream::Host::CreateConnectionData conn_info = cluster_manager_.tcpConnForCluster(cluster_name);
+  Upstream::Host::CreateConnectionData conn_info =
+      cluster_manager_.tcpConnForCluster(cluster_name, this);
 
   upstream_connection_ = std::move(conn_info.connection_);
   read_callbacks_->upstreamHost(conn_info.host_description_);

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -86,7 +86,9 @@ typedef std::shared_ptr<TcpProxyConfig> TcpProxyConfigSharedPtr;
  * connection using the defined load balancing proxy for the configured cluster. All data will
  * be proxied back and forth between the two connections.
  */
-class TcpProxy : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
+class TcpProxy : public Network::ReadFilter,
+                 Upstream::LoadBalancerContext,
+                 Logger::Loggable<Logger::Id::filter> {
 public:
   TcpProxy(TcpProxyConfigSharedPtr config, Upstream::ClusterManager& cluster_manager);
   ~TcpProxy();
@@ -95,6 +97,10 @@ public:
   Network::FilterStatus onData(Buffer::Instance& data) override;
   Network::FilterStatus onNewConnection() override { return initializeUpstreamConnection(); }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+
+  // Upstream::LoadBalancerContext
+  Optional<uint64_t> hashKey() const { return 0; }
+  const Network::Connection* downstreamConnection() const { return &read_callbacks_->connection(); }
 
   // These two functions allow enabling/disabling reads on the upstream and downstream connections.
   // They are called by the Downstream/Upstream Watermark callbacks to limit buffering.

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -99,8 +99,10 @@ public:
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
 
   // Upstream::LoadBalancerContext
-  Optional<uint64_t> hashKey() const { return 0; }
-  const Network::Connection* downstreamConnection() const { return &read_callbacks_->connection(); }
+  Optional<uint64_t> hashKey() const override { return {}; }
+  const Network::Connection* downstreamConnection() const override {
+    return &read_callbacks_->connection();
+  }
 
   // These two functions allow enabling/disabling reads on the upstream and downstream connections.
   // They are called by the Downstream/Upstream Watermark callbacks to limit buffering.

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1305,7 +1305,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
       },
       "type" : {
         "type" : "string",
-        "enum" : ["static", "strict_dns", "logical_dns", "sds"]
+        "enum" : ["static", "strict_dns", "logical_dns", "sds", "original_dst"]
       },
       "connect_timeout_ms" : {
         "type" : "integer",
@@ -1319,7 +1319,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
       },
       "lb_type" : {
         "type" : "string",
-        "enum" : ["round_robin", "least_request", "random", "ring_hash"]
+        "enum" : ["round_robin", "least_request", "random", "ring_hash", "original_dst_lb"]
       },
       "hosts" : {
         "type" : "array",

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -45,7 +45,7 @@ class ConnectionImpl : public virtual Connection,
 public:
   ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                  Address::InstanceConstSharedPtr remote_address,
-                 Address::InstanceConstSharedPtr local_address);
+                 Address::InstanceConstSharedPtr local_address, bool using_original_dst);
 
   ~ConnectionImpl();
 
@@ -73,6 +73,7 @@ public:
   void write(Buffer::Instance& data) override;
   void setBufferLimits(uint32_t limit) override;
   uint32_t bufferLimit() const override { return read_buffer_limit_; }
+  bool usingOriginalDst() const override { return using_original_dst_; }
 
   // Network::BufferSource
   Buffer::Instance& getReadBuffer() override { return *read_buffer_; }
@@ -146,6 +147,7 @@ private:
   // readDisabled(true) this allows the connection to only resume reads when readDisabled(false)
   // has been called N times.
   uint32_t read_disable_count_{0};
+  bool using_original_dst_;
 };
 
 /**

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -29,7 +29,8 @@ public:
    * @param local_address supplies the local address for the new connection.
    */
   virtual void newConnection(int fd, Address::InstanceConstSharedPtr remote_address,
-                             Address::InstanceConstSharedPtr local_address);
+                             Address::InstanceConstSharedPtr local_address,
+                             bool using_original_dst);
 
   /**
    * @return the socket supplied to the listener at construction time
@@ -65,7 +66,8 @@ public:
 
   // ListenerImpl
   void newConnection(int fd, Address::InstanceConstSharedPtr remote_address,
-                     Address::InstanceConstSharedPtr local_address) override;
+                     Address::InstanceConstSharedPtr local_address,
+                     bool using_original_dst) override;
 
 private:
   Ssl::Context& ssl_ctx_;

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -110,7 +110,7 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
 
   removeFromList(parent_.connections_);
 
-  listener.newConnection(fd, remote_address, local_address);
+  listener.newConnection(fd, remote_address, local_address, true);
 }
 
 void ProxyProtocol::ActiveConnection::close() {

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -159,6 +159,7 @@ private:
 
     // Upstream::LoadBalancerContext
     Optional<uint64_t> hashKey() const override { return hash_key_; }
+    const Network::Connection* downstreamConnection() const override { return nullptr; }
 
     const Optional<uint64_t> hash_key_;
   };

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -135,6 +135,9 @@ public:
     }
     return {};
   }
+  const Network::Connection* downstreamConnection() const override {
+    return callbacks_->connection();
+  }
 
 private:
   struct UpstreamRequest : public Http::StreamDecoder,

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -31,9 +31,9 @@ getNullLocalAddress(const Network::Address::Instance& address) {
 
 ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                Network::Address::InstanceConstSharedPtr remote_address,
-                               Network::Address::InstanceConstSharedPtr local_address, Context& ctx,
-                               InitialState state)
-    : Network::ConnectionImpl(dispatcher, fd, remote_address, local_address),
+                               Network::Address::InstanceConstSharedPtr local_address,
+                               bool using_original_dst, Context& ctx, InitialState state)
+    : Network::ConnectionImpl(dispatcher, fd, remote_address, local_address, using_original_dst),
       ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
   BIO* bio = BIO_new_socket(fd, 0);
   SSL_set_bio(ssl_.get(), bio, bio);
@@ -294,7 +294,7 @@ std::string ConnectionImpl::getUriSanFromCertificate(X509* cert) {
 ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Context& ctx,
                                            Network::Address::InstanceConstSharedPtr address)
     : ConnectionImpl(dispatcher, address->socket(Network::Address::SocketType::Stream), address,
-                     getNullLocalAddress(*address), ctx, InitialState::Client) {}
+                     getNullLocalAddress(*address), false, ctx, InitialState::Client) {}
 
 void ClientConnectionImpl::connect() { doConnect(); }
 

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -17,8 +17,8 @@ public:
 
   ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                  Network::Address::InstanceConstSharedPtr remote_address,
-                 Network::Address::InstanceConstSharedPtr local_address, Context& ctx,
-                 InitialState state);
+                 Network::Address::InstanceConstSharedPtr local_address, bool using_original_dst,
+                 Context& ctx, InitialState state);
   ~ConnectionImpl();
 
   // Network::Connection

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -153,7 +153,7 @@ void TcpStatsdSink::TlsSink::write(const std::string& stat) {
 
   if (!connection_) {
     Upstream::Host::CreateConnectionData info =
-        parent_.cluster_manager_.tcpConnForCluster(parent_.cluster_info_->name());
+        parent_.cluster_manager_.tcpConnForCluster(parent_.cluster_info_->name(), nullptr);
     if (!info.connection_) {
       return;
     }

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -120,6 +120,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "original_dst_cluster_lib",
+    srcs = ["original_dst_cluster.cc"],
+    hdrs = ["original_dst_cluster.h"],
+    deps = [
+        ":upstream_includes",
+        "//source/common/common:empty_string",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "outlier_detection_lib",
     srcs = ["outlier_detection_impl.cc"],
     hdrs = ["outlier_detection_impl.h"],
@@ -210,6 +222,7 @@ envoy_cc_library(
         ":eds_lib",
         ":health_checker_lib",
         ":logical_dns_cluster_lib",
+        ":original_dst_cluster_lib",
         ":upstream_includes",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:timer_interface",

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -21,6 +21,7 @@
 #include "common/router/shadow_writer_impl.h"
 #include "common/upstream/cds_api_impl.h"
 #include "common/upstream/load_balancer_impl.h"
+#include "common/upstream/original_dst_cluster.h"
 #include "common/upstream/ring_hash_lb.h"
 
 #include "spdlog/spdlog.h"
@@ -534,6 +535,11 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
   case LoadBalancerType::RingHash: {
     lb_.reset(new RingHashLoadBalancer(host_set_, cluster->stats(), parent.parent_.runtime_,
                                        parent.parent_.random_));
+    break;
+  }
+  case LoadBalancerType::OriginalDst: {
+    lb_.reset(new OriginalDstCluster::LoadBalancer(
+        host_set_, parent.parent_.primary_clusters_.at(cluster->name()).cluster_));
     break;
   }
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -378,7 +378,8 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(
   });
 }
 
-Host::CreateConnectionData ClusterManagerImpl::tcpConnForCluster(const std::string& cluster) {
+Host::CreateConnectionData ClusterManagerImpl::tcpConnForCluster(const std::string& cluster,
+                                                                 LoadBalancerContext* context) {
   ThreadLocalClusterManagerImpl& cluster_manager =
       tls_.getTyped<ThreadLocalClusterManagerImpl>(thread_local_slot_);
 
@@ -387,7 +388,7 @@ Host::CreateConnectionData ClusterManagerImpl::tcpConnForCluster(const std::stri
     throw EnvoyException(fmt::format("unknown cluster '{}'", cluster));
   }
 
-  HostConstSharedPtr logical_host = entry->second->lb_->chooseHost(nullptr);
+  HostConstSharedPtr logical_host = entry->second->lb_->chooseHost(context);
   if (logical_host) {
     return logical_host->createConnection(cluster_manager.thread_local_dispatcher_);
   } else {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -209,11 +209,11 @@ private:
 
   struct PrimaryClusterData {
     PrimaryClusterData(uint64_t config_hash, bool added_via_api, ClusterPtr&& cluster)
-        : config_hash_(config_hash), added_via_api_(added_via_api), cluster_(std::move(cluster)) {}
+        : config_hash_(config_hash), added_via_api_(added_via_api), cluster_(cluster.release()) {}
 
     const uint64_t config_hash_;
     const bool added_via_api_;
-    ClusterPtr cluster_;
+    ClusterSharedPtr cluster_;
   };
 
   static ClusterManagerStats generateStats(Stats::Scope& scope);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -141,7 +141,8 @@ public:
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
                                                          ResourcePriority priority,
                                                          LoadBalancerContext* context) override;
-  Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) override;
+  Host::CreateConnectionData tcpConnForCluster(const std::string& cluster,
+                                               LoadBalancerContext* context) override;
   Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) override;
   bool removePrimaryCluster(const std::string& cluster) override;
   void shutdown() override {

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "envoy/thread_local/thread_local.h"
+
+#include "common/common/empty_string.h"
+#include "common/common/logger.h"
+#include "common/upstream/upstream_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * The OriginalDstCluster is a dynamic cluster that automatically adds hosts as needed based on the
+ * original destination address of the downstream connection.  These hosts are also automatically
+ * cleaned up after they have not seen traffic for a configurable cleanup interval time
+ * ("cleanup_interval_ms").
+ */
+class OriginalDstCluster : public ClusterImplBase {
+public:
+  OriginalDstCluster(const Json::Object& config, Runtime::Loader& runtime, Stats::Store& stats,
+                     Ssl::ContextManager& ssl_context_manager, Event::Dispatcher& dispatcher,
+                     bool added_via_api);
+
+  // Upstream::Cluster
+  void initialize() override {}
+  InitializePhase initializePhase() const override { return InitializePhase::Primary; }
+  void setInitializedCb(std::function<void()> callback) override { callback(); }
+
+  /**
+   * Special Load Balancer for Original Dst Cluster.
+   *
+   * Load balancer gets called with the downstream context which can be used to make sure the
+   * Original Dst cluster has a Host for the original destination.  Normally load balancers can't
+   * modify clusters, but in this case we access a singleton OriginalDstCluster that we can ask to
+   * add hosts on demand.  Additions are synced with all other threads so that the host set in the
+   * cluster remains (eventually) consistent.  If multiple threads add a host to the same upstream
+   * address then two distinct HostSharedPtr's (with the same upstream IP address) will be added,
+   * and both of them will eventually time out.
+   */
+  class LoadBalancer : public Upstream::LoadBalancer {
+  public:
+    LoadBalancer(HostSet& host_set, ClusterSharedPtr& parent);
+
+    // Upstream::LoadBalancer
+    HostConstSharedPtr chooseHost(const LoadBalancerContext* context) override;
+
+  private:
+    /**
+     * Map from an host IP address/port to a HostSharedPtr.  Due to races multiple distinct host
+     * objects with the same address can be created, so we need to use a multimap.
+     */
+    class HostMap {
+    public:
+      bool insert(const HostSharedPtr& host, bool check = true) {
+        if (check) {
+          auto range = map_.equal_range(host->address()->asString());
+          auto it = std::find_if(
+              range.first, range.second,
+              [&host](const decltype(map_)::value_type pair) { return pair.second == host; });
+          if (it != range.second) {
+            return false; // 'host' already in the map, no need to insert.
+          }
+        }
+        map_.emplace(host->address()->asString(), host);
+        return true;
+      }
+
+      bool remove(const HostSharedPtr& host) {
+        auto range = map_.equal_range(host->address()->asString());
+        auto it =
+            std::find_if(range.first, range.second, [&host](const decltype(map_)::value_type pair) {
+              return pair.second == host;
+            });
+        if (it != range.second) {
+          map_.erase(it); // found 'host'
+          return true;
+        }
+        return false;
+      }
+
+      HostSharedPtr find(const Network::Address::Instance& address) {
+        auto it = map_.find(address.asString());
+
+        if (it != map_.end()) {
+          return it->second;
+        }
+        return nullptr;
+      }
+
+    private:
+      std::unordered_multimap<std::string, HostSharedPtr> map_;
+    };
+
+    HostSet& host_set_;             // Thread local host set.
+    std::weak_ptr<Cluster> parent_; // Primary cluster managed by the main thread.
+    ClusterInfoConstSharedPtr info_;
+    HostMap host_map_;
+  };
+
+private:
+  void addHost(HostSharedPtr&);
+  void cleanup();
+
+  Event::Dispatcher& dispatcher_;
+  const std::chrono::milliseconds cleanup_interval_ms_;
+  Event::TimerPtr cleanup_timer_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -83,7 +83,7 @@ public:
   HostImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
            Network::Address::InstanceConstSharedPtr address, bool canary, uint32_t initial_weight,
            const std::string& zone)
-      : HostDescriptionImpl(cluster, hostname, address, canary, zone) {
+      : HostDescriptionImpl(cluster, hostname, address, canary, zone), used_(true) {
     weight(initial_weight);
   }
 
@@ -100,6 +100,11 @@ public:
   bool healthy() const override { return !health_flags_; }
   uint32_t weight() const override { return weight_; }
   void weight(uint32_t new_weight) override;
+  bool used(bool new_used) override {
+    bool ret = used_;
+    used_ = new_used;
+    return ret;
+  }
 
 protected:
   static Network::ClientConnectionPtr
@@ -109,6 +114,7 @@ protected:
 private:
   std::atomic<uint64_t> health_flags_{};
   std::atomic<uint32_t> weight_;
+  std::atomic<bool> used_;
 };
 
 typedef std::shared_ptr<std::vector<HostSharedPtr>> HostVectorSharedPtr;

--- a/source/server/config_validation/cluster_manager.cc
+++ b/source/server/config_validation/cluster_manager.cc
@@ -39,7 +39,8 @@ ValidationClusterManager::httpConnPoolForCluster(const std::string&, ResourcePri
   return nullptr;
 }
 
-Host::CreateConnectionData ValidationClusterManager::tcpConnForCluster(const std::string&) {
+Host::CreateConnectionData ValidationClusterManager::tcpConnForCluster(const std::string&,
+                                                                       LoadBalancerContext*) {
   return Host::CreateConnectionData{nullptr, nullptr};
 }
 

--- a/source/server/config_validation/cluster_manager.h
+++ b/source/server/config_validation/cluster_manager.h
@@ -46,7 +46,7 @@ public:
 
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string&, ResourcePriority,
                                                          LoadBalancerContext*) override;
-  Host::CreateConnectionData tcpConnForCluster(const std::string&) override;
+  Host::CreateConnectionData tcpConnForCluster(const std::string&, LoadBalancerContext*) override;
   Http::AsyncClient& httpAsyncClientForCluster(const std::string&) override;
 
 private:

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -379,12 +379,14 @@ public:
       conn_info.host_.reset(
           new Upstream::HostImpl(cluster_manager_.thread_local_cluster_.cluster_.info_, "",
                                  Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
-      EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+      EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+          .WillOnce(Return(conn_info));
       EXPECT_CALL(*upstream_connection_, addReadFilter(_))
           .WillOnce(SaveArg<0>(&upstream_read_filter_));
     } else {
       Upstream::MockHost::MockCreateConnectionData conn_info;
-      EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+      EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+          .WillOnce(Return(conn_info));
     }
 
     filter_.reset(new TcpProxy(config_, cluster_manager_));
@@ -582,7 +584,7 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
   EXPECT_CALL(connection_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
   // Expect filter to try to open a connection to specified cluster
-  EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster"));
+  EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _));
 
   filter_->onNewConnection();
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -68,7 +68,7 @@ TEST_P(ConnectionImplDeathTest, BadFd) {
   Event::DispatcherImpl dispatcher;
   EXPECT_DEATH(ConnectionImpl(dispatcher, -1,
                               Network::Test::getCanonicalLoopbackAddress(GetParam()),
-                              Network::Test::getCanonicalLoopbackAddress(GetParam())),
+                              Network::Test::getCanonicalLoopbackAddress(GetParam()), false),
                ".*assert failure: fd_ != -1.*");
 }
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -161,7 +161,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   conn_info.host_.reset(new Upstream::HostImpl(cm.thread_local_cluster_.cluster_.info_, "",
                                                Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1,
                                                ""));
-  EXPECT_CALL(cm, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+  EXPECT_CALL(cm, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);
 

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -64,19 +64,21 @@ public:
                    ListenSocket& socket, ListenerCallbacks& cb, Stats::Store& stats_store,
                    const Network::ListenerOptions& listener_options)
       : ListenerImpl(conn_handler, dispatcher, socket, cb, stats_store, listener_options) {
-    ON_CALL(*this, newConnection(_, _, _))
-        .WillByDefault(Invoke([this](int fd, Address::InstanceConstSharedPtr remote_address,
-                                     Address::InstanceConstSharedPtr local_address) -> void {
-          ListenerImpl::newConnection(fd, remote_address, local_address);
-        }
+    ON_CALL(*this, newConnection(_, _, _, _))
+        .WillByDefault(Invoke(
+            [this](int fd, Address::InstanceConstSharedPtr remote_address,
+                   Address::InstanceConstSharedPtr local_address, bool using_original_dst) -> void {
+              ListenerImpl::newConnection(fd, remote_address, local_address, using_original_dst);
+            }
 
-                              ));
+            ));
   }
 
   MOCK_METHOD1(getLocalAddress, Address::InstanceConstSharedPtr(int fd));
   MOCK_METHOD1(getOriginalDst, Address::InstanceConstSharedPtr(int fd));
-  MOCK_METHOD3(newConnection, void(int fd, Address::InstanceConstSharedPtr remote_address,
-                                   Address::InstanceConstSharedPtr local_address));
+  MOCK_METHOD4(newConnection,
+               void(int fd, Address::InstanceConstSharedPtr remote_address,
+                    Address::InstanceConstSharedPtr local_address, bool using_original_dst));
 };
 
 class ListenerImplTest : public testing::TestWithParam<Address::IpVersion> {
@@ -120,8 +122,8 @@ TEST_P(ListenerImplTest, NormalRedirect) {
   EXPECT_CALL(connection_handler, findListenerByAddress(Eq(ByRef(*alt_address_))))
       .WillOnce(Return(&listenerDst));
 
-  EXPECT_CALL(listener, newConnection(_, _, _)).Times(0);
-  EXPECT_CALL(listenerDst, newConnection(_, _, _));
+  EXPECT_CALL(listener, newConnection(_, _, _, _)).Times(0);
+  EXPECT_CALL(listenerDst, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks2, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(*alt_address_, conn->localAddress());
@@ -161,8 +163,8 @@ TEST_P(ListenerImplTest, FallbackToWildcardListener) {
   EXPECT_CALL(connection_handler, findListenerByAddress(Eq(ByRef(*alt_address_))))
       .WillOnce(Return(&listenerDst));
 
-  EXPECT_CALL(listener, newConnection(_, _, _)).Times(0);
-  EXPECT_CALL(listenerDst, newConnection(_, _, _));
+  EXPECT_CALL(listener, newConnection(_, _, _, _)).Times(0);
+  EXPECT_CALL(listenerDst, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks2, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(*alt_address_, conn->localAddress());
@@ -200,7 +202,7 @@ TEST_P(ListenerImplTest, WildcardListenerWithOriginalDst) {
   EXPECT_CALL(connection_handler, findListenerByAddress(Eq(ByRef(*alt_address_))))
       .WillOnce(Return(&listener));
 
-  EXPECT_CALL(listener, newConnection(_, _, _));
+  EXPECT_CALL(listener, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(conn->localAddress(), *alt_address_);
@@ -237,7 +239,7 @@ TEST_P(ListenerImplTest, WildcardListenerNoOriginalDst) {
   EXPECT_CALL(listener, getOriginalDst(_)).WillOnce(Return(local_dst_address));
   EXPECT_CALL(connection_handler, findListenerByAddress(_)).Times(0);
 
-  EXPECT_CALL(listener, newConnection(_, _, _));
+  EXPECT_CALL(listener, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(conn->localAddress(), *local_dst_address);
@@ -276,8 +278,8 @@ TEST_P(ListenerImplTest, UseActualDst) {
   EXPECT_CALL(listener, getOriginalDst(_)).Times(0);
   EXPECT_CALL(connection_handler, findListenerByAddress(_)).Times(0);
 
-  EXPECT_CALL(listener, newConnection(_, _, _)).Times(1);
-  EXPECT_CALL(listenerDst, newConnection(_, _, _)).Times(0);
+  EXPECT_CALL(listener, newConnection(_, _, _, _)).Times(1);
+  EXPECT_CALL(listenerDst, newConnection(_, _, _, _)).Times(0);
   EXPECT_CALL(listener_callbacks1, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(conn->localAddress(), *socket.localAddress());
@@ -313,7 +315,7 @@ TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
   EXPECT_CALL(listener, getOriginalDst(_)).Times(0);
   EXPECT_CALL(connection_handler, findListenerByAddress(_)).Times(0);
 
-  EXPECT_CALL(listener, newConnection(_, _, _)).Times(1);
+  EXPECT_CALL(listener, newConnection(_, _, _, _)).Times(1);
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(conn->localAddress(), *local_dst_address);

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -39,7 +39,8 @@ public:
         Upstream::ClusterInfoConstSharedPtr{new Upstream::MockClusterInfo}, "",
         Network::Utility::resolveUrl("tcp://127.0.0.1:80"), false, 1, ""));
 
-    EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster")).WillOnce(Return(conn_info));
+    EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+        .WillOnce(Return(conn_info));
     EXPECT_CALL(*connection_, setBufferStats(_));
     EXPECT_CALL(*connection_, connect());
   }

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -136,6 +136,22 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "original_dst_cluster_test",
+    srcs = ["original_dst_cluster_test.cc"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/upstream:original_dst_cluster_lib",
+        "//source/common/upstream:upstream_lib",
+        "//test/mocks:common_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "outlier_detection_impl_test",
     srcs = ["outlier_detection_impl_test.cc"],
     deps = [

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -326,6 +326,44 @@ TEST_F(ClusterManagerImplTest, InvalidClusterNameChars) {
                             "key: #/name");
 }
 
+TEST_F(ClusterManagerImplTest, OriginalDstLbRestriction) {
+  const std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster_1",
+      "connect_timeout_ms": 250,
+      "type": "original_dst",
+      "lb_type": "round_robin"
+    }]
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  EXPECT_THROW_WITH_MESSAGE(
+      create(*loader), EnvoyException,
+      "cluster: cluster type 'original_dst' may only be used with LB type 'original_dst_lb'");
+}
+
+TEST_F(ClusterManagerImplTest, OriginalDstLbRestriction2) {
+  const std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster_1",
+      "connect_timeout_ms": 250,
+      "type": "static",
+      "lb_type": "original_dst_lb"
+    }]
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  EXPECT_THROW_WITH_MESSAGE(
+      create(*loader), EnvoyException,
+      "cluster: LB type 'original_dst_lb' may only be used with cluser type 'original_dst'");
+}
+
 TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
   const std::string json = R"EOF(
   {
@@ -827,6 +865,39 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.3"}));
   dns_timer_->callback_();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2"}));
+
+  factory_.tls_.shutdownThread();
+}
+
+TEST_F(ClusterManagerImplTest, OriginalDstInitialization) {
+  const std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "cluster_1",
+      "connect_timeout_ms": 250,
+      "type": "original_dst",
+      "lb_type": "original_dst_lb"
+    }]
+  }
+  )EOF"; // "
+
+  ReadyWatcher initialized;
+  EXPECT_CALL(initialized, ready());
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  create(*loader);
+
+  // Set up for an initialize callback.
+  cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
+
+  EXPECT_FALSE(cluster_manager_->get("cluster_1")->info()->addedViaApi());
+
+  // Test for no hosts returning the correct values before we have hosts.
+  EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("cluster_1",
+                                                              ResourcePriority::Default, nullptr));
+  EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1").connection_);
+  EXPECT_EQ(2UL, factory_.stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
 
   factory_.tls_.shutdownThread();
 }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -419,7 +419,7 @@ TEST_F(ClusterManagerImplTest, UnknownCluster) {
   EXPECT_EQ(nullptr, cluster_manager_->get("hello"));
   EXPECT_EQ(nullptr,
             cluster_manager_->httpConnPoolForCluster("hello", ResourcePriority::Default, nullptr));
-  EXPECT_THROW(cluster_manager_->tcpConnForCluster("hello"), EnvoyException);
+  EXPECT_THROW(cluster_manager_->tcpConnForCluster("hello", nullptr), EnvoyException);
   EXPECT_THROW(cluster_manager_->httpAsyncClientForCluster("hello"), EnvoyException);
   factory_.tls_.shutdownThread();
 }
@@ -447,7 +447,7 @@ TEST_F(ClusterManagerImplTest, VerifyBufferLimits) {
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   EXPECT_CALL(*connection, setBufferLimits(8192));
   EXPECT_CALL(factory_.tls_.dispatcher_, createClientConnection_(_)).WillOnce(Return(connection));
-  auto conn_data = cluster_manager_->tcpConnForCluster("cluster_1");
+  auto conn_data = cluster_manager_->tcpConnForCluster("cluster_1", nullptr);
   EXPECT_EQ(connection, conn_data.connection_.get());
   factory_.tls_.shutdownThread();
 }
@@ -804,7 +804,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   // Test for no hosts returning the correct values before we have hosts.
   EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("cluster_1",
                                                               ResourcePriority::Default, nullptr));
-  EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1").connection_);
+  EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1", nullptr).connection_);
   EXPECT_EQ(2UL, factory_.stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
 
   // Set up for an initialize callback.
@@ -896,7 +896,7 @@ TEST_F(ClusterManagerImplTest, OriginalDstInitialization) {
   // Test for no hosts returning the correct values before we have hosts.
   EXPECT_EQ(nullptr, cluster_manager_->httpConnPoolForCluster("cluster_1",
                                                               ResourcePriority::Default, nullptr));
-  EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1").connection_);
+  EXPECT_EQ(nullptr, cluster_manager_->tcpConnForCluster("cluster_1", nullptr).connection_);
   EXPECT_EQ(2UL, factory_.stats_.counter("cluster.cluster_1.upstream_cx_none_healthy").value());
 
   factory_.tls_.shutdownThread();

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -1,0 +1,425 @@
+#include <chrono>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "common/network/address_impl.h"
+#include "common/network/utility.h"
+#include "common/upstream/original_dst_cluster.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/ssl/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::_;
+
+namespace Upstream {
+
+class TestLoadBalancerContext : public LoadBalancerContext {
+public:
+  TestLoadBalancerContext(const Network::Connection* connection) : connection_(connection) {}
+
+  // Upstream::LoadBalancerContext
+  Optional<uint64_t> hashKey() const override { return 0; }
+  const Network::Connection* downstreamConnection() const override { return connection_; }
+
+  Optional<uint64_t> hash_key_;
+  const Network::Connection* connection_;
+};
+
+class OriginalDstClusterTest : public testing::Test {
+public:
+  // cleanup timer must be created before the cluster (in setup()), so that we can set expectations
+  // on it. Ownership is transferred to the cluster at the cluster constructor, so the cluster will
+  // take care of destructing it!
+  OriginalDstClusterTest() : cleanup_timer_(new Event::MockTimer(&dispatcher_)) {}
+
+  void setup(const std::string& json) {
+    Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
+    cluster_.reset(new OriginalDstCluster(*config, runtime_, stats_store_, ssl_context_manager_,
+                                          dispatcher_, false));
+    cluster_->addMemberUpdateCb(
+        [&](const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&) -> void {
+          membership_updated_.ready();
+        });
+    cluster_->setInitializedCb([&]() -> void { initialized_.ready(); });
+  }
+
+  Stats::IsolatedStoreImpl stats_store_;
+  Ssl::MockContextManager ssl_context_manager_;
+  ClusterSharedPtr cluster_;
+  ReadyWatcher membership_updated_;
+  ReadyWatcher initialized_;
+  NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  Event::MockTimer* cleanup_timer_;
+};
+
+TEST_F(OriginalDstClusterTest, BadConfig) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "hosts": [{"url": "tcp://foo.bar.com:443"}]
+  }
+  )EOF"; // Help Emacs balance quotation marks: "
+
+  EXPECT_THROW(setup(json), EnvoyException);
+}
+
+TEST_F(OriginalDstClusterTest, CleanupInterval) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "cleanup_interval_ms": 1000
+  }
+  )EOF"; // Help Emacs balance quotation marks: "
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(membership_updated_, ready()).Times(0);
+  EXPECT_CALL(*cleanup_timer_, enableTimer(std::chrono::milliseconds(1000)));
+  setup(json);
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+}
+
+TEST_F(OriginalDstClusterTest, NoContext) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 1250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+  }
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(membership_updated_, ready()).Times(0);
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  setup(json);
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  // No downstream connection => no host.
+  {
+    TestLoadBalancerContext lb_context(nullptr);
+    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    EXPECT_CALL(dispatcher_, post(_)).Times(0);
+    HostConstSharedPtr host = lb.chooseHost(&lb_context);
+    EXPECT_EQ(host, nullptr);
+  }
+
+  // Downstream connection is not using original dst => no host.
+  {
+    NiceMock<Network::MockConnection> connection;
+    TestLoadBalancerContext lb_context(&connection);
+
+    EXPECT_CALL(connection, usingOriginalDst()).WillOnce(Return(false));
+    // First argument is normally the reference to the ThreadLocalCluster's HostSet, but in these
+    // tests we do not have the thread local clusters, so we pass a reference to the HostSet of the
+    // primary cluster.  The implementation handles both cases the same.
+    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    EXPECT_CALL(dispatcher_, post(_)).Times(0);
+    HostConstSharedPtr host = lb.chooseHost(&lb_context);
+    EXPECT_EQ(host, nullptr);
+  }
+
+  // No host for non-IP address
+  {
+    NiceMock<Network::MockConnection> connection;
+    TestLoadBalancerContext lb_context(&connection);
+    Network::Address::PipeInstance local_address("unix://foo");
+    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
+
+    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    EXPECT_CALL(dispatcher_, post(_)).Times(0);
+    HostConstSharedPtr host = lb.chooseHost(&lb_context);
+    EXPECT_EQ(host, nullptr);
+  }
+}
+
+TEST_F(OriginalDstClusterTest, Membership) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 1250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+  }
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  setup(json);
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  EXPECT_CALL(membership_updated_, ready());
+
+  // Host gets the local address of the downstream connection.
+
+  NiceMock<Network::MockConnection> connection;
+  TestLoadBalancerContext lb_context(&connection);
+  Network::Address::Ipv4Instance local_address("10.10.11.11");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
+
+  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+  Event::PostCb post_cb;
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host = lb.chooseHost(&lb_context);
+  post_cb();
+  auto cluster_hosts = cluster_->hosts();
+
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(local_address, *host->address());
+
+  EXPECT_EQ(1UL, cluster_->hosts().size());
+  EXPECT_EQ(1UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  EXPECT_EQ(host, cluster_->hosts()[0]);
+  EXPECT_EQ(local_address, *cluster_->hosts()[0]->address());
+
+  // Same host is returned on the 2nd call
+  HostConstSharedPtr host2 = lb.chooseHost(&lb_context);
+  EXPECT_EQ(host2, host);
+
+  // Make host time out, no membership changes happen on the first timeout.
+  ASSERT_EQ(1UL, cluster_->hosts().size());
+  EXPECT_EQ(true, cluster_->hosts()[0]->used(true));
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  cleanup_timer_->callback_();
+  EXPECT_EQ(cluster_hosts, cluster_->hosts()); // hosts vector remains the same
+
+  // host gets removed on the 2nd timeout.
+  ASSERT_EQ(1UL, cluster_->hosts().size());
+  EXPECT_EQ(false, cluster_->hosts()[0]->used(false));
+
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  EXPECT_CALL(membership_updated_, ready());
+  cleanup_timer_->callback_();
+  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  cluster_hosts = cluster_->hosts();
+
+  // New host gets created
+  EXPECT_CALL(membership_updated_, ready());
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host3 = lb.chooseHost(&lb_context);
+  post_cb();
+  EXPECT_NE(host3, nullptr);
+  EXPECT_NE(host3, host);
+  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+
+  EXPECT_EQ(1UL, cluster_->hosts().size());
+  EXPECT_EQ(host3, cluster_->hosts()[0]);
+}
+
+TEST_F(OriginalDstClusterTest, Membership2) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 1250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+  }
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  setup(json);
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  // Host gets the local address of the downstream connection.
+
+  NiceMock<Network::MockConnection> connection1;
+  TestLoadBalancerContext lb_context1(&connection1);
+  Network::Address::Ipv4Instance local_address1("10.10.11.11");
+  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(ReturnRef(local_address1));
+  EXPECT_CALL(connection1, usingOriginalDst()).WillRepeatedly(Return(true));
+
+  NiceMock<Network::MockConnection> connection2;
+  TestLoadBalancerContext lb_context2(&connection2);
+  Network::Address::Ipv4Instance local_address2("10.10.11.12");
+  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(ReturnRef(local_address2));
+  EXPECT_CALL(connection2, usingOriginalDst()).WillRepeatedly(Return(true));
+
+  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+
+  EXPECT_CALL(membership_updated_, ready());
+  Event::PostCb post_cb;
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
+  post_cb();
+  ASSERT_NE(host1, nullptr);
+  EXPECT_EQ(local_address1, *host1->address());
+
+  EXPECT_CALL(membership_updated_, ready());
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host2 = lb.chooseHost(&lb_context2);
+  post_cb();
+  ASSERT_NE(host2, nullptr);
+  EXPECT_EQ(local_address2, *host2->address());
+
+  EXPECT_EQ(2UL, cluster_->hosts().size());
+  EXPECT_EQ(2UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  EXPECT_EQ(host1, cluster_->hosts()[0]);
+  EXPECT_EQ(local_address1, *cluster_->hosts()[0]->address());
+
+  EXPECT_EQ(host2, cluster_->hosts()[1]);
+  EXPECT_EQ(local_address2, *cluster_->hosts()[1]->address());
+
+  auto cluster_hosts = cluster_->hosts();
+
+  // Make hosts time out, no membership changes happen on the first timeout.
+  ASSERT_EQ(2UL, cluster_->hosts().size());
+  EXPECT_EQ(true, cluster_->hosts()[0]->used(true));
+  EXPECT_EQ(true, cluster_->hosts()[1]->used(true));
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  cleanup_timer_->callback_();
+  EXPECT_EQ(cluster_hosts, cluster_->hosts()); // hosts vector remains the same
+
+  // both hosts get removed on the 2nd timeout.
+  ASSERT_EQ(2UL, cluster_->hosts().size());
+  EXPECT_EQ(false, cluster_->hosts()[0]->used(false));
+  EXPECT_EQ(false, cluster_->hosts()[1]->used(false));
+
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  EXPECT_CALL(membership_updated_, ready());
+  cleanup_timer_->callback_();
+  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+}
+
+TEST_F(OriginalDstClusterTest, Connection) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 1250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+  }
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  setup(json);
+
+  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->hostsPerZone().size());
+  EXPECT_EQ(0UL, cluster_->healthyHostsPerZone().size());
+
+  EXPECT_CALL(membership_updated_, ready());
+
+  // Connection to the host is made to the downstream connection's local address.
+  NiceMock<Network::MockConnection> connection;
+  TestLoadBalancerContext lb_context(&connection);
+  Network::Address::Ipv6Instance local_address("FD00::1");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
+
+  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+  Event::PostCb post_cb;
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host = lb.chooseHost(&lb_context);
+  post_cb();
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(local_address, *host->address());
+
+  EXPECT_CALL(dispatcher_, createClientConnection_(PointeesEq(&local_address)))
+      .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
+  host->createConnection(dispatcher_);
+}
+
+TEST_F(OriginalDstClusterTest, MultipleClusters) {
+  std::string json = R"EOF(
+  {
+    "name": "name",
+    "connect_timeout_ms": 1250,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+  }
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_));
+  setup(json);
+
+  HostSetImpl second;
+  cluster_->addMemberUpdateCb([&](const std::vector<HostSharedPtr>& added,
+                                  const std::vector<HostSharedPtr>& removed) -> void {
+    // Update second hostset accordingly;
+    HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>(cluster_->hosts()));
+    HostVectorSharedPtr healthy_hosts(new std::vector<HostSharedPtr>(cluster_->hosts()));
+    const HostListsConstSharedPtr empty_host_lists{new std::vector<std::vector<HostSharedPtr>>()};
+
+    second.updateHosts(new_hosts, healthy_hosts, empty_host_lists, empty_host_lists, added,
+                       removed);
+  });
+
+  EXPECT_CALL(membership_updated_, ready());
+
+  // Connection to the host is made to the downstream connection's local address.
+  NiceMock<Network::MockConnection> connection;
+  TestLoadBalancerContext lb_context(&connection);
+  Network::Address::Ipv6Instance local_address("FD00::1");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
+
+  OriginalDstCluster::LoadBalancer lb1(*cluster_, cluster_);
+  OriginalDstCluster::LoadBalancer lb2(second, cluster_);
+  Event::PostCb post_cb;
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host = lb1.chooseHost(&lb_context);
+  post_cb();
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(local_address, *host->address());
+
+  EXPECT_EQ(1UL, cluster_->hosts().size());
+  // Check that lb2 also gets updated
+  EXPECT_EQ(1UL, second.hosts().size());
+
+  EXPECT_EQ(host, cluster_->hosts()[0]);
+  EXPECT_EQ(host, second.hosts()[0]);
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -29,6 +29,7 @@ public:
 
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return hash_key_; }
+  const Network::Connection* downstreamConnection() const override { return nullptr; }
 
   Optional<uint64_t> hash_key_;
 };

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -25,6 +25,9 @@ MockDispatcher::~MockDispatcher() {}
 
 MockTimer::MockTimer() {}
 
+// Ownership of each MockTimer instance is transferred to the (caller of) dispatcher's
+// createTimer_(), so to avoid destructing it twice, the MockTimer must have been dynamically
+// allocated and must not be deleted by it's creator.
 MockTimer::MockTimer(MockDispatcher* dispatcher) {
   EXPECT_CALL(*dispatcher, createTimer_(_))
       .WillOnce(DoAll(SaveArg<0>(&callback_), Return(this)))

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -68,6 +68,7 @@ public:
   MOCK_METHOD1(write, void(Buffer::Instance& data));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
   MOCK_CONST_METHOD0(bufferLimit, uint32_t());
+  MOCK_CONST_METHOD0(usingOriginalDst, bool());
 };
 
 /**
@@ -101,6 +102,7 @@ public:
   MOCK_METHOD1(write, void(Buffer::Instance& data));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
   MOCK_CONST_METHOD0(bufferLimit, uint32_t());
+  MOCK_CONST_METHOD0(usingOriginalDst, bool());
 
   // Network::ClientConnection
   MOCK_METHOD0(connect, void());

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -117,6 +117,7 @@ public:
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(weight, uint32_t());
   MOCK_METHOD1(weight, void(uint32_t new_weight));
+  MOCK_METHOD1(used, bool(bool new_used));
   MOCK_CONST_METHOD0(zone, const std::string&());
 
   testing::NiceMock<MockClusterInfo> cluster_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -90,8 +90,9 @@ public:
   MockClusterManager();
   ~MockClusterManager();
 
-  Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) override {
-    MockHost::MockCreateConnectionData data = tcpConnForCluster_(cluster);
+  Host::CreateConnectionData tcpConnForCluster(const std::string& cluster,
+                                               LoadBalancerContext* context) override {
+    MockHost::MockCreateConnectionData data = tcpConnForCluster_(cluster, context);
     return {Network::ClientConnectionPtr{data.connection_}, data.host_};
   }
 
@@ -104,7 +105,9 @@ public:
                Http::ConnectionPool::Instance*(const std::string& cluster,
                                                ResourcePriority priority,
                                                LoadBalancerContext* context));
-  MOCK_METHOD1(tcpConnForCluster_, MockHost::MockCreateConnectionData(const std::string& cluster));
+  MOCK_METHOD2(tcpConnForCluster_,
+               MockHost::MockCreateConnectionData(const std::string& cluster,
+                                                  LoadBalancerContext* context));
   MOCK_METHOD1(httpAsyncClientForCluster, Http::AsyncClient&(const std::string& cluster));
   MOCK_METHOD1(removePrimaryCluster, bool(const std::string& cluster));
   MOCK_METHOD0(shutdown, void());

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -45,7 +45,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
       factory.clusterManagerFromJson(*config, stats, tls, runtime, random, local_info, log_manager);
   EXPECT_EQ(nullptr,
             cluster_manager->httpConnPoolForCluster("cluster", ResourcePriority::Default, nullptr));
-  Host::CreateConnectionData data = cluster_manager->tcpConnForCluster("cluster");
+  Host::CreateConnectionData data = cluster_manager->tcpConnForCluster("cluster", nullptr);
   EXPECT_EQ(nullptr, data.connection_);
   EXPECT_EQ(nullptr, data.host_description_);
 


### PR DESCRIPTION
Envoy already supports SO_ORIGINAL_DST to retrieve the original
destination IP address and L4 port number that were overwritten by
netfilter REDIRECT action.  So far the original destination address
has been only used to switch from the initial listener to another
listener on the original address.

This patch adds a new cluster type that uses the original
destination address as the upstream destination for the requests
coming from a connection where the SO_ORIGINAL_DST returns an address
that is different from the initial destination address the connection
was received on.  The request must be routed to this new cluster type
for this to happen, and other cluster types can still be used as
before, ignoring the original destination address on the upstream
side.

The "original_dst" cluster type makes transparent proxying with envoy
easier in scenarios where it is impractical to configure a dedicated
cluster for each possible upstream host, e.g., when acting as an
egress proxy facing a large external network.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
