### PR TITLE
Fixing flow control events in watermark buffer

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -70,6 +70,7 @@ void OwnedImpl::move(Instance& rhs) {
   int rc = evbuffer_add_buffer(buffer_.get(), static_cast<LibEventInstance&>(rhs).buffer().get());
   ASSERT(rc == 0);
   UNREFERENCED_PARAMETER(rc);
+  static_cast<LibEventInstance&>(rhs).postProcess();
 }
 
 void OwnedImpl::move(Instance& rhs, uint64_t length) {
@@ -78,6 +79,7 @@ void OwnedImpl::move(Instance& rhs, uint64_t length) {
                                   length);
   ASSERT(static_cast<uint64_t>(rc) == length);
   UNREFERENCED_PARAMETER(rc);
+  static_cast<LibEventInstance&>(rhs).postProcess();
 }
 
 int OwnedImpl::read(int fd, uint64_t max_length) {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -18,7 +18,10 @@ public:
 
 class LibEventInstance : public Instance {
 public:
+  // Allows access into the underlying buffer for move() optimizations.
   virtual Event::Libevent::BufferPtr& buffer() PURE;
+  // Called after accessing the memory in buffer() directly to allow any post-processing.
+  virtual void postProcess() PURE;
 };
 
 /**
@@ -49,6 +52,7 @@ public:
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   ssize_t search(const void* data, uint64_t size, size_t start) const override;
   int write(int fd) override;
+  void postProcess() override {}
 
   Event::Libevent::BufferPtr& buffer() override { return buffer_; }
 

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -50,6 +50,7 @@ public:
   Event::Libevent::BufferPtr& buffer() override {
     return static_cast<LibEventInstance&>(*wrapped_buffer_).buffer();
   }
+  void postProcess() override { checkLowWatermark(); }
 
   void setWatermarks(uint32_t low_watermark, uint32_t high_watermark);
 


### PR DESCRIPTION
Previously, low watermark events didn't fire when data was moved out of a watermark buffer.  This wasn't caught by existing tests as this code path appears to not be used in the pure TCP case, but is in the H2 path.

I'm not thrilled at buffer_impl having to be mildly aware of watermark buffer's existence but this is the cleanest way I could support move semantics and also watermarks working as expected.  