### PR TITLE
Enabled heap check (#1306)

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -100,6 +100,18 @@ bazel test //test/... --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 bazel test //test/... --test_env=ENVOY_IP_TEST_VERSIONS=v6only
 ```
 
+By default, tests are run with the [gperftools](https://github.com/gperftools/gperftools) heap
+checker enabled in "normal" mode to detect leaks. For other mode options, see the gperftools
+heap checker [documentation](https://gperftools.github.io/gperftools/heap_checker.html). To
+disable the heap checker or change the mode, set the HEAPCHECK environment variable:
+
+```
+# Disables the heap checker
+bazel test //test/... --test_env=HEAPCHECK=
+# Changes the heap checker to "minimal" mode
+bazel test //test/... --test_env=HEAPCHECK=minimal
+```
+
 Bazel will by default cache successful test results. To force it to rerun tests:
 
 ```

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -66,7 +66,7 @@ export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=stand
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
   --jobs=${NUM_CPUS} --show_task_finish"
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
-  --test_env=HEAPCHECK --test_output=all"
+  --cache_test_results=no --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
 ln -sf /thirdparty "${ENVOY_SRCDIR}"/ci/prebuilt
 ln -sf /thirdparty_build "${ENVOY_SRCDIR}"/ci/prebuilt

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -4,7 +4,6 @@
 
 set -e
 
-export HEAPCHECK=normal
 export PPROF_PATH=/thirdparty_build/bin/pprof
 
 NUM_CPUS=`grep -c ^processor /proc/cpuinfo`

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -66,7 +66,7 @@ export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=stand
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
   --jobs=${NUM_CPUS} --show_task_finish"
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
-  --test_env=HEAPCHECK --test_env=PPROF_PATH --cache_test_results=no --test_output=all"
+  --test_env=HEAPCHECK --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
 ln -sf /thirdparty "${ENVOY_SRCDIR}"/ci/prebuilt
 ln -sf /thirdparty_build "${ENVOY_SRCDIR}"/ci/prebuilt

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -66,7 +66,7 @@ export BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=stand
   --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
   --jobs=${NUM_CPUS} --show_task_finish"
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
-  --cache_test_results=no --test_output=all"
+  --test_env=HEAPCHECK --test_env=PPROF_PATH --cache_test_results=no --test_output=all"
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && "${BAZEL}" clean --expunge
 ln -sf /thirdparty "${ENVOY_SRCDIR}"/ci/prebuilt
 ln -sf /thirdparty_build "${ENVOY_SRCDIR}"/ci/prebuilt

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -38,3 +38,6 @@ build:clang-msan --copt -fsanitize=memory
 build:clang-msan --linkopt -fsanitize=memory
 build:clang-msan --define tcmalloc=disabled
 build:clang-msan --copt -fsanitize-memory-track-origins=2
+
+# Test options
+test --test_env=HEAPCHECK --test_env=PPROF_PATH

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -40,4 +40,4 @@ build:clang-msan --define tcmalloc=disabled
 build:clang-msan --copt -fsanitize-memory-track-origins=2
 
 # Test options
-test --test_env=HEAPCHECK --test_env=PPROF_PATH
+test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH


### PR DESCRIPTION

Fixes #1306.  Heap check was disabled because the environment variables that enable it were not accessible to the running tests.  This was fixed by explicitly adding those environment variables to the bazel test options.  We now see stack traces for leaks like the following (symbol name availability depends on the build mode):
```
Leak of 8 bytes in 2 objects allocated from:
        @ 677c96 Envoy::Router::Filter::Filter
        @ 677b07 _ZN5Envoy6Router10ProdFilterCI2NS0_6FilterEERNS0_12FilterConfigE
        @ 958ec0 Envoy::Http::AsyncStreamImpl::AsyncStreamImpl
        @ 958757 Envoy::Http::AsyncRequestImpl::AsyncRequestImpl
        @ 958562 Envoy::Http::AsyncClientImpl::send
        @ 99f595 Envoy::Http::RestApiFetcher::refresh
        @ 99f3f5 Envoy::Http::RestApiFetcher::initialize
        @ 5885b9 Envoy::Upstream::CdsApiImpl::initialize
        @ 5667b9 Envoy::Upstream::ClusterManagerInitHelper::maybeFinishInitialize
        @ 566891 Envoy::Upstream::ClusterManagerInitHelper::onSt
Leak of 8 bytes in 2 objects allocated from:
        @ 677d38 Envoy::Router::Filter::Filter
        @ 677b07 _ZN5Envoy6Router10ProdFilterCI2NS0_6FilterEERNS0_12FilterConfigE
        @ 958ec0 Envoy::Http::AsyncStreamImpl::AsyncStreamImpl
        @ 958757 Envoy::Http::AsyncRequestImpl::AsyncRequestImpl
        @ 958562 Envoy::Http::AsyncClientImpl::send
        @ 99f595 Envoy::Http::RestApiFetcher::refresh
        @ 99f3f5 Envoy::Http::RestApiFetcher::initialize
        @ 5885b9 Envoy::Upstream::CdsApiImpl::initialize
        @ 5667b9 Envoy::Upstream::ClusterManagerInitHelper::maybeFinishInitialize
        @ 566891 Envoy::Upstream::ClusterManagerInitHelper::onSt
```