### PR TITLE
protobuf: update for google import

### DIFF
--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -21,8 +21,8 @@ using Envoy::Protobuf::DescriptorPool;
 using Envoy::Protobuf::FileDescriptor;
 using Envoy::Protobuf::FileDescriptorSet;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
-using Envoy::Protobuf::util::Status;
-using Envoy::Protobuf::util::error::Code;
+using Envoy::ProtobufUtil::Status;
+using Envoy::ProtobufUtil::error::Code;
 using google::grpc::transcoding::JsonRequestTranslator;
 using google::grpc::transcoding::PathMatcherBuilder;
 using google::grpc::transcoding::PathMatcherUtility;
@@ -123,9 +123,9 @@ Status JsonTranscoderConfig::createTranscoder(
     const Http::HeaderMap& headers, ZeroCopyInputStream& request_input,
     google::grpc::transcoding::TranscoderInputStream& response_input,
     std::unique_ptr<Transcoder>& transcoder, const Protobuf::MethodDescriptor*& method_descriptor) {
-  const std::string method = headers.Method()->value().c_str();
-  std::string path = headers.Path()->value().c_str();
-  std::string args;
+  const ProtobufTypes::String method = headers.Method()->value().c_str();
+  ProtobufTypes::String path = headers.Path()->value().c_str();
+  ProtobufTypes::String args;
 
   const size_t pos = path.find('?');
   if (pos != std::string::npos) {
@@ -171,7 +171,7 @@ Status JsonTranscoderConfig::createTranscoder(
 
   transcoder.reset(
       new TranscoderImpl(std::move(request_translator), std::move(response_translator)));
-  return Status::OK;
+  return Status();
 }
 
 Status JsonTranscoderConfig::methodToRequestInfo(const Protobuf::MethodDescriptor* method,
@@ -179,11 +179,12 @@ Status JsonTranscoderConfig::methodToRequestInfo(const Protobuf::MethodDescripto
   auto request_type_url = TYPE_URL_PREFIX + "/" + method->input_type()->full_name();
   info->message_type = type_helper_->Info()->GetTypeByTypeUrl(request_type_url);
   if (info->message_type == nullptr) {
-    ENVOY_LOG(debug, "Cannot resolve input-type: {}", method->input_type()->full_name());
+    ENVOY_LOG(debug, "Cannot resolve input-type: {}",
+              ProtobufTypes::FromString(method->input_type()->full_name()));
     return Status(Code::NOT_FOUND, "Could not resolve type: " + method->input_type()->full_name());
   }
 
-  return Status::OK;
+  return Status();
 }
 
 JsonTranscoderFilter::JsonTranscoderFilter(JsonTranscoderConfig& config) : config_(config) {}
@@ -212,10 +213,11 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::HeaderMap& h
 
     const auto& request_status = transcoder_->RequestStatus();
     if (!request_status.ok()) {
-      ENVOY_LOG(debug, "Transcoding request error " + request_status.ToString());
+      ENVOY_LOG(debug, "Transcoding request error " +
+                           ProtobufTypes::FromString(request_status.ToString()));
       error_ = true;
       Http::Utility::sendLocalReply(*decoder_callbacks_, stream_reset_, Http::Code::BadRequest,
-                                    request_status.error_message().ToString());
+                                    request_status.error_message());
 
       return Http::FilterHeadersStatus::StopIteration;
     }
@@ -248,10 +250,11 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
   const auto& request_status = transcoder_->RequestStatus();
 
   if (!request_status.ok()) {
-    ENVOY_LOG(debug, "Transcoding request error " + request_status.ToString());
+    ENVOY_LOG(debug,
+              "Transcoding request error " + ProtobufTypes::FromString(request_status.ToString()));
     error_ = true;
     Http::Utility::sendLocalReply(*decoder_callbacks_, stream_reset_, Http::Code::BadRequest,
-                                  request_status.error_message().ToString());
+                                  request_status.error_message());
 
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }

--- a/source/common/grpc/json_transcoder_filter.h
+++ b/source/common/grpc/json_transcoder_filter.h
@@ -29,9 +29,9 @@ struct VariableBinding {
   // The location of the field in the protobuf message, where the value
   // needs to be inserted, e.g. "shelf.theme" would mean the "theme" field
   // of the nested "shelf" message of the request protobuf message.
-  std::vector<std::string> field_path;
+  std::vector<ProtobufTypes::String> field_path;
   // The value to be inserted.
-  std::string value;
+  ProtobufTypes::String value;
 };
 
 /**
@@ -54,7 +54,7 @@ public:
    * @param method_descriptor output parameter for the method looked up from config
    * @return status whether the Transcoder instance are successfully created or not
    */
-  Protobuf::util::Status
+  ProtobufUtil::Status
   createTranscoder(const Http::HeaderMap& headers, Protobuf::io::ZeroCopyInputStream& request_input,
                    google::grpc::transcoding::TranscoderInputStream& response_input,
                    std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
@@ -64,8 +64,8 @@ private:
   /**
    * Convert method descriptor to RequestInfo that needed for transcoding library
    */
-  Protobuf::util::Status methodToRequestInfo(const Protobuf::MethodDescriptor* method,
-                                             google::grpc::transcoding::RequestInfo* info);
+  ProtobufUtil::Status methodToRequestInfo(const Protobuf::MethodDescriptor* method,
+                                           google::grpc::transcoding::RequestInfo* info);
 
 private:
   Protobuf::DescriptorPool descriptor_pool_;

--- a/source/common/protobuf/protobuf.h
+++ b/source/common/protobuf/protobuf.h
@@ -24,6 +24,9 @@ namespace Envoy {
 // Google we have more than one protobuf implementation.
 namespace Protobuf = google::protobuf;
 
+// Allows mapping from google::protobuf::util to other util libraries.
+namespace ProtobufUtil = google::protobuf::util;
+
 // Protobuf well-known types (WKT) should be referenced via the ProtobufWkt
 // namespace.
 namespace ProtobufWkt = google::protobuf;

--- a/test/common/grpc/json_transcoder_filter_test.cc
+++ b/test/common/grpc/json_transcoder_filter_test.cc
@@ -29,8 +29,8 @@ using Envoy::Protobuf::MethodDescriptor;
 
 using Envoy::Protobuf::FileDescriptorSet;
 using Envoy::Protobuf::util::MessageDifferencer;
-using Envoy::Protobuf::util::Status;
-using Envoy::Protobuf::util::error::Code;
+using Envoy::ProtobufUtil::Status;
+using Envoy::ProtobufUtil::error::Code;
 using google::api::HttpRule;
 using google::grpc::transcoding::Transcoder;
 
@@ -149,7 +149,7 @@ TEST_F(GrpcJsonTranscoderConfigTest, InvalidVariableBinding) {
   auto status =
       config.createTranscoder(headers, request_in, response_in, transcoder, method_descriptor);
 
-  EXPECT_EQ(Protobuf::util::error::Code::INVALID_ARGUMENT, status.error_code());
+  EXPECT_EQ(Code::INVALID_ARGUMENT, status.error_code());
   EXPECT_EQ("Could not find field \"b\" in the type \"bookstore.GetBookRequest\".",
             status.error_message());
   EXPECT_FALSE(transcoder);

--- a/test/config/integration/server_grpc_json_transcoder.json
+++ b/test/config/integration/server_grpc_json_transcoder.json
@@ -60,7 +60,7 @@
   }],
 
   "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
-  "statsd_local_udp_port": 8125,
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
 
   "cluster_manager": {
     "clusters": [


### PR DESCRIPTION
This PR allows mapping from protobuf::util to other util namespaces in addition to plumbing through some other protobuf related mapping. Also one IPv6 related change. Needed for google import.