### PR TITLE
Skylark function for basic cc_library envoy targets

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -58,8 +58,8 @@ def envoy_include_prefix(path):
 # passed to cc_library should be specified with this function. Note: this exists to ensure that
 # all envoy targets pass through an envoy-declared skylark function where they can be modified
 # before being passed to a native bazel function.
-def basic_envoy_cc_library(name, **kargs):
-    native.cc_library(name = name, **kwargs)
+def envoy_basic_cc_library(name, **kargs):
+    native.cc_library(name = name, **kargs)
 
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -54,6 +54,13 @@ def envoy_include_prefix(path):
         return '/'.join(path.split('/')[1:])
     return None
 
+# Envoy C++ library targets that need no transformations or additional dependencies before being
+# passed to cc_library should be specified with this function. Note: this exists to ensure that
+# all envoy targets pass through an envoy-declared skylark function where they can be modified
+# before being passed to a native bazel function.
+def basic_envoy_cc_library(name, **kargs):
+    native.cc_library(name = name, **kwargs)
+
 # Envoy C++ library targets should be specified with this function.
 def envoy_cc_library(name,
                      srcs = [],

--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -3,12 +3,13 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_basic_cc_library",
     "envoy_package",
 )
 
 envoy_package()
 
-basic_envoy_cc_library(
+envoy_basic_cc_library(
     name = "base_includes",
     hdrs = [
         "exception.h",

--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -8,7 +8,7 @@ load(
 
 envoy_package()
 
-cc_library(
+basic_envoy_cc_library(
     name = "base_includes",
     hdrs = [
         "exception.h",

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -9,7 +9,7 @@ load(
 
 envoy_package()
 
-cc_library(
+basic_envoy_cc_library(
     name = "printers_includes",
     hdrs = ["printers.h"],
 )

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -3,13 +3,14 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_basic_cc_library",
     "envoy_cc_test_library",
     "envoy_package",
 )
 
 envoy_package()
 
-basic_envoy_cc_library(
+envoy_basic_cc_library(
     name = "printers_includes",
     hdrs = ["printers.h"],
 )


### PR DESCRIPTION
Added skylark function for envoy targets that currently call cc_library directly.  This will help us, in particular, with our import.  It should also be generally useful so that all envoy targets go through a skylark function declared in `bazel/envoy_build_system.bzl` allowing easy modifications of general classes of targets.