### PR TITLE
test: parameterize statsd address

### DIFF
--- a/test/config/integration/server_ratelimit.json
+++ b/test/config/integration/server_ratelimit.json
@@ -63,7 +63,7 @@
   }],
 
   "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
-  "statsd_local_udp_port": 8125,
+  "statsd_udp_ip_address": "{{ ip_loopback_address }}:8125",
 
   "rate_limit_service": {
     "type": "grpc_service",


### PR DESCRIPTION
Needed for IPv4/IPv6 only environment testing.