### PR TITLE
ratelimit: make HTTP filter timeout configurable.

### DIFF
--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -22,7 +22,8 @@ If the rate limit service is called, and the response for any of the descriptors
     "config": {
       "domain": "...",
       "stage": "...",
-      "request_type": "..."
+      "request_type": "...",
+      "timeout_ms": "..."
     }
   }
 
@@ -42,6 +43,10 @@ request_type
   :ref:`x-envoy-internal<config_http_conn_man_headers_x-envoy-internal>` is not set or false, a
   request is considered external. The filter defaults to *both*, and it will apply to all request
   types.
+
+timeout_ms
+  *(optional, integer)* The timeout in milliseconds for the rate limit service RPC. If not set,
+  this defaults to 20ms.
 
 Statistics
 ----------

--- a/docs/configuration/network_filters/rate_limit_filter.rst
+++ b/docs/configuration/network_filters/rate_limit_filter.rst
@@ -13,7 +13,8 @@ Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
     "config": {
       "stat_prefix": "...",
       "domain": "...",
-      "descriptors": []
+      "descriptors": [],
+      "timeout_ms": "..."
     }
   }
 
@@ -34,6 +35,10 @@ descriptors
       [{"key": "hello", "value": "world"}, {"key": "foo", "value": "bar"}],
       [{"key": "foo2", "value": "bar2"}]
     ]
+
+timeout_ms
+  *(optional, integer)* The timeout in milliseconds for the rate limit service RPC. If not set,
+  this defaults to 20ms.
 
 .. _config_network_filters_rate_limit_stats:
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -377,6 +377,11 @@ const std::string Json::Schema::RATELIMIT_NETWORK_FILTER_SCHEMA(R"EOF(
             "additionalProperties": false
           }
         }
+      },
+      "timeout_ms" : {
+        "type" : "integer",
+        "minimum" : 0,
+        "exclusiveMinimum" : true
       }
     },
     "required": ["stat_prefix", "descriptors", "domain"],

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -974,6 +974,11 @@ const std::string Json::Schema::RATE_LIMIT_HTTP_FILTER_SCHEMA(R"EOF(
       "request_type" : {
         "type" : "string",
         "enum" : ["internal", "external", "both"]
+      },
+      "timeout_ms" : {
+        "type" : "integer",
+        "minimum" : 0,
+        "exclusiveMinimum" : true
       }
     },
     "required" : ["domain"],

--- a/source/server/config/http/ratelimit.cc
+++ b/source/server/config/http/ratelimit.cc
@@ -16,9 +16,11 @@ HttpFilterFactoryCb RateLimitFilterConfig::createFilterFactory(const Json::Objec
                                                                FactoryContext& context) {
   Http::RateLimit::FilterConfigSharedPtr filter_config(new Http::RateLimit::FilterConfig(
       config, context.localInfo(), context.scope(), context.runtime(), context.clusterManager()));
-  return [filter_config, &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  const uint32_t timeout_ms = config.getInteger("timeout_ms", 20);
+  return [filter_config, timeout_ms,
+          &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{new Http::RateLimit::Filter(
-        filter_config, context.rateLimitClient(std::chrono::milliseconds(20)))});
+        filter_config, context.rateLimitClient(std::chrono::milliseconds(timeout_ms)))});
   };
 }
 

--- a/source/server/config/network/ratelimit.cc
+++ b/source/server/config/network/ratelimit.cc
@@ -16,9 +16,10 @@ NetworkFilterFactoryCb RateLimitConfigFactory::createFilterFactory(const Json::O
                                                                    FactoryContext& context) {
   RateLimit::TcpFilter::ConfigSharedPtr config(
       new RateLimit::TcpFilter::Config(json_config, context.scope(), context.runtime()));
-  return [config, &context](Network::FilterManager& filter_manager) -> void {
+  const uint32_t timeout_ms = config.getInteger("timeout_ms", 20);
+  return [config, timeout_ms, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new RateLimit::TcpFilter::Instance(
-        config, context.rateLimitClient(Optional<std::chrono::milliseconds>()))});
+        config, context.rateLimitClient(timeout_ms))});
   };
 }
 

--- a/source/server/config/network/ratelimit.cc
+++ b/source/server/config/network/ratelimit.cc
@@ -16,10 +16,10 @@ NetworkFilterFactoryCb RateLimitConfigFactory::createFilterFactory(const Json::O
                                                                    FactoryContext& context) {
   RateLimit::TcpFilter::ConfigSharedPtr config(
       new RateLimit::TcpFilter::Config(json_config, context.scope(), context.runtime()));
-  const uint32_t timeout_ms = config.getInteger("timeout_ms", 20);
+  const uint32_t timeout_ms = json_config.getInteger("timeout_ms", 20);
   return [config, timeout_ms, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new RateLimit::TcpFilter::Instance(
-        config, context.rateLimitClient(timeout_ms))});
+        config, context.rateLimitClient(std::chrono::milliseconds(timeout_ms)))});
   };
 }
 

--- a/test/config/integration/server_ratelimit.json
+++ b/test/config/integration/server_ratelimit.json
@@ -55,7 +55,7 @@
         },
         "filters": [
           { "type": "decoder", "name": "rate_limit",
-            "config": { "domain": "some_domain" }},
+            "config": { "domain": "some_domain", "timeout_ms": 500 }},
           { "type": "decoder", "name": "router", "config": {} }
         ]
       }

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -60,6 +60,38 @@ TEST(HttpFilterConfigTest, BadBufferFilterConfig) {
   EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
 }
 
+TEST(HttpFilterConfigTest, RateLimitFilter) {
+  std::string json_string = R"EOF(
+  {
+    "domain" : "test",
+    "timeout_ms" : 1337
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
+  NiceMock<MockFactoryContext> context;
+  RateLimitFilterConfig factory;
+  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
+  HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpFilterConfigTest, BadRateLimitFilterConfig) {
+  std::string json_string = R"EOF(
+  {
+    "domain" : "test",
+    "timeout_ms" : 0
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
+  NiceMock<MockFactoryContext> context;
+  RateLimitFilterConfig factory;
+  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
+}
+
 TEST(HttpFilterConfigTest, DynamoFilter) {
   std::string json_string = R"EOF(
   {

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -162,7 +162,8 @@ TEST(NetworkFilterConfigTest, Ratelimit) {
   {
     "stat_prefix": "my_stat_prefix",
     "domain" : "fake_domain",
-    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]]
+    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]],
+    "timeout_ms": 1337
   }
   )EOF";
 


### PR DESCRIPTION
This was a requested feature in #990 and it also turns out that
//test/integration:ratelimit_integration_test was flaking on the low
default timeout in ASAN builds.

There are still some other flakes that occur in --runs_per_test=1000,
but these seem unrelated.

Fixes #990.