### PR TITLE
test: deflake //test/integration:ratelimit_integration_test.

### DIFF
--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -185,7 +185,7 @@ TEST_P(RatelimitIntegrationTest, ConnectImmediateDisconnect) {
   initiateClientConnection();
   fake_ratelimit_connection_ = fake_upstreams_[1]->waitForHttpConnection(*dispatcher_);
   fake_ratelimit_connection_->close();
-  fake_ratelimit_connection_->waitForDisconnect();
+  fake_ratelimit_connection_->waitForDisconnect(true);
   fake_ratelimit_connection_ = nullptr;
   // Rate limiter fails open
   waitForSuccessfulUpstreamResponse();


### PR DESCRIPTION
On the immediate connect/disconnect case, there may be some data in the
pipe prior to the disconnect.