### PR TITLE
redis: support mset, del, exists, touch, unlink

### DIFF
--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -125,6 +125,7 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   }
   case RespType::Error: {
     error_count_++;
+    // fall through
   }
   case RespType::BulkString: {
     pending_response_->asArray()[index].asString().swap(value->asString());
@@ -189,8 +190,10 @@ void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
 
   switch (value->type()) {
   case RespType::SimpleString: {
-    if (value->asString() == "OK")
+    if (value->asString() == "OK") {
       break;
+    }
+    // else fall through
   }
   default: {
     error_count_++;
@@ -234,7 +237,8 @@ SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
     PendingRequest& pending_request = request_ptr->pending_requests_.back();
 
     single_fragment.asArray()[1].asString() = incoming_request.asArray()[i].asString();
-    ENVOY_LOG(debug, "redis: parallel del: '{}'", single_fragment.toString());
+    ENVOY_LOG(debug, "redis: parallel {}: '{}'", incoming_request.asArray()[0].asString(),
+              single_fragment.toString());
     pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
                                                     single_fragment, pending_request);
     if (!pending_request.handle_) {

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -70,17 +70,21 @@ void FragmentedRequest::cancel() {
   }
 }
 
+void FragmentedRequest::onChildFailure(uint32_t index) {
+  onChildResponse(Utility::makeError("upstream failure"), index);
+}
+
 SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
                                     const RespValue& incoming_request, SplitCallbacks& callbacks) {
   std::unique_ptr<MGETRequest> request_ptr{new MGETRequest(callbacks)};
 
   request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
+  request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
   request_ptr->pending_response_.reset(new RespValue());
   request_ptr->pending_response_->type(RespType::Array);
   std::vector<RespValue> responses(request_ptr->num_pending_responses_);
   request_ptr->pending_response_->asArray().swap(responses);
-  request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
   std::vector<RespValue> values(2);
   values[0].type(RespType::BulkString);
@@ -112,14 +116,17 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   pending_response_->asArray()[index].type(value->type());
   switch (value->type()) {
   case RespType::Array:
-  case RespType::Integer: {
+  case RespType::Integer:
+  case RespType::SimpleString: {
     pending_response_->asArray()[index].type(RespType::Error);
     pending_response_->asArray()[index].asString() = "upstream protocol error";
+    error_count_++;
     break;
   }
-  case RespType::SimpleString:
-  case RespType::BulkString:
   case RespType::Error: {
+    error_count_++;
+  }
+  case RespType::BulkString: {
     pending_response_->asArray()[index].asString().swap(value->asString());
     break;
   }
@@ -134,22 +141,154 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   }
 }
 
-void MGETRequest::onChildFailure(uint32_t index) {
-  onChildResponse(Utility::makeError("upstream failure"), index);
+SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
+                                    const RespValue& incoming_request, SplitCallbacks& callbacks) {
+  if ((incoming_request.asArray().size() - 1) % 2 != 0) {
+    callbacks.onResponse(Utility::makeError("wrong number of arguments for command"));
+    return nullptr;
+  }
+
+  std::unique_ptr<MSETRequest> request_ptr{new MSETRequest(callbacks)};
+
+  request_ptr->num_pending_responses_ = (incoming_request.asArray().size() - 1) / 2;
+  request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
+
+  request_ptr->pending_response_.reset(new RespValue());
+  request_ptr->pending_response_->type(RespType::SimpleString);
+
+  std::vector<RespValue> values(3);
+  values[0].type(RespType::BulkString);
+  values[0].asString() = "set";
+  values[1].type(RespType::BulkString);
+  values[2].type(RespType::BulkString);
+  RespValue single_mset;
+  single_mset.type(RespType::Array);
+  single_mset.asArray().swap(values);
+
+  uint64_t fragment_index = 0;
+  for (uint64_t i = 1; i < incoming_request.asArray().size(); i += 2) {
+    request_ptr->pending_requests_.emplace_back(*request_ptr, fragment_index++);
+    PendingRequest& pending_request = request_ptr->pending_requests_.back();
+
+    single_mset.asArray()[1].asString() = incoming_request.asArray()[i].asString();
+    single_mset.asArray()[2].asString() = incoming_request.asArray()[i + 1].asString();
+
+    ENVOY_LOG(debug, "redis: parallel set: '{}'", single_mset.toString());
+    pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
+                                                    single_mset, pending_request);
+    if (!pending_request.handle_) {
+      pending_request.onResponse(Utility::makeError("no upstream host"));
+    }
+  }
+
+  return request_ptr->num_pending_responses_ > 0 ? std::move(request_ptr) : nullptr;
+}
+
+void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
+  pending_requests_[index].handle_ = nullptr;
+
+  switch (value->type()) {
+  case RespType::SimpleString: {
+    if (value->asString() == "OK")
+      break;
+  }
+  default: {
+    error_count_++;
+    break;
+  }
+  }
+
+  ASSERT(num_pending_responses_ > 0);
+  if (--num_pending_responses_ == 0) {
+    if (error_count_ == 0) {
+      pending_response_->asString() = "OK";
+      callbacks_.onResponse(std::move(pending_response_));
+    } else {
+      callbacks_.onResponse(
+          Utility::makeError(fmt::format("finished with {} error(s)", error_count_)));
+    }
+  }
+}
+
+SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
+                                                  const RespValue& incoming_request,
+                                                  SplitCallbacks& callbacks) {
+  std::unique_ptr<SplitKeysSumResultRequest> request_ptr{new SplitKeysSumResultRequest(callbacks)};
+
+  request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
+  request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
+
+  request_ptr->pending_response_.reset(new RespValue());
+  request_ptr->pending_response_->type(RespType::Integer);
+
+  std::vector<RespValue> values(2);
+  values[0].type(RespType::BulkString);
+  values[0].asString() = incoming_request.asArray()[0].asString();
+  values[1].type(RespType::BulkString);
+  RespValue single_fragment;
+  single_fragment.type(RespType::Array);
+  single_fragment.asArray().swap(values);
+
+  for (uint64_t i = 1; i < incoming_request.asArray().size(); i++) {
+    request_ptr->pending_requests_.emplace_back(*request_ptr, i - 1);
+    PendingRequest& pending_request = request_ptr->pending_requests_.back();
+
+    single_fragment.asArray()[1].asString() = incoming_request.asArray()[i].asString();
+    ENVOY_LOG(debug, "redis: parallel del: '{}'", single_fragment.toString());
+    pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
+                                                    single_fragment, pending_request);
+    if (!pending_request.handle_) {
+      pending_request.onResponse(Utility::makeError("no upstream host"));
+    }
+  }
+
+  return request_ptr->num_pending_responses_ > 0 ? std::move(request_ptr) : nullptr;
+}
+
+void SplitKeysSumResultRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
+  pending_requests_[index].handle_ = nullptr;
+
+  switch (value->type()) {
+  case RespType::Integer: {
+    total_ += value->asInteger();
+    break;
+  }
+  default: {
+    error_count_++;
+    break;
+  }
+  }
+
+  ASSERT(num_pending_responses_ > 0);
+  if (--num_pending_responses_ == 0) {
+    if (error_count_ == 0) {
+      pending_response_->asInteger() = total_;
+      callbacks_.onResponse(std::move(pending_response_));
+    } else {
+      callbacks_.onResponse(
+          Utility::makeError(fmt::format("finished with {} error(s)", error_count_)));
+    }
+  }
 }
 
 InstanceImpl::InstanceImpl(ConnPool::InstancePtr&& conn_pool, Stats::Scope& scope,
                            const std::string& stat_prefix)
     : conn_pool_(std::move(conn_pool)), simple_command_handler_(*conn_pool_),
-      mget_handler_(*conn_pool_), stats_{ALL_COMMAND_SPLITTER_STATS(
-                                      POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))} {
+      mget_handler_(*conn_pool_), mset_handler_(*conn_pool_),
+      split_keys_sum_result_handler_(*conn_pool_),
+      stats_{ALL_COMMAND_SPLITTER_STATS(POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))} {
   // TODO(mattklein123) PERF: Make this a trie (like in header_map_impl).
-  for (const std::string& command : SupportedCommands::allToOneCommands()) {
+  for (const std::string& command : SupportedCommands::simpleCommands()) {
     addHandler(scope, stat_prefix, command, simple_command_handler_);
   }
 
-  // TODO(danielhochman): support for other multi-shard operations (del, mset)
-  addHandler(scope, stat_prefix, "mget", mget_handler_);
+  for (const std::string& command : SupportedCommands::hashMultipleSumResultCommands()) {
+    addHandler(scope, stat_prefix, command, split_keys_sum_result_handler_);
+  }
+
+  // TODO(danielhochman): support for EVAL
+  addHandler(scope, stat_prefix, SupportedCommands::mget(), mget_handler_);
+  addHandler(scope, stat_prefix, SupportedCommands::mset(), mset_handler_);
 }
 
 SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbacks& callbacks) {

--- a/source/common/redis/command_splitter_impl.h
+++ b/source/common/redis/command_splitter_impl.h
@@ -103,6 +103,7 @@ public:
 private:
   MGETRequest(SplitCallbacks& callbacks) : FragmentedRequest(callbacks) {}
 
+  // Redis::CommandSplitter::FragmentedRequest
   void onChildResponse(RespValuePtr&& value, uint32_t index) override;
   void onChildFailure(uint32_t index) override;
 };

--- a/source/common/redis/supported_commands.h
+++ b/source/common/redis/supported_commands.h
@@ -10,9 +10,7 @@ struct SupportedCommands {
   /**
    * @return commands which hash to a single server
    */
-  static const std::vector<std::string>& allToOneCommands() {
-    // TODO(danielhochman): DEL should hash to multiple servers and is only added for testing single
-    // key deletes
+  static const std::vector<std::string>& simpleCommands() {
     static const std::vector<std::string>* commands =
         new std::vector<std::string>{"append",
                                      "bitcount",
@@ -20,7 +18,6 @@ struct SupportedCommands {
                                      "bitpos",
                                      "decr",
                                      "decrby",
-                                     "del",
                                      "dump",
                                      "expire",
                                      "expireat",
@@ -106,7 +103,33 @@ struct SupportedCommands {
                                      "zscore"};
     return *commands;
   }
-  // TODO(danielhochman): static vector of commands that hash to multiple servers: mget, mset, del
+
+  /**
+   * @return commands which are sent to multiple servers and coalesced by summing the responses
+   */
+  static const std::vector<std::string>& hashMultipleSumResultCommands() {
+    static const std::vector<std::string>* commands =
+        new std::vector<std::string>{"del", "exists", "touch", "unlink"};
+    return *commands;
+  }
+
+  /**
+   * @return mget command
+   */
+  static const std::string& mget() {
+    static const std::string* command = new std::string("mget");
+    return *command;
+  }
+
+  /**
+   * @return mset command
+   */
+  static const std::string& mset() {
+    static const std::string* command = new std::string("mset");
+    return *command;
+  }
+
+  // TODO(danielhochman): support for EVAL with argument enforcement
 };
 
 } // namespace Redis

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -72,6 +72,7 @@ TEST_F(RedisEncoderDecoderImplTest, Integer) {
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
+  EXPECT_EQ(value.asInteger(), 9223372036854775807);
 }
 
 TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerSmall) {

--- a/test/common/redis/codec_impl_test.cc
+++ b/test/common/redis/codec_impl_test.cc
@@ -72,7 +72,6 @@ TEST_F(RedisEncoderDecoderImplTest, Integer) {
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
-  EXPECT_EQ(value.asInteger(), 9223372036854775807);
 }
 
 TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerSmall) {

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -195,7 +195,7 @@ TEST_P(RedisSimpleRequestCommandHandlerTest, NoUpstream) {
 };
 
 INSTANTIATE_TEST_CASE_P(RedisSimpleRequestCommandHandlerTest, RedisSimpleRequestCommandHandlerTest,
-                        testing::ValuesIn(SupportedCommands::allToOneCommands()));
+                        testing::ValuesIn(SupportedCommands::simpleCommands()));
 
 INSTANTIATE_TEST_CASE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
                         RedisSimpleRequestCommandHandlerTest, testing::Values("INCR", "inCrBY"));
@@ -381,6 +381,109 @@ TEST_F(RedisMGETCommandHandlerTest, Cancel) {
   EXPECT_CALL(pool_requests_[1], cancel());
   handle_->cancel();
 };
+
+class RedisMSETCommandHandlerTest : public RedisCommandSplitterImplTest {
+public:
+  void setup(uint32_t num_sets, const std::list<uint64_t>& null_handle_indexes) {
+    std::vector<std::string> request_strings = {"mset"};
+    for (uint32_t i = 0; i < num_sets; i++) {
+      // key
+      request_strings.push_back(std::to_string(i));
+      // value
+      request_strings.push_back(std::to_string(i));
+    }
+
+    RespValue request;
+    makeBulkStringArray(request, request_strings);
+
+    std::vector<RespValue> tmp_expected_requests(num_sets);
+    expected_requests_.swap(tmp_expected_requests);
+    pool_callbacks_.resize(num_sets);
+    std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_sets);
+    pool_requests_.swap(tmp_pool_requests);
+    for (uint32_t i = 0; i < num_sets; i++) {
+      makeBulkStringArray(expected_requests_[i], {"set", std::to_string(i), std::to_string(i)});
+      ConnPool::PoolRequest* request_to_use = nullptr;
+      if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
+          null_handle_indexes.end()) {
+        request_to_use = &pool_requests_[i];
+      }
+      EXPECT_CALL(*conn_pool_, makeRequest(std::to_string(i), Eq(ByRef(expected_requests_[i])), _))
+          .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callbacks_[i])), Return(request_to_use)));
+    }
+
+    handle_ = splitter_.makeRequest(request, callbacks_);
+  }
+
+  std::vector<RespValue> expected_requests_;
+  std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
+  std::vector<ConnPool::MockPoolRequest> pool_requests_;
+};
+
+TEST_F(RedisMSETCommandHandlerTest, Normal) {
+  InSequence s;
+
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  RespValue expected_response;
+  expected_response.type(RespType::SimpleString);
+  expected_response.asString() = "OK";
+
+  RespValuePtr response2(new RespValue());
+  response2->type(RespType::SimpleString);
+  response2->asString() = "OK";
+  pool_callbacks_[1]->onResponse(std::move(response2));
+
+  RespValuePtr response1(new RespValue());
+  response1->type(RespType::SimpleString);
+  response1->asString() = "OK";
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[0]->onResponse(std::move(response1));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.mset.total").value());
+};
+
+TEST_F(RedisMSETCommandHandlerTest, NoUpstreamHostForAll) {
+  // No InSequence to avoid making setup() more complicated.
+
+  RespValue expected_response;
+  expected_response.type(RespType::Error);
+  expected_response.asString() = "finished with 2 error(s)";
+
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  setup(2, {0, 1});
+  EXPECT_EQ(nullptr, handle_);
+};
+
+TEST_F(RedisMSETCommandHandlerTest, NoUpstreamHostForOne) {
+  InSequence s;
+
+  setup(2, {0});
+  EXPECT_NE(nullptr, handle_);
+
+  RespValue expected_response;
+  expected_response.type(RespType::Error);
+  expected_response.asString() = "finished with 1 error(s)";
+
+  RespValuePtr response2(new RespValue());
+  response2->type(RespType::SimpleString);
+  response2->asString() = "OK";
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(std::move(response2));
+};
+
+TEST_F(RedisMSETCommandHandlerTest, Cancel) {
+  InSequence s;
+
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  EXPECT_CALL(pool_requests_[0], cancel());
+  EXPECT_CALL(pool_requests_[1], cancel());
+  handle_->cancel();
+};
+
 
 } // namespace CommandSplitter
 } // namespace Redis

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -484,7 +484,6 @@ TEST_F(RedisMSETCommandHandlerTest, Cancel) {
   handle_->cancel();
 };
 
-
 } // namespace CommandSplitter
 } // namespace Redis
 } // namespace Envoy

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -484,6 +484,105 @@ TEST_F(RedisMSETCommandHandlerTest, Cancel) {
   handle_->cancel();
 };
 
+class RedisSplitKeysSumResultHandlerTest : public RedisCommandSplitterImplTest,
+                                           public testing::WithParamInterface<std::string> {
+public:
+  void setup(uint32_t num_commands, const std::list<uint64_t>& null_handle_indexes) {
+    std::vector<std::string> request_strings = {GetParam()};
+    for (uint32_t i = 0; i < num_commands; i++) {
+      request_strings.push_back(std::to_string(i));
+    }
+
+    RespValue request;
+    makeBulkStringArray(request, request_strings);
+
+    std::vector<RespValue> tmp_expected_requests(num_commands);
+    expected_requests_.swap(tmp_expected_requests);
+    pool_callbacks_.resize(num_commands);
+    std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_commands);
+    pool_requests_.swap(tmp_pool_requests);
+    for (uint32_t i = 0; i < num_commands; i++) {
+      makeBulkStringArray(expected_requests_[i], {GetParam(), std::to_string(i)});
+      ConnPool::PoolRequest* request_to_use = nullptr;
+      if (std::find(null_handle_indexes.begin(), null_handle_indexes.end(), i) ==
+          null_handle_indexes.end()) {
+        request_to_use = &pool_requests_[i];
+      }
+      EXPECT_CALL(*conn_pool_, makeRequest(std::to_string(i), Eq(ByRef(expected_requests_[i])), _))
+          .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callbacks_[i])), Return(request_to_use)));
+    }
+
+    handle_ = splitter_.makeRequest(request, callbacks_);
+  }
+
+  std::vector<RespValue> expected_requests_;
+  std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
+  std::vector<ConnPool::MockPoolRequest> pool_requests_;
+};
+
+TEST_P(RedisSplitKeysSumResultHandlerTest, Normal) {
+  InSequence s;
+
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  RespValue expected_response;
+  expected_response.type(RespType::Integer);
+  expected_response.asInteger() = 2;
+
+  RespValuePtr response2(new RespValue());
+  response2->type(RespType::Integer);
+  response2->asInteger() = 1;
+  pool_callbacks_[1]->onResponse(std::move(response2));
+
+  RespValuePtr response1(new RespValue());
+  response1->type(RespType::Integer);
+  response1->asInteger() = 1;
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[0]->onResponse(std::move(response1));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command." + GetParam() + ".total").value());
+};
+
+TEST_P(RedisSplitKeysSumResultHandlerTest, NormalOneZero) {
+  InSequence s;
+
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  RespValue expected_response;
+  expected_response.type(RespType::Integer);
+  expected_response.asInteger() = 1;
+
+  RespValuePtr response2(new RespValue());
+  response2->type(RespType::Integer);
+  response2->asInteger() = 0;
+  pool_callbacks_[1]->onResponse(std::move(response2));
+
+  RespValuePtr response1(new RespValue());
+  response1->type(RespType::Integer);
+  response1->asInteger() = 1;
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[0]->onResponse(std::move(response1));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command." + GetParam() + ".total").value());
+};
+
+TEST_P(RedisSplitKeysSumResultHandlerTest, NoUpstreamHostForAll) {
+  // No InSequence to avoid making setup() more complicated.
+
+  RespValue expected_response;
+  expected_response.type(RespType::Error);
+  expected_response.asString() = "finished with 2 error(s)";
+
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  setup(2, {0, 1});
+  EXPECT_EQ(nullptr, handle_);
+};
+
+INSTANTIATE_TEST_CASE_P(RedisSplitKeysSumResultHandlerTest, RedisSplitKeysSumResultHandlerTest,
+                        testing::ValuesIn(SupportedCommands::hashMultipleSumResultCommands()));
+
 } // namespace CommandSplitter
 } // namespace Redis
 } // namespace Envoy

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -484,6 +484,18 @@ TEST_F(RedisMSETCommandHandlerTest, Cancel) {
   handle_->cancel();
 };
 
+TEST_F(RedisMSETCommandHandlerTest, WrongNumberOfArgs) {
+  InSequence s;
+
+  RespValue response;
+  response.type(RespType::Error);
+  response.asString() = "wrong number of arguments for command";
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
+  RespValue request;
+  makeBulkStringArray(request, {"mset", "foo", "bar", "fizz"});
+  EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
+};
+
 class RedisSplitKeysSumResultHandlerTest : public RedisCommandSplitterImplTest,
                                            public testing::WithParamInterface<std::string> {
 public:


### PR DESCRIPTION
Refactors support for commands which hash to multiple servers into the `FragementedRequest` abstract base and adds support for two new types of commands.