### PR TITLE
perf: optimize tcp statsd stat flushing

### DIFF
--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -101,6 +101,12 @@ public:
   virtual ~Sink() {}
 
   /**
+   * This will be called before a sequence of flushCounter() and flushGauge() calls. Sinks can
+   * choose to optimize writing if desired with a paired endFlush() call.
+   */
+  virtual void beginFlush() PURE;
+
+  /**
    * Flush a counter delta.
    */
   virtual void flushCounter(const std::string& name, uint64_t delta) PURE;
@@ -109,6 +115,12 @@ public:
    * Flush a gauge value.
    */
   virtual void flushGauge(const std::string& name, uint64_t value) PURE;
+
+  /**
+   * This will be called after beginFlush(), some number of flushCounter(), and some number of
+   * flushGauge(). Sinks can use this to optimize writing if desired.
+   */
+  virtual void endFlush() PURE;
 
   /**
    * Flush a histogram value.

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -33,9 +33,8 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
         "//source/common/config:utility_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:utility_lib",
     ],
 )
 

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -113,7 +113,8 @@ void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
 void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value, char stat_type) {
   ASSERT(current_slice_mem_ != nullptr);
   // 40 > 6 (prefix) + 4 (random chars) + 30 for number (bigger than it will ever be)
-  if (current_buffer_slice_.len_ - usedBuffer() < name.size() + 40) {
+  const uint32_t max_size = name.size() + 40;
+  if (current_buffer_slice_.len_ - usedBuffer() < max_size) {
     endFlush(false);
     beginFlush(false);
   }
@@ -132,7 +133,7 @@ void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value
   *current_slice_mem_++ = stat_type;
   *current_slice_mem_++ = '\n';
 
-  ASSERT(static_cast<uint64_t>(current_slice_mem_ - snapped_current) < name.size() + 40);
+  ASSERT(static_cast<uint64_t>(current_slice_mem_ - snapped_current) < max_size);
   UNREFERENCED_PARAMETER(snapped_current);
 }
 

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -8,11 +8,9 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
+#include "common/common/utility.h"
 #include "common/config/utility.h"
-#include "common/network/address_impl.h"
-#include "common/network/utility.h"
 
 #include "spdlog/spdlog.h"
 
@@ -74,6 +72,8 @@ void UdpStatsdSink::onTimespanComplete(const std::string& name, std::chrono::mil
   tls_->getTyped<Writer>().writeTimer(name, ms);
 }
 
+char TcpStatsdSink::StatPrefix[] = "envoy.";
+
 TcpStatsdSink::TcpStatsdSink(const LocalInfo::LocalInfo& local_info,
                              const std::string& cluster_name, ThreadLocal::SlotAllocator& tls,
                              Upstream::ClusterManager& cluster_manager, Stats::Scope& scope)
@@ -97,12 +97,55 @@ TcpStatsdSink::TlsSink::~TlsSink() {
   }
 }
 
+void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
+  ASSERT(!expect_empty_buffer || buffer_.length() == 0);
+  ASSERT(current_slice_mem_ == nullptr);
+  UNREFERENCED_PARAMETER(expect_empty_buffer);
+
+  uint64_t num_iovecs = buffer_.reserve(FlushSliceSizeBytes, &current_buffer_slice_, 1);
+  ASSERT(num_iovecs == 1);
+  UNREFERENCED_PARAMETER(num_iovecs);
+
+  ASSERT(current_buffer_slice_.len_ >= FlushSliceSizeBytes);
+  current_slice_mem_ = reinterpret_cast<char*>(current_buffer_slice_.mem_);
+}
+
+void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value, char stat_type) {
+  ASSERT(current_slice_mem_ != nullptr);
+  // 40 > 6 (prefix) + 4 (random chars) + 30 for number (bigger than it will ever be)
+  if (current_buffer_slice_.len_ - usedBuffer() < name.size() + 40) {
+    endFlush(false);
+    beginFlush(false);
+  }
+
+  // Produces something like "envoy.{}:{}|c\n"
+  memcpy(current_slice_mem_, StatPrefix, sizeof(StatPrefix) - 1);
+  current_slice_mem_ += sizeof(StatPrefix) - 1;
+  memcpy(current_slice_mem_, name.c_str(), name.size());
+  current_slice_mem_ += name.size();
+  *current_slice_mem_++ = ':';
+  current_slice_mem_ += StringUtil::itoa(current_slice_mem_, 30, value);
+  *current_slice_mem_++ = '|';
+  *current_slice_mem_++ = stat_type;
+  *current_slice_mem_++ = '\n';
+}
+
 void TcpStatsdSink::TlsSink::flushCounter(const std::string& name, uint64_t delta) {
-  write(fmt::format("envoy.{}:{}|c\n", name, delta));
+  commonFlush(name, delta, 'c');
 }
 
 void TcpStatsdSink::TlsSink::flushGauge(const std::string& name, uint64_t value) {
-  write(fmt::format("envoy.{}:{}|g\n", name, value));
+  commonFlush(name, value, 'g');
+}
+
+void TcpStatsdSink::TlsSink::endFlush(bool do_write) {
+  ASSERT(current_slice_mem_ != nullptr);
+  current_buffer_slice_.len_ = usedBuffer();
+  buffer_.commit(&current_buffer_slice_, 1);
+  current_slice_mem_ = nullptr;
+  if (do_write) {
+    write(buffer_);
+  }
 }
 
 void TcpStatsdSink::TlsSink::onEvent(uint32_t events) {
@@ -114,10 +157,12 @@ void TcpStatsdSink::TlsSink::onEvent(uint32_t events) {
 
 void TcpStatsdSink::TlsSink::onTimespanComplete(const std::string& name,
                                                 std::chrono::milliseconds ms) {
-  write(fmt::format("envoy.{}:{}|ms\n", name, ms.count()));
+  // Ultimately it would be nice to perf optimize this path also, but it's not very frequent.
+  Buffer::OwnedImpl buffer(fmt::format("envoy.{}:{}|ms\n", name, ms.count()));
+  write(buffer);
 }
 
-void TcpStatsdSink::TlsSink::write(const std::string& stat) {
+void TcpStatsdSink::TlsSink::write(Buffer::Instance& buffer) {
   // Guard against the stats connection backing up. In this case we probably have no visibility
   // into what is going on externally, but we also increment a stat that should be viewable
   // locally.
@@ -134,6 +179,7 @@ void TcpStatsdSink::TlsSink::write(const std::string& stat) {
       connection_->close(Network::ConnectionCloseType::NoFlush);
     }
     parent_.cx_overflow_stat_.inc();
+    buffer.drain(buffer.length());
     return;
   }
 
@@ -153,8 +199,12 @@ void TcpStatsdSink::TlsSink::write(const std::string& stat) {
     connection_->connect();
   }
 
-  Buffer::OwnedImpl buffer(stat);
   connection_->write(buffer);
+}
+
+uint64_t TcpStatsdSink::TlsSink::usedBuffer() {
+  ASSERT(current_slice_mem_ != nullptr);
+  return current_slice_mem_ - reinterpret_cast<char*>(current_buffer_slice_.mem_);
 }
 
 } // namespace Statsd

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -122,13 +122,13 @@ private:
   };
 
   // Somewhat arbitrary 16MiB limit for buffered stats.
-  static constexpr uint32_t MaxBufferedStatsBytes = (1024 * 1024 * 16);
+  static constexpr uint32_t MAX_BUFFERED_STATS_BYTES = (1024 * 1024 * 16);
 
   // 16KiB intermediate buffer for flushing.
-  static constexpr uint32_t FlushSliceSizeBytes = (1024 * 16);
+  static constexpr uint32_t FLUSH_SLICE_SIZE_BYTES = (1024 * 16);
 
   // Prefix for all flushed stats.
-  static char StatPrefix[];
+  static char STAT_PREFIX[];
 
   Upstream::ClusterInfoConstSharedPtr cluster_info_;
   ThreadLocal::SlotPtr tls_;

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -10,6 +10,8 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/buffer/buffer_impl.h"
+
 namespace Envoy {
 namespace Stats {
 namespace Statsd {
@@ -43,8 +45,10 @@ public:
   UdpStatsdSink(ThreadLocal::SlotAllocator& tls, Network::Address::InstanceConstSharedPtr address);
 
   // Stats::Sink
+  void beginFlush() override {}
   void flushCounter(const std::string& name, uint64_t delta) override;
   void flushGauge(const std::string& name, uint64_t value) override;
+  void endFlush() override {}
   void onHistogramComplete(const std::string& name, uint64_t value) override {
     // For statsd histograms are just timers.
     onTimespanComplete(name, std::chrono::milliseconds(value));
@@ -68,6 +72,8 @@ public:
                 Stats::Scope& scope);
 
   // Stats::Sink
+  void beginFlush() override { tls_->getTyped<TlsSink>().beginFlush(true); }
+
   void flushCounter(const std::string& name, uint64_t delta) override {
     tls_->getTyped<TlsSink>().flushCounter(name, delta);
   }
@@ -75,6 +81,8 @@ public:
   void flushGauge(const std::string& name, uint64_t value) override {
     tls_->getTyped<TlsSink>().flushGauge(name, value);
   }
+
+  void endFlush() override { tls_->getTyped<TlsSink>().endFlush(true); }
 
   void onHistogramComplete(const std::string& name, uint64_t value) override {
     // For statsd histograms are just timers.
@@ -90,10 +98,15 @@ private:
     TlsSink(TcpStatsdSink& parent, Event::Dispatcher& dispatcher);
     ~TlsSink();
 
+    void beginFlush(bool expect_empty_buffer);
+    void checkSize();
+    void commonFlush(const std::string& name, uint64_t value, char stat_type);
     void flushCounter(const std::string& name, uint64_t delta);
     void flushGauge(const std::string& name, uint64_t value);
+    void endFlush(bool do_write);
     void onTimespanComplete(const std::string& name, std::chrono::milliseconds ms);
-    void write(const std::string& stat);
+    uint64_t usedBuffer();
+    void write(Buffer::Instance& buffer);
 
     // Network::ConnectionCallbacks
     void onEvent(uint32_t events) override;
@@ -103,10 +116,19 @@ private:
     TcpStatsdSink& parent_;
     Event::Dispatcher& dispatcher_;
     Network::ClientConnectionPtr connection_;
+    Buffer::OwnedImpl buffer_;
+    Buffer::RawSlice current_buffer_slice_;
+    char* current_slice_mem_{};
   };
 
   // Somewhat arbitrary 16MiB limit for buffered stats.
   static constexpr uint32_t MaxBufferedStatsBytes = (1024 * 1024 * 16);
+
+  // 16KiB intermediate buffer for flushing.
+  static constexpr uint32_t FlushSliceSizeBytes = (1024 * 16);
+
+  // Prefix for all flushed stats.
+  static char StatPrefix[];
 
   Upstream::ClusterInfoConstSharedPtr cluster_info_;
   ThreadLocal::SlotPtr tls_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -83,7 +83,8 @@ void InstanceImpl::failHealthcheck(bool fail) {
   server_stats_.live_.set(!fail);
 }
 
-void InstanceUtil::flushHelper(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store) {
+void InstanceUtil::flushCountersAndGaugesToSinks(const std::list<Stats::SinkPtr>& sinks,
+                                                 Stats::Store& store) {
   for (const auto& sink : sinks) {
     sink->beginFlush();
   }
@@ -123,7 +124,7 @@ void InstanceImpl::flushStats() {
   server_stats_.days_until_first_cert_expiring_.set(
       sslContextManager().daysUntilFirstCertExpires());
 
-  InstanceUtil::flushHelper(stat_sinks_, stats_store_);
+  InstanceUtil::flushCountersAndGaugesToSinks(stat_sinks_, stats_store_);
   stat_flush_timer_->enableTimer(config_->statsFlushInterval());
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -83,6 +83,33 @@ void InstanceImpl::failHealthcheck(bool fail) {
   server_stats_.live_.set(!fail);
 }
 
+void InstanceUtil::flushHelper(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store) {
+  for (const auto& sink : sinks) {
+    sink->beginFlush();
+  }
+
+  for (const Stats::CounterSharedPtr& counter : store.counters()) {
+    uint64_t delta = counter->latch();
+    if (counter->used()) {
+      for (const auto& sink : sinks) {
+        sink->flushCounter(counter->name(), delta);
+      }
+    }
+  }
+
+  for (const Stats::GaugeSharedPtr& gauge : store.gauges()) {
+    if (gauge->used()) {
+      for (const auto& sink : sinks) {
+        sink->flushGauge(gauge->name(), gauge->value());
+      }
+    }
+  }
+
+  for (const auto& sink : sinks) {
+    sink->endFlush();
+  }
+}
+
 void InstanceImpl::flushStats() {
   ENVOY_LOG(debug, "flushing stats");
   HotRestart::GetParentStatsInfo info;
@@ -96,23 +123,7 @@ void InstanceImpl::flushStats() {
   server_stats_.days_until_first_cert_expiring_.set(
       sslContextManager().daysUntilFirstCertExpires());
 
-  for (const Stats::CounterSharedPtr& counter : stats_store_.counters()) {
-    uint64_t delta = counter->latch();
-    if (counter->used()) {
-      for (const auto& sink : stat_sinks_) {
-        sink->flushCounter(counter->name(), delta);
-      }
-    }
-  }
-
-  for (const Stats::GaugeSharedPtr& gauge : stats_store_.gauges()) {
-    if (gauge->used()) {
-      for (const auto& sink : stat_sinks_) {
-        sink->flushGauge(gauge->name(), gauge->value());
-      }
-    }
-  }
-
+  InstanceUtil::flushHelper(stat_sinks_, stats_store_);
   stat_flush_timer_->enableTimer(config_->statsFlushInterval());
 }
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -78,11 +78,13 @@ public:
   static Runtime::LoaderPtr createRuntime(Instance& server, Server::Configuration::Initial& config);
 
   /**
-   * Helper for flushing counters and gauges to sinks.
+   * Helper for flushing counters and gauges to sinks. This takes care of calling beginFlush(),
+   * latching of counters and flushing, flushing of gauges, and calling endFlush(), on each sink.
    * @param sinks supplies the list of sinks.
    * @param store supplies the store to flush.
    */
-  static void flushHelper(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store);
+  static void flushCountersAndGaugesToSinks(const std::list<Stats::SinkPtr>& sinks,
+                                            Stats::Store& store);
 };
 
 /**

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -76,6 +76,13 @@ public:
    * integration tests where a mock runtime is not needed.
    */
   static Runtime::LoaderPtr createRuntime(Instance& server, Server::Configuration::Initial& config);
+
+  /**
+   * Helper for flushing counters and gauges to sinks.
+   * @param sinks supplies the list of sinks.
+   * @param store supplies the store to flush.
+   */
+  static void flushHelper(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store);
 };
 
 /**

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -52,7 +52,15 @@ public:
   Network::MockClientConnection* connection_{};
 };
 
-TEST_F(TcpStatsdSinkTest, All) {
+TEST_F(TcpStatsdSinkTest, EmptyFlush) {
+  InSequence s;
+
+  sink_->beginFlush();
+  expectCreateConnection();
+  sink_->endFlush();
+}
+
+TEST_F(TcpStatsdSinkTest, BasicFlow) {
   InSequence s;
 
   sink_->beginFlush();

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -57,6 +57,7 @@ TEST_F(TcpStatsdSinkTest, EmptyFlush) {
 
   sink_->beginFlush();
   expectCreateConnection();
+  EXPECT_CALL(*connection_, write(BufferStringEqual("")));
   sink_->endFlush();
 }
 

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -14,12 +14,13 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 using testing::InSequence;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::_;
 
+namespace Envoy {
 namespace Stats {
 namespace Statsd {
 
@@ -54,12 +55,14 @@ public:
 TEST_F(TcpStatsdSinkTest, All) {
   InSequence s;
 
-  expectCreateConnection();
-  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
+  sink_->beginFlush();
   sink_->flushCounter("test_counter", 1);
-
-  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_gauge:2|g\n")));
   sink_->flushGauge("test_gauge", 2);
+
+  expectCreateConnection();
+  EXPECT_CALL(*connection_,
+              write(BufferStringEqual("envoy.test_counter:1|c\nenvoy.test_gauge:2|g\n")));
+  sink_->endFlush();
 
   // Test a disconnect. We should connect again.
   connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
@@ -75,26 +78,51 @@ TEST_F(TcpStatsdSinkTest, All) {
   tls_.shutdownThread();
 }
 
+TEST_F(TcpStatsdSinkTest, BufferReallocate) {
+  InSequence s;
+
+  sink_->beginFlush();
+  for (int i = 0; i < 2000; i++) {
+    sink_->flushCounter("test_counter", 1);
+  }
+
+  expectCreateConnection();
+  EXPECT_CALL(*connection_, write(_)).WillOnce(Invoke([](Buffer::Instance& buffer) -> void {
+    std::string compare;
+    for (int i = 0; i < 2000; i++) {
+      compare += "envoy.test_counter:1|c\n";
+    }
+    EXPECT_EQ(compare, TestUtility::bufferToString(buffer));
+  }));
+  sink_->endFlush();
+}
+
 TEST_F(TcpStatsdSinkTest, Overflow) {
   InSequence s;
 
   // Synthetically set buffer above high watermark. Make sure we don't write anything.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 17);
+  sink_->beginFlush();
   sink_->flushCounter("test_counter", 1);
+  sink_->endFlush();
 
   // Lower and make sure we write.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 15);
+  sink_->beginFlush();
+  sink_->flushCounter("test_counter", 1);
   expectCreateConnection();
   EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
-  sink_->flushCounter("test_counter", 1);
+  sink_->endFlush();
 
   // Raise and make sure we don't write and kill connection.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 17);
-  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  sink_->beginFlush();
   sink_->flushCounter("test_counter", 1);
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  sink_->endFlush();
 
   EXPECT_EQ(2UL, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
                      .counter("statsd.cx_overflow")

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -59,9 +59,10 @@ public:
   MockSink();
   ~MockSink();
 
-  MOCK_METHOD1(initialize, void(Upstream::ClusterManager& cluster_manager));
+  MOCK_METHOD0(beginFlush, void());
   MOCK_METHOD2(flushCounter, void(const std::string& name, uint64_t delta));
   MOCK_METHOD2(flushGauge, void(const std::string& name, uint64_t value));
+  MOCK_METHOD0(endFlush, void());
   MOCK_METHOD2(onHistogramComplete, void(const std::string& name, uint64_t value));
   MOCK_METHOD2(onTimespanComplete, void(const std::string& name, std::chrono::milliseconds ms));
 };

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -29,7 +29,7 @@ TEST(ServerInstanceUtil, flushHelper) {
 
   std::list<Stats::SinkPtr> sinks;
   sinks.emplace_back(std::move(sink));
-  InstanceUtil::flushHelper(sinks, store);
+  InstanceUtil::flushCountersAndGaugesToSinks(sinks, store);
 }
 
 // Class creates minimally viable server instance for testing.


### PR DESCRIPTION
With small flush intervals and a lot of stats, this code starts showing
up pretty heavily on perf traces.