### PR TITLE
redis: support LDS

### DIFF
--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -149,6 +149,7 @@ private:
     Event::Dispatcher& dispatcher_;
     Upstream::ThreadLocalCluster* cluster_;
     std::unordered_map<Upstream::HostConstSharedPtr, ThreadLocalActiveClientPtr> client_map_;
+    Common::CallbackHandle* local_host_set_member_update_cb_handle_;
   };
 
   struct LbContextImpl : public Upstream::LoadBalancerContext {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -121,13 +121,14 @@ void InstanceImpl::shutdownThread() {
 
   // Destruction of slots is done in *reverse* order. This is so that filters and higher layer
   // things that are built on top of the cluster manager, stats, etc. will be destroyed before
-  // more base layer things. The reason reverse ordering is done is to deal with the potentially
-  // likely case that leaf objects depend in some way on "persistent" objects (particularly the
-  // cluster manager) that are created very early on with a known slot number and never destroyed
-  // until shutdown. For example, if we chose to create persistent per-thread gRPC clients we would
-  // potentially run into shutdown issues if that thing got destroyed after the cluster manager.
-  // Examples of things with TLS that are created early on and are never destroyed until server
-  // shutdown are stats, runtime, and the cluster manager (see server.cc).
+  // more base layer things. The reason reverse ordering is done is to deal with the case that leaf
+  // objects depend in some way on "persistent" objects (particularly the cluster manager) that are
+  // created very early on with a known slot number and never destroyed until shutdown. For example,
+  // if we chose to create persistent per-thread gRPC clients we would potentially run into shutdown
+  // issues if that thing got destroyed after the cluster manager. This happens in practice
+  // currently when a redis connection pool is destroyed and removes its member update callback from
+  // the backing cluster. Examples of things with TLS that are created early on and are never
+  // destroyed until server shutdown are stats, runtime, and the cluster manager (see server.cc).
   //
   // It's possible this might need to become more complicated later but it's OK for now. Note that
   // this is always safe to do because:

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -425,6 +425,13 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
   tls_.shutdownThread();
 }
 
+TEST_F(RedisConnPoolImplTest, DeleteFollowedByClusterUpdateCallback) {
+  conn_pool_.reset();
+
+  std::shared_ptr<Upstream::Host> host(new Upstream::MockHost());
+  cm_.thread_local_cluster_.cluster_.runCallbacks({}, {host});
+}
+
 TEST_F(RedisConnPoolImplTest, NoHost) {
   InSequence s;
 

--- a/test/common/tracing/lightstep_tracer_impl_test.cc
+++ b/test/common/tracing/lightstep_tracer_impl_test.cc
@@ -72,13 +72,13 @@ public:
   SystemTime start_time_;
   Http::AccessLog::MockRequestInfo request_info_;
 
+  NiceMock<ThreadLocal::MockInstance> tls_;
   std::unique_ptr<LightStepDriver> driver_;
   NiceMock<Event::MockTimer>* timer_;
   Stats::IsolatedStoreImpl stats_;
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
-  NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 

--- a/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
@@ -67,12 +67,12 @@ public:
   SystemTime start_time_;
   Http::AccessLog::MockRequestInfo request_info_;
 
+  NiceMock<ThreadLocal::MockInstance> tls_;
   std::unique_ptr<Driver> driver_;
   NiceMock<Event::MockTimer>* timer_;
   Stats::IsolatedStoreImpl stats_;
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Runtime::MockLoader> runtime_;
-  NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Runtime::MockRandomGenerator> random_;
 };

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -228,6 +228,21 @@
         ]
       }
     }]
+  },
+  {
+    "address": "tcp://{{ ip_loopback_address }}:0",
+    "filters": [
+    {
+      "type": "read",
+      "name": "redis_proxy",
+      "config": {
+        "cluster_name": "redis",
+        "stat_prefix": "redis",
+        "conn_pool": {
+          "op_timeout_ms": 400
+        }
+      }
+    }]
   }],
 
   "admin": { "access_log_path": "/dev/null",
@@ -292,6 +307,14 @@
       "connect_timeout_ms": 5000,
       "type": "strict_dns",
       "lb_type": "round_robin",
+      "dns_lookup_family": "{{ dns_lookup_family }}",
+      "hosts": [{"url": "tcp://localhost:4"}]
+    },
+    {
+      "name": "redis",
+      "connect_timeout_ms": 5000,
+      "type": "strict_dns",
+      "lb_type": "ring_hash",
       "dns_lookup_family": "{{ dns_lookup_family }}",
       "hosts": [{"url": "tcp://localhost:4"}]
     }]


### PR DESCRIPTION
redis should now be safely usable via LDS. (CDS still does not work).