### PR TITLE
Add watchdog configs to schema validation (Fixes #1352)

### DIFF
--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1176,6 +1176,10 @@ const std::string Json::Schema::TOP_LEVEL_CONFIG_SCHEMA(R"EOF(
       "statsd_udp_ip_address" : {"type" : "string"},
       "statsd_tcp_cluster_name" : {"type" : "string"},
       "stats_flush_interval_ms" : {"type" : "integer"},
+      "watchdog_miss_timeout_ms" : {"type" : "integer"},
+      "watchdog_megamiss_timeout_ms" : {"type" : "integer"},
+      "watchdog_kill_timeout_ms" : {"type" : "integer"},
+      "watchdog_multikill_timeout_ms" : {"type" : "integer"},
       "tracing" : {
         "type" : "object",
         "properties" : {

--- a/test/common/json/config_schemas_test_data/test_top_level_config_schema.py
+++ b/test/common/json/config_schemas_test_data/test_top_level_config_schema.py
@@ -14,7 +14,11 @@ TOP_LEVEL_CONFIG_BLOB = {
     "admin": {
         "access_log_path": "/var/log/envoy/admin_access.log", 
         "address": "tcp://0.0.0.0:9901"
-    }, 
+    },
+    "watchdog_miss_timeout_ms": 100,
+    "watchdog_megamiss_timeout_ms": 200,
+    "watchdog_kill_timeout_ms": 300,
+    "watchdog_multikill_timeout_ms": 400,
     "tracing": {
         "http": {
             "driver": {
@@ -30,7 +34,6 @@ TOP_LEVEL_CONFIG_BLOB = {
 
 
 def test(writer):
-    
     writer.write_test_file(
         'Valid',
         schema='TOP_LEVEL_CONFIG_SCHEMA',


### PR DESCRIPTION
Watchdog configuration wasn't in the top level schema validation
resulting in a validation error. Add it, and add watchdog configuration
into the config_schemas_test's config.

Fixes #1352