### PR TITLE
common: add byte_order.h to provide htole32 et al in OS X

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -27,6 +27,11 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "byte_order_lib",
+    hdrs = ["byte_order.h"],
+)
+
+envoy_cc_library(
     name = "c_smart_ptr_lib",
     hdrs = ["c_smart_ptr.h"],
 )

--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+
+#endif
+
+namespace Envoy {
+
+#ifdef __APPLE__
+#define htole32(x) OSSwapHostToLittleInt32((x))
+#define htole64(x) OSSwapHostToLittleInt64((x))
+#define le32toh(x) OSSwapLittleToHostInt32((x))
+#define le64toh(x) OSSwapLittleToHostInt64((x))
+#endif
+
+} // Envoy

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/mongo:bson_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:byte_order_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "common/common/assert.h"
+#include "common/common/byte_order.h"
 #include "common/common/hex.h"
 #include "common/common/utility.h"
 


### PR DESCRIPTION
Provides `htole32`, `htole64`, `le32toh`, and `le64toh` for OS X. (Split out from #1348, in support of #128).