### PR TITLE
osx: thread id and signal stack support

### DIFF
--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -32,6 +32,8 @@ int32_t Thread::currentThreadId() {
   uint64_t tid;
   pthread_threadid_np(NULL, &tid);
   return static_cast<int32_t>(tid);
+#else
+#error "Enable and test pthread id retrieval code for you arch in thread.cc"
 #endif
 }
 

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -1,6 +1,10 @@
 #include "common/common/thread.h"
 
+#ifdef __linux__
 #include <sys/syscall.h>
+#elif defined(__APPLE__)
+#include <mach/mach.h>
+#endif
 
 #include <functional>
 
@@ -21,7 +25,15 @@ Thread::Thread(std::function<void()> thread_routine) : thread_routine_(thread_ro
   UNREFERENCED_PARAMETER(rc);
 }
 
-int32_t Thread::currentThreadId() { return syscall(SYS_gettid); }
+int32_t Thread::currentThreadId() {
+#ifdef __linux__
+  return syscall(SYS_gettid);
+#elif defined(__APPLE__)
+  int ret = mach_thread_self();
+  mach_port_deallocate(mach_task_self(), ret);
+  return ret;
+#endif
+}
 
 void Thread::join() {
   int rc = pthread_join(thread_id_, nullptr);

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -4,6 +4,7 @@
 #include <sys/syscall.h>
 #elif defined(__APPLE__)
 #include <mach/mach.h>
+#include <pthread.h>
 #endif
 
 #include <functional>
@@ -29,9 +30,7 @@ int32_t Thread::currentThreadId() {
 #ifdef __linux__
   return syscall(SYS_gettid);
 #elif defined(__APPLE__)
-  int ret = mach_thread_self();
-  mach_port_deallocate(mach_task_self(), ret);
-  return ret;
+  return pthread_mach_thread_np(pthread_self());
 #endif
 }
 

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -3,7 +3,6 @@
 #ifdef __linux__
 #include <sys/syscall.h>
 #elif defined(__APPLE__)
-#include <mach/mach.h>
 #include <pthread.h>
 #endif
 
@@ -30,7 +29,9 @@ int32_t Thread::currentThreadId() {
 #ifdef __linux__
   return syscall(SYS_gettid);
 #elif defined(__APPLE__)
-  return pthread_mach_thread_np(pthread_self());
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+  return static_cast<int32_t>(tid);
 #endif
 }
 

--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -16,6 +16,8 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
 #ifdef REG_RIP
     // x86_64
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_RIP]);
+#elif defined(__APPLE__) && defined(__x86_64__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);
@@ -57,12 +59,23 @@ void SignalAction::installSigHandlers() {
 }
 
 void SignalAction::removeSigHandlers() {
+#if defined(__APPLE__)
+  // ss_flags contains SS_DISABLE, but Darwin still checks the size, contrary to the man page
+  if (previous_altstack_.ss_size < MINSIGSTKSZ) {
+    previous_altstack_.ss_size = MINSIGSTKSZ;
+  }
+#endif
   RELEASE_ASSERT(sigaltstack(&previous_altstack_, nullptr) == 0);
+
   int hidx = 0;
   for (const auto& sig : FATAL_SIGS) {
     RELEASE_ASSERT(sigaction(sig, &previous_handlers_[hidx++], nullptr) == 0);
   }
 }
+
+#if defined(__APPLE__) && !defined(MAP_STACK)
+#define MAP_STACK (0)
+#endif
 
 void SignalAction::mapAndProtectStackMemory() {
   // Per docs MAP_STACK doesn't actually do anything today but provides a

--- a/source/exe/signal_action.h
+++ b/source/exe/signal_action.h
@@ -3,6 +3,8 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <algorithm>
+
 #include "common/common/non_copyable.h"
 
 #include "server/backtrace.h"
@@ -47,7 +49,9 @@ namespace Envoy {
 class SignalAction : NonCopyable {
 public:
   SignalAction()
-      : guard_size_(sysconf(_SC_PAGE_SIZE)), altstack_size_(guard_size_ * 4), altstack_(nullptr) {
+      : guard_size_(sysconf(_SC_PAGE_SIZE)),
+        altstack_size_(std::max(guard_size_ * 4, static_cast<size_t>(MINSIGSTKSZ))),
+        altstack_(nullptr) {
     mapAndProtectStackMemory();
     installSigHandlers();
   }


### PR DESCRIPTION
Modifies `source/common/common/thread.cc` to retrieve a thread id on OS X.

Modifies `source/exe/signal_action.cc` to retrieve RIP in OS X. Increases alt stack size used for signal handlers to meet the OS minimum values. Handles an OS X bug where disabling the alt signal stack fails because the size field in the original stack_t is less than MINSIGSTKSZ.

(Split out from #1348, in support of #128.)