### PR TITLE
osx: minor os-independent changes required for OS X

### DIFF
--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 
 #include "common/buffer/buffer_impl.h"

--- a/source/common/common/to_lower_table.h
+++ b/source/common/common/to_lower_table.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 
 namespace Envoy {
 /**

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -84,7 +84,7 @@ public:
 
   bool featureEnabled(const std::string& key, uint64_t default_value) const override {
     // Avoid PNRG if we know we don't need it.
-    uint64_t cutoff = std::min(getInteger(key, default_value), 100UL);
+    uint64_t cutoff = std::min(getInteger(key, default_value), static_cast<uint64_t>(100));
     if (cutoff == 0) {
       return false;
     } else if (cutoff == 100) {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -28,13 +28,13 @@ SlotPtr InstanceImpl::allocateSlot() {
     if (slots_[i] == nullptr) {
       std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, i));
       slots_[i] = slot.get();
-      return slot;
+      return std::move(slot);
     }
   }
 
   std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, slots_.size()));
   slots_.push_back(slot.get());
-  return slot;
+  return std::move(slot);
 }
 
 ThreadLocalObjectSharedPtr InstanceImpl::SlotImpl::get() {

--- a/source/server/drain_manager_impl.h
+++ b/source/server/drain_manager_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/instance.h"


### PR DESCRIPTION
Adds some missing header #includes.

The static cast for to is needed because `uint64_t` is `unsigned long long` in OS X. So the constant would have to be `100ULL` (with an #ifdef) to keep the compiler happy.

The `std::move` calls in `thread_local_impl.cc` fix an apparent difference in strictness across compilers. (c.f. https://stackoverflow.com/questions/22018115/converting-stdunique-ptrderived-to-stdunique-ptrbase).

Fixes https://github.com/lyft/envoy/issues/1371