### PR TITLE
config: CDS/EDS v2 API experimental support.

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -173,10 +173,10 @@ public:
                                       bool added_via_api) PURE;
 
   /**
-   * Create a CDS API provider from configuration JSON.
+   * Create a CDS API provider from configuration proto.
    */
-  virtual CdsApiPtr createCds(const Json::Object& config, const Optional<SdsConfig>& sds_config,
-                              ClusterManager& cm) PURE;
+  virtual CdsApiPtr createCds(const envoy::api::v2::ConfigSource& cds_config,
+                              const Optional<SdsConfig>& sds_config, ClusterManager& cm) PURE;
 };
 
 } // namespace Upstream

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -59,7 +59,8 @@ private:
       config_update_available = true;
       callbacks_->onConfigUpdate(typed_resources);
       stats_.update_success_.inc();
-      ENVOY_LOG(debug, "Filesystem config update accepted for {}", path_);
+      ENVOY_LOG(debug, "Filesystem config update accepted for {}: {}", path_,
+                message.DebugString());
       // TODO(htuch): Add some notion of current version for every API in stats/admin.
     } catch (const EnvoyException& e) {
       if (config_update_available) {

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -59,6 +59,7 @@ private:
       config_update_available = true;
       callbacks_->onConfigUpdate(typed_resources);
       stats_.update_success_.inc();
+      ENVOY_LOG(debug, "Filesystem config update accepted for {}", path_);
       // TODO(htuch): Add some notion of current version for every API in stats/admin.
     } catch (const EnvoyException& e) {
       if (config_update_available) {

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -17,7 +17,6 @@ envoy_cc_library(
         ":cds_subscription_lib",
         "//include/envoy/config:subscription_interface",
         "//include/envoy/event:dispatcher_interface",
-        "//include/envoy/json:json_object_interface",
         "//include/envoy/local_info:local_info_interface",
         "//source/common/common:logger_lib",
         "//source/common/config:subscription_factory_lib",
@@ -50,6 +49,7 @@ envoy_cc_library(
     name = "cluster_manager_lib",
     srcs = ["cluster_manager_impl.cc"],
     hdrs = ["cluster_manager_impl.h"],
+    external_deps = ["envoy_base"],
     deps = [
         ":cds_api_lib",
         ":load_balancer_lib",

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -9,16 +9,10 @@
 namespace Envoy {
 namespace Upstream {
 
-CdsApiPtr CdsApiImpl::create(const Json::Object& config, const Optional<SdsConfig>& sds_config,
-                             ClusterManager& cm, Event::Dispatcher& dispatcher,
-                             Runtime::RandomGenerator& random,
+CdsApiPtr CdsApiImpl::create(const envoy::api::v2::ConfigSource& cds_config,
+                             const Optional<SdsConfig>& sds_config, ClusterManager& cm,
+                             Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                              const LocalInfo::LocalInfo& local_info, Stats::Store& store) {
-  if (!config.hasObject("cds")) {
-    return nullptr;
-  }
-
-  envoy::api::v2::ConfigSource cds_config;
-  Config::Utility::translateCdsConfig(*config.getObject("cds"), cds_config);
   return CdsApiPtr{
       new CdsApiImpl(cds_config, sds_config, cm, dispatcher, random, local_info, store)};
 }

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -4,7 +4,6 @@
 
 #include "envoy/config/subscription.h"
 #include "envoy/event/dispatcher.h"
-#include "envoy/json/json_object.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -22,10 +21,10 @@ class CdsApiImpl : public CdsApi,
                    Config::SubscriptionCallbacks<envoy::api::v2::Cluster>,
                    Logger::Loggable<Logger::Id::upstream> {
 public:
-  static CdsApiPtr create(const Json::Object& config, const Optional<SdsConfig>& sds_config,
-                          ClusterManager& cm, Event::Dispatcher& dispatcher,
-                          Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-                          Stats::Store& store);
+  static CdsApiPtr create(const envoy::api::v2::ConfigSource& cds_config,
+                          const Optional<SdsConfig>& sds_config, ClusterManager& cm,
+                          Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+                          const LocalInfo::LocalInfo& local_info, Stats::Store& store);
 
   // Upstream::CdsApi
   void initialize() override { subscription_->start({}, *this); }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -154,6 +154,38 @@ void ClusterManagerInitHelper::setInitializedCb(std::function<void()> callback) 
   }
 }
 
+void ClusterManagerImpl::initializeClustersFromV1Json(const Json::Object& config) {
+  envoy::api::v2::ConfigSource cds_config;
+  if (config.hasObject("cds")) {
+    envoy::api::v2::Cluster cds_cluster;
+    Config::CdsJson::translateCluster(*config.getObject("cds")->getObject("cluster"), sds_config_,
+                                      cds_cluster);
+    loadCluster(cds_cluster, false);
+    Config::Utility::translateCdsConfig(*config.getObject("cds"), cds_config);
+    // We can now potentially create the CDS API once the backing cluster exists.
+    cds_api_ = factory_.createCds(cds_config, sds_config_, *this);
+    init_helper_.setCds(cds_api_.get());
+  } else {
+    init_helper_.setCds(nullptr);
+  }
+
+  for (const Json::ObjectSharedPtr& cluster_config : config.getObjectArray("clusters")) {
+    envoy::api::v2::Cluster cluster;
+    Config::CdsJson::translateCluster(*cluster_config, sds_config_, cluster);
+    loadCluster(cluster, false);
+  }
+}
+
+void ClusterManagerImpl::initializeClustersFromV2Proto(const envoy::api::v2::Bootstrap& bootstrap) {
+  for (const auto& cluster : bootstrap.bootstrap_clusters()) {
+    loadCluster(cluster, false);
+  }
+
+  // We can now potentially create the CDS API once the backing cluster exists.
+  cds_api_ = factory_.createCds(bootstrap.cds_config(), sds_config_, *this);
+  init_helper_.setCds(cds_api_.get());
+}
+
 ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config,
                                        const envoy::api::v2::Bootstrap& bootstrap,
                                        ClusterManagerFactory& factory, Stats::Store& stats,
@@ -165,7 +197,6 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config,
       random_(random), local_info_(local_info), cm_stats_(generateStats(stats)) {
 
   config.validateSchema(Json::Schema::CLUSTER_MANAGER_SCHEMA);
-  UNREFERENCED_PARAMETER(bootstrap);
 
   if (config.hasObject("outlier_detection")) {
     std::string event_log_file_path =
@@ -190,21 +221,13 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config,
     sds_config_.value(sds_config);
   }
 
-  if (config.hasObject("cds")) {
-    envoy::api::v2::Cluster cds_cluster;
-    Config::CdsJson::translateCluster(*config.getObject("cds")->getObject("cluster"), sds_config_,
-                                      cds_cluster);
-    loadCluster(cds_cluster, false);
-  }
-
-  // We can now potentially create the CDS API once the backing cluster exists.
-  cds_api_ = factory_.createCds(config, sds_config_, *this);
-  init_helper_.setCds(cds_api_.get());
-
-  for (const Json::ObjectSharedPtr& cluster_config : config.getObjectArray("clusters")) {
-    envoy::api::v2::Cluster cluster;
-    Config::CdsJson::translateCluster(*cluster_config, sds_config_, cluster);
-    loadCluster(cluster, false);
+  if (bootstrap.has_cds_config()) {
+    initializeClustersFromV2Proto(bootstrap);
+  } else {
+    // TODO(htuch): Make this similar to the v1 -> v2 translation elsewhere,
+    // convert the JSON to envoy::api::v2::Bootstrap and use initializeClustersFromV2Proto()
+    // instead.
+    initializeClustersFromV1Json(config);
   }
 
   Optional<std::string> local_cluster_name;
@@ -607,10 +630,10 @@ ClusterPtr ProdClusterManagerFactory::clusterFromProto(
                                  outlier_event_logger, added_via_api);
 }
 
-CdsApiPtr ProdClusterManagerFactory::createCds(const Json::Object& config,
+CdsApiPtr ProdClusterManagerFactory::createCds(const envoy::api::v2::ConfigSource& cds_config,
                                                const Optional<SdsConfig>& sds_config,
                                                ClusterManager& cm) {
-  return CdsApiImpl::create(config, sds_config, cm, primary_dispatcher_, random_, local_info_,
+  return CdsApiImpl::create(cds_config, sds_config, cm, primary_dispatcher_, random_, local_info_,
                             stats_);
 }
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -20,6 +20,8 @@
 #include "common/json/json_loader.h"
 #include "common/upstream/upstream_impl.h"
 
+#include "api/bootstrap.pb.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -50,8 +52,8 @@ public:
   ClusterPtr clusterFromProto(const envoy::api::v2::Cluster& cluster, ClusterManager& cm,
                               Outlier::EventLoggerSharedPtr outlier_event_logger,
                               bool added_via_api) override;
-  CdsApiPtr createCds(const Json::Object& config, const Optional<SdsConfig>& sds_config,
-                      ClusterManager& cm) override;
+  CdsApiPtr createCds(const envoy::api::v2::ConfigSource& cds_config,
+                      const Optional<SdsConfig>& sds_config, ClusterManager& cm) override;
 
 private:
   Runtime::Loader& runtime_;
@@ -215,6 +217,8 @@ private:
   };
 
   static ClusterManagerStats generateStats(Stats::Scope& scope);
+  void initializeClustersFromV1Json(const Json::Object& config);
+  void initializeClustersFromV2Proto(const envoy::api::v2::Bootstrap& bootstrap);
   void loadCluster(const envoy::api::v2::Cluster& cluster, bool added_via_api);
   void postInitializeCluster(Cluster& cluster);
   void postThreadLocalClusterUpdate(const Cluster& primary_cluster,

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -18,7 +18,9 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
                                Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                                bool added_via_api)
     : BaseDynamicClusterImpl(cluster, runtime, stats, ssl_context_manager, added_via_api),
-      local_info_(local_info), cluster_name_(cluster.deprecated_v1().service_name()) {
+      local_info_(local_info),
+      cluster_name_(cluster.has_deprecated_v1() ? cluster.deprecated_v1().service_name()
+                                                : cluster.name()) {
   envoy::api::v2::Node node;
   Config::Utility::localInfoToNode(local_info, node);
   const auto& eds_config = cluster.eds_config();
@@ -43,7 +45,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
   const auto& cluster_load_assignment = resources[0];
   if (ProtobufTypes::FromString(cluster_load_assignment.cluster_name()) != cluster_name_) {
     throw EnvoyException(
-        fmt::format("Unexpected EDS cluster: {}",
+        fmt::format("Unexpected EDS cluster (expecting {}): {}", cluster_name_,
                     ProtobufTypes::FromString(cluster_load_assignment.cluster_name())));
   }
   for (const auto& locality_lb_endpoint : cluster_load_assignment.endpoints()) {
@@ -54,12 +56,9 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
                                                           Config::MetadataFilters::get().ENVOY_LB,
                                                           Config::MetadataEnvoyLbKeys::get().CANARY)
                               .bool_value();
-      new_hosts.emplace_back(
-          new HostImpl(info_, "",
-                       Network::Address::InstanceConstSharedPtr{new Network::Address::Ipv4Instance(
-                           lb_endpoint.endpoint().address().socket_address().ip_address(),
-                           lb_endpoint.endpoint().address().socket_address().port().value())},
-                       canary, lb_endpoint.load_balancing_weight().value(), zone));
+      new_hosts.emplace_back(new HostImpl(
+          info_, "", Network::Utility::fromProtoResolvedAddress(lb_endpoint.endpoint().address()),
+          canary, lb_endpoint.load_balancing_weight().value(), zone));
     }
   }
 

--- a/source/server/config_validation/cluster_manager.cc
+++ b/source/server/config_validation/cluster_manager.cc
@@ -19,11 +19,11 @@ ClusterManagerPtr ValidationClusterManagerFactory::clusterManagerFromJson(
                                                         runtime, random, local_info, log_manager)};
 }
 
-CdsApiPtr ValidationClusterManagerFactory::createCds(const Json::Object& config,
+CdsApiPtr ValidationClusterManagerFactory::createCds(const envoy::api::v2::ConfigSource& cds_config,
                                                      const Optional<SdsConfig>& sds_config,
                                                      ClusterManager& cm) {
   // Create the CdsApiImpl...
-  ProdClusterManagerFactory::createCds(config, sds_config, cm);
+  ProdClusterManagerFactory::createCds(cds_config, sds_config, cm);
   // ... and then throw it away, so that we don't actually connect to it.
   return nullptr;
 }

--- a/source/server/config_validation/cluster_manager.h
+++ b/source/server/config_validation/cluster_manager.h
@@ -30,8 +30,8 @@ public:
 
   // Delegates to ProdClusterManagerFactory::createCds, but discards the result and returns nullptr
   // unconditionally.
-  CdsApiPtr createCds(const Json::Object& config, const Optional<SdsConfig>& sds_config,
-                      ClusterManager& cm) override;
+  CdsApiPtr createCds(const envoy::api::v2::ConfigSource& cds_config,
+                      const Optional<SdsConfig>& sds_config, ClusterManager& cm) override;
 };
 
 /**

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     srcs = ["cds_api_impl_test.cc"],
     deps = [
         ":utility_lib",
+        "//source/common/config:utility_lib",
         "//source/common/http:message_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/upstream:cds_api_lib",

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -64,9 +64,8 @@ public:
     return ClusterPtr{clusterFromProto_(cluster, cm, outlier_event_logger, added_via_api)};
   }
 
-  CdsApiPtr createCds(const Json::Object&, const Optional<SdsConfig>& sds_config,
+  CdsApiPtr createCds(const envoy::api::v2::ConfigSource&, const Optional<SdsConfig>&,
                       ClusterManager&) override {
-    UNREFERENCED_PARAMETER(sds_config);
     return CdsApiPtr{createCds_()};
   }
 

--- a/test/config/integration/BUILD
+++ b/test/config/integration/BUILD
@@ -22,6 +22,16 @@ exports_files([
 ])
 
 filegroup(
+    name = "server_xds_files",
+    srcs = [
+        "server_xds.bootstrap.json",
+        "server_xds.cds.json",
+        "server_xds.eds.json",
+        "server_xds.json",
+    ],
+)
+
+filegroup(
     name = "server_config_files",
     srcs = [
         "server.json",

--- a/test/config/integration/server_xds.bootstrap.json
+++ b/test/config/integration/server_xds.bootstrap.json
@@ -1,0 +1,5 @@
+{
+  "cds_config": {
+    "path": "{{ cds_json_path }}"
+  }
+}

--- a/test/config/integration/server_xds.cds.json
+++ b/test/config/integration/server_xds.cds.json
@@ -1,0 +1,16 @@
+{
+  "versionInfo": "0",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "cluster_1",
+      "connectTimeout": { "seconds": 5 },
+      "type": "EDS",
+      "edsConfig": {
+        "path": "{{ eds_json_path }}"
+      },
+      "lbPolicy": "ROUND_ROBIN",
+      "http2ProtocolOptions": {}
+    }
+  ]
+}

--- a/test/config/integration/server_xds.eds.json
+++ b/test/config/integration/server_xds.eds.json
@@ -1,0 +1,19 @@
+{
+  "versionInfo": "0",
+  "resources": [{
+    "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+    "clusterName": "cluster_1",
+    "endpoints": [{
+      "lbEndpoints": [{
+        "endpoint": {
+          "address": {
+            "socketAddress": {
+              "ipAddress": "{{ ip_loopback_address }}",
+              "port": {"value": {{ upstream_0 }} }
+            }
+          }
+        }
+      }]
+    }]
+  }]
+}

--- a/test/config/integration/server_xds.json
+++ b/test/config/integration/server_xds.json
@@ -1,0 +1,40 @@
+{
+  "listeners": [
+  {
+    "address": "tcp://{{ ip_loopback_address }}:0",
+    "filters": [
+    {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+        "codec_type": "http2",
+        "drain_timeout_ms": 5000,
+        "stat_prefix": "router",
+        "route_config":
+        {
+          "virtual_hosts": [
+            {
+              "name": "integration",
+              "domains": [ "*" ],
+              "routes": [
+                {
+                  "prefix": "/test/long/url",
+                  "cluster": "cluster_1"
+                }
+              ]
+            }
+          ]
+        },
+        "filters": [
+          { "type": "decoder", "name": "router", "config": {}}
+        ]
+      }
+    }]
+  }],
+
+  "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
+
+  "cluster_manager": {
+    "clusters": []
+  }
+}

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -25,7 +25,7 @@ namespace ConfigTest {
 
 class ConfigTest {
 public:
-  ConfigTest(const std::string& file_path) : options_(file_path) {
+  ConfigTest(const std::string& file_path) : options_(file_path, std::string()) {
     ON_CALL(server_, options()).WillByDefault(ReturnRef(options_));
     ON_CALL(server_, random()).WillByDefault(ReturnRef(random_));
     ON_CALL(server_, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -274,6 +274,32 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "uds_integration_test",
+    srcs = [
+        "uds_integration_test.cc",
+        "uds_integration_test.h",
+    ],
+    data = ["//test/config/integration:server_uds.json"],
+    deps = [
+        ":integration_lib",
+        "//source/common/event:dispatcher_includes",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/http:codec_client_lib",
+        "//source/common/stats:stats_lib",
+        "//test/test_common:environment_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "xds_integration_test",
+    srcs = ["xds_integration_test.cc"],
+    data = ["//test/config/integration:server_xds_files"],
+    deps = [
+        ":integration_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "xfcc_integration_test",
     srcs = [
         "ssl_integration_test.h",
@@ -288,22 +314,5 @@ envoy_cc_test(
         ":integration_lib",
         "//source/common/http:header_map_lib",
         "//test/test_common:utility_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "uds_integration_test",
-    srcs = [
-        "uds_integration_test.cc",
-        "uds_integration_test.h",
-    ],
-    data = ["//test/config/integration:server_uds.json"],
-    deps = [
-        ":integration_lib",
-        "//source/common/event:dispatcher_includes",
-        "//source/common/event:dispatcher_lib",
-        "//source/common/http:codec_client_lib",
-        "//source/common/stats:stats_lib",
-        "//test/test_common:environment_lib",
     ],
 )

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -149,6 +149,12 @@ private:
 
 typedef std::unique_ptr<IntegrationTcpClient> IntegrationTcpClientPtr;
 
+struct ApiFilesystemConfig {
+  std::string bootstrap_path_;
+  std::string cds_path_;
+  std::string eds_path_;
+};
+
 /**
  * Test fixture for all integration tests.
  */
@@ -178,6 +184,9 @@ public:
   void sendRawHttpAndWaitForResponse(const char* http, std::string* response);
   void registerTestServerPorts(const std::vector<std::string>& port_names);
   void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);
+  void createApiTestServer(const std::string& json_path,
+                           const ApiFilesystemConfig& api_filesystem_config,
+                           const std::vector<std::string>& port_names);
 
   Api::ApiPtr api_;
   MockBufferFactory* mock_buffer_factory_; // Will point to the dispatcher's factory.

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -35,8 +35,9 @@ public:
 } // namespace Server
 
 IntegrationTestServerPtr IntegrationTestServer::create(const std::string& config_path,
+                                                       const std::string& bootstrap_path,
                                                        const Network::Address::IpVersion version) {
-  IntegrationTestServerPtr server{new IntegrationTestServer(config_path)};
+  IntegrationTestServerPtr server{new IntegrationTestServer(config_path, bootstrap_path)};
   server->start(version);
   return server;
 }
@@ -89,7 +90,7 @@ void IntegrationTestServer::onWorkerListenerRemoved() {
 }
 
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version) {
-  Server::TestOptionsImpl options(config_path_);
+  Server::TestOptionsImpl options(config_path_, bootstrap_path_);
   Server::TestHotRestart restarter;
   Thread::MutexBasicLockable lock;
   LocalInfo::LocalInfoImpl local_info(Network::Utility::getLocalAddress(version), "zone_name",

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -27,7 +27,8 @@ namespace Server {
  */
 class TestOptionsImpl : public Options {
 public:
-  TestOptionsImpl(const std::string& config_path) : config_path_(config_path) {}
+  TestOptionsImpl(const std::string& config_path, const std::string& bootstrap_path)
+      : config_path_(config_path), bootstrap_path_(bootstrap_path) {}
 
   // Server::Options
   uint64_t baseId() override { return 0; }
@@ -175,6 +176,7 @@ class IntegrationTestServer : Logger::Loggable<Logger::Id::testing>,
                               public Server::ComponentFactory {
 public:
   static IntegrationTestServerPtr create(const std::string& config_path,
+                                         const std::string& bootstrap_path,
                                          const Network::Address::IpVersion version);
   ~IntegrationTestServer();
 
@@ -212,7 +214,8 @@ public:
   }
 
 protected:
-  IntegrationTestServer(const std::string& config_path) : config_path_(config_path) {}
+  IntegrationTestServer(const std::string& config_path, const std::string& bootstrap_path)
+      : config_path_(config_path), bootstrap_path_(bootstrap_path) {}
 
 private:
   /**
@@ -221,6 +224,7 @@ private:
   void threadRoutine(const Network::Address::IpVersion version);
 
   const std::string config_path_;
+  const std::string bootstrap_path_;
   Thread::ThreadPtr thread_;
   std::condition_variable listeners_cv_;
   std::mutex listeners_mutex_;

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -34,7 +34,7 @@ public:
 
 private:
   MockRuntimeIntegrationTestServer(const std::string& config_path)
-      : IntegrationTestServer(config_path) {}
+      : IntegrationTestServer(config_path, std::string()) {}
 };
 
 class SslIntegrationTest : public BaseIntegrationTest,

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -1,0 +1,42 @@
+#include "test/integration/integration.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+// This is a minimal litmus test for the v2 xDS APIs. TODO(htuch): Convert all integration tests to
+// be parameterized with v2 configs.
+class XdsIntegrationTest : public BaseIntegrationTest,
+                           public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  XdsIntegrationTest() : BaseIntegrationTest(GetParam()) {}
+
+  void SetUp() override {
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
+    registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
+    createApiTestServer("test/config/integration/server_xds.json",
+                        {
+                            .bootstrap_path_ = "test/config/integration/server_xds.bootstrap.json",
+                            .cds_path_ = "test/config/integration/server_xds.cds.json",
+                            .eds_path_ = "test/config/integration/server_xds.eds.json",
+                        },
+                        {"http"});
+  }
+
+  void TearDown() override {
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, XdsIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(XdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
+  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")),
+                                       Http::CodecClient::Type::HTTP2, 1024, 512, false);
+}
+
+} // namespace
+} // namespace Envoy


### PR DESCRIPTION
* Complete plumbing of bootstrap proto to ClusterManager. The bootstrap proto acts as an overlay and
  can provide CDS config.

* xDS v2 JSON filesystem based litmus integration test. This sources both CDS and EDS from the
  filesystem and demonstrates request processing via the returned endpoint.

This does not have constraint checks for CDS/EDS equivalent to the v1 API, so is not suitable for
production use yet.