### PR TITLE
grpc: add missing te header.

### DIFF
--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -97,6 +97,7 @@ public:
       callbacks_->onConfigUpdate(typed_resources);
       request_.set_version_info(ProtobufTypes::FromString(message->version_info()));
       stats_.update_success_.inc();
+      ENVOY_LOG(debug, "gRPC config update accepted: {}", message->DebugString());
     } catch (const EnvoyException& e) {
       ENVOY_LOG(warn, "gRPC config update rejected: {}", e.what());
       stats_.update_rejected_.inc();

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -140,6 +140,7 @@ Http::MessagePtr Common::prepareHeaders(const std::string& upstream_cluster,
   message->headers().insertPath().value().append(method_name.c_str(), method_name.size());
   message->headers().insertHost().value(upstream_cluster);
   message->headers().insertContentType().value().setReference(Common::GRPC_CONTENT_TYPE);
+  message->headers().insertTE().value().setReference(Http::Headers::get().TEValues.Trailers);
 
   return message;
 }

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -120,7 +120,8 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
       {":method", "POST"},
       {":path", "/envoy.api.v2.EndpointDiscoveryService/StreamEndpoints"},
       {":authority", "eds_cluster"},
-      {"content-type", "application/grpc"}};
+      {"content-type", "application/grpc"},
+      {"te", "trailers"}};
   EXPECT_CALL(stream, sendHeaders(HeaderMapEqualRef(&headers), _));
   EXPECT_CALL(cm_.async_client_.dispatcher_, deferredDelete_(_));
   subscriptionFromConfigSource(config)->start({"foo"}, callbacks_);

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -170,7 +170,8 @@ public:
     Http::TestHeaderMapImpl headers{{":method", "POST"},
                                     {":path", "/helloworld.Greeter/SayHello"},
                                     {":authority", "test_cluster"},
-                                    {"content-type", "application/grpc"}};
+                                    {"content-type", "application/grpc"},
+                                    {"te", "trailers"}};
     for (auto& value : initial_metadata) {
       headers.addReference(value.first, value.second);
     }

--- a/test/common/grpc/rpc_channel_impl_test.cc
+++ b/test/common/grpc/rpc_channel_impl_test.cc
@@ -70,6 +70,7 @@ TEST_F(GrpcRequestImplTest, NoError) {
                                                    {":path", "/helloworld.Greeter/SayHello"},
                                                    {":authority", "fake_cluster"},
                                                    {"content-type", "application/grpc"},
+                                                   {"te", "trailers"},
                                                    {"foo", "bar"}};
 
   EXPECT_THAT(http_request_->headers(), HeaderMapEqualRef(&expected_request_headers));


### PR DESCRIPTION
"te: trailers" is optional in H2 but mandatory in gRPC (https://grpc.io/docs/guides/wire.html). The
Google gRPC C/C++ libraries require the presence of this in headers and reject streams that don't
have it.