### PR TITLE
bazel: non-git version info for distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cscope.*
 BROWSE
 .deps
 *.pyc
+SOURCE_VERSION

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -12,6 +12,16 @@
 # If the script exits with non-zero code, it's considered as a failure
 # and the output will be discarded.
 
+# If this SOURCE_VERSION file exists then it must have been placed here by a
+# distribution doing a non-git, source build.
+# Distributions would be expected to echo the commit/tag as BUILD_SCM_REVISION
+if [ -f SOURCE_VERSION ]
+then
+    echo "BUILD_SCM_REVISION $(cat SOURCE_VERSION)"
+    echo "BUILD_SCM_STATUS Distribution"
+    exit 0
+fi
+
 # The code below presents an implementation that works for git repository
 git_rev=$(git rev-parse HEAD)
 if [[ $? != 0 ]];


### PR DESCRIPTION
When packaging envoy for a distribution package (rpm, deb, etc), the
source will often not be a `git clone` but a downloaded zip or tar
archive from the project.

This avoids the use of calls to `git` for compiling in version
information to the binary, and instead allows for distributions to
provide a SOURCE_VERSION file at the root of the source tree.
If present, that information will be used instead. If the file isn't
present, continue as usual to calling `git`.

For testing, I `echo -n %{git_commit} > SOURCE_VERSION`, and got the
following output:
```
$ bazel --version

bazel version: 5ad63908951d98a5bc31352d8ac218b6590d4b12/Distribution/DEBUG
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>