### PR TITLE
osx: UUID generation, fix CLI arg parsing, fix trivial shutdown bug

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -24,6 +24,10 @@ def envoy_copts(repository, test = False):
     }) + select({
         repository + "//bazel:disable_signal_trace": [],
         "//conditions:default": ["-DENVOY_HANDLE_SIGNALS"],
+    }) + select({
+        # TCLAP command line parser needs this to support int64_t/uint64_t
+        "@bazel_tools//tools/osx:darwin": ["-DHAVE_LONG_LONG"],
+        "//conditions:default": [],
     })
 
 # Compute the final linkopts based on various options.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -27,7 +27,7 @@ const size_t RandomGeneratorImpl::UUID_LENGTH = 36;
 
 std::string RandomGeneratorImpl::uuid() {
 #ifdef __APPLE__
-  // TODO (zuercher): factor out a sensible interface for UUID generation to make it easier
+  // TODO(zuercher): factor out a sensible interface for UUID generation to make it easier
   // to put a faster implementation in later.
   char generated_uuid[UUID_LENGTH + 1];
   uuid_t uuid;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -61,6 +61,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
+    thread_local_.shutdownGlobalThreading();
     thread_local_.shutdownThread();
     exit(1);
   }


### PR DESCRIPTION
source/common/runtime: use libuuid for UUID generation on OS X
source/server: fix crash on shutdown (e.g., when no config is specified)
build: set HAVE_LONG_LONG to allow TCLAP to support uint64_T flags

(Split out from #1348, in support of #128.)