### PR TITLE
http:support for adding dynamic request headers to the upstream requests

### DIFF
--- a/docs/configuration/http_conn_man/headers.rst
+++ b/docs/configuration/http_conn_man/headers.rst
@@ -186,6 +186,8 @@ A few very important notes about XFF:
      XFF is parsed to determine if a request is internal. In this scenario, do not forward XFF and
      allow Envoy to generate a new one with a single internal origin IP.
 
+.. _config_http_conn_man_headers_x-forwarded-proto:
+
 x-forwarded-proto
 -----------------
 

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -403,11 +403,11 @@ specified in the following form:
 Envoy supports adding static and dynamic values to the request headers. The dynamic values supported are:
 
 %CLIENT_IP%
-   The Original Client IP which is already added by envoy as an  
+   The Original client IP which is already added by envoy as an  
    :ref:`X-Forwarded-For <config_http_conn_man_headers_x-forwarded-for>` request header. 
 
 %PROTOCOL%
-    The Original Protocol which is already added by envoy as an 
+    The Original protocol which is already added by envoy as an 
     :ref:`X-Forwarded-Proto <config_http_conn_man_headers_x-forwarded-proto>` request header. 
 
 An example for adding dynamic value to the request headers would be as follows:

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -400,6 +400,21 @@ specified in the following form:
     {"key": "header2", "value": "value2"}
   ]
 
+Envoy also supports adding the Original Client IP and Protocol to the request that matches a specific route:
+
+.. code-block:: json
+
+ [
+   {"key": "X-Client-IP", "value":"%CLIENT_IP%"},
+   {"key": "X-Client-Proto", "value":"%PROTOCOL%"}
+ ]
+
+The Original Client IP and Protocol are already added by envoy as an  
+:ref:`X-Forwarded-For <config_http_conn_man_headers_x-forwarded-for>` 
+and :ref:`X-Forwarded-Proto <config_http_conn_man_headers_x-forwarded-proto>` headers. 
+The above feature lets you customize the header name to be added to the request(X-Client-IP 
+and X-Client-Proto in the above example).
+
 *Note:* Headers are appended to requests in the following order:
 route-level headers, :ref:`virtual host level <config_http_conn_man_route_table_vhost_add_req_headers>`
 headers and finally global :ref:`route_config <config_http_conn_man_route_table_add_req_headers>`

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -400,21 +400,23 @@ specified in the following form:
     {"key": "header2", "value": "value2"}
   ]
 
-Envoy also supports adding the Original Client IP and Protocol to the request headers that matches a 
-specific route:
+Envoy supports adding static and dynamic values to the request headers. The dynamic values supported are:
+
+%CLIENT_IP%
+   The Original Client IP which is already added by envoy as an  
+   :ref:`X-Forwarded-For <config_http_conn_man_headers_x-forwarded-for>` request header. 
+
+%PROTOCOL%
+    The Original Protocol which is already added by envoy as an 
+    :ref:`X-Forwarded-Proto <config_http_conn_man_headers_x-forwarded-proto>` request header. 
+
+An example for adding dynamic value to the request headers would be as follows:
 
 .. code-block:: json
 
- [
-   {"key": "X-Client-IP", "value":"%CLIENT_IP%"},
-   {"key": "X-Client-Proto", "value":"%PROTOCOL%"}
- ]
-
-The Original Client IP and Protocol are already added by envoy as an  
-:ref:`X-Forwarded-For <config_http_conn_man_headers_x-forwarded-for>` 
-and :ref:`X-Forwarded-Proto <config_http_conn_man_headers_x-forwarded-proto>` headers. 
-The above feature lets you customize the header name to be added to the request headers (X-Client-IP 
-and X-Client-Proto in the above example).
+  [
+   {"key": "X-Client-IP", "value":"%CLIENT_IP%"}
+  ]
 
 *Note:* Headers are appended to requests in the following order:
 route-level headers, :ref:`virtual host level <config_http_conn_man_route_table_vhost_add_req_headers>`

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -400,7 +400,8 @@ specified in the following form:
     {"key": "header2", "value": "value2"}
   ]
 
-Envoy also supports adding the Original Client IP and Protocol to the request that matches a specific route:
+Envoy also supports adding the Original Client IP and Protocol to the request headers that matches a 
+specific route:
 
 .. code-block:: json
 

--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -413,7 +413,7 @@ specific route:
 The Original Client IP and Protocol are already added by envoy as an  
 :ref:`X-Forwarded-For <config_http_conn_man_headers_x-forwarded-for>` 
 and :ref:`X-Forwarded-Proto <config_http_conn_man_headers_x-forwarded-proto>` headers. 
-The above feature lets you customize the header name to be added to the request(X-Client-IP 
+The above feature lets you customize the header name to be added to the request headers (X-Client-IP 
 and X-Client-Proto in the above example).
 
 *Note:* Headers are appended to requests in the following order:

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -114,6 +114,16 @@ public:
    * Set whether the request is a health check request or not.
    */
   virtual void healthCheck(bool is_hc) PURE;
+
+  /**
+   * Set the downstream address
+   */
+  virtual void setDownstreamAddress(const std::string& address) PURE;
+
+  /**
+   * Get the down stream address.
+   */
+  virtual const std::string& getDownstreamAddress() const PURE;
 };
 
 /**

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -116,11 +116,6 @@ public:
   virtual void healthCheck(bool is_hc) PURE;
 
   /**
-   * Set the downstream address.
-   */
-  virtual void setDownstreamAddress(const std::string& address) PURE;
-
-  /**
    * Get the down stream address.
    */
   virtual const std::string& getDownstreamAddress() const PURE;

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -116,7 +116,7 @@ public:
   virtual void healthCheck(bool is_hc) PURE;
 
   /**
-   * Set the downstream address
+   * Set the downstream address.
    */
   virtual void setDownstreamAddress(const std::string& address) PURE;
 

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -116,7 +116,7 @@ public:
   virtual void healthCheck(bool is_hc) PURE;
 
   /**
-   * Get the down stream address.
+   * Get the downstream address.
    */
   virtual const std::string& getDownstreamAddress() const PURE;
 };

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -37,6 +37,12 @@ private:
   std::string string_;
 };
 
+struct LowerCaseStringHasher {
+  std::size_t operator()(const LowerCaseString& value) const {
+    return std::hash<std::string>{}(value.get());
+  }
+};
+
 /**
  * This is a string implementation for use in header processing. It is heavily optimized for
  * performance. It supports 3 different types of storage and can switch between them:

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -187,9 +187,10 @@ public:
    * example URL prefix rewriting, adding headers, etc. This should only be called ONCE
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.
    * @param headers supplies the request headers, which may be modified during this call.
+   * @param request_info holds additional information about the request.
    */
   virtual void finalizeRequestHeaders(Http::HeaderMap& headers,
-                                      const Http::AccessLog::RequestInfo& requestInfo) const PURE;
+                                      const Http::AccessLog::RequestInfo& request_info) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "envoy/common/optional.h"
+#include "envoy/http/access_log.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
 #include "envoy/upstream/resource_manager.h"
@@ -187,7 +188,8 @@ public:
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.
    * @param headers supplies the request headers, which may be modified during this call.
    */
-  virtual void finalizeRequestHeaders(Http::HeaderMap& headers) const PURE;
+  virtual void finalizeRequestHeaders(Http::HeaderMap& headers,
+                                      const Http::AccessLog::RequestInfo& requestInfo) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,6 +46,13 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
+  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
+
+  /**
+   * Get the down stream address.
+   */
+  const std::string& getDownstreamAddress() const override { return downstream_address_; };
+
   Protocol protocol_;
   const SystemTime start_time_;
   uint64_t bytes_received_{};
@@ -54,6 +61,7 @@ struct RequestInfoImpl : public RequestInfo {
   uint64_t response_flags_{};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool hc_request_{};
+  std::string downstream_address_;
 };
 
 } // namespace AccessLog

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,8 +46,6 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
-
   /**
    * Get the down stream address.
    */

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -46,9 +46,6 @@ struct RequestInfoImpl : public RequestInfo {
 
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
-  /**
-   * Get the downstream address.
-   */
   const std::string& getDownstreamAddress() const override { return downstream_address_; };
 
   Protocol protocol_;

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -47,7 +47,7 @@ struct RequestInfoImpl : public RequestInfo {
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
   /**
-   * Get the down stream address.
+   * Get the downstream address.
    */
   const std::string& getDownstreamAddress() const override { return downstream_address_; };
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -127,7 +127,8 @@ private:
 
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
-    void finalizeRequestHeaders(Http::HeaderMap&) const override {}
+    void finalizeRequestHeaders(Http::HeaderMap&,
+                                const Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -544,6 +544,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Set the trusted address for the connection by taking the last address in XFF.
   downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
+  request_info_.setDownstreamAddress(downstream_address_);
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -507,8 +507,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
         ENVOY_STREAM_LOG(debug, "found websocket connection. (end_stream={}):", *this, end_stream);
 
         connection_manager_.ws_connection_.reset(new WebSocket::WsHandlerImpl(
-            *request_headers_, *route_entry, *this, connection_manager_.cluster_manager_,
-            connection_manager_.read_callbacks_));
+            *request_headers_, request_info_, *route_entry, *this,
+            connection_manager_.cluster_manager_, connection_manager_.read_callbacks_));
         connection_manager_.ws_connection_->onNewConnection();
         connection_manager_.stats_.named_.downstream_cx_websocket_active_.inc();
         connection_manager_.stats_.named_.downstream_cx_http1_active_.dec();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -543,7 +543,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   // Set the trusted address for the connection by taking the last address in XFF.
-  request_info_.setDownstreamAddress(Utility::getLastAddressFromXFF(*request_headers_));
+  request_info_.downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -543,8 +543,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   // Set the trusted address for the connection by taking the last address in XFF.
-  downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
-  request_info_.setDownstreamAddress(downstream_address_);
+  request_info_.setDownstreamAddress(Utility::getLastAddressFromXFF(*request_headers_));
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 
@@ -1135,7 +1134,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::resetStream() {
 uint64_t ConnectionManagerImpl::ActiveStreamFilterBase::streamId() { return parent_.stream_id_; }
 
 const std::string& ConnectionManagerImpl::ActiveStreamFilterBase::downstreamAddress() {
-  return parent_.downstream_address_;
+  return parent_.request_info_.getDownstreamAddress();
 }
 
 } // namespace Http

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -527,7 +527,6 @@ private:
     Stats::TimespanPtr request_timer_;
     State state_;
     AccessLog::RequestInfoImpl request_info_;
-    std::string downstream_address_;
     Optional<Router::RouteConstSharedPtr> cached_route_;
     DownstreamWatermarkCallbacks* watermark_callbacks_{nullptr};
     uint32_t high_watermark_count_{0};

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -13,12 +13,12 @@ namespace Envoy {
 namespace Http {
 namespace WebSocket {
 
-WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, const Router::RouteEntry& route_entry,
-                             WsHandlerCallbacks& callbacks,
+WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, AccessLog::RequestInfo& request_info,
+                             const Router::RouteEntry& route_entry, WsHandlerCallbacks& callbacks,
                              Upstream::ClusterManager& cluster_manager,
                              Network::ReadFilterCallbacks* read_callbacks)
     : Filter::TcpProxy(nullptr, cluster_manager), request_headers_(request_headers),
-      route_entry_(route_entry), ws_callbacks_(callbacks) {
+      request_info_(request_info), route_entry_(route_entry), ws_callbacks_(callbacks) {
 
   read_callbacks_ = read_callbacks;
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
@@ -32,7 +32,7 @@ void WsHandlerImpl::onInitFailure() {
 
 void WsHandlerImpl::onUpstreamHostReady() {
   // path and host rewrites
-  route_entry_.finalizeRequestHeaders(request_headers_);
+  route_entry_.finalizeRequestHeaders(request_headers_, request_info_);
   // for auto host rewrite
   if (route_entry_.autoHostRewrite() && !read_callbacks_->upstreamHost()->hostname().empty()) {
     request_headers_.Host()->value(read_callbacks_->upstreamHost()->hostname());

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -13,7 +13,7 @@ namespace Envoy {
 namespace Http {
 namespace WebSocket {
 
-WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, AccessLog::RequestInfo& request_info,
+WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, const AccessLog::RequestInfo& request_info,
                              const Router::RouteEntry& route_entry, WsHandlerCallbacks& callbacks,
                              Upstream::ClusterManager& cluster_manager,
                              Network::ReadFilterCallbacks* read_callbacks)

--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -25,7 +25,7 @@ namespace WebSocket {
  */
 class WsHandlerImpl : public Filter::TcpProxy {
 public:
-  WsHandlerImpl(HeaderMap& request_headers, AccessLog::RequestInfo& request_info,
+  WsHandlerImpl(HeaderMap& request_headers, const AccessLog::RequestInfo& request_info,
                 const Router::RouteEntry& route_entry, WsHandlerCallbacks& callbacks,
                 Upstream::ClusterManager& cluster_manager,
                 Network::ReadFilterCallbacks* read_callbacks);
@@ -47,7 +47,7 @@ private:
   };
 
   HeaderMap& request_headers_;
-  AccessLog::RequestInfo& request_info_;
+  const AccessLog::RequestInfo& request_info_;
   const Router::RouteEntry& route_entry_;
   WsHandlerCallbacks& ws_callbacks_;
   NullHttpConnectionCallbacks http_conn_callbacks_;

--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -25,8 +25,9 @@ namespace WebSocket {
  */
 class WsHandlerImpl : public Filter::TcpProxy {
 public:
-  WsHandlerImpl(HeaderMap& request_headers, const Router::RouteEntry& route_entry,
-                WsHandlerCallbacks& callbacks, Upstream::ClusterManager& cluster_manager,
+  WsHandlerImpl(HeaderMap& request_headers, AccessLog::RequestInfo& request_info,
+                const Router::RouteEntry& route_entry, WsHandlerCallbacks& callbacks,
+                Upstream::ClusterManager& cluster_manager,
                 Network::ReadFilterCallbacks* read_callbacks);
 
 protected:
@@ -46,6 +47,7 @@ private:
   };
 
   HeaderMap& request_headers_;
+  AccessLog::RequestInfo& request_info_;
   const Router::RouteEntry& route_entry_;
   WsHandlerCallbacks& ws_callbacks_;
   NullHttpConnectionCallbacks http_conn_callbacks_;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["config_impl.h"],
     deps = [
         ":config_utility_lib",
+        ":req_header_formatter_lib",
         ":retry_state_lib",
         ":router_ratelimit_lib",
         "//include/envoy/common:optional",
@@ -29,6 +30,9 @@ envoy_cc_library(
         "//source/common/config:rds_json_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
+        "//source/common/json:config_schemas_lib",
+        "//source/common/json:json_loader_lib",
         "//source/common/protobuf:utility_lib",
     ],
 )
@@ -171,5 +175,16 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/http:headers_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "req_header_formatter_lib",
+    srcs = ["req_header_formatter.cc"],
+    hdrs = ["req_header_formatter.h"],
+    deps = [
+        "//source/common/http:headers_lib",
+        "//source/common/http/access_log:access_log_formatter_lib",
+        "//source/common/json:json_loader_lib",
     ],
 )

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -187,5 +187,6 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -30,7 +30,6 @@ envoy_cc_library(
         "//source/common/config:rds_json_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
-        "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/json:config_schemas_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -183,6 +183,7 @@ envoy_cc_library(
     srcs = ["req_header_formatter.cc"],
     hdrs = ["req_header_formatter.h"],
     deps = [
+        "//source/common/config:rds_json_lib",
         "//source/common/http:headers_lib",
         "//source/common/http/access_log:access_log_formatter_lib",
         "//source/common/json:json_loader_lib",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -151,15 +151,13 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
 void RouteEntryImplBase::finalizeRequestHeaders(
-    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& request_info) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
-  request_headers_parser_->evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
+  request_headers_parser_->evaluateRequestHeaders(headers, request_info);
 
-  vhost_.requestHeaderParser().evaluateRequestHeaders(headers, requestInfo,
-                                                      vhost_.requestHeadersToAdd());
-  vhost_.globalRouteConfig().requestHeaderParser().evaluateRequestHeaders(
-      headers, requestInfo, vhost_.globalRouteConfig().requestHeadersToAdd());
+  vhost_.requestHeaderParser().evaluateRequestHeaders(headers, request_info);
+  vhost_.globalRouteConfig().requestHeaderParser().evaluateRequestHeaders(headers, request_info);
 
   if (host_rewrite_.empty()) {
     return;
@@ -331,8 +329,8 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost,
     : RouteEntryImplBase(vhost, route, loader), prefix_(route.match().prefix()) {}
 
 void PrefixRouteEntryImpl::finalizeRequestHeaders(
-    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& request_info) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, request_info);
 
   finalizePathHeader(headers, prefix_);
 }
@@ -351,8 +349,8 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
     : RouteEntryImplBase(vhost, route, loader), path_(route.match().path()) {}
 
 void PathRouteEntryImpl::finalizeRequestHeaders(
-    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& request_info) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, request_info);
 
   finalizePathHeader(headers, path_);
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -18,6 +18,7 @@
 #include "common/common/utility.h"
 #include "common/config/metadata.h"
 #include "common/config/rds_json.h"
+#include "common/http/access_log/access_log_formatter.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 #include "common/protobuf/utility.h"
@@ -91,6 +92,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       path_redirect_(route.redirect().path_redirect()), retry_policy_(route.route()),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
+      request_headers_parser_(RequestHeaderParser::parse(route)),	
       opaque_config_(parseOpaqueConfig(route)) {
   // If this is a weighted_cluster, we create N internal route entries
   // (called WeightedClusterEntry), such that each object is a simple
@@ -149,19 +151,16 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
 
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
-void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers) const {
+void RouteEntryImplBase::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add : requestHeadersToAdd()) {
-    headers.addReference(to_add.first, to_add.second);
-  }
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add : vhost_.requestHeadersToAdd()) {
-    headers.addReference(to_add.first, to_add.second);
-  }
-  for (const std::pair<Http::LowerCaseString, std::string>& to_add :
-       vhost_.globalRouteConfig().requestHeadersToAdd()) {
-    headers.addReference(to_add.first, to_add.second);
-  }
+  request_headers_parser_->evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
+
+  vhost_.requestHeaderParser()->evaluateRequestHeaders(headers, requestInfo,
+                                                       vhost_.requestHeadersToAdd());
+  vhost_.globalRouteConfig().requestHeaderParser()->evaluateRequestHeaders(
+      headers, requestInfo, vhost_.globalRouteConfig().requestHeadersToAdd());
 
   if (host_rewrite_.empty()) {
     return;
@@ -332,8 +331,9 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost,
                                            Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), prefix_(route.match().prefix()) {}
 
-void PrefixRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers);
+void PrefixRouteEntryImpl::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, prefix_);
 }
@@ -351,8 +351,9 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::Route& route, Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader), path_(route.match().path()) {}
 
-void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers);
+void PathRouteEntryImpl::finalizeRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers, requestInfo);
 
   finalizePathHeader(headers, path_);
 }
@@ -389,7 +390,8 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::VirtualHost& virtual_host
                                  const ConfigImpl& global_route_config, Runtime::Loader& runtime,
                                  Upstream::ClusterManager& cm, bool validate_clusters)
     : name_(virtual_host.name()), rate_limit_policy_(virtual_host.rate_limits()),
-      global_route_config_(global_route_config) {
+      global_route_config_(global_route_config),
+      request_headers_parser_(RequestHeaderParser::parse(virtual_host)){
   switch (virtual_host.require_tls()) {
   case envoy::api::v2::VirtualHost::NONE:
     ssl_requirements_ = SslRequirements::NONE;
@@ -605,6 +607,7 @@ ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config, Runtime
     request_headers_to_add_.push_back({Http::LowerCaseString(header_value_option.header().key()),
                                        header_value_option.header().value()});
   }
+  request_headers_parser_ = RequestHeaderParser::parse(config);
 }
 
 } // namespace Router

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -92,7 +92,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       path_redirect_(route.redirect().path_redirect()), retry_policy_(route.route()),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
-      request_headers_parser_(RequestHeaderParser::parse(route)),	
+      request_headers_parser_(RequestHeaderParser::parseRoute(route)),
       opaque_config_(parseOpaqueConfig(route)) {
   // If this is a weighted_cluster, we create N internal route entries
   // (called WeightedClusterEntry), such that each object is a simple
@@ -391,7 +391,7 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::VirtualHost& virtual_host
                                  Upstream::ClusterManager& cm, bool validate_clusters)
     : name_(virtual_host.name()), rate_limit_policy_(virtual_host.rate_limits()),
       global_route_config_(global_route_config),
-      request_headers_parser_(RequestHeaderParser::parse(virtual_host)){
+      request_headers_parser_(RequestHeaderParser::parseVirtualHost(virtual_host)) {
   switch (virtual_host.require_tls()) {
   case envoy::api::v2::VirtualHost::NONE:
     ssl_requirements_ = SslRequirements::NONE;
@@ -607,7 +607,7 @@ ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config, Runtime
     request_headers_to_add_.push_back({Http::LowerCaseString(header_value_option.header().key()),
                                        header_value_option.header().value()});
   }
-  request_headers_parser_ = RequestHeaderParser::parse(config);
+  request_headers_parser_ = RequestHeaderParser::parseRouteConfiguration(config);
 }
 
 } // namespace Router

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -155,7 +155,7 @@ void RouteEntryImplBase::finalizeRequestHeaders(
     Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
-  request_headers_parser_.evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
+  request_headers_parser_->evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
 
   vhost_.requestHeaderParser().evaluateRequestHeaders(headers, requestInfo,
                                                       vhost_.requestHeadersToAdd());

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -155,11 +155,11 @@ void RouteEntryImplBase::finalizeRequestHeaders(
     Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo) const {
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
-  request_headers_parser_->evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
+  request_headers_parser_.evaluateRequestHeaders(headers, requestInfo, requestHeadersToAdd());
 
-  vhost_.requestHeaderParser()->evaluateRequestHeaders(headers, requestInfo,
-                                                       vhost_.requestHeadersToAdd());
-  vhost_.globalRouteConfig().requestHeaderParser()->evaluateRequestHeaders(
+  vhost_.requestHeaderParser().evaluateRequestHeaders(headers, requestInfo,
+                                                      vhost_.requestHeadersToAdd());
+  vhost_.globalRouteConfig().requestHeaderParser().evaluateRequestHeaders(
       headers, requestInfo, vhost_.globalRouteConfig().requestHeadersToAdd());
 
   if (host_rewrite_.empty()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -88,7 +88,7 @@ public:
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
 
-  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -121,7 +121,7 @@ private:
   const RateLimitPolicyImpl rate_limit_policy_;
   const ConfigImpl& global_route_config_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParser request_headers_parser_;
+  RequestHeaderParserPtr request_headers_parser_;
 };
 
 typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
@@ -234,7 +234,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -339,7 +339,7 @@ private:
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParser request_headers_parser_;
+  RequestHeaderParserPtr request_headers_parser_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;
@@ -448,7 +448,7 @@ public:
 
   bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
-  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
@@ -456,7 +456,7 @@ private:
   std::list<std::pair<Http::LowerCaseString, std::string>> response_headers_to_add_;
   std::list<Http::LowerCaseString> response_headers_to_remove_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParser request_headers_parser_;
+  RequestHeaderParserPtr request_headers_parser_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -87,7 +87,7 @@ public:
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
 
-  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -233,7 +233,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  RequestHeaderParser& requestHeaderParser() { return *request_headers_parser_; };
+  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -447,7 +447,7 @@ public:
 
   bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
-  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -234,7 +234,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  RequestHeaderParser& requestHeaderParser() { return *request_headers_parser_; };
 
 private:
   struct RuntimeData {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -15,7 +15,6 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "common/http/access_log/access_log_formatter.h"
 #include "common/router/config_utility.h"
 #include "common/router/req_header_formatter.h"
 #include "common/router/router_ratelimit.h"

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -199,7 +199,7 @@ public:
   // Router::RouteEntry
   const std::string& clusterName() const override;
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& request_info) const override;
 
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
@@ -250,8 +250,8 @@ private:
     const std::string& clusterName() const override { return cluster_name_; }
 
     void finalizeRequestHeaders(Http::HeaderMap& headers,
-                                const Http::AccessLog::RequestInfo& requestInfo) const override {
-      return parent_->finalizeRequestHeaders(headers, requestInfo);
+                                const Http::AccessLog::RequestInfo& request_info) const override {
+      return parent_->finalizeRequestHeaders(headers, request_info);
     }
 
     const HashPolicy* hashPolicy() const override { return parent_->hashPolicy(); }
@@ -354,7 +354,7 @@ public:
 
   // Router::RouteEntry
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& request_info) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -373,7 +373,7 @@ public:
 
   // Router::RouteEntry
   void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const Http::AccessLog::RequestInfo& requestInfo) const override;
+                              const Http::AccessLog::RequestInfo& request_info) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -15,7 +15,9 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/http/access_log/access_log_formatter.h"
 #include "common/router/config_utility.h"
+#include "common/router/req_header_formatter.h"
 #include "common/router/router_ratelimit.h"
 
 #include "api/rds.pb.h"
@@ -86,6 +88,8 @@ public:
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
 
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
+
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
 
@@ -117,6 +121,7 @@ private:
   const RateLimitPolicyImpl rate_limit_policy_;
   const ConfigImpl& global_route_config_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
+  RequestHeaderParserSharedPtr request_headers_parser_;
 };
 
 typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
@@ -194,7 +199,9 @@ public:
 
   // Router::RouteEntry
   const std::string& clusterName() const override;
-  void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
+
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
@@ -227,6 +234,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -242,8 +250,9 @@ private:
     // Router::RouteEntry
     const std::string& clusterName() const override { return cluster_name_; }
 
-    void finalizeRequestHeaders(Http::HeaderMap& headers) const override {
-      return parent_->finalizeRequestHeaders(headers);
+    void finalizeRequestHeaders(Http::HeaderMap& headers,
+                                const Http::AccessLog::RequestInfo& requestInfo) const override {
+      return parent_->finalizeRequestHeaders(headers, requestInfo);
     }
 
     const HashPolicy* hashPolicy() const override { return parent_->hashPolicy(); }
@@ -330,6 +339,7 @@ private:
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
+  RequestHeaderParserSharedPtr request_headers_parser_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;
@@ -344,7 +354,8 @@ public:
                        Runtime::Loader& loader);
 
   // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -362,7 +373,8 @@ public:
                      Runtime::Loader& loader);
 
   // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
+  void finalizeRequestHeaders(Http::HeaderMap& headers,
+                              const Http::AccessLog::RequestInfo& requestInfo) const override;
 
   // Router::Matchable
   RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
@@ -436,12 +448,15 @@ public:
 
   bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
+  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
+
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
   std::list<Http::LowerCaseString> internal_only_headers_;
   std::list<std::pair<Http::LowerCaseString, std::string>> response_headers_to_add_;
   std::list<Http::LowerCaseString> response_headers_to_remove_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
+  RequestHeaderParserSharedPtr request_headers_parser_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -88,7 +88,7 @@ public:
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
 
-  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -121,7 +121,7 @@ private:
   const RateLimitPolicyImpl rate_limit_policy_;
   const ConfigImpl& global_route_config_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParserSharedPtr request_headers_parser_;
+  RequestHeaderParser request_headers_parser_;
 };
 
 typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
@@ -234,7 +234,7 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -339,7 +339,7 @@ private:
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParserSharedPtr request_headers_parser_;
+  RequestHeaderParser request_headers_parser_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;
@@ -448,7 +448,7 @@ public:
 
   bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
 
-  RequestHeaderParserSharedPtr requestHeaderParser() const { return request_headers_parser_; };
+  RequestHeaderParser requestHeaderParser() const { return request_headers_parser_; };
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
@@ -456,7 +456,7 @@ private:
   std::list<std::pair<Http::LowerCaseString, std::string>> response_headers_to_add_;
   std::list<Http::LowerCaseString> response_headers_to_remove_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
-  RequestHeaderParserSharedPtr request_headers_parser_;
+  RequestHeaderParser request_headers_parser_;
 };
 
 /**

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -1,0 +1,92 @@
+#include "common/router/req_header_formatter.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/http/headers.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Router {
+
+HeaderFormatterSharedPtr RequestHeaderParser::parseInternal(const std::string& format) {
+  std::string variable_name;
+  if (format.find("%") == 0) {
+    size_t last_occ_pos = format.rfind("%");
+    if (last_occ_pos == std::string::npos || last_occ_pos <= 1) {
+      throw EnvoyException(fmt::format(
+          "Incorrect configuration: {}. Expected the variable to be of format %<variable_name>%",
+          format));
+    }
+    variable_name = format.substr(1, last_occ_pos - 1);
+
+  } else {
+    HeaderFormatterSharedPtr plain_header_formatter_shared_ptr(new PlainHeaderFormatter(format));
+    return plain_header_formatter_shared_ptr;
+  }
+  HeaderFormatterSharedPtr request_header_formatter_shared_ptr(
+      new RequestHeaderFormatter(variable_name));
+  return request_header_formatter_shared_ptr;
+}
+
+RequestHeaderParserSharedPtr RequestHeaderParser::parse(const Json::Object& config) {
+
+  RequestHeaderParserSharedPtr request_header_parser(new RequestHeaderParser());
+  if (config.hasObject("request_headers_to_add")) {
+    std::vector<Json::ObjectSharedPtr> request_headers =
+        config.getObjectArray("request_headers_to_add");
+    for (const Json::ObjectSharedPtr& header : request_headers) {
+      if (!header->getString("key").empty() && !header->getString("value").empty()) {
+        ENVOY_LOG(debug, "adding key {} to header formatter map", header->getString("key"));
+        request_header_parser->header_formatter_map_.emplace(
+            Http::LowerCaseString(header->getString("key")),
+            RequestHeaderParser::parseInternal(header->getString("value")));
+      }
+    }
+  }
+
+  return request_header_parser;
+}
+
+void RequestHeaderParser::evaluateRequestHeaders(
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
+    const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
+
+  for (const auto& to_add : requestHeadersToAdd) {
+    ENVOY_LOG(debug, "request headers key {}", to_add.first.get());
+    auto search = header_formatter_map_.find(to_add.first);
+    if (search != header_formatter_map_.end()) {
+      const std::string formatted_header_value = search->second->format(requestInfo);
+      headers.addReferenceKey(to_add.first, formatted_header_value);
+    } else {
+      headers.addReference(to_add.first, to_add.second);
+    }
+  }
+}
+
+RequestHeaderFormatter::RequestHeaderFormatter(const std::string& field_name) {
+  if (field_name == "PROTOCOL") {
+    field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+      return Envoy::Http::AccessLog::AccessLogFormatUtils::protocolToString(
+          request_info.protocol());
+    };
+  } else if (field_name == "CLIENT_IP") {
+    field_extractor_ = [](const Envoy::Http::AccessLog::RequestInfo& request_info) {
+      return request_info.getDownstreamAddress();
+    };
+  } else {
+    throw EnvoyException(
+        fmt::format("field '{}' not supported as custom request header", field_name));
+  }
+}
+
+std::string
+RequestHeaderFormatter::format(const Envoy::Http::AccessLog::RequestInfo& request_info) const {
+  return field_extractor_(request_info);
+}
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "common/config/rds_json.h"
-#include "common/http/access_log/access_log_formatter.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
 
@@ -16,33 +15,17 @@ namespace Router {
 
 HeaderFormatterPtr RequestHeaderParser::parseInternal(const std::string& format) {
   if (format.find("%") == 0) {
-    size_t last_occ_pos = format.rfind("%");
+    const size_t last_occ_pos = format.rfind("%");
     if (last_occ_pos == std::string::npos || last_occ_pos <= 1) {
       throw EnvoyException(fmt::format(
           "Incorrect configuration: {}. Expected the variable to be of format %<variable_name>%",
           format));
     }
     const std::string variable_name = format.substr(1, last_occ_pos - 1);
-    HeaderFormatterPtr request_header_formatter_ptr(new RequestHeaderFormatter(variable_name));
-    return request_header_formatter_ptr;
+    return HeaderFormatterPtr{new RequestHeaderFormatter(variable_name)};
   } else {
-    HeaderFormatterPtr plain_header_formatter_ptr(new PlainHeaderFormatter(format));
-    return plain_header_formatter_ptr;
+    return HeaderFormatterPtr{new PlainHeaderFormatter(format)};
   }
-}
-
-RequestHeaderParserPtr RequestHeaderParser::parseRoute(const envoy::api::v2::Route& route) {
-  return parse(route.route().request_headers_to_add());
-}
-
-RequestHeaderParserPtr
-RequestHeaderParser::parseVirtualHost(const envoy::api::v2::VirtualHost& virtualHost) {
-  return parse(virtualHost.request_headers_to_add());
-}
-
-RequestHeaderParserPtr RequestHeaderParser::parseRouteConfiguration(
-    const envoy::api::v2::RouteConfiguration& routeConfig) {
-  return parse(routeConfig.request_headers_to_add());
 }
 
 RequestHeaderParserPtr RequestHeaderParser::parse(

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -32,8 +32,8 @@ HeaderFormatterPtr RequestHeaderParser::parseInternal(const std::string& format)
   return request_header_formatter_shared_ptr;
 }
 
-RequestHeaderParser RequestHeaderParser::parse(const Json::Object& config) {
-  RequestHeaderParser request_header_parser;
+RequestHeaderParserPtr RequestHeaderParser::parse(const Json::Object& config) {
+  RequestHeaderParserPtr request_header_parser(new RequestHeaderParser());
   std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
       header_formatter_map;
   if (config.hasObject("request_headers_to_add")) {
@@ -44,8 +44,8 @@ RequestHeaderParser RequestHeaderParser::parse(const Json::Object& config) {
         ENVOY_LOG(debug, "adding key {} to header formatter map", header->getString("key"));
         HeaderFormatterPtr header_formatter =
             RequestHeaderParser::parseInternal(header->getString("value"));
-        request_header_parser.header_formatter_map_.emplace(
-            Http::LowerCaseString(header->getString("key")), header_formatter);
+        request_header_parser->header_formatter_map_.emplace(
+            Http::LowerCaseString(header->getString("key")), std::move(header_formatter));
       }
     }
   }

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -62,7 +62,6 @@ RequestHeaderParserPtr RequestHeaderParser::parse(
 void RequestHeaderParser::evaluateRequestHeaders(
     Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
     const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
-
   for (const auto& to_add : requestHeadersToAdd) {
     ENVOY_LOG(debug, "request headers key {}", to_add.first.get());
     auto search = header_formatter_map_.find(to_add.first);

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -26,11 +26,11 @@ HeaderFormatterPtr RequestHeaderParser::parseInternal(const std::string& format)
     variable_name = format.substr(1, last_occ_pos - 1);
 
   } else {
-    HeaderFormatterPtr plain_header_formatter_shared_ptr(new PlainHeaderFormatter(format));
-    return plain_header_formatter_shared_ptr;
+    HeaderFormatterPtr plain_header_formatter_ptr(new PlainHeaderFormatter(format));
+    return plain_header_formatter_ptr;
   }
-  HeaderFormatterPtr request_header_formatter_shared_ptr(new RequestHeaderFormatter(variable_name));
-  return request_header_formatter_shared_ptr;
+  HeaderFormatterPtr request_header_formatter_ptr(new RequestHeaderFormatter(variable_name));
+  return request_header_formatter_ptr;
 }
 
 RequestHeaderParserPtr RequestHeaderParser::parseRoute(const envoy::api::v2::Route& route) {

--- a/source/common/router/req_header_formatter.cc
+++ b/source/common/router/req_header_formatter.cc
@@ -17,9 +17,9 @@ HeaderFormatterPtr RequestHeaderParser::parseInternal(const std::string& format)
   if (format.find("%") == 0) {
     const size_t last_occ_pos = format.rfind("%");
     if (last_occ_pos == std::string::npos || last_occ_pos <= 1) {
-      throw EnvoyException(fmt::format(
-          "Incorrect configuration: {}. Expected the variable to be of format %<variable_name>%",
-          format));
+      throw EnvoyException(fmt::format("Incorrect header configuration: {}. Expected the variable "
+                                       "to be of format %<variable_name>%",
+                                       format));
     }
     const std::string variable_name = format.substr(1, last_occ_pos - 1);
     return HeaderFormatterPtr{new RequestHeaderFormatter(variable_name)};
@@ -32,28 +32,20 @@ RequestHeaderParserPtr RequestHeaderParser::parse(
     const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers) {
   RequestHeaderParserPtr request_header_parser(new RequestHeaderParser());
   for (const auto& header_value_option : headers) {
-    ENVOY_LOG(debug, "adding key {} to header formatter map", header_value_option.header().key());
     HeaderFormatterPtr header_formatter =
         RequestHeaderParser::parseInternal(header_value_option.header().value());
-    request_header_parser->header_formatter_map_.emplace(
-        Http::LowerCaseString(header_value_option.header().key()), std::move(header_formatter));
+    request_header_parser->header_formatters_.push_back(
+        {Http::LowerCaseString(header_value_option.header().key()), std::move(header_formatter)});
   }
 
   return request_header_parser;
 }
 
 void RequestHeaderParser::evaluateRequestHeaders(
-    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
-    const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const {
-  for (const auto& to_add : requestHeadersToAdd) {
-    ENVOY_LOG(debug, "request headers key {}", to_add.first.get());
-    auto search = header_formatter_map_.find(to_add.first);
-    if (search != header_formatter_map_.end()) {
-      const std::string formatted_header_value = search->second->format(requestInfo);
-      headers.addReferenceKey(to_add.first, formatted_header_value);
-    } else {
-      headers.addReference(to_add.first, to_add.second);
-    }
+    Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& request_info) const {
+  for (const auto& formatter : header_formatters_) {
+    const std::string formatted_header_value = formatter.second->format(request_info);
+    headers.addReferenceKey(formatter.first, formatted_header_value);
   }
 }
 

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include "common/common/logger.h"
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * Interface for all types of header formatters used for custom request headers.
+ */
+class HeaderFormatter {
+
+public:
+  virtual ~HeaderFormatter(){};
+
+  virtual std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
+};
+
+typedef std::shared_ptr<HeaderFormatter> HeaderFormatterSharedPtr;
+
+/**
+ * a formatter that expands the request header variable to a value based on info in RequestInfo.
+ */
+class RequestHeaderFormatter : public HeaderFormatter, Logger::Loggable<Logger::Id::config> {
+
+public:
+  virtual ~RequestHeaderFormatter(){};
+  RequestHeaderFormatter(const std::string& field_name);
+
+  // HeaderFormatter::format
+  std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const override;
+
+private:
+  std::function<std::string(const Envoy::Http::AccessLog::RequestInfo&)> field_extractor_;
+};
+/**
+ * Returns back the same static header value.
+ */
+class PlainHeaderFormatter : public HeaderFormatter {
+
+public:
+  virtual ~PlainHeaderFormatter(){};
+
+  PlainHeaderFormatter(const std::string& static_header_value) {
+    static_value_ = static_header_value;
+  };
+
+  // HeaderFormatter::format
+  std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
+    return static_value_;
+  };
+
+private:
+  std::string static_value_;
+};
+
+// forward declaring the typedef and class
+class RequestHeaderParser;
+
+typedef std::shared_ptr<RequestHeaderParser> RequestHeaderParserSharedPtr;
+
+/**
+ * This class will hold the parsing logic required during configuration build and
+ * also perform evaluation for the variables at runtime.
+ */
+class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
+
+public:
+  virtual ~RequestHeaderParser(){};
+
+  static RequestHeaderParserSharedPtr parse(const Json::Object& config);
+
+  static HeaderFormatterSharedPtr parseInternal(const std::string& format);
+
+  void evaluateRequestHeaders(
+      Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
+      const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
+
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+  headerFormatterMap() {
+    return header_formatter_map_;
+  };
+
+private:
+  /**
+   * building a map of request header formatters.
+   */
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+      header_formatter_map_;
+};
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -16,44 +16,40 @@ namespace Router {
  * Interface for all types of header formatters used for custom request headers.
  */
 class HeaderFormatter {
-
 public:
-  virtual ~HeaderFormatter(){};
+  virtual ~HeaderFormatter() {}
 
-  virtual std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
+  virtual const std::string
+  format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
 };
 
-typedef std::shared_ptr<HeaderFormatter> HeaderFormatterSharedPtr;
+typedef std::shared_ptr<HeaderFormatter> HeaderFormatterPtr;
 
 /**
  * a formatter that expands the request header variable to a value based on info in RequestInfo.
  */
 class RequestHeaderFormatter : public HeaderFormatter, Logger::Loggable<Logger::Id::config> {
-
 public:
-  virtual ~RequestHeaderFormatter(){};
   RequestHeaderFormatter(const std::string& field_name);
 
   // HeaderFormatter::format
-  std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const override;
+  const std::string format(const Envoy::Http::AccessLog::RequestInfo& request_info) const override;
 
 private:
   std::function<std::string(const Envoy::Http::AccessLog::RequestInfo&)> field_extractor_;
 };
+
 /**
  * Returns back the same static header value.
  */
 class PlainHeaderFormatter : public HeaderFormatter {
-
 public:
-  virtual ~PlainHeaderFormatter(){};
-
   PlainHeaderFormatter(const std::string& static_header_value) {
     static_value_ = static_header_value;
   };
 
   // HeaderFormatter::format
-  std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
+  const std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
     return static_value_;
   };
 
@@ -61,29 +57,23 @@ private:
   std::string static_value_;
 };
 
-// forward declaring the typedef and class
-class RequestHeaderParser;
-
-typedef std::shared_ptr<RequestHeaderParser> RequestHeaderParserSharedPtr;
-
 /**
  * This class will hold the parsing logic required during configuration build and
  * also perform evaluation for the variables at runtime.
  */
 class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
-
 public:
-  virtual ~RequestHeaderParser(){};
+  virtual ~RequestHeaderParser() {}
 
-  static RequestHeaderParserSharedPtr parse(const Json::Object& config);
+  static RequestHeaderParser parse(const Json::Object& config);
 
-  static HeaderFormatterSharedPtr parseInternal(const std::string& format);
+  static HeaderFormatterPtr parseInternal(const std::string& format);
 
   void evaluateRequestHeaders(
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
 
-  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>&
   headerFormatterMap() {
     return header_formatter_map_;
   };
@@ -92,7 +82,7 @@ private:
   /**
    * building a map of request header formatters.
    */
-  std::unordered_map<Http::LowerCaseString, HeaderFormatterSharedPtr, Http::LowerCaseStringHasher>
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
       header_formatter_map_;
 };
 

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -44,9 +44,7 @@ private:
  */
 class PlainHeaderFormatter : public HeaderFormatter {
 public:
-  PlainHeaderFormatter(const std::string& static_header_value) {
-    static_value_ = static_header_value;
-  };
+  PlainHeaderFormatter(const std::string& static_header_value): static_value_(static_header_value) {};
 
   // HeaderFormatter::format
   const std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
@@ -54,7 +52,7 @@ public:
   };
 
 private:
-  std::string static_value_;
+  const std::string static_value_;
 };
 
 /**

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -73,13 +73,11 @@ public:
   static RequestHeaderParserPtr
   parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
 
-  void evaluateRequestHeaders(
-      Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
-      const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
+  void evaluateRequestHeaders(Http::HeaderMap& headers,
+                              const Http::AccessLog::RequestInfo& request_info) const;
 
 private:
-  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
-      header_formatter_map_;
+  std::list<std::pair<Http::LowerCaseString, HeaderFormatterPtr>> header_formatters_;
 
   static HeaderFormatterPtr parseInternal(const std::string& format);
 };

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -43,7 +43,7 @@ private:
 };
 
 /**
- * Returns back the same static header value.
+ * A formatter that returns back the same static header value.
  */
 class PlainHeaderFormatter : public HeaderFormatter {
 public:
@@ -77,11 +77,6 @@ public:
   static RequestHeaderParserPtr
   parseRouteConfiguration(const envoy::api::v2::RouteConfiguration& routeConfig);
 
-  static RequestHeaderParserPtr
-  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
-
-  static HeaderFormatterPtr parseInternal(const std::string& format);
-
   void evaluateRequestHeaders(
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
@@ -92,6 +87,11 @@ private:
    */
   std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
       header_formatter_map_;
+
+  static RequestHeaderParserPtr
+  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
+
+  static HeaderFormatterPtr parseInternal(const std::string& format);
 };
 } // namespace Router
 } // namespace Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -81,15 +81,13 @@ public:
   void evaluateRequestHeaders(
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
-};
 
 private:
-/**
- * Building a map of request header formatters.
- */
-std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
-    header_formatter_map_;
-}; // namespace Router
-
-} // namespace Envoy
+  /**
+   * Building a map of request header formatters.
+   */
+  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
+      header_formatter_map_;
+};
+} // namespace Router
 } // namespace Envoy

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -44,7 +44,8 @@ private:
  */
 class PlainHeaderFormatter : public HeaderFormatter {
 public:
-  PlainHeaderFormatter(const std::string& static_header_value): static_value_(static_header_value) {};
+  PlainHeaderFormatter(const std::string& static_header_value)
+      : static_value_(static_header_value){};
 
   // HeaderFormatter::format
   const std::string format(const Envoy::Http::AccessLog::RequestInfo&) const override {
@@ -71,7 +72,7 @@ public:
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
 
-  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>&
+  const std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>&
   headerFormatterMap() {
     return header_formatter_map_;
   };

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -8,6 +8,7 @@
 #include "common/common/logger.h"
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/json/json_loader.h"
+#include "common/protobuf/protobuf.h"
 
 #include "api/rds.pb.h"
 
@@ -75,6 +76,9 @@ public:
 
   static RequestHeaderParserPtr
   parseRouteConfiguration(const envoy::api::v2::RouteConfiguration& routeConfig);
+
+  static RequestHeaderParserPtr
+  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
 
   static HeaderFormatterPtr parseInternal(const std::string& format);
 

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -23,7 +23,7 @@ public:
   format(const Envoy::Http::AccessLog::RequestInfo& request_info) const PURE;
 };
 
-typedef std::shared_ptr<HeaderFormatter> HeaderFormatterPtr;
+typedef std::unique_ptr<HeaderFormatter> HeaderFormatterPtr;
 
 /**
  * a formatter that expands the request header variable to a value based on info in RequestInfo.
@@ -56,6 +56,9 @@ private:
   const std::string static_value_;
 };
 
+class RequestHeaderParser;
+typedef std::unique_ptr<RequestHeaderParser> RequestHeaderParserPtr;
+
 /**
  * This class will hold the parsing logic required during configuration build and
  * also perform evaluation for the variables at runtime.
@@ -64,7 +67,7 @@ class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
 public:
   virtual ~RequestHeaderParser() {}
 
-  static RequestHeaderParser parse(const Json::Object& config);
+  static RequestHeaderParserPtr parse(const Json::Object& config);
 
   static HeaderFormatterPtr parseInternal(const std::string& format);
 

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -9,6 +9,8 @@
 #include "common/http/access_log/access_log_formatter.h"
 #include "common/json/json_loader.h"
 
+#include "api/rds.pb.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -67,7 +69,12 @@ class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
 public:
   virtual ~RequestHeaderParser() {}
 
-  static RequestHeaderParserPtr parse(const Json::Object& config);
+  static RequestHeaderParserPtr parseRoute(const envoy::api::v2::Route& route);
+
+  static RequestHeaderParserPtr parseVirtualHost(const envoy::api::v2::VirtualHost& virtualHost);
+
+  static RequestHeaderParserPtr
+  parseRouteConfiguration(const envoy::api::v2::RouteConfiguration& routeConfig);
 
   static HeaderFormatterPtr parseInternal(const std::string& format);
 

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -70,26 +70,16 @@ class RequestHeaderParser : Logger::Loggable<Logger::Id::config> {
 public:
   virtual ~RequestHeaderParser() {}
 
-  static RequestHeaderParserPtr parseRoute(const envoy::api::v2::Route& route);
-
-  static RequestHeaderParserPtr parseVirtualHost(const envoy::api::v2::VirtualHost& virtualHost);
-
   static RequestHeaderParserPtr
-  parseRouteConfiguration(const envoy::api::v2::RouteConfiguration& routeConfig);
+  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
 
   void evaluateRequestHeaders(
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
 
 private:
-  /**
-   * Building a map of request header formatters.
-   */
   std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
       header_formatter_map_;
-
-  static RequestHeaderParserPtr
-  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
 
   static HeaderFormatterPtr parseInternal(const std::string& format);
 };

--- a/source/common/router/req_header_formatter.h
+++ b/source/common/router/req_header_formatter.h
@@ -28,7 +28,7 @@ public:
 typedef std::unique_ptr<HeaderFormatter> HeaderFormatterPtr;
 
 /**
- * a formatter that expands the request header variable to a value based on info in RequestInfo.
+ * A formatter that expands the request header variable to a value based on info in RequestInfo.
  */
 class RequestHeaderFormatter : public HeaderFormatter, Logger::Loggable<Logger::Id::config> {
 public:
@@ -81,19 +81,15 @@ public:
   void evaluateRequestHeaders(
       Http::HeaderMap& headers, const Http::AccessLog::RequestInfo& requestInfo,
       const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd) const;
-
-  const std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>&
-  headerFormatterMap() {
-    return header_formatter_map_;
-  };
-
-private:
-  /**
-   * building a map of request header formatters.
-   */
-  std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
-      header_formatter_map_;
 };
 
-} // namespace Router
+private:
+/**
+ * Building a map of request header formatters.
+ */
+std::unordered_map<Http::LowerCaseString, HeaderFormatterPtr, Http::LowerCaseStringHasher>
+    header_formatter_map_;
+}; // namespace Router
+
+} // namespace Envoy
 } // namespace Envoy

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -159,6 +159,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Determine if there is a route entry or a redirect for the request.
   route_ = callbacks_->route();
+
   if (!route_) {
     config_.stats_.no_route_.inc();
     ENVOY_STREAM_LOG(debug, "no cluster match for URL '{}'", *callbacks_,
@@ -228,8 +229,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     timeout_response_code_ = Http::Code::NoContent;
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
-
-  route_entry_->finalizeRequestHeaders(headers);
+  log().debug("downstream address: '{}'\n", callbacks_->downstreamAddress());
+  route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);
   retry_state_ =
       createRetryState(route_entry_->retryPolicy(), headers, *cluster_, config_.runtime_,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -159,7 +159,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Determine if there is a route entry or a redirect for the request.
   route_ = callbacks_->route();
-
   if (!route_) {
     config_.stats_.no_route_.inc();
     ENVOY_STREAM_LOG(debug, "no cluster match for URL '{}'", *callbacks_,
@@ -229,7 +228,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
     timeout_response_code_ = Http::Code::NoContent;
     headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
   }
-  log().debug("downstream address: '{}'\n", callbacks_->downstreamAddress());
   route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);
   retry_state_ =

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -74,8 +74,6 @@ public:
   Upstream::HostDescriptionConstSharedPtr upstreamHost() const override { return upstream_host_; }
   bool healthCheck() const override { return hc_request_; }
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
-
-  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
   const std::string& getDownstreamAddress() const override { return downstream_address_; }
 
   SystemTime start_time_;

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -75,6 +75,9 @@ public:
   bool healthCheck() const override { return hc_request_; }
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
+  void setDownstreamAddress(const std::string& address) override { downstream_address_ = address; }
+  const std::string& getDownstreamAddress() const override { return downstream_address_; }
+
   SystemTime start_time_;
   Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;
@@ -82,6 +85,7 @@ public:
   uint64_t duration_{3};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool hc_request_{};
+  std::string downstream_address_;
 };
 
 class AccessLogImplTest : public testing::Test {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -676,7 +676,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixRewrite) {
       .WillByDefault(Return(true));
 
   EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_,
-              finalizeRequestHeaders(_));
+              finalizeRequestHeaders(_, _));
   EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, autoHostRewrite())
       .WillOnce(Return(false));
   // TODO (rshriram) figure out how to test the auto host rewrite. Need handle over headers.

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -106,6 +106,7 @@ envoy_cc_test(
     name = "req_header_formatter_test",
     srcs = ["req_header_formatter_test.cc"],
     deps = [
+        "//source/common/config:rds_json_lib",
         "//source/common/router:req_header_formatter_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -101,3 +101,14 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
     ],
 )
+
+envoy_cc_test(
+    name = "req_header_formatter_test",
+    srcs = ["req_header_formatter_test.cc"],
+    deps = [
+        "//source/common/router:req_header_formatter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -7,7 +7,9 @@
 #include "common/config/rds_json.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
+#include "common/http/utility.h"
 #include "common/json/json_loader.h"
+#include "common/network/address_impl.h"
 #include "common/router/config_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
@@ -173,6 +175,7 @@ TEST(RouteMatcherTest, TestRoutes) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -227,7 +230,7 @@ TEST(RouteMatcherTest, TestRoutes) {
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     EXPECT_EQ("www2", route->clusterName());
     EXPECT_EQ("www2", route->virtualHost().name());
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/api/new_endpoint/foo", headers.get_(Http::Headers::get().Path));
   }
 
@@ -236,14 +239,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/api/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/foo", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/bar", headers.get_(Http::Headers::get().Path));
   }
 
@@ -251,7 +254,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/host/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -260,14 +263,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/API/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/fooD", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/cAndy", headers.get_(Http::Headers::get().Path));
   }
 
@@ -275,14 +278,14 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/FOO", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/FOO", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/ApPles", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/ApPles", headers.get_(Http::Headers::get().Path));
   }
 
@@ -290,7 +293,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/oLDhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().Host));
   }
 
@@ -298,7 +301,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/Tart", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("/Tart", headers.get_(Http::Headers::get().Path));
   }
 
@@ -306,7 +309,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/newhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers);
+    route->finalizeRequestHeaders(headers, requestInfo);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -453,6 +456,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   // Request header manipulation testing.
@@ -460,7 +464,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("route-override", headers.get_("x-global-header1"));
       EXPECT_EQ("route-override", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-new_endpoint", headers.get_("x-route-header"));
@@ -470,7 +474,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("vhost-override", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allpath", headers.get_("x-route-header"));
@@ -480,7 +484,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www-staging.lyft.net", "/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2_staging", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allprefix", headers.get_("x-route-header"));
@@ -490,7 +494,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers);
+      route->finalizeRequestHeaders(headers, requestInfo);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
     }
   }
@@ -776,6 +780,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -795,7 +800,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 
     // Make sure things forward and don't crash.
     EXPECT_EQ(std::chrono::milliseconds(0), route->routeEntry()->timeout());
-    route->routeEntry()->finalizeRequestHeaders(headers);
+    route->routeEntry()->finalizeRequestHeaders(headers, requestInfo);
     route->routeEntry()->priority();
     route->routeEntry()->rateLimitPolicy();
     route->routeEntry()->retryPolicy();
@@ -2031,6 +2036,232 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
+<<<<<<< ac16d35e8cd21d745dc752199841d9a130ca8b15
 } // namespace
+=======
+TEST(CustomRequestHeadersTest, AddNewHeader) {
+  const std::string json = R"EOF(
+	{
+  "virtual_hosts": [
+    {
+      "name": "www2",
+      "domains": [
+        "lyft.com",
+        "www.lyft.com",
+        "w.lyft.com",
+        "ww.lyft.com",
+        "wwww.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-client-ip",
+          "value": "%CLIENT_IP%"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        },
+        {
+          "path": "/",
+          "cluster": "root_www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        },
+        {
+          "prefix": "/",
+          "cluster": "www2"
+        }
+      ]
+    },
+    {
+      "name": "www2_staging",
+      "domains": [
+        "www-staging.lyft.net",
+        "www-staging-orca.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-vhost-header1",
+          "value": "vhost1-www2_staging"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "www2_staging",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "default",
+      "domains": [
+        "*"
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "instant-server",
+          "timeout_ms": 30000
+        }
+      ]
+    }
+  ],
+  "request_headers_to_add": [
+    {
+      "key": "x-client-ip",
+      "value": "%CLIENT_IP%"
+    }
+  ]
+}
+	  )EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  ConfigImpl config(*loader, runtime, cm, true);
+
+  // Request header manipulation testing.
+  {
+    {
+      std::string s1 = ("127.0.0.1");
+      Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
+      ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+      const RouteEntry* route = config.route(headers, 0)->routeEntry();
+      route->finalizeRequestHeaders(headers, requestInfo);
+      EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));
+    }
+  }
+}
+
+bool CheckFormatMessage(const std::string errorMessage) {
+  std::size_t found = errorMessage.find("Incorrect configuration");
+  return (found != std::string::npos);
+}
+
+TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
+  std::string json = R"EOF(
+	{
+  "virtual_hosts": [
+    {
+      "name": "www2",
+      "domains": [
+        "lyft.com",
+        "www.lyft.com",
+        "w.lyft.com",
+        "ww.lyft.com",
+        "wwww.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-client-ip",
+          "value": "%CLIENT_IP%"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        },
+        {
+          "path": "/",
+          "cluster": "root_www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        },
+        {
+          "prefix": "/",
+          "cluster": "www2"
+        }
+      ]
+    },
+    {
+      "name": "www2_staging",
+      "domains": [
+        "www-staging.lyft.net",
+        "www-staging-orca.lyft.com"
+      ],
+      "request_headers_to_add": [
+        {
+          "key": "x-vhost-header1",
+          "value": "vhost1-www2_staging"
+        }
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "www2_staging",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "default",
+      "domains": [
+        "*"
+      ],
+      "routes": [
+        {
+          "prefix": "/",
+          "cluster": "instant-server",
+          "timeout_ms": 30000
+        }
+      ]
+    }
+  ],
+  "request_headers_to_add": [
+    {
+      "key": "x-client-ip",
+      "value": "%CLIENT_IP"
+    }
+  ]
+}
+	  )EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  ASSERT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
+  try {
+    ConfigImpl config(*loader, runtime, cm, true);
+  } catch (EnvoyException& ex) {
+    EXPECT_PRED1(CheckFormatMessage, ex.what());
+  }
+}
+
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -175,7 +175,7 @@ TEST(RouteMatcherTest, TestRoutes) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -230,7 +230,7 @@ TEST(RouteMatcherTest, TestRoutes) {
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     EXPECT_EQ("www2", route->clusterName());
     EXPECT_EQ("www2", route->virtualHost().name());
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/api/new_endpoint/foo", headers.get_(Http::Headers::get().Path));
   }
 
@@ -239,14 +239,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/api/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/foo", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/bar", headers.get_(Http::Headers::get().Path));
   }
 
@@ -254,7 +254,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/host/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -263,14 +263,14 @@ TEST(RouteMatcherTest, TestRoutes) {
     Http::TestHeaderMapImpl headers =
         genHeaders("api.lyft.com", "/API/locations?works=true", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/fooD", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/cAndy", headers.get_(Http::Headers::get().Path));
   }
 
@@ -278,14 +278,14 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/FOO", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/FOO", headers.get_(Http::Headers::get().Path));
   }
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/ApPles", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/ApPles", headers.get_(Http::Headers::get().Path));
   }
 
@@ -293,7 +293,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/oLDhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().Host));
   }
 
@@ -301,7 +301,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/Tart", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("/Tart", headers.get_(Http::Headers::get().Path));
   }
 
@@ -309,7 +309,7 @@ TEST(RouteMatcherTest, TestRoutes) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/newhost/rewrite/me", "GET");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
-    route->finalizeRequestHeaders(headers, requestInfo);
+    route->finalizeRequestHeaders(headers, request_info);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
   }
 
@@ -456,7 +456,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   // Request header manipulation testing.
@@ -464,7 +464,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers, requestInfo);
+      route->finalizeRequestHeaders(headers, request_info);
       EXPECT_EQ("route-override", headers.get_("x-global-header1"));
       EXPECT_EQ("route-override", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-new_endpoint", headers.get_("x-route-header"));
@@ -474,7 +474,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers, requestInfo);
+      route->finalizeRequestHeaders(headers, request_info);
       EXPECT_EQ("vhost-override", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allpath", headers.get_("x-route-header"));
@@ -484,7 +484,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("www-staging.lyft.net", "/foo", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers, requestInfo);
+      route->finalizeRequestHeaders(headers, request_info);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2_staging", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allprefix", headers.get_("x-route-header"));
@@ -494,7 +494,7 @@ TEST(RouteMatcherTest, TestAddRemoveReqRespHeaders) {
     {
       Http::TestHeaderMapImpl headers = genHeaders("api.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers, requestInfo);
+      route->finalizeRequestHeaders(headers, request_info);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
     }
   }
@@ -780,7 +780,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   EXPECT_FALSE(config.usesRuntime());
@@ -800,7 +800,7 @@ TEST(RouteMatcherTest, ClusterHeader) {
 
     // Make sure things forward and don't crash.
     EXPECT_EQ(std::chrono::milliseconds(0), route->routeEntry()->timeout());
-    route->routeEntry()->finalizeRequestHeaders(headers, requestInfo);
+    route->routeEntry()->finalizeRequestHeaders(headers, request_info);
     route->routeEntry()->priority();
     route->routeEntry()->rateLimitPolicy();
     route->routeEntry()->retryPolicy();
@@ -2132,7 +2132,7 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
 	  )EOF";
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   // Request header manipulation testing.
@@ -2140,16 +2140,16 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
     {
       std::string s1 = ("127.0.0.1");
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
-      ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+      ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
       const RouteEntry* route = config.route(headers, 0)->routeEntry();
-      route->finalizeRequestHeaders(headers, requestInfo);
+      route->finalizeRequestHeaders(headers, request_info);
       EXPECT_EQ("127.0.0.1", headers.get_("x-client-ip"));
     }
   }
 }
 
-bool CheckFormatMessage(const std::string errorMessage) {
-  std::size_t found = errorMessage.find("Incorrect configuration");
+static bool CheckFormatMessage(const std::string errorMessage) {
+  const std::size_t found = errorMessage.find("Incorrect header configuration");
   return (found != std::string::npos);
 }
 
@@ -2249,7 +2249,7 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
 	  )EOF";
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   EXPECT_THROW(ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true),
                EnvoyException);
   try {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2036,9 +2036,6 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
-<<<<<<< ac16d35e8cd21d745dc752199841d9a130ca8b15
-} // namespace
-=======
 TEST(CustomRequestHeadersTest, AddNewHeader) {
   const std::string json = R"EOF(
 	{
@@ -2133,11 +2130,10 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
   ]
 }
 	  )EOF";
-  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  ConfigImpl config(*loader, runtime, cm, true);
+  ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
   // Request header manipulation testing.
   {
@@ -2251,17 +2247,17 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
   ]
 }
 	  )EOF";
-  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  ASSERT_THROW(ConfigImpl config(*loader, runtime, cm, true), EnvoyException);
+  ASSERT_THROW(ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true),
+               EnvoyException);
   try {
-    ConfigImpl config(*loader, runtime, cm, true);
+    ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
   } catch (EnvoyException& ex) {
     EXPECT_PRED1(CheckFormatMessage, ex.what());
   }
 }
-
+} // namespace
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2250,7 +2250,7 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  ASSERT_THROW(ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true),
+  EXPECT_THROW(ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true),
                EnvoyException);
   try {
     ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -1,0 +1,98 @@
+#include <string>
+
+#include "envoy/http/protocol.h"
+
+#include "common/http/access_log/access_log_formatter.h"
+#include "common/router/req_header_formatter.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Router {
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::_;
+
+TEST(RequestHeaderFormatterTest, TestFormatWithClientIpVariable) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::string variable = "CLIENT_IP";
+  RequestHeaderFormatter requestHeaderFormatter(variable);
+  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  EXPECT_EQ("127.0.0.1", formatted_string);
+}
+
+TEST(RequestHeaderFormatterTest, TestFormatWithProtocolVariable) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  ON_CALL(requestInfo, protocol()).WillByDefault(Return(Envoy::Http::Protocol::Http11));
+  std::string variable = "PROTOCOL";
+  RequestHeaderFormatter requestHeaderFormatter(variable);
+  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  EXPECT_EQ("HTTP/1.1", formatted_string);
+}
+
+TEST(RequestHeaderFormatterTest, WrongVariableToFormat) {
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::string variable = "INVALID_VARIABLE";
+  ASSERT_THROW(RequestHeaderFormatter requestHeaderFormatter(variable), EnvoyException);
+}
+
+TEST(RequestHeaderParserTest, EvaluateHeaders) {
+  std::string json = R"EOF(
+		{
+	     "request_headers_to_add": [
+	    	{
+	      		"key": "x-client-ip",
+	      		"value": "%CLIENT_IP%"
+	    	}
+	   	]
+	  })EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
+      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::string s1 = "127.0.0.1";
+  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  std::pair<Http::LowerCaseString, std::string> client_ip_req_header(
+      Http::LowerCaseString{"x-client-ip"}, "%CLIENT_IP%");
+  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
+      client_ip_req_header};
+  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  EXPECT_TRUE(headerMap.has("x-client-ip"));
+}
+
+TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
+  std::string json = R"EOF(
+		{
+	     "request_headers_to_add": [
+	    	{
+	      		"key": "static-header",
+	      		"value": "static-value"
+	    	}
+	   	]
+	  })EOF";
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
+      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  std::pair<Http::LowerCaseString, std::string> static_req_header(
+      Http::LowerCaseString{"static-header"}, "static-value");
+  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
+      static_req_header};
+  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  EXPECT_TRUE(headerMap.has("static-header"));
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -57,8 +57,7 @@ TEST(RequestHeaderParserTest, EvaluateHeaders) {
 	   	]
 	  })EOF";
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
-      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  RequestHeaderParser req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   std::string s1 = "127.0.0.1";
@@ -67,7 +66,7 @@ TEST(RequestHeaderParserTest, EvaluateHeaders) {
       Http::LowerCaseString{"x-client-ip"}, "%CLIENT_IP%");
   std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
       client_ip_req_header};
-  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  req_header_parser.evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
   EXPECT_TRUE(headerMap.has("x-client-ip"));
 }
 
@@ -82,15 +81,14 @@ TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
 	   	]
 	  })EOF";
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  RequestHeaderParserSharedPtr req_header_parser_shared_ptr =
-      Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  RequestHeaderParser req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   std::pair<Http::LowerCaseString, std::string> static_req_header(
       Http::LowerCaseString{"static-header"}, "static-value");
   std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
       static_req_header};
-  req_header_parser_shared_ptr->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  req_header_parser.evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
   EXPECT_TRUE(headerMap.has("static-header"));
 }
 

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -29,7 +29,7 @@ static envoy::api::v2::Route parseRouteFromJson(const std::string& json_string) 
 
 static bool CheckFormatMessage(const std::string error_message,
                                const std::string expected_message) {
-  std::size_t found = error_message.find(expected_message);
+  const std::size_t found = error_message.find(expected_message);
   return (found != std::string::npos);
 }
 
@@ -134,5 +134,6 @@ TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
   req_header_parser->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
   EXPECT_TRUE(headerMap.has("static-header"));
 }
+
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -57,7 +57,7 @@ TEST(RequestHeaderParserTest, EvaluateHeaders) {
 	   	]
 	  })EOF";
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  RequestHeaderParser req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  RequestHeaderParserPtr req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   std::string s1 = "127.0.0.1";
@@ -66,7 +66,7 @@ TEST(RequestHeaderParserTest, EvaluateHeaders) {
       Http::LowerCaseString{"x-client-ip"}, "%CLIENT_IP%");
   std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
       client_ip_req_header};
-  req_header_parser.evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  req_header_parser->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
   EXPECT_TRUE(headerMap.has("x-client-ip"));
 }
 
@@ -81,14 +81,14 @@ TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
 	   	]
 	  })EOF";
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
-  RequestHeaderParser req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
+  RequestHeaderParserPtr req_header_parser = Envoy::Router::RequestHeaderParser::parse(*loader.get());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
   std::pair<Http::LowerCaseString, std::string> static_req_header(
       Http::LowerCaseString{"static-header"}, "static-value");
   std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
       static_req_header};
-  req_header_parser.evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  req_header_parser->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
   EXPECT_TRUE(headerMap.has("static-header"));
 }
 

--- a/test/common/router/req_header_formatter_test.cc
+++ b/test/common/router/req_header_formatter_test.cc
@@ -13,12 +13,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
 using testing::_;
 
+namespace Envoy {
 namespace Router {
 static envoy::api::v2::Route parseRouteFromJson(const std::string& json_string) {
   envoy::api::v2::Route route;
@@ -34,28 +34,28 @@ static bool CheckFormatMessage(const std::string error_message,
 }
 
 TEST(RequestHeaderFormatterTest, TestFormatWithClientIpVariable) {
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   std::string s1 = "127.0.0.1";
-  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
   std::string variable = "CLIENT_IP";
   RequestHeaderFormatter requestHeaderFormatter(variable);
-  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  std::string formatted_string = requestHeaderFormatter.format(request_info);
   EXPECT_EQ("127.0.0.1", formatted_string);
 }
 
 TEST(RequestHeaderFormatterTest, TestFormatWithProtocolVariable) {
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  ON_CALL(requestInfo, protocol()).WillByDefault(Return(Envoy::Http::Protocol::Http11));
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
+  ON_CALL(request_info, protocol()).WillByDefault(Return(Envoy::Http::Protocol::Http11));
   std::string variable = "PROTOCOL";
   RequestHeaderFormatter requestHeaderFormatter(variable);
-  std::string formatted_string = requestHeaderFormatter.format(requestInfo);
+  std::string formatted_string = requestHeaderFormatter.format(request_info);
   EXPECT_EQ("HTTP/1.1", formatted_string);
 }
 
 TEST(RequestHeaderFormatterTest, WrongVariableToFormat) {
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   std::string s1 = "127.0.0.1";
-  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
   std::string variable = "INVALID_VARIABLE";
   ASSERT_THROW(RequestHeaderFormatter requestHeaderFormatter(variable), EnvoyException);
   try {
@@ -84,54 +84,50 @@ TEST(RequestHeaderFormatterTest, WrongFormatOnVariable) {
     Envoy::Router::RequestHeaderParser::parse(
         parseRouteFromJson(json).route().request_headers_to_add());
   } catch (EnvoyException& ex) {
-    EXPECT_PRED2(CheckFormatMessage, ex.what(), "Incorrect configuration");
+    EXPECT_PRED2(CheckFormatMessage, ex.what(), "Incorrect header configuration");
   }
 }
 
 TEST(RequestHeaderParserTest, EvaluateHeaders) {
-  std::string json = R"EOF(
-		{
-	     "request_headers_to_add": [
-	    	{
-	      		"key": "x-client-ip",
-	      		"value": "%CLIENT_IP%"
-	    	}
-	   	]
-	  })EOF";
+  std::string json = R"EOF({
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "x-client-ip",
+              "value": "%CLIENT_IP%"
+            }
+          ]
+        })EOF";
   RequestHeaderParserPtr req_header_parser = Envoy::Router::RequestHeaderParser::parse(
       parseRouteFromJson(json).route().request_headers_to_add());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   std::string s1 = "127.0.0.1";
-  ON_CALL(requestInfo, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
-  std::pair<Http::LowerCaseString, std::string> client_ip_req_header(
-      Http::LowerCaseString{"x-client-ip"}, "%CLIENT_IP%");
-  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
-      client_ip_req_header};
-  req_header_parser->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(s1));
+  req_header_parser->evaluateRequestHeaders(headerMap, request_info);
   EXPECT_TRUE(headerMap.has("x-client-ip"));
 }
 
 TEST(RequestHeaderParserTest, EvaluateStaticHeaders) {
-  std::string json = R"EOF(
-		{
-	     "request_headers_to_add": [
-	    	{
-	      		"key": "static-header",
-	      		"value": "static-value"
-	    	}
-	   	]
-	  })EOF";
+  std::string json = R"EOF({
+          "prefix": "/new_endpoint",
+          "prefix_rewrite": "/api/new_endpoint",
+          "cluster": "www2",
+          "request_headers_to_add": [
+            {
+              "key": "static-header",
+              "value": "static-value"
+            }
+          ]
+        })EOF";
   Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
   RequestHeaderParserPtr req_header_parser = Envoy::Router::RequestHeaderParser::parse(
       parseRouteFromJson(json).route().request_headers_to_add());
   Http::TestHeaderMapImpl headerMap{{":method", "POST"}};
-  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> requestInfo;
-  std::pair<Http::LowerCaseString, std::string> static_req_header(
-      Http::LowerCaseString{"static-header"}, "static-value");
-  std::list<std::pair<Http::LowerCaseString, std::string>> requestHeadersToAdd = {
-      static_req_header};
-  req_header_parser->evaluateRequestHeaders(headerMap, requestInfo, requestHeadersToAdd);
+  NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
+  req_header_parser->evaluateRequestHeaders(headerMap, request_info);
   EXPECT_TRUE(headerMap.has("static-header"));
 }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -58,6 +58,8 @@ public:
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
+  MOCK_CONST_METHOD0(getDownstreamAddress, const std::string&());
+  MOCK_METHOD1(setDownstreamAddress, void(const std::string& downstream_address));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -59,7 +59,6 @@ public:
   MOCK_CONST_METHOD0(healthCheck, bool());
   MOCK_METHOD1(healthCheck, void(bool is_hc));
   MOCK_CONST_METHOD0(getDownstreamAddress, const std::string&());
-  MOCK_METHOD1(setDownstreamAddress, void(const std::string& downstream_address));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -157,8 +157,9 @@ public:
 
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD2(finalizeRequestHeaders, void(Http::HeaderMap& headers,
-                                                  const Http::AccessLog::RequestInfo& requestInfo));
+  MOCK_CONST_METHOD2(finalizeRequestHeaders,
+                     void(Http::HeaderMap& headers,
+                          const Http::AccessLog::RequestInfo& request_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -157,7 +157,8 @@ public:
 
   // Router::Config
   MOCK_CONST_METHOD0(clusterName, const std::string&());
-  MOCK_CONST_METHOD1(finalizeRequestHeaders, void(Http::HeaderMap& headers));
+  MOCK_CONST_METHOD2(finalizeRequestHeaders, void(Http::HeaderMap& headers,
+                                                  const Http::AccessLog::RequestInfo& requestInfo));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());

--- a/test/tools/router_check/json/tool_config_schemas.cc
+++ b/test/tools/router_check/json/tool_config_schemas.cc
@@ -60,6 +60,19 @@ const std::string& Json::ToolSchema::routerCheckSchema() {
                  "required": ["field", "value"],
                  "maxProperties": 2
                 }
+              },
+              "custom_header_fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {"type": "string"},
+                    "value": {"type": "string"}
+                  },
+                 "additionalProperties": false,
+                 "required": ["field", "value"],
+                 "maxProperties": 2
+                }
               }
             },
             "minProperties": 1,

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -158,9 +158,9 @@ bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-
+  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
     actual = tool_config.headers_->get_(Http::Headers::get().Path);
   }
   return compareResults(actual, expected, "path_rewrite");
@@ -168,9 +168,9 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-
+  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
     actual = tool_config.headers_->get_(Http::Headers::get().Host);
   }
   return compareResults(actual, expected, "host_rewrite");

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -60,7 +60,6 @@ RouterCheckTool::RouterCheckTool(std::unique_ptr<NiceMock<Runtime::MockLoader>> 
     : runtime_(std::move(runtime)), cm_(std::move(cm)), config_(std::move(config)) {}
 
 bool RouterCheckTool::compareEntriesInJson(const std::string& expected_route_json) {
-
   Json::ObjectSharedPtr loader = Json::Factory::loadFromFile(expected_route_json);
   loader->validateSchema(Json::ToolSchema::routerCheckSchema());
 
@@ -170,9 +169,9 @@ bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
+  Envoy::Http::AccessLog::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info);
     actual = tool_config.headers_->get_(Http::Headers::get().Path);
   }
   return compareResults(actual, expected, "path_rewrite");
@@ -180,9 +179,9 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
+  Envoy::Http::AccessLog::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info);
     actual = tool_config.headers_->get_(Http::Headers::get().Host);
   }
   return compareResults(actual, expected, "host_rewrite");
@@ -207,10 +206,10 @@ bool RouterCheckTool::compareHeaderField(ToolConfig& tool_config, const std::str
 bool RouterCheckTool::compareCustomHeaderField(ToolConfig& tool_config, const std::string& field,
                                                const std::string& expected) {
   std::string actual = "";
-  Envoy::Http::AccessLog::RequestInfoImpl requestInfo(Envoy::Http::Protocol::Http11);
-  requestInfo.downstream_address_ = "127.0.0.1";
+  Envoy::Http::AccessLog::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
+  request_info.downstream_address_ = "127.0.0.1";
   if (tool_config.route_->routeEntry() != nullptr) {
-    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, requestInfo);
+    tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info);
     actual = tool_config.headers_->get_(field);
   }
   return compareResults(actual, expected, "custom_header");

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -75,6 +75,8 @@ private:
   bool compareRedirectPath(ToolConfig& tool_config, const std::string& expected);
   bool compareHeaderField(ToolConfig& tool_config, const std::string& field,
                           const std::string& expected);
+  bool compareCustomHeaderField(ToolConfig& tool_config, const std::string& field,
+                                const std::string& expected);
   /**
    * Compare the expected and acutal route parameter values. Print out match details if details_
    * flag is set.

--- a/test/tools/router_check/test/config/TestRoutes.golden.json
+++ b/test/tools/router_check/test/config/TestRoutes.golden.json
@@ -288,5 +288,21 @@
         }
       ]
     }
-  }
+  },
+ {
+    "test_name": "CustomHeaderFields",
+    "input": {
+      ":authority": "api.lyft.com",
+      ":path": "/customheaders",
+      ":method": "GET"
+    },
+    "validate": {
+      "custom_header_fields": [
+        {
+          "field": "X-Client-IP",
+          "value": "127.0.0.1"
+        }
+      ]
+    }
+ }
 ]

--- a/test/tools/router_check/test/config/TestRoutes.golden.json
+++ b/test/tools/router_check/test/config/TestRoutes.golden.json
@@ -289,7 +289,7 @@
       ]
     }
   },
- {
+  {
     "test_name": "CustomHeaderFields",
     "input": {
       ":authority": "api.lyft.com",
@@ -304,5 +304,5 @@
         }
       ]
     }
- }
+  }
 ]

--- a/test/tools/router_check/test/config/TestRoutes.json
+++ b/test/tools/router_check/test/config/TestRoutes.json
@@ -100,7 +100,7 @@
           "cluster": "instant-server",
           "timeout_ms": 30000
         }
-        ],
+       ],
       "virtual_clusters": [
         {"pattern": "^/rides$", "method": "POST", "name": "ride_request"},
         {"pattern": "^/rides/\\d+$", "method": "PUT", "name": "update_ride"},

--- a/test/tools/router_check/test/config/TestRoutes.json
+++ b/test/tools/router_check/test/config/TestRoutes.json
@@ -87,11 +87,20 @@
           "cluster": "instant-server",
           "case_sensitive": true
         },
+	{
+          "prefix": "/customheaders",
+          "cluster": "ats",
+          "host_rewrite": "new_host",
+	  "request_headers_to_add":[
+	    {"key": "X-Client-IP", "value":"%CLIENT_IP%"}
+	  ]
+        },
         {
           "prefix": "/",
           "cluster": "instant-server",
           "timeout_ms": 30000
-        }],
+        }
+        ],
       "virtual_clusters": [
         {"pattern": "^/rides$", "method": "POST", "name": "ride_request"},
         {"pattern": "^/rides/\\d+$", "method": "PUT", "name": "update_ride"},


### PR DESCRIPTION
created a new PR as a continuation to PR #1131 which could not be reopened after it was closed. 

@mattklein123 @htuch @RomanDzhabarov 

GT #1016 