### PR TITLE
config: fix missing ProtobufTypes::FromString snafu in recent DebugSt…

### DIFF
--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -60,7 +60,7 @@ private:
       callbacks_->onConfigUpdate(typed_resources);
       stats_.update_success_.inc();
       ENVOY_LOG(debug, "Filesystem config update accepted for {}: {}", path_,
-                message.DebugString());
+                ProtobufTypes::FromString(message.DebugString()));
       // TODO(htuch): Add some notion of current version for every API in stats/admin.
     } catch (const EnvoyException& e) {
       if (config_update_available) {

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -97,7 +97,8 @@ public:
       callbacks_->onConfigUpdate(typed_resources);
       request_.set_version_info(ProtobufTypes::FromString(message->version_info()));
       stats_.update_success_.inc();
-      ENVOY_LOG(debug, "gRPC config update accepted: {}", message->DebugString());
+      ENVOY_LOG(debug, "gRPC config update accepted: {}",
+                ProtobufTypes::FromString(message->DebugString()));
     } catch (const EnvoyException& e) {
       ENVOY_LOG(warn, "gRPC config update rejected: {}", e.what());
       stats_.update_rejected_.inc();


### PR DESCRIPTION
…ring() additions.

We need a better way to catch this upstream or fix our multiple string type issue, given the number
of fixup PRs we're seeing, the status quo won't work.