### PR TITLE
source/common: explicit switch fall-through

### DIFF
--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -16,4 +16,15 @@ namespace Envoy {
  * Stop the compiler from complaining about an unreferenced parameter.
  */
 #define UNREFERENCED_PARAMETER(X) ((void)(X))
+
+/**
+ * Have a generic fall-through for different versions of C++
+ */
+#if __cplusplus >= 201402L // C++14, C++17 and above
+#define FALLTHRU [[fallthrough]]
+#elif __cplusplus >= 201103L && __GNUC__ >= 7 // C++11 gcc 7
+#define FALLTHRU [[gnu::fallthrough]]
+#else // C++11 on gcc 6, and all other cases
+#define FALLTHRU
+#endif
 } // Envoy

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -70,6 +70,8 @@ void HeaderString::append(const char* data, uint32_t size) {
     type_ = Type::Inline;
     buffer_.dynamic_ = inline_buffer_;
     string_length_ = 0;
+
+    FALLTHRU;
   }
 
   case Type::Inline: {
@@ -78,7 +80,7 @@ void HeaderString::append(const char* data, uint32_t size) {
       break;
     }
 
-    // Fall through.
+    FALLTHRU;
   }
 
   case Type::Dynamic: {
@@ -111,7 +113,7 @@ void HeaderString::clear() {
   }
   case Type::Inline: {
     inline_buffer_[0] = 0;
-    // fall through
+    FALLTHRU;
   }
   case Type::Dynamic: {
     string_length_ = 0;
@@ -125,6 +127,8 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
     // Switch back to inline and fall through.
     type_ = Type::Inline;
     buffer_.dynamic_ = inline_buffer_;
+
+    FALLTHRU;
   }
 
   case Type::Inline: {
@@ -133,7 +137,7 @@ void HeaderString::setCopy(const char* data, uint32_t size) {
       break;
     }
 
-    // Fall through.
+    FALLTHRU;
   }
 
   case Type::Dynamic: {
@@ -164,6 +168,8 @@ void HeaderString::setInteger(uint64_t value) {
     // Switch back to inline and fall through.
     type_ = Type::Inline;
     buffer_.dynamic_ = inline_buffer_;
+
+    FALLTHRU;
   }
 
   case Type::Inline:

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -395,7 +395,7 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
         stream->waiting_for_non_informational_headers_ = true;
       }
 
-      // Fall through.
+      FALLTHRU;
     }
 
     case NGHTTP2_HCAT_REQUEST: {

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -125,7 +125,7 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   }
   case RespType::Error: {
     error_count_++;
-    // fall through
+    FALLTHRU;
   }
   case RespType::BulkString: {
     pending_response_->asArray()[index].asString().swap(value->asString());
@@ -193,7 +193,7 @@ void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
     if (value->asString() == "OK") {
       break;
     }
-    // else fall through
+    FALLTHRU;
   }
   default: {
     error_count_++;


### PR DESCRIPTION
On gcc-c++ 7.1.1, it treats implicit fall-throughs as errors.
Thought the semantics for an explicit-fall-through vary widely enough
(versions of C++, or flag settings, etc.).

This change provides a uniform way to explicitly fallthrough while we're
on C++11 and prep for C++14/17.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>