### PR TITLE
*: include <functional> header

### DIFF
--- a/include/envoy/server/drain_manager.h
+++ b/include/envoy/server/drain_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "envoy/network/drain_decision.h"

--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/server/guarddog.h"
 
 namespace Envoy {

--- a/source/common/common/callback_impl.h
+++ b/source/common/common/callback_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <list>
 
 #include "envoy/common/callback.h"

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/config/subscription.h"
 
 #include "common/config/filesystem_subscription_impl.h"

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"

--- a/source/server/init_manager_impl.cc
+++ b/source/server/init_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "server/init_manager_impl.h"
 
+#include <functional>
+
 #include "common/common/assert.h"
 
 namespace Envoy {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -1,5 +1,7 @@
 #include "server/lds_api.h"
 
+#include <functional>
+
 #include "common/config/utility.h"
 #include "common/http/headers.h"
 #include "common/json/config_schemas.h"

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/init/init.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/stats/stats_macros.h"

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -1,5 +1,7 @@
 #include "server/worker_impl.h"
 
+#include <functional>
+
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/server/configuration.h"

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "envoy/api/api.h"

--- a/test/common/grpc/json_transcoder_filter_test.cc
+++ b/test/common/grpc/json_transcoder_filter_test.cc
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <functional>
 
 #include "common/buffer/buffer_impl.h"
 #include "common/filesystem/filesystem_impl.h"


### PR DESCRIPTION
g++ 7 is failing on missing definitions of `std::function`

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>