### PR TITLE
Base64 decode: handle invalid inputs

### DIFF
--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -52,25 +52,26 @@ std::string Base64::decode(const std::string& input) {
   while (bytes_left > 0) {
     // Take first 6 bits from 1st converted char and first 2 bits from 2nd converted char,
     // make 8 bits char from it.
-    // Use conversion table to map char to decoded value (value is between 0 and 64).
-    unsigned char a = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read])];
-    unsigned char b = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 1])];
+    // Use conversion table to map char to decoded value (value is between 0 and 63 inclusive for a
+    // valid character).
+    const unsigned char a = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read])];
+    const unsigned char b = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 1])];
     if (a == 64 || b == 64) {
-      // input contains an invalid character.
+      // Input contains an invalid character.
       return EMPTY_STRING;
     }
     result.push_back(a << 2 | b >> 4);
-    unsigned char c = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 2])];
+    const unsigned char c = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 2])];
 
     // Decoded value 64 means invalid character unless we already know it is a valid padding.
     // If so, following characters are all padding.
-    // Also we should check there is no unused bits.
+    // Also we should check there are no unused bits.
     if (c == 64) {
       if (first_padding_index != cur_read + 2) {
-        // input contains an invalid character.
+        // Input contains an invalid character.
         return EMPTY_STRING;
       } else if (b & 0b1111) {
-        // there are unused bits at tail.
+        // There are unused bits at tail.
         return EMPTY_STRING;
       } else {
         return result;
@@ -79,13 +80,13 @@ std::string Base64::decode(const std::string& input) {
     // Take last 4 bits from 2nd converted char and 4 first bits from 3rd converted char.
     result.push_back(b << 4 | c >> 2);
 
-    unsigned char d = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 3])];
+    const unsigned char d = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 3])];
     if (d == 64) {
       if (first_padding_index != cur_read + 3) {
-        // input contains an invalid character.
+        // Input contains an invalid character.
         return EMPTY_STRING;
       } else if (c & 0b11) {
-        // there are unused bits at tail.
+        // There are unused bits at tail.
         return EMPTY_STRING;
       } else {
         return result;

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -65,14 +65,14 @@ std::string Base64::decode(const std::string& input) {
     // Decoded value 64 means invalid character unless we already know it is a valid padding.
     // If so, following characters are all padding.
     // Also we should check there is no unused bits.
-    if(c == 64){
-      if (first_padding_index != cur_read + 2){
+    if (c == 64) {
+      if (first_padding_index != cur_read + 2) {
         // input contains an invalid character.
         return EMPTY_STRING;
-      }else if (b & 0b1111){
+      } else if (b & 0b1111) {
         // there are unused bits at tail.
         return EMPTY_STRING;
-      }else{
+      } else {
         return result;
       }
     }
@@ -80,14 +80,14 @@ std::string Base64::decode(const std::string& input) {
     result.push_back(b << 4 | c >> 2);
 
     unsigned char d = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 3])];
-    if(d == 64){
-      if (first_padding_index != cur_read + 3){
+    if (d == 64) {
+      if (first_padding_index != cur_read + 3) {
         // input contains an invalid character.
         return EMPTY_STRING;
-      }else if (c & 0b11){
+      } else if (c & 0b11) {
         // there are unused bits at tail.
         return EMPTY_STRING;
-      }else{
+      } else {
         return result;
       }
     }

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -39,6 +39,7 @@ TEST(Base64Test, Decode) {
   EXPECT_EQ("", Base64::decode(""));
   EXPECT_EQ("foo", Base64::decode("Zm9v"));
   EXPECT_EQ("fo", Base64::decode("Zm8="));
+  EXPECT_EQ("f", Base64::decode("Zg=="));
   EXPECT_EQ("foobar", Base64::decode("Zm9vYmFy"));
   EXPECT_EQ("foob", Base64::decode("Zm9vYg=="));
   EXPECT_EQ("", Base64::decode("123"));
@@ -72,6 +73,16 @@ TEST(Base64Test, Decode) {
     std::string decoded = Base64::decode(test_string);
     EXPECT_EQ(test_string, Base64::encode(decoded.c_str(), decoded.length()));
   }
+}
+
+TEST(Base64Test, DecodeFailure){
+  EXPECT_EQ("", Base64::decode("==Zg"));
+  EXPECT_EQ("", Base64::decode("=Zm8"));
+  EXPECT_EQ("", Base64::decode("Zm=8"));
+  EXPECT_EQ("", Base64::decode("Zg=A"));
+  EXPECT_EQ("", Base64::decode("Zm9="));  // 011001 100110 111101 <- unused bit at tail
+  EXPECT_EQ("", Base64::decode("Zg.."));
+  EXPECT_EQ("", Base64::decode("..Zg"));
 }
 
 TEST(Base64Test, MultiSlicesBufferEncode) {

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -42,7 +42,6 @@ TEST(Base64Test, Decode) {
   EXPECT_EQ("f", Base64::decode("Zg=="));
   EXPECT_EQ("foobar", Base64::decode("Zm9vYmFy"));
   EXPECT_EQ("foob", Base64::decode("Zm9vYg=="));
-  EXPECT_EQ("", Base64::decode("123"));
 
   {
     const char* test_string = "\0\1\2\3\b\n\t";
@@ -80,9 +79,12 @@ TEST(Base64Test, DecodeFailure) {
   EXPECT_EQ("", Base64::decode("=Zm8"));
   EXPECT_EQ("", Base64::decode("Zm=8"));
   EXPECT_EQ("", Base64::decode("Zg=A"));
+  EXPECT_EQ("", Base64::decode("Zh==")); // 011001 100001 <- unused bit at tail
   EXPECT_EQ("", Base64::decode("Zm9=")); // 011001 100110 111101 <- unused bit at tail
   EXPECT_EQ("", Base64::decode("Zg.."));
   EXPECT_EQ("", Base64::decode("..Zg"));
+  EXPECT_EQ("", Base64::decode("A==="));
+  EXPECT_EQ("", Base64::decode("123"));
 }
 
 TEST(Base64Test, MultiSlicesBufferEncode) {

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -75,12 +75,12 @@ TEST(Base64Test, Decode) {
   }
 }
 
-TEST(Base64Test, DecodeFailure){
+TEST(Base64Test, DecodeFailure) {
   EXPECT_EQ("", Base64::decode("==Zg"));
   EXPECT_EQ("", Base64::decode("=Zm8"));
   EXPECT_EQ("", Base64::decode("Zm=8"));
   EXPECT_EQ("", Base64::decode("Zg=A"));
-  EXPECT_EQ("", Base64::decode("Zm9="));  // 011001 100110 111101 <- unused bit at tail
+  EXPECT_EQ("", Base64::decode("Zm9=")); // 011001 100110 111101 <- unused bit at tail
   EXPECT_EQ("", Base64::decode("Zg.."));
   EXPECT_EQ("", Base64::decode("..Zg"));
 }


### PR DESCRIPTION
Fixed the following problems of `Base64::decode()`:
- It said it skips invalid characters, but no reason to do that. It should treat them as invalid input and return empty string.
- There should not be unused bits but it was not handled. (e.g. `"AB=="` (`000000 000001`) should be an invalid input because the last 4 bits of second character `B` contains `1`)