### PR TITLE
config: some cds/eds fixups encountered during integration testing.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -108,7 +108,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "0b35f3efc31621953bc2eb7458d01d8eab984394",
+        commit = "dcdd8e3bd6b70d04099c4af841e9995ec8101f9b",
     )
     bind_targets = ["address", "base", "bootstrap", "cds", "eds", "health_check", "protocol", "tls_context"]
     for t in bind_targets:

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -117,8 +117,9 @@ void CdsJson::translateCluster(const Json::Object& json_cluster,
   } else {
     ASSERT(string_type == "sds");
     cluster.set_type(envoy::api::v2::Cluster::EDS);
-    Utility::sdsConfigToEdsConfig(sds_config.value(), *cluster.mutable_eds_config());
-    cluster.mutable_deprecated_v1()->set_service_name(json_cluster.getString("service_name", ""));
+    auto* eds_cluster_config = cluster.mutable_eds_cluster_config();
+    Utility::sdsConfigToEdsConfig(sds_config.value(), *eds_cluster_config->mutable_eds_config());
+    eds_cluster_config->set_service_name(json_cluster.getString("service_name", ""));
   }
 
   JSON_UTIL_SET_DURATION(json_cluster, cluster, connect_timeout);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -182,8 +182,12 @@ void ClusterManagerImpl::initializeClustersFromV2Proto(const envoy::api::v2::Boo
   }
 
   // We can now potentially create the CDS API once the backing cluster exists.
-  cds_api_ = factory_.createCds(bootstrap.cds_config(), sds_config_, *this);
-  init_helper_.setCds(cds_api_.get());
+  if (bootstrap.has_cds_config()) {
+    cds_api_ = factory_.createCds(bootstrap.cds_config(), sds_config_, *this);
+    init_helper_.setCds(cds_api_.get());
+  } else {
+    init_helper_.setCds(nullptr);
+  }
 }
 
 ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config,
@@ -221,7 +225,7 @@ ClusterManagerImpl::ClusterManagerImpl(const Json::Object& config,
     sds_config_.value(sds_config);
   }
 
-  if (bootstrap.has_cds_config()) {
+  if (bootstrap.has_cds_config() || !bootstrap.bootstrap_clusters().empty()) {
     initializeClustersFromV2Proto(bootstrap);
   } else {
     // TODO(htuch): Make this similar to the v1 -> v2 translation elsewhere,

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -18,12 +18,12 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
                                Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                                bool added_via_api)
     : BaseDynamicClusterImpl(cluster, runtime, stats, ssl_context_manager, added_via_api),
-      local_info_(local_info),
-      cluster_name_(cluster.has_deprecated_v1() ? cluster.deprecated_v1().service_name()
-                                                : cluster.name()) {
+      local_info_(local_info), cluster_name_(cluster.eds_cluster_config().service_name().empty()
+                                                 ? cluster.name()
+                                                 : cluster.eds_cluster_config().service_name()) {
   envoy::api::v2::Node node;
   Config::Utility::localInfoToNode(local_info, node);
-  const auto& eds_config = cluster.eds_config();
+  const auto& eds_config = cluster.eds_cluster_config().eds_config();
   subscription_ = Config::SubscriptionFactory::subscriptionFromConfigSource<
       envoy::api::v2::ClusterLoadAssignment>(
       eds_config, node, dispatcher, cm, random, info_->statsScope(),

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -141,7 +141,7 @@ ClusterPtr ClusterImplBase::create(const envoy::api::v2::Cluster& cluster, Clust
                                             selected_dns_resolver, tls, dispatcher, added_via_api));
     break;
   case envoy::api::v2::Cluster::EDS:
-    if (!cluster.has_eds_config()) {
+    if (!cluster.has_eds_cluster_config()) {
       throw EnvoyException("cannot create an sds cluster without an sds config");
     }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -104,11 +104,14 @@ public:
 
 class ClusterManagerImplTest : public testing::Test {
 public:
-  void create(const Json::Object& config) {
-    envoy::api::v2::Bootstrap bootstrap;
+  void createWithBootstrap(const Json::Object& config, const envoy::api::v2::Bootstrap& bootstrap) {
     cluster_manager_.reset(new ClusterManagerImpl(
         config, bootstrap, factory_, factory_.stats_, factory_.tls_, factory_.runtime_,
         factory_.random_, factory_.local_info_, log_manager_));
+  }
+
+  void create(const Json::Object& config) {
+    createWithBootstrap(config, envoy::api::v2::Bootstrap());
   }
 
   NiceMock<TestClusterManagerFactory> factory_;
@@ -363,6 +366,32 @@ TEST_F(ClusterManagerImplTest, ShutdownOrder) {
   // Thread local reference should be gone.
   factory_.tls_.shutdownThread();
   EXPECT_EQ(3U, cluster.info().use_count());
+}
+
+// Validate that the v2 envoy::api::v2::Bootstrap overrides JSON config.
+TEST_F(ClusterManagerImplTest, CdsBootstrap) {
+  const std::string json = R"EOF(
+  {
+    "clusters": [
+    {
+      "name": "clusterwithareallyreallylongnamemorethanmaxcharsallowedbyschema"
+    }]
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr loader = Json::Factory::loadFromString(json);
+  EXPECT_THROW_WITH_MESSAGE(create(*loader), Json::Exception,
+                            "JSON at lines 4-6 does not conform to schema.\n Invalid schema: "
+                            "#/properties/name\n Schema violation: maxLength\n Offending "
+                            "document key: #/name");
+
+  envoy::api::v2::Bootstrap cds_config_bootstrap;
+  cds_config_bootstrap.mutable_cds_config();
+  createWithBootstrap(*loader, cds_config_bootstrap);
+
+  envoy::api::v2::Bootstrap clusters_bootstrap;
+  clusters_bootstrap.mutable_bootstrap_clusters()->Add()->CopyFrom(defaultStaticCluster("foo"));
+  createWithBootstrap(*loader, clusters_bootstrap);
 }
 
 TEST_F(ClusterManagerImplTest, InitializeOrder) {

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -17,7 +17,7 @@ namespace Upstream {
 class EdsTest : public testing::Test {
 protected:
   EdsTest() {
-    std::string raw_config = R"EOF(
+    resetCluster(R"EOF(
     {
       "name": "name",
       "connect_timeout_ms": 250,
@@ -25,11 +25,13 @@ protected:
       "lb_type": "round_robin",
       "service_name": "fare"
     }
-    )EOF";
+    )EOF");
+  }
 
+  void resetCluster(const std::string& json_config) {
     SdsConfig sds_config{"eds", std::chrono::milliseconds(30000)};
     local_info_.zone_name_ = "us-east-1a";
-    eds_cluster_ = parseSdsClusterFromJson(raw_config, sds_config);
+    eds_cluster_ = parseSdsClusterFromJson(json_config, sds_config);
     cluster_.reset(new EdsClusterImpl(eds_cluster_, runtime_, stats_, ssl_context_manager_,
                                       local_info_, cm_, dispatcher_, random_, false));
     EXPECT_EQ(Cluster::InitializePhase::Secondary, cluster_->initializePhase());
@@ -84,6 +86,25 @@ TEST_F(EdsTest, OnSuccessConfigUpdate) {
   Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;
   auto* cluster_load_assignment = resources.Add();
   cluster_load_assignment->set_cluster_name("fare");
+  bool initialized = false;
+  cluster_->setInitializedCb([&initialized] { initialized = true; });
+  EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));
+  EXPECT_TRUE(initialized);
+}
+
+// Validate that onConfigupdate() with no service name accepts config.
+TEST_F(EdsTest, NoServiceNameOnSuccessConfigUpdate) {
+  resetCluster(R"EOF(
+    {
+      "name": "name",
+      "connect_timeout_ms": 250,
+      "type": "sds",
+      "lb_type": "round_robin"
+    }
+    )EOF");
+  Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;
+  auto* cluster_load_assignment = resources.Add();
+  cluster_load_assignment->set_cluster_name("name");
   bool initialized = false;
   cluster_->setInitializedCb([&initialized] { initialized = true; });
   EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));

--- a/test/config/integration/server_xds.cds.json
+++ b/test/config/integration/server_xds.cds.json
@@ -6,8 +6,10 @@
       "name": "cluster_1",
       "connectTimeout": { "seconds": 5 },
       "type": "EDS",
-      "edsConfig": {
-        "path": "{{ eds_json_path }}"
+      "edsClusterConfig": {
+        "edsConfig": {
+          "path": "{{ eds_json_path }}"
+        }
       },
       "lbPolicy": "ROUND_ROBIN",
       "http2ProtocolOptions": {}


### PR DESCRIPTION
* Promote service_name from deprecated following https://github.com/lyft/envoy-api/pull/129.

* Allow bootstrap proto to work with just EDS. Previously it required CDS before it would overlay.