### PR TITLE
config: use Node definition in v2 bootstrap, add Node to LocalInfo.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -108,7 +108,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "dcdd8e3bd6b70d04099c4af841e9995ec8101f9b",
+        commit = "004656ecb6d0c72f0d85a5e5c6ff7a18b312103d",
     )
     bind_targets = ["address", "base", "bootstrap", "cds", "eds", "health_check", "protocol", "tls_context"]
     for t in bind_targets:

--- a/include/envoy/local_info/BUILD
+++ b/include/envoy/local_info/BUILD
@@ -11,5 +11,6 @@ envoy_package()
 envoy_cc_library(
     name = "local_info_interface",
     hdrs = ["local_info.h"],
+    external_deps = ["envoy_base"],
     deps = ["//include/envoy/network:address_interface"],
 )

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -5,6 +5,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 
+#include "api/base.pb.h"
+
 namespace Envoy {
 namespace LocalInfo {
 
@@ -34,7 +36,14 @@ public:
    * Human readable individual node name. E.g., "i-123456".
    */
   virtual const std::string& nodeName() const PURE;
+
+  /**
+   * v2 API Node protobuf. This is the full node identity presented to management servers.
+   */
+  virtual const envoy::api::v2::Node& node() const PURE;
 };
+
+typedef std::unique_ptr<LocalInfo> LocalInfoPtr;
 
 } // namespace LocalInfo
 } // namespace Envoy

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -108,6 +108,21 @@ public:
    * @return std::chrono::milliseconds the duration in msec between log flushes.
    */
   virtual std::chrono::milliseconds fileFlushIntervalMsec() PURE;
+
+  /**
+   * @return const std::string& the server's cluster.
+   */
+  virtual const std::string& serviceClusterName() PURE;
+
+  /**
+   * @return const std::string& the server's node identification.
+   */
+  virtual const std::string& serviceNodeName() PURE;
+
+  /**
+   * @return const std::string& the server's zone.
+   */
+  virtual const std::string& serviceZone() PURE;
 };
 
 } // namespace Server

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -40,14 +40,6 @@ void Utility::checkLocalInfo(const std::string& error_prefix,
   }
 }
 
-void Utility::localInfoToNode(const LocalInfo::LocalInfo& local_info, envoy::api::v2::Node& node) {
-  checkLocalInfo("envoy::api::v2::Node", local_info);
-  node.set_id(local_info.nodeName());
-  node.mutable_locality()->set_zone(local_info.zoneName());
-  (*node.mutable_metadata()->mutable_fields())["cluster"].set_string_value(
-      local_info.clusterName());
-}
-
 std::chrono::milliseconds
 Utility::apiConfigSourceRefreshDelay(const envoy::api::v2::ApiConfigSource& api_config_source) {
   return std::chrono::milliseconds(

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -68,13 +68,6 @@ public:
                              const LocalInfo::LocalInfo& local_info);
 
   /**
-   * Convert LocalInfo::LocalInfo to v2 envoy::api::v2::Node identifier.
-   * @param local_info source LocalInfo::LocalInfo.
-   * @param node destination envoy::api::Node.
-   */
-  static void localInfoToNode(const LocalInfo::LocalInfo& local_info, envoy::api::v2::Node& node);
-
-  /**
    * Convert a v1 SdsConfig to v2 EDS envoy::api::v2::ConfigSource.
    * @param sds_config source v1 SdsConfig.
    * @param eds_config destination v2 EDS envoy::api::v2::ConfigSource.

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -9,21 +9,30 @@ namespace LocalInfo {
 
 class LocalInfoImpl : public LocalInfo {
 public:
-  LocalInfoImpl(Network::Address::InstanceConstSharedPtr address, const std::string zone_name,
-                const std::string cluster_name, const std::string node_name)
-      : address_(address), zone_name_(zone_name), cluster_name_(cluster_name),
-        node_name_(node_name) {}
+  LocalInfoImpl(const envoy::api::v2::Node& node, Network::Address::InstanceConstSharedPtr address,
+                const std::string zone_name, const std::string cluster_name,
+                const std::string node_name)
+      : node_(node), address_(address) {
+    if (!zone_name.empty()) {
+      node_.mutable_locality()->set_zone(zone_name);
+    }
+    if (!cluster_name.empty()) {
+      node_.set_cluster(cluster_name);
+    }
+    if (!node_name.empty()) {
+      node_.set_id(node_name);
+    }
+  }
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-  const std::string& zoneName() const override { return zone_name_; }
-  const std::string& clusterName() const override { return cluster_name_; }
-  const std::string& nodeName() const override { return node_name_; }
+  const std::string& zoneName() const override { return node_.locality().zone(); }
+  const std::string& clusterName() const override { return node_.cluster(); }
+  const std::string& nodeName() const override { return node_.id(); }
+  const envoy::api::v2::Node& node() const override { return node_; }
 
 private:
+  envoy::api::v2::Node node_;
   Network::Address::InstanceConstSharedPtr address_;
-  const std::string zone_name_;
-  const std::string cluster_name_;
-  const std::string node_name_;
 };
 
 } // namespace LocalInfo

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -22,10 +22,10 @@ CdsApiImpl::CdsApiImpl(const envoy::api::v2::ConfigSource& cds_config,
                        Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                        const LocalInfo::LocalInfo& local_info, Stats::Store& store)
     : cm_(cm), scope_(store.createScope("cluster_manager.cds.")) {
-  Config::Utility::localInfoToNode(local_info, node_);
+  Config::Utility::checkLocalInfo("cds", local_info);
   subscription_ =
       Config::SubscriptionFactory::subscriptionFromConfigSource<envoy::api::v2::Cluster>(
-          cds_config, node_, dispatcher, cm, random, *scope_,
+          cds_config, local_info.node(), dispatcher, cm, random, *scope_,
           [this, &cds_config, &sds_config, &cm, &dispatcher, &random,
            &local_info]() -> Config::Subscription<envoy::api::v2::Cluster>* {
             return new CdsSubscription(Config::Utility::generateStats(*scope_), cds_config,

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -44,7 +44,6 @@ private:
 
   ClusterManager& cm_;
   std::unique_ptr<Config::Subscription<envoy::api::v2::Cluster>> subscription_;
-  envoy::api::v2::Node node_;
   std::function<void()> initialize_callback_;
   Stats::ScopePtr scope_;
 };

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -21,12 +21,11 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
       local_info_(local_info), cluster_name_(cluster.eds_cluster_config().service_name().empty()
                                                  ? cluster.name()
                                                  : cluster.eds_cluster_config().service_name()) {
-  envoy::api::v2::Node node;
-  Config::Utility::localInfoToNode(local_info, node);
+  Config::Utility::checkLocalInfo("eds", local_info);
   const auto& eds_config = cluster.eds_cluster_config().eds_config();
   subscription_ = Config::SubscriptionFactory::subscriptionFromConfigSource<
       envoy::api::v2::ClusterLoadAssignment>(
-      eds_config, node, dispatcher, cm, random, info_->statsScope(),
+      eds_config, local_info.node(), dispatcher, cm, random, info_->statsScope(),
       [this, &eds_config, &cm, &dispatcher,
        &random]() -> Config::Subscription<envoy::api::v2::ClusterLoadAssignment>* {
         return new SdsSubscription(info_->stats(), eds_config, cm, dispatcher, random);

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -24,7 +24,6 @@ envoy_cc_library(
     name = "envoy_common_lib",
     deps = [
         "//source/common/event:libevent_lib",
-        "//source/common/local_info:local_info_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:stats_lib",
         "//source/common/stats:thread_local_store_lib",

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -208,6 +208,7 @@ envoy_cc_library(
         "//source/common/api:api_lib",
         "//source/common/common:utility_lib",
         "//source/common/common:version_lib",
+        "//source/common/local_info:local_info_lib",
         "//source/common/memory:stats_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_lib",

--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -75,6 +75,7 @@ envoy_cc_library(
         "//include/envoy/tracing:http_tracer_interface",
         "//source/common/access_log:access_log_manager_lib",
         "//source/common/common:assert_lib",
+        "//source/common/local_info:local_info_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/ssl:context_lib",

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -1,5 +1,6 @@
 #include "server/config_validation/server.h"
 
+#include "common/local_info/local_info_impl.h"
 #include "common/protobuf/utility.h"
 
 #include "server/configuration_impl.h"
@@ -9,13 +10,14 @@
 namespace Envoy {
 namespace Server {
 
-bool validateConfig(Options& options, ComponentFactory& component_factory,
-                    const LocalInfo::LocalInfo& local_info) {
+bool validateConfig(Options& options, Network::Address::InstanceConstSharedPtr local_address,
+                    ComponentFactory& component_factory) {
   Thread::MutexBasicLockable access_log_lock;
   Stats::IsolatedStoreImpl stats_store;
 
   try {
-    ValidationInstance server(options, stats_store, access_log_lock, component_factory, local_info);
+    ValidationInstance server(options, local_address, stats_store, access_log_lock,
+                              component_factory);
     std::cout << "configuration '" << options.configPath() << "' OK" << std::endl;
     server.shutdown();
     return true;
@@ -24,17 +26,18 @@ bool validateConfig(Options& options, ComponentFactory& component_factory,
   }
 }
 
-ValidationInstance::ValidationInstance(Options& options, Stats::IsolatedStoreImpl& store,
+ValidationInstance::ValidationInstance(Options& options,
+                                       Network::Address::InstanceConstSharedPtr local_address,
+                                       Stats::IsolatedStoreImpl& store,
                                        Thread::BasicLockable& access_log_lock,
-                                       ComponentFactory& component_factory,
-                                       const LocalInfo::LocalInfo& local_info)
+                                       ComponentFactory& component_factory)
     : options_(options), stats_store_(store),
       api_(new Api::ValidationImpl(options.fileFlushIntervalMsec())),
-      dispatcher_(api_->allocateDispatcher()), local_info_(local_info),
+      dispatcher_(api_->allocateDispatcher()),
       access_log_manager_(*api_, *dispatcher_, access_log_lock, store),
       listener_manager_(*this, *this, *this) {
   try {
-    initialize(options, component_factory);
+    initialize(options, local_address, component_factory);
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
@@ -43,7 +46,9 @@ ValidationInstance::ValidationInstance(Options& options, Stats::IsolatedStoreImp
   }
 }
 
-void ValidationInstance::initialize(Options& options, ComponentFactory& component_factory) {
+void ValidationInstance::initialize(Options& options,
+                                    Network::Address::InstanceConstSharedPtr local_address,
+                                    ComponentFactory& component_factory) {
   // See comments on InstanceImpl::initialize() for the overall flow here.
   //
   // For validation, we only do a subset of normal server initialization: everything that could fail
@@ -58,6 +63,10 @@ void ValidationInstance::initialize(Options& options, ComponentFactory& componen
   if (!options.bootstrapPath().empty()) {
     MessageUtil::loadFromFile(options.bootstrapPath(), bootstrap);
   }
+
+  local_info_.reset(
+      new LocalInfo::LocalInfoImpl(bootstrap.node(), local_address, options.serviceZone(),
+                                   options.serviceClusterName(), options.serviceNodeName()));
 
   Configuration::InitialImpl initial_config(*config_json);
   thread_local_.registerThread(*dispatcher_, true);

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -17,10 +17,6 @@ public:
   OptionsImpl(int argc, char** argv, const std::string& hot_restart_version,
               spdlog::level::level_enum default_log_level);
 
-  const std::string& serviceClusterName() { return service_cluster_; }
-  const std::string& serviceNodeName() { return service_node_; }
-  const std::string& serviceZone() { return service_zone_; }
-
   // Server::Options
   uint64_t baseId() override { return base_id_; }
   uint32_t concurrency() override { return concurrency_; }
@@ -34,6 +30,9 @@ public:
   uint64_t restartEpoch() override { return restart_epoch_; }
   Server::Mode mode() const override { return mode_; }
   std::chrono::milliseconds fileFlushIntervalMsec() override { return file_flush_interval_msec_; }
+  const std::string& serviceClusterName() override { return service_cluster_; }
+  const std::string& serviceNodeName() override { return service_node_; }
+  const std::string& serviceZone() override { return service_zone_; }
 
 private:
   uint64_t base_id_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -16,6 +16,7 @@
 #include "common/api/api_impl.h"
 #include "common/common/utility.h"
 #include "common/common/version.h"
+#include "common/local_info/local_info_impl.h"
 #include "common/memory/stats.h"
 #include "common/network/address_impl.h"
 #include "common/protobuf/utility.h"
@@ -33,10 +34,10 @@
 namespace Envoy {
 namespace Server {
 
-InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& restarter,
-                           Stats::StoreRoot& store, Thread::BasicLockable& access_log_lock,
-                           ComponentFactory& component_factory,
-                           const LocalInfo::LocalInfo& local_info, ThreadLocal::Instance& tls)
+InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstSharedPtr local_address,
+                           TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
+                           Thread::BasicLockable& access_log_lock,
+                           ComponentFactory& component_factory, ThreadLocal::Instance& tls)
     : options_(options), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_),
       stats_store_(store), server_stats_{ALL_SERVER_STATS(
@@ -45,7 +46,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
       dispatcher_(api_->allocateDispatcher()),
       handler_(new ConnectionHandlerImpl(log(), *dispatcher_)), listener_component_factory_(*this),
       worker_factory_(thread_local_, *api_, hooks),
-      dns_resolver_(dispatcher_->createDnsResolver({})), local_info_(local_info),
+      dns_resolver_(dispatcher_->createDnsResolver({})),
       access_log_manager_(*api_, *dispatcher_, access_log_lock, store) {
 
   failHealthcheck(false);
@@ -60,7 +61,7 @@ InstanceImpl::InstanceImpl(Options& options, TestHooks& hooks, HotRestart& resta
   drain_manager_ = component_factory.createDrainManager(*this);
 
   try {
-    initialize(options, component_factory);
+    initialize(options, local_address, component_factory);
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}",
               options.configPath() +
@@ -141,7 +142,9 @@ void InstanceImpl::getParentStats(HotRestart::GetParentStatsInfo& info) {
 
 bool InstanceImpl::healthCheckFailed() { return server_stats_.live_.value() == 0; }
 
-void InstanceImpl::initialize(Options& options, ComponentFactory& component_factory) {
+void InstanceImpl::initialize(Options& options,
+                              Network::Address::InstanceConstSharedPtr local_address,
+                              ComponentFactory& component_factory) {
   ENVOY_LOG(warn, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
             restarter_.version());
 
@@ -151,6 +154,11 @@ void InstanceImpl::initialize(Options& options, ComponentFactory& component_fact
   if (!options.bootstrapPath().empty()) {
     MessageUtil::loadFromFile(options.bootstrapPath(), bootstrap);
   }
+  bootstrap.mutable_node()->set_build_version(VersionInfo::version());
+
+  local_info_.reset(
+      new LocalInfo::LocalInfoImpl(bootstrap.node(), local_address, options.serviceZone(),
+                                   options.serviceClusterName(), options.serviceNodeName()));
 
   Configuration::InitialImpl initial_config(*config_json);
   ENVOY_LOG(info, "admin address: {}", initial_config.admin().address()->asString());
@@ -274,7 +282,7 @@ void InstanceImpl::initializeStatSinks() {
   if (config_->statsdTcpClusterName().valid()) {
     ENVOY_LOG(info, "statsd TCP cluster: {}", config_->statsdTcpClusterName().value());
     stat_sinks_.emplace_back(
-        new Stats::Statsd::TcpStatsdSink(local_info_, config_->statsdTcpClusterName().value(),
+        new Stats::Statsd::TcpStatsdSink(*local_info_, config_->statsdTcpClusterName().value(),
                                          thread_local_, config_->clusterManager(), stats_store_));
     stats_store_.addSink(*stat_sinks_.back());
   }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -92,9 +92,10 @@ public:
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>, public Instance {
 public:
-  InstanceImpl(Options& options, TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
+  InstanceImpl(Options& options, Network::Address::InstanceConstSharedPtr local_address,
+               TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
                Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory,
-               const LocalInfo::LocalInfo& local_info, ThreadLocal::Instance& tls);
+               ThreadLocal::Instance& tls);
 
   ~InstanceImpl() override;
 
@@ -130,11 +131,12 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Tracing::HttpTracer& httpTracer() override;
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
-  const LocalInfo::LocalInfo& localInfo() override { return local_info_; }
+  const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
 
 private:
   void flushStats();
-  void initialize(Options& options, ComponentFactory& component_factory);
+  void initialize(Options& options, Network::Address::InstanceConstSharedPtr local_address,
+                  ComponentFactory& component_factory);
   void initializeStatSinks();
   void loadServerFlags(const Optional<std::string>& flags_path);
   uint64_t numConnections();
@@ -165,7 +167,7 @@ private:
   Event::SignalEventPtr sig_hup_;
   Network::DnsResolverSharedPtr dns_resolver_;
   Event::TimerPtr stat_flush_timer_;
-  const LocalInfo::LocalInfo& local_info_;
+  LocalInfo::LocalInfoPtr local_info_;
   DrainManagerPtr drain_manager_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<Upstream::ClusterManagerFactory> cluster_manager_factory_;

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -38,21 +38,6 @@ TEST(UtilityTest, ApiConfigSourceRefreshDelay) {
   EXPECT_EQ(1234, Utility::apiConfigSourceRefreshDelay(api_config_source).count());
 }
 
-TEST(UtilityTest, LocalInfoToNode) {
-  LocalInfo::MockLocalInfo local_info;
-  std::string foo_id("foo_id");
-  EXPECT_CALL(local_info, nodeName()).Times(AtLeast(1)).WillRepeatedly(ReturnRef(foo_id));
-  std::string foo_zone("foo_zone");
-  EXPECT_CALL(local_info, zoneName()).Times(AtLeast(1)).WillRepeatedly(ReturnRef(foo_zone));
-  std::string foo_cluster("foo_cluster");
-  EXPECT_CALL(local_info, clusterName()).Times(AtLeast(1)).WillRepeatedly(ReturnRef(foo_cluster));
-  envoy::api::v2::Node node;
-  Utility::localInfoToNode(local_info, node);
-  EXPECT_EQ("foo_id", node.id());
-  EXPECT_EQ("foo_zone", node.locality().zone());
-  EXPECT_EQ("foo_cluster", node.metadata().fields().find("cluster")->second.string_value());
-}
-
 TEST(UtilityTest, SdsConfigToEdsConfig) {
   Upstream::SdsConfig sds_config{"sds", std::chrono::milliseconds(30000)};
   envoy::api::v2::ConfigSource config;

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -25,7 +25,8 @@ namespace ConfigTest {
 
 class ConfigTest {
 public:
-  ConfigTest(const std::string& file_path) : options_(file_path, std::string()) {
+  ConfigTest(const std::string& file_path)
+      : options_(file_path, std::string(), Network::Address::IpVersion::v6) {
     ON_CALL(server_, options()).WillByDefault(ReturnRef(options_));
     ON_CALL(server_, random()).WillByDefault(ReturnRef(random_));
     ON_CALL(server_, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -75,18 +75,16 @@ void IntegrationTestServer::onWorkerListenerRemoved() {
 }
 
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version) {
-  Server::TestOptionsImpl options(config_path_, bootstrap_path_);
+  Server::TestOptionsImpl options(config_path_, bootstrap_path_, version);
   Server::HotRestartNopImpl restarter;
   Thread::MutexBasicLockable lock;
-  LocalInfo::LocalInfoImpl local_info(Network::Utility::getLocalAddress(version), "zone_name",
-                                      "cluster_name", "node_name");
 
   ThreadLocal::InstanceImpl tls;
   Stats::HeapRawStatDataAllocator stats_allocator;
   Stats::ThreadLocalStoreImpl stats_store(stats_allocator);
   stat_store_ = &stats_store;
-  server_.reset(new Server::InstanceImpl(options, *this, restarter, stats_store, lock, *this,
-                                         local_info, tls));
+  server_.reset(new Server::InstanceImpl(options, Network::Utility::getLocalAddress(version), *this,
+                                         restarter, stats_store, lock, *this, tls));
   pending_listeners_ = server_->listenerManager().listeners().size();
   ENVOY_LOG(info, "waiting for {} test server listeners", pending_listeners_);
   server_set_.setReady();

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -27,8 +27,11 @@ namespace Server {
  */
 class TestOptionsImpl : public Options {
 public:
-  TestOptionsImpl(const std::string& config_path, const std::string& bootstrap_path)
-      : config_path_(config_path), bootstrap_path_(bootstrap_path) {}
+  TestOptionsImpl(const std::string& config_path, const std::string& bootstrap_path,
+                  Network::Address::IpVersion ip_version)
+      : config_path_(config_path), bootstrap_path_(bootstrap_path),
+        local_address_ip_version_(ip_version), service_cluster_name_("cluster_name"),
+        service_node_name_("node_name"), service_zone_("zone_name") {}
 
   // Server::Options
   uint64_t baseId() override { return 0; }
@@ -45,12 +48,18 @@ public:
     return std::chrono::milliseconds(10000);
   }
   Mode mode() const override { return Mode::Serve; }
+  const std::string& serviceClusterName() override { return service_cluster_name_; }
+  const std::string& serviceNodeName() override { return service_node_name_; }
+  const std::string& serviceZone() override { return service_zone_; }
 
 private:
   const std::string config_path_;
   const std::string bootstrap_path_;
   const std::string admin_address_path_;
-  Network::Address::IpVersion local_address_ip_version_;
+  const Network::Address::IpVersion local_address_ip_version_;
+  const std::string service_cluster_name_;
+  const std::string service_node_name_;
+  const std::string service_zone_;
 };
 
 class TestDrainManager : public DrainManager {

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -16,6 +16,7 @@ MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("12
   ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(zone_name_));
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
   ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_name_));
+  ON_CALL(*this, node()).WillByDefault(ReturnRef(node_));
 }
 
 MockLocalInfo::~MockLocalInfo() {}

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -18,11 +18,15 @@ public:
   MOCK_CONST_METHOD0(zoneName, std::string&());
   MOCK_CONST_METHOD0(clusterName, std::string&());
   MOCK_CONST_METHOD0(nodeName, std::string&());
+  MOCK_CONST_METHOD0(node, envoy::api::v2::Node&());
 
   Network::Address::InstanceConstSharedPtr address_;
   std::string zone_name_{"zone_name"};
   std::string cluster_name_{"cluster_name"};
   std::string node_name_{"node_name"};
+  // TODO(htuch): Make this behave closer to the real implementation, with the various property
+  // methods using node_ as the source of truth.
+  envoy::api::v2::Node node_;
 };
 
 } // namespace LocalInfo

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -20,6 +20,9 @@ MockOptions::MockOptions(const std::string& config_path, const std::string& boot
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
   ON_CALL(*this, bootstrapPath()).WillByDefault(ReturnRef(bootstrap_path_));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
+  ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
+  ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));
+  ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -55,10 +55,16 @@ public:
   MOCK_METHOD0(restartEpoch, uint64_t());
   MOCK_METHOD0(fileFlushIntervalMsec, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(mode, Mode());
+  MOCK_METHOD0(serviceClusterName, const std::string&());
+  MOCK_METHOD0(serviceNodeName, const std::string&());
+  MOCK_METHOD0(serviceZone, const std::string&());
 
   std::string config_path_;
   std::string bootstrap_path_;
   std::string admin_address_path_;
+  std::string service_cluster_name_;
+  std::string service_node_name_;
+  std::string service_zone_name_;
 };
 
 class MockAdmin : public Admin {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -110,10 +110,12 @@ envoy_cc_test(
     srcs = ["server_test.cc"],
     data = [
         ":empty_bootstrap.json",
+        ":node_bootstrap.json",
         "//test/config/integration:server.json",
         "//test/config/integration:server_config_files",
     ],
     deps = [
+        "//source/common/common:version_lib",
         "//source/server:server_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -24,13 +24,13 @@ protected:
 
   testing::NiceMock<MockOptions> options_;
   TestComponentFactory component_factory_;
-  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
 };
 
 std::string ValidationServerTest::directory_ = "";
 
 TEST_P(ValidationServerTest, Validate) {
-  EXPECT_TRUE(validateConfig(options_, component_factory_, local_info_));
+  EXPECT_TRUE(
+      validateConfig(options_, Network::Address::InstanceConstSharedPtr(), component_factory_));
 }
 
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against

--- a/test/server/node_bootstrap.json
+++ b/test/server/node_bootstrap.json
@@ -1,0 +1,11 @@
+{
+  "node": {
+    "id": "bootstrap_id",
+    "cluster": "bootstrap_cluster",
+    "locality": {
+      "zone": "bootstrap_zone",
+      "sub_zone": "bootstrap_sub_zone"
+    },
+    "build_version": "should_be_ignored"
+  }
+}

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1,3 +1,5 @@
+#include "common/common/version.h"
+#include "common/network/address_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
 #include "server/server.h"
@@ -35,18 +37,22 @@ TEST(ServerInstanceUtil, flushHelper) {
 // Class creates minimally viable server instance for testing.
 class ServerInstanceImplTest : public testing::TestWithParam<Network::Address::IpVersion> {
 protected:
-  ServerInstanceImplTest()
-      : version_(GetParam()),
-        options_(TestEnvironment::temporaryFileSubstitute("test/config/integration/server.json",
-                                                          {{"upstream_0", 0}, {"upstream_1", 0}},
-                                                          version_),
-                 TestEnvironment::runfilesPath("test/server/empty_bootstrap.json")),
-        server_(options_, hooks_, restart_, stats_store_, fakelock_, component_factory_,
-                local_info_, thread_local_) {}
+  ServerInstanceImplTest() : version_(GetParam()) {}
+
+  void initialize(const std::string& bootstrap_path) {
+    options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
+        "test/config/integration/server.json", {{"upstream_0", 0}, {"upstream_1", 0}}, version_);
+    options_.bootstrap_path_ = TestEnvironment::runfilesPath(bootstrap_path);
+    server_.reset(new InstanceImpl(
+        options_,
+        Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+        hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_));
+  }
+
   void TearDown() override {
-    server_.threadLocal().shutdownGlobalThreading();
-    server_.clusterManager().shutdown();
-    server_.threadLocal().shutdownThread();
+    server_->threadLocal().shutdownGlobalThreading();
+    server_->clusterManager().shutdown();
+    server_->threadLocal().shutdownThread();
   }
 
   Network::Address::IpVersion version_;
@@ -57,15 +63,40 @@ protected:
   Stats::TestIsolatedStoreImpl stats_store_;
   Thread::MutexBasicLockable fakelock_;
   TestComponentFactory component_factory_;
-  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
-  InstanceImpl server_;
+  std::unique_ptr<InstanceImpl> server_;
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ServerInstanceImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(ServerInstanceImplTest, Stats) {
+  options_.service_cluster_name_ = "some_cluster_name";
+  options_.service_node_name_ = "some_node_name";
+  initialize("test/server/empty_bootstrap.json");
   EXPECT_NE(nullptr, TestUtility::findCounter(stats_store_, "server.watchdog_miss"));
+}
+
+// Validate server localInfo() from bootstrap Node.
+TEST_P(ServerInstanceImplTest, BootstrapNode) {
+  initialize("test/server/node_bootstrap.json");
+  EXPECT_EQ("bootstrap_zone", server_->localInfo().zoneName());
+  EXPECT_EQ("bootstrap_cluster", server_->localInfo().clusterName());
+  EXPECT_EQ("bootstrap_id", server_->localInfo().nodeName());
+  EXPECT_EQ("bootstrap_sub_zone", server_->localInfo().node().locality().sub_zone());
+  EXPECT_EQ(VersionInfo::version(), server_->localInfo().node().build_version());
+}
+
+// Validate server localInfo() from bootstrap Node with CLI overrides.
+TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
+  options_.service_cluster_name_ = "some_cluster_name";
+  options_.service_node_name_ = "some_node_name";
+  options_.service_zone_name_ = "some_zone_name";
+  initialize("test/server/node_bootstrap.json");
+  EXPECT_EQ("some_zone_name", server_->localInfo().zoneName());
+  EXPECT_EQ("some_cluster_name", server_->localInfo().clusterName());
+  EXPECT_EQ("some_node_name", server_->localInfo().nodeName());
+  EXPECT_EQ("bootstrap_sub_zone", server_->localInfo().node().locality().sub_zone());
+  EXPECT_EQ(VersionInfo::version(), server_->localInfo().node().build_version());
 }
 
 } // namespace Server


### PR DESCRIPTION
Service name/zone/cluster can still be specified on the CLI, they override their respect definitions
in the bootstrap Node identifier.

This PR also introduces support for build version information incorporation in the Node proto.

Fixes #1277.