### PR TITLE
router: hard drop support for virtual cluster priorities.

### DIFF
--- a/docs/configuration/http_conn_man/route_config/vcluster.rst
+++ b/docs/configuration/http_conn_man/route_config/vcluster.rst
@@ -22,8 +22,7 @@ such that they include network level failures.
   {
     "pattern": "...",
     "name": "...",
-    "method": "...",
-    "priority": "..."
+    "method": "..."
   }
 
 pattern
@@ -38,9 +37,5 @@ name
 method
   *(optional, string)* Optionally specifies the HTTP method to match on. For example *GET*, *PUT*,
   etc.
-
-priority
-  *(optional, string)* Optionally specifies the virtual cluster :ref:`routing priority
-  <arch_overview_http_routing_priority>`.
 
 Documentation for :ref:`virtual cluser statistics <config_http_filters_router_stats>`.

--- a/docs/intro/arch_overview/http_routing.rst
+++ b/docs/intro/arch_overview/http_routing.rst
@@ -80,16 +80,11 @@ headers <config_http_filters_router_headers>`. The following configurations are 
 Priority routing
 ----------------
 
-Envoy supports priority routing both at the :ref:`route <config_http_conn_man_route_table_route>`
-and the :ref:`virtual cluster <config_http_conn_man_route_table_vcluster>` level. The current
-priority implementation uses different :ref:`connection pool <arch_overview_conn_pool>` and
-:ref:`circuit breaking <config_cluster_manager_cluster_circuit_breakers>` settings for each priority
-level. This means that even for HTTP/2 requests, two physical connections will be used to an
-upstream host. In the future Envoy will likely support true HTTP/2 priority over a single
+Envoy supports priority routing at the :ref:`route <config_http_conn_man_route_table_route>` level.
+The current priority implementation uses different :ref:`connection pool <arch_overview_conn_pool>`
+and :ref:`circuit breaking <config_cluster_manager_cluster_circuit_breakers>` settings for each
+priority level. This means that even for HTTP/2 requests, two physical connections will be used to
+an upstream host. In the future Envoy will likely support true HTTP/2 priority over a single
 connection.
-
-Note that if a route matches a virtual cluster, the virtual cluster priority is used. This feature
-is useful for splitting circuit breaking limits between different traffic priorities such that low
-priority traffic does not starve higher priority traffic.
 
 The currently supported priorities are *default* and *high*.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -130,11 +130,6 @@ public:
    * @return the name of the virtual cluster.
    */
   virtual const std::string& name() const PURE;
-
-  /**
-   * @return the priority of the virtual cluster.
-   */
-  virtual Upstream::ResourcePriority priority() const PURE;
 };
 
 class RateLimitPolicy;

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -541,8 +541,7 @@ const std::string Json::Schema::VIRTUAL_HOST_CONFIGURATION_SCHEMA(R"EOF(
         "properties" : {
           "pattern" : {"type" : "string"},
           "string" : {"type" : "string"},
-          "method" : {"type" : "string"},
-          "priority" : {"type" : "string"}
+          "method" : {"type" : "string"}
         },
         "required" : ["pattern", "name"],
         "additionalProperties" : false

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -482,7 +482,6 @@ VirtualHostImpl::VirtualClusterEntry::VirtualClusterEntry(const Json::Object& vi
 
   pattern_ = std::regex{virtual_cluster.getString("pattern"), std::regex::optimize};
   name_ = virtual_cluster.getString("name");
-  priority_ = ConfigUtility::parsePriority(virtual_cluster);
 }
 
 const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(const std::string& host) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -91,20 +91,15 @@ private:
 
     // Router::VirtualCluster
     const std::string& name() const override { return name_; }
-    Upstream::ResourcePriority priority() const override { return priority_; }
 
     std::regex pattern_;
     Optional<std::string> method_;
     std::string name_;
-    Upstream::ResourcePriority priority_;
   };
 
   struct CatchAllVirtualCluster : public VirtualCluster {
     // Router::VirtualCluster
     const std::string& name() const override { return name_; }
-    Upstream::ResourcePriority priority() const override {
-      return Upstream::ResourcePriority::Default;
-    }
 
     std::string name_{"other"};
   };

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -215,7 +215,6 @@ private:
                                          Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                                          Event::Dispatcher& dispatcher,
                                          Upstream::ResourcePriority priority) PURE;
-  Upstream::ResourcePriority finalPriority();
   Http::ConnectionPool::Instance* getConnPool();
   void maybeDoShadowing();
   void onRequestComplete();

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -518,7 +518,7 @@ TEST(RouteMatcherTest, Priority) {
         }
       ],
       "virtual_clusters": [
-        {"pattern": "^/bar$", "method": "POST", "name": "foo", "priority": "high"}]
+        {"pattern": "^/bar$", "method": "POST", "name": "foo"}]
     }
   ]
 }
@@ -535,18 +535,6 @@ TEST(RouteMatcherTest, Priority) {
             config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry()->priority());
   EXPECT_EQ(Upstream::ResourcePriority::Default,
             config.route(genHeaders("www.lyft.com", "/bar", "GET"), 0)->routeEntry()->priority());
-
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "POST");
-    EXPECT_EQ(Upstream::ResourcePriority::High,
-              config.route(headers, 0)->routeEntry()->virtualCluster(headers)->priority());
-  }
-
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");
-    EXPECT_EQ(Upstream::ResourcePriority::Default,
-              config.route(headers, 0)->routeEntry()->virtualCluster(headers)->priority());
-  }
 }
 
 TEST(RouteMatcherTest, NoHostRewriteAndAutoRewrite) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -113,7 +113,8 @@ TEST_F(RouterTest, ClusterNotFound) {
 }
 
 TEST_F(RouterTest, PoolFailureWithPriority) {
-  callbacks_.route_->route_entry_.virtual_cluster_.priority_ = Upstream::ResourcePriority::High;
+  ON_CALL(callbacks_.route_->route_entry_, priority())
+      .WillByDefault(Return(Upstream::ResourcePriority::High));
   EXPECT_CALL(cm_, httpConnPoolForCluster(_, Upstream::ResourcePriority::High, &router_));
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -114,10 +114,8 @@ class TestVirtualCluster : public VirtualCluster {
 public:
   // Router::VirtualCluster
   const std::string& name() const override { return name_; }
-  Upstream::ResourcePriority priority() const override { return priority_; }
 
   std::string name_{"fake_virtual_cluster"};
-  Upstream::ResourcePriority priority_{Upstream::ResourcePriority::Default};
 };
 
 class MockVirtualHost : public VirtualHost {


### PR DESCRIPTION
We removed these from the v2 API, since priorities are not a stats concept (which VCs are intended
to be a logical grouping for) and instead affect the route action. We're not aware of any use of
this feature today, this PR attempts to simplify the v2 RDS protoization by doing a hard drop of
support (rather than following the usual deprecation process).

Please comment if you are aware of any uses of virtual cluster priorities today and we can switch to
doing a soft deprecation instead.