### PR TITLE
build_recipe: patch lightstep in the meantime

### DIFF
--- a/ci/build_container/build_recipes/lightstep.sh
+++ b/ci/build_container/build_recipes/lightstep.sh
@@ -7,6 +7,22 @@ VERSION=0.36
 wget -O lightstep-tracer-cpp-$VERSION.tar.gz https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v${VERSION//./_}/lightstep-tracer-cpp-$VERSION.tar.gz
 tar xf lightstep-tracer-cpp-$VERSION.tar.gz
 cd lightstep-tracer-cpp-$VERSION
+
+# see https://github.com/lyft/envoy/issues/1387 for progress
+cat > ../lightstep-missing-header.diff << EOF
+--- ./src/c++11/lightstep/options.h.bak	2017-08-04 09:30:19.527076744 -0400
++++ ./src/c++11/lightstep/options.h	2017-08-04 09:30:33.742106924 -0400
+@@ -5,6 +5,7 @@
+ // Options for Tracer implementations, starting Spans, and finishing
+ // Spans.
+ 
++#include <functional>
+ #include <chrono>
+ #include <memory>
+ 
+EOF
+patch -p0 < ../lightstep-missing-header.diff
+
 # Added for legacy compatibility, should not be needed in new build recipes.
 [ -z "$PROTOBUF_BUILD" ] && PROTOBUF_BUILD="$THIRDPARTY_BUILD"
 ./configure --disable-grpc --prefix=$THIRDPARTY_BUILD --enable-shared=no \


### PR DESCRIPTION
Fixes: #1387

While we wait for
https://github.com/lightstep/lightstep-tracer-cpp/pull/51
and then further, for an update to newer lightstep, this fetches an
absolute path to a patch that lets our lightstep build work on newer gcc
versions (>= 7).

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>