### PR TITLE
HttpTracer: Add upstream_cluster tag to the tracing span (#1419)

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -147,6 +147,10 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
   }
   span.setTag("request_size", std::to_string(request_info_.bytesReceived()));
 
+  if (nullptr != request_info_.upstreamHost()) {
+    span.setTag("upstream_cluster", request_info_.upstreamHost()->cluster().name());
+  }
+
   // Post response data.
   span.setTag("response_code", buildResponseCode(request_info_));
   span.setTag("response_size", std::to_string(request_info_.bytesSent()));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -283,17 +283,15 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
 TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
-  const std::string expected_cluster_name = "<my_upstream_cluster>";
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(11));
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
   EXPECT_CALL(request_info, upstreamHost()).WillRepeatedly(Return(request_info.host_));
-  EXPECT_CALL(*request_info.host_, cluster()).WillOnce(ReturnRef(request_info.host_->cluster_));
-  EXPECT_CALL(request_info.host_->cluster_, name()).WillOnce(ReturnRef(expected_cluster_name));
+  request_info.host_->cluster_.name_ = "my_upstream_cluster";
 
-  EXPECT_CALL(*span, setTag("upstream_cluster", expected_cluster_name));
+  EXPECT_CALL(*span, setTag("upstream_cluster", "my_upstream_cluster"));
   EXPECT_CALL(*span, setTag("response_code", "0"));
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "11"));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -273,6 +273,7 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(*span, setTag("response_size", "11"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
+  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
   NiceMock<MockConfig> config;
 
   HttpConnManFinalizerImpl finalizer(nullptr, request_info, config);
@@ -335,6 +336,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "100"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
+  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
 
   NiceMock<MockConfig> config;
 
@@ -390,6 +392,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(*span, setTag("response_code", "503"));
   EXPECT_CALL(*span, setTag("response_size", "100"));
   EXPECT_CALL(*span, setTag("response_flags", "UT"));
+  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
 
   HttpConnManFinalizerImpl finalizer(&request_headers, request_info, config);
   finalizer.finalize(*span);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -283,17 +283,15 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
 TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
-  auto upstream_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
-  NiceMock<Upstream::MockClusterInfo> cluster_info;
   const std::string expected_cluster_name = "<my_upstream_cluster>";
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(11));
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
-  EXPECT_CALL(request_info, upstreamHost()).WillRepeatedly(Return(upstream_host));
-  EXPECT_CALL(*upstream_host, cluster()).WillOnce(ReturnRef(cluster_info));
-  EXPECT_CALL(cluster_info, name()).WillOnce(ReturnRef(expected_cluster_name));
+  EXPECT_CALL(request_info, upstreamHost()).WillRepeatedly(Return(request_info.host_));
+  EXPECT_CALL(*request_info.host_, cluster()).WillOnce(ReturnRef(request_info.host_->cluster_));
+  EXPECT_CALL(request_info.host_->cluster_, name()).WillOnce(ReturnRef(expected_cluster_name));
 
   EXPECT_CALL(*span, setTag("upstream_cluster", expected_cluster_name));
   EXPECT_CALL(*span, setTag("response_code", "0"));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -283,13 +283,13 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
 TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
+  request_info.host_->cluster_.name_ = "my_upstream_cluster";
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(11));
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
-  EXPECT_CALL(request_info, upstreamHost()).WillRepeatedly(Return(request_info.host_));
-  request_info.host_->cluster_.name_ = "my_upstream_cluster";
+  EXPECT_CALL(request_info, upstreamHost()).Times(2);
 
   EXPECT_CALL(*span, setTag("upstream_cluster", "my_upstream_cluster"));
   EXPECT_CALL(*span, setTag("response_code", "0"));


### PR DESCRIPTION
Fixes #1419
* If the upstreamHost is available, then the tracer will add a tag with the upstream cluster name.
* Updated existing tests to work as before
* Added new test to verify the new behavior