### PR TITLE
rds: migrate RDS to Subscription model.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -108,9 +108,9 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "989d49cf1eb31533254a770a2800bc994c971bbf",
+        commit = "86b33525f45caab498d241c86337894da4081cd3",
     )
-    bind_targets = [
+    api_bind_targets = [
         "address",
         "base",
         "bootstrap",
@@ -121,10 +121,18 @@ def envoy_api_deps(skip_targets):
         "rds",
         "tls_context",
     ]
-    for t in bind_targets:
+    for t in api_bind_targets:
         native.bind(
             name = "envoy_" + t,
             actual = "@envoy_api//api:" + t + "_cc",
+        )
+    filter_bind_targets = [
+        "http_connection_manager",
+    ]
+    for t in filter_bind_targets:
+        native.bind(
+            name = "envoy_filter_" + t,
+            actual = "@envoy_api//api/filter:" + t + "_cc",
         )
     native.bind(
         name = "http_api_protos",

--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "route_config_provider_manager_interface",
     hdrs = ["route_config_provider_manager.h"],
+    external_deps = ["envoy_filter_http_connection_manager"],
     deps = [
         ":rds_interface",
         "//include/envoy/event:dispatcher_interface",

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -12,6 +12,8 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "api/filter/http_connection_manager.pb.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -31,16 +33,15 @@ public:
    * ptrs happen from the destructor of the RouteConfigProvider. This function creates a
    * RouteConfigProvider if there isn't one with the same (route_config_name, cluster) already.
    * Otherwise, it returns a RouteConfigProviderSharedPtr created from the manager held weak_ptr.
-   * @param config supplies the json configuration of an RdsRouteConfigProvider.
+   * @param rds supplies the proto configuration of an RdsRouteConfigProvider.
    * @param scope supplies the scope to use for the route config provider.
    * @param stat_prefix supplies the stat_prefix to use for the provider stats.
    * @param init_manager supplies the init manager.
    */
-  virtual RouteConfigProviderSharedPtr getRouteConfigProvider(const Json::Object& config,
-                                                              Upstream::ClusterManager& cm,
-                                                              Stats::Scope& scope,
-                                                              const std::string& stat_prefix,
-                                                              Init::Manager& init_manager) PURE;
+  virtual RouteConfigProviderSharedPtr
+  getRouteConfigProvider(const envoy::api::v2::filter::Rds& rds, Upstream::ClusterManager& cm,
+                         Stats::Scope& scope, const std::string& stat_prefix,
+                         Init::Manager& init_manager) PURE;
 };
 
 /**

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -171,7 +171,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["envoy_base"],
+    external_deps = [
+        "envoy_base",
+        "envoy_filter_http_connection_manager",
+    ],
     deps = [
         ":json_utility_lib",
         "//include/envoy/config:subscription_interface",
@@ -179,5 +182,6 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:hex_lib",
+        "//source/common/json:config_schemas_lib",
     ],
 )

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -3,6 +3,7 @@
 #include "common/common/hex.h"
 #include "common/common/utility.h"
 #include "common/config/json_utility.h"
+#include "common/json/config_schemas.h"
 #include "common/protobuf/protobuf.h"
 
 #include "spdlog/spdlog.h"
@@ -63,6 +64,17 @@ void Utility::translateCdsConfig(const Json::Object& json_config,
   api_config_source->mutable_refresh_delay()->CopyFrom(
       Protobuf::util::TimeUtil::MillisecondsToDuration(
           json_config.getInteger("refresh_delay_ms", 30000)));
+}
+
+void Utility::translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds) {
+  json_rds.validateSchema(Json::Schema::RDS_CONFIGURATION_SCHEMA);
+  auto* api_config_source = rds.mutable_config_source()->mutable_api_config_source();
+  api_config_source->set_api_type(envoy::api::v2::ApiConfigSource::REST_LEGACY);
+  api_config_source->add_cluster_name(json_rds.getString("cluster"));
+  api_config_source->mutable_refresh_delay()->CopyFrom(
+      Protobuf::util::TimeUtil::MillisecondsToDuration(
+          json_rds.getInteger("refresh_delay_ms", 30000)));
+  JSON_UTIL_SET_STRING(json_rds, rds, route_config_name);
 }
 
 } // namespace Config

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -7,6 +7,7 @@
 #include "common/protobuf/protobuf.h"
 
 #include "api/base.pb.h"
+#include "api/filter/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Config {
@@ -82,6 +83,13 @@ public:
    */
   static void translateCdsConfig(const Json::Object& json_config,
                                  envoy::api::v2::ConfigSource& cds_config);
+
+  /**
+   * Convert a v1 RDS JSON config to v2 RDS envoy::api::v2::filter::Rds.
+   * @param json_rds source v1 RDS JSON config.
+   * @param rds destination v2 RDS envoy::api::v2::filter::Rds.
+   */
+  static void translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds);
 
   /**
    * Generate a SubscriptionStats object from stats scope.

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -52,8 +52,14 @@ envoy_cc_library(
     name = "rds_lib",
     srcs = ["rds_impl.cc"],
     hdrs = ["rds_impl.h"],
+    external_deps = [
+        "envoy_filter_http_connection_manager",
+        "envoy_rds",
+    ],
     deps = [
         ":config_lib",
+        ":rds_subscription_lib",
+        "//include/envoy/config:subscription_interface",
         "//include/envoy/init:init_interface",
         "//include/envoy/json:json_object_interface",
         "//include/envoy/local_info:local_info_interface",
@@ -63,9 +69,27 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/common/config:rds_json_lib",
+        "//source/common/config:subscription_factory_lib",
         "//source/common/config:utility_lib",
-        "//source/common/http:rest_api_fetcher_lib",
         "//source/common/json:config_schemas_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "rds_subscription_lib",
+    srcs = ["rds_subscription.cc"],
+    hdrs = ["rds_subscription.h"],
+    external_deps = [
+        "envoy_filter_http_connection_manager",
+    ],
+    deps = [
+        "//include/envoy/config:subscription_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/config:rds_json_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/http:headers_lib",
+        "//source/common/http:rest_api_fetcher_lib",
+        "//source/common/json:json_loader_lib",
     ],
 )
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -158,12 +158,10 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
     const envoy::api::v2::filter::Rds& rds, Upstream::ClusterManager& cm, Stats::Scope& scope,
     const std::string& stat_prefix, Init::Manager& init_manager) {
 
-  // RdsRouteConfigProviders are unique based on their
-  // <route_config_name>MAP_CONCATENATOR<serialized RDS config>.
+  // RdsRouteConfigProviders are unique based on their serialized RDS config.
   // TODO(htuch): Full serialization here gives large IDs, could get away with a
   // strong hash instead.
-  const std::string manager_identifier =
-      rds.route_config_name() + MAP_CONCATENATOR + rds.SerializeAsString();
+  const std::string manager_identifier = rds.SerializeAsString();
 
   auto it = route_config_providers_.find(manager_identifier);
   if (it == route_config_providers_.end()) {

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -7,9 +7,11 @@
 
 #include "common/common/assert.h"
 #include "common/config/rds_json.h"
+#include "common/config/subscription_factory.h"
 #include "common/config/utility.h"
 #include "common/json/config_schemas.h"
 #include "common/router/config_impl.h"
+#include "common/router/rds_subscription.h"
 
 namespace Envoy {
 namespace Router {
@@ -30,9 +32,10 @@ RouteConfigProviderUtil::create(const Json::Object& config, Runtime::Loader& run
     return RouteConfigProviderSharedPtr{
         new StaticRouteConfigProviderImpl(*config.getObject("route_config"), runtime, cm)};
   } else {
-    Json::ObjectSharedPtr rds_config = config.getObject("rds");
-    rds_config->validateSchema(Json::Schema::RDS_CONFIGURATION_SCHEMA);
-    return route_config_provider_manager.getRouteConfigProvider(*rds_config, cm, scope, stat_prefix,
+    Json::ObjectSharedPtr json_rds = config.getObject("rds");
+    envoy::api::v2::filter::Rds rds;
+    Envoy::Config::Utility::translateRdsConfig(*json_rds, rds);
+    return route_config_provider_manager.getRouteConfigProvider(rds, cm, scope, stat_prefix,
                                                                 init_manager);
   }
 }
@@ -47,29 +50,36 @@ StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(const Json::Object&
       }()) {}
 
 RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
-    const Json::Object& config, const std::string& manager_identifier, Runtime::Loader& runtime,
-    Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-    const LocalInfo::LocalInfo& local_info, Stats::Scope& scope, const std::string& stat_prefix,
-    ThreadLocal::SlotAllocator& tls, RouteConfigProviderManagerImpl& route_config_provider_manager)
-
-    : RestApiFetcher(cm, config.getString("cluster"), dispatcher, random,
-                     std::chrono::milliseconds(config.getInteger("refresh_delay_ms", 30000))),
-      runtime_(runtime), local_info_(local_info), tls_(tls.allocateSlot()),
-      route_config_name_(config.getString("route_config_name")),
-      stats_({ALL_RDS_STATS(POOL_COUNTER_PREFIX(scope, stat_prefix + "rds."))}),
+    const envoy::api::v2::filter::Rds& rds, const std::string& manager_identifier,
+    Runtime::Loader& runtime, Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+    Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
+    const std::string& stat_prefix, ThreadLocal::SlotAllocator& tls,
+    RouteConfigProviderManagerImpl& route_config_provider_manager)
+    : runtime_(runtime), cm_(cm), tls_(tls.allocateSlot()),
+      route_config_name_(rds.route_config_name()), scope_(scope.createScope(stat_prefix + "rds.")),
+      stats_({ALL_RDS_STATS(POOL_COUNTER(*scope_))}),
       route_config_provider_manager_(route_config_provider_manager),
       manager_identifier_(manager_identifier) {
-
-  ::Envoy::Config::Utility::checkClusterAndLocalInfo("rds", remote_cluster_name_, cm, local_info);
+  ::Envoy::Config::Utility::checkLocalInfo("rds", local_info);
   ConfigConstSharedPtr initial_config(new NullConfigImpl());
   tls_->set([initial_config](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<ThreadLocalConfig>(initial_config);
   });
+  subscription_ = Envoy::Config::SubscriptionFactory::subscriptionFromConfigSource<
+      envoy::api::v2::RouteConfiguration>(
+      rds.config_source(), local_info.node(), dispatcher, cm, random, *scope_,
+      [this, &rds, &dispatcher, &random,
+       &local_info]() -> Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>* {
+        return new RdsSubscription(Envoy::Config::Utility::generateStats(*scope_), rds, cm_,
+                                   dispatcher, random, local_info);
+      },
+      "envoy.api.v2.RouteDiscoveryService.FetchRoutes",
+      "envoy.api.v2.RouteDiscoveryService.StreamRoutes");
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {
   // If we get destroyed during initialization, make sure we signal that we "initialized".
-  onFetchComplete();
+  runInitializeCallbackIfAny();
 
   // The ownership of RdsRouteConfigProviderImpl is shared among all HttpConnectionManagers that
   // hold a shared_ptr to it. The RouteConfigProviderManager holds weak_ptrs to the
@@ -82,23 +92,18 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
   return tls_->getTyped<ThreadLocalConfig>().config_;
 }
 
-void RdsRouteConfigProviderImpl::createRequest(Http::Message& request) {
-  ENVOY_LOG(debug, "rds: starting request");
-  stats_.update_attempt_.inc();
-  request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
-  request.headers().insertPath().value(fmt::format("/v1/routes/{}/{}/{}", route_config_name_,
-                                                   local_info_.clusterName(),
-                                                   local_info_.nodeName()));
-}
-
-void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
-  ENVOY_LOG(debug, "rds: parsing response");
-  Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
-  uint64_t new_hash = response_json->hash();
+void RdsRouteConfigProviderImpl::onConfigUpdate(const ResourceVector& resources) {
+  if (resources.size() != 1) {
+    throw EnvoyException(fmt::format("Unexpected RDS resource length: {}", resources.size()));
+  }
+  const auto& route_config = resources[0];
+  if (ProtobufTypes::FromString(route_config.name()) != route_config_name_) {
+    throw EnvoyException(fmt::format("Unexpected RDS configuration (expecting {}): {}",
+                                     route_config_name_,
+                                     ProtobufTypes::FromString(route_config.name())));
+  }
+  const uint64_t new_hash = MessageUtil::hash(route_config);
   if (new_hash != last_config_hash_ || !initialized_) {
-    response_json->validateSchema(Json::Schema::ROUTE_CONFIGURATION_SCHEMA);
-    envoy::api::v2::RouteConfiguration route_config;
-    Envoy::Config::RdsJson::translateRouteConfiguration(*response_json, route_config);
     ConfigConstSharedPtr new_config(new ConfigImpl(route_config, runtime_, cm_, false));
     initialized_ = true;
     last_config_hash_ = new_hash;
@@ -108,23 +113,19 @@ void RdsRouteConfigProviderImpl::parseResponse(const Http::Message& response) {
     tls_->runOnAllThreads(
         [this, new_config]() -> void { tls_->getTyped<ThreadLocalConfig>().config_ = new_config; });
   }
-
-  stats_.update_success_.inc();
+  runInitializeCallbackIfAny();
 }
 
-void RdsRouteConfigProviderImpl::onFetchComplete() {
+void RdsRouteConfigProviderImpl::onConfigUpdateFailed(const EnvoyException*) {
+  // We need to allow server startup to continue, even if we have a bad
+  // config.
+  runInitializeCallbackIfAny();
+}
+
+void RdsRouteConfigProviderImpl::runInitializeCallbackIfAny() {
   if (initialize_callback_) {
     initialize_callback_();
     initialize_callback_ = nullptr;
-  }
-}
-
-void RdsRouteConfigProviderImpl::onFetchFailure(const EnvoyException* e) {
-  stats_.update_failure_.inc();
-  if (e) {
-    ENVOY_LOG(warn, "rds: fetch failure: {}", e->what());
-  } else {
-    ENVOY_LOG(info, "rds: fetch failure: network error");
   }
 }
 
@@ -154,12 +155,15 @@ RouteConfigProviderManagerImpl::routeConfigProviders() {
 };
 
 Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteConfigProvider(
-    const Json::Object& config, Upstream::ClusterManager& cm, Stats::Scope& scope,
+    const envoy::api::v2::filter::Rds& rds, Upstream::ClusterManager& cm, Stats::Scope& scope,
     const std::string& stat_prefix, Init::Manager& init_manager) {
 
-  // RdsRouteConfigProviders are unique based on their <route_config_name>MAP_CONCATENATOR<cluster>.
+  // RdsRouteConfigProviders are unique based on their
+  // <route_config_name>MAP_CONCATENATOR<serialized RDS config>.
+  // TODO(htuch): Full serialization here gives large IDs, could get away with a
+  // strong hash instead.
   const std::string manager_identifier =
-      config.getString("route_config_name") + MAP_CONCATENATOR + config.getString("cluster");
+      rds.route_config_name() + MAP_CONCATENATOR + rds.SerializeAsString();
 
   auto it = route_config_providers_.find(manager_identifier);
   if (it == route_config_providers_.end()) {
@@ -167,8 +171,8 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
     // around it. However, since this is not a performance critical path we err on the side
     // of simplicity.
     std::shared_ptr<RdsRouteConfigProviderImpl> new_provider{
-        new RdsRouteConfigProviderImpl(config, manager_identifier, runtime_, cm, dispatcher_,
-                                       random_, local_info_, scope, stat_prefix, tls_, *this)};
+        new RdsRouteConfigProviderImpl(rds, manager_identifier, runtime_, cm, dispatcher_, random_,
+                                       local_info_, scope, stat_prefix, tls_, *this)};
 
     new_provider->registerInitTarget(init_manager);
 

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -146,7 +146,6 @@ public:
                                                       Init::Manager& init_manager) override;
 
 private:
-  const std::string MAP_CONCATENATOR = "_this_string_concatenates_route_config_name_and_cluster_";
   std::unordered_map<std::string, std::weak_ptr<RouteConfigProvider>> route_config_providers_;
   Runtime::Loader& runtime_;
   Event::Dispatcher& dispatcher_;

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "envoy/config/subscription.h"
 #include "envoy/init/init.h"
 #include "envoy/json/json_object.h"
 #include "envoy/local_info/local_info.h"
@@ -13,7 +14,9 @@
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/logger.h"
-#include "common/http/rest_api_fetcher.h"
+
+#include "api/filter/http_connection_manager.pb.h"
+#include "api/rds.pb.h"
 
 namespace Envoy {
 namespace Router {
@@ -53,10 +56,8 @@ private:
  */
 // clang-format off
 #define ALL_RDS_STATS(COUNTER)                                                                     \
-  COUNTER(config_reload)                                                                           \
-  COUNTER(update_attempt)                                                                          \
-  COUNTER(update_success)                                                                          \
-  COUNTER(update_failure)
+  COUNTER(config_reload)
+
 // clang-format on
 
 /**
@@ -72,27 +73,26 @@ class RouteConfigProviderManagerImpl;
  * Implementation of RouteConfigProvider that fetches the route configuration dynamically using
  * the RDS API.
  */
-class RdsRouteConfigProviderImpl : public RouteConfigProvider,
-                                   public Init::Target,
-                                   Http::RestApiFetcher,
-                                   Logger::Loggable<Logger::Id::router> {
+class RdsRouteConfigProviderImpl
+    : public RouteConfigProvider,
+      public Init::Target,
+      Envoy::Config::SubscriptionCallbacks<envoy::api::v2::RouteConfiguration>,
+      Logger::Loggable<Logger::Id::router> {
 public:
   ~RdsRouteConfigProviderImpl();
 
   // Init::Target
   void initialize(std::function<void()> callback) override {
     initialize_callback_ = callback;
-    RestApiFetcher::initialize();
+    subscription_->start({route_config_name_}, *this);
   }
 
   // Router::RouteConfigProvider
   Router::ConfigConstSharedPtr config() override;
 
-  // Http::RestApiFetcher
-  void createRequest(Http::Message& request) override;
-  void parseResponse(const Http::Message& response) override;
-  void onFetchComplete() override;
-  void onFetchFailure(const EnvoyException* e) override;
+  // Config::SubscriptionCallbacks
+  void onConfigUpdate(const ResourceVector& resources) override;
+  void onConfigUpdateFailed(const EnvoyException* e) override;
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {
@@ -101,20 +101,24 @@ private:
     ConfigConstSharedPtr config_;
   };
 
-  RdsRouteConfigProviderImpl(const Json::Object& config, const std::string& manager_identifier,
-                             Runtime::Loader& runtime, Upstream::ClusterManager& cm,
-                             Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+  RdsRouteConfigProviderImpl(const envoy::api::v2::filter::Rds& rds,
+                             const std::string& manager_identifier, Runtime::Loader& runtime,
+                             Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+                             Runtime::RandomGenerator& random,
                              const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
                              const std::string& stat_prefix, ThreadLocal::SlotAllocator& tls,
                              RouteConfigProviderManagerImpl& route_config_provider_manager);
   void registerInitTarget(Init::Manager& init_manager);
+  void runInitializeCallbackIfAny();
 
   Runtime::Loader& runtime_;
-  const LocalInfo::LocalInfo& local_info_;
+  Upstream::ClusterManager& cm_;
+  std::unique_ptr<Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>> subscription_;
   ThreadLocal::SlotPtr tls_;
   const std::string route_config_name_;
   bool initialized_{};
   uint64_t last_config_hash_{};
+  Stats::ScopePtr scope_;
   RdsStats stats_;
   std::function<void()> initialize_callback_;
   RouteConfigProviderManagerImpl& route_config_provider_manager_;
@@ -135,7 +139,7 @@ public:
   // ServerRouteConfigProviderManager
   std::vector<RouteConfigProviderSharedPtr> routeConfigProviders() override;
   // RouteConfigProviderManager
-  RouteConfigProviderSharedPtr getRouteConfigProvider(const Json::Object& config,
+  RouteConfigProviderSharedPtr getRouteConfigProvider(const envoy::api::v2::filter::Rds& rds,
                                                       Upstream::ClusterManager& cm,
                                                       Stats::Scope& scope,
                                                       const std::string& stat_prefix,

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -1,0 +1,64 @@
+#include "common/router/rds_subscription.h"
+
+#include "common/common/assert.h"
+#include "common/config/rds_json.h"
+#include "common/config/utility.h"
+#include "common/http/headers.h"
+#include "common/json/json_loader.h"
+
+namespace Envoy {
+namespace Router {
+
+RdsSubscription::RdsSubscription(Envoy::Config::SubscriptionStats stats,
+                                 const envoy::api::v2::filter::Rds& rds,
+                                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+                                 Runtime::RandomGenerator& random,
+                                 const LocalInfo::LocalInfo& local_info)
+    : RestApiFetcher(
+          cm, rds.config_source().api_config_source().cluster_name()[0], dispatcher, random,
+          Config::Utility::apiConfigSourceRefreshDelay(rds.config_source().api_config_source())),
+      local_info_(local_info), stats_(stats) {
+  const auto& api_config_source = rds.config_source().api_config_source();
+  UNREFERENCED_PARAMETER(api_config_source);
+  // If we are building an RdsSubscription, the ConfigSource should be REST_LEGACY.
+  ASSERT(api_config_source.api_type() == envoy::api::v2::ApiConfigSource::REST_LEGACY);
+  // TODO(htuch): Add support for multiple clusters, #1170.
+  ASSERT(api_config_source.cluster_name().size() == 1);
+  ASSERT(api_config_source.has_refresh_delay());
+  Envoy::Config::Utility::checkClusterAndLocalInfo(
+      "rds", rds.config_source().api_config_source().cluster_name()[0], cm, local_info);
+}
+
+void RdsSubscription::createRequest(Http::Message& request) {
+  ENVOY_LOG(debug, "rds: starting request");
+  stats_.update_attempt_.inc();
+  request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
+  request.headers().insertPath().value(fmt::format("/v1/routes/{}/{}/{}", route_config_name_,
+                                                   local_info_.clusterName(),
+                                                   local_info_.nodeName()));
+}
+
+void RdsSubscription::parseResponse(const Http::Message& response) {
+  ENVOY_LOG(debug, "rds: parsing response");
+  Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
+  Protobuf::RepeatedPtrField<envoy::api::v2::RouteConfiguration> resources;
+  Envoy::Config::RdsJson::translateRouteConfiguration(*response_json, *resources.Add());
+  resources[0].set_name(route_config_name_);
+  callbacks_->onConfigUpdate(resources);
+  stats_.update_success_.inc();
+}
+
+void RdsSubscription::onFetchComplete() {}
+
+void RdsSubscription::onFetchFailure(const EnvoyException* e) {
+  callbacks_->onConfigUpdateFailed(e);
+  stats_.update_failure_.inc();
+  if (e) {
+    ENVOY_LOG(warn, "rds: fetch failure: {}", e->what());
+  } else {
+    ENVOY_LOG(info, "rds: fetch failure: network error");
+  }
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/rds_subscription.h
+++ b/source/common/router/rds_subscription.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "envoy/config/subscription.h"
+
+#include "common/common/assert.h"
+#include "common/http/rest_api_fetcher.h"
+
+#include "api/filter/http_connection_manager.pb.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * Subscription implementation that reads host information from the v1 REST Route Discovery
+ * Service.
+ */
+class RdsSubscription : public Http::RestApiFetcher,
+                        public Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>,
+                        Logger::Loggable<Logger::Id::upstream> {
+public:
+  RdsSubscription(Envoy::Config::SubscriptionStats stats, const envoy::api::v2::filter::Rds& rds,
+                  Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+                  Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
+
+private:
+  // Config::Subscription
+  void start(const std::vector<std::string>& resources,
+             Envoy::Config::SubscriptionCallbacks<envoy::api::v2::RouteConfiguration>& callbacks)
+      override {
+    // We can only handle a single cluster route configuration, it's a design error to ever use this
+    // type of Subscription with more than a single cluster.
+    ASSERT(resources.size() == 1);
+    route_config_name_ = resources[0];
+    callbacks_ = &callbacks;
+    RestApiFetcher::initialize();
+  }
+
+  void updateResources(const std::vector<std::string>& resources) override {
+    // We should never hit this at runtime, since this legacy adapter is only used by HTTP
+    // connection manager that doesn't do dynamic modification of resources.
+    UNREFERENCED_PARAMETER(resources);
+    NOT_IMPLEMENTED;
+  }
+
+  // Http::RestApiFetcher
+  void createRequest(Http::Message& request) override;
+  void parseResponse(const Http::Message& response) override;
+  void onFetchComplete() override;
+  void onFetchFailure(const EnvoyException* e) override;
+
+  std::string route_config_name_;
+  const LocalInfo::LocalInfo& local_info_;
+  Envoy::Config::SubscriptionCallbacks<envoy::api::v2::RouteConfiguration>* callbacks_;
+  Envoy::Config::SubscriptionStats stats_;
+};
+
+} // namespace Router
+} // namespace Envoy

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
     name = "rds_impl_test",
     srcs = ["rds_impl_test.cc"],
     deps = [
+        "//source/common/config:utility_lib",
         "//source/common/http:message_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/router:rds_lib",

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -220,7 +220,7 @@ public:
 
   MOCK_METHOD0(routeConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
   MOCK_METHOD5(getRouteConfigProvider,
-               RouteConfigProviderSharedPtr(const Json::Object& config,
+               RouteConfigProviderSharedPtr(const envoy::api::v2::filter::Rds& rds,
                                             Upstream::ClusterManager& cm, Stats::Scope& scope,
                                             const std::string& stat_prefix,
                                             Init::Manager& init_manager));


### PR DESCRIPTION
Legacy REST adapter translates REST JSON API fetches to a v2 Subscription, similar to
CDS/SDS/EDS.