### PR TITLE
build: External deps build output to stderr

### DIFF
--- a/bazel/repositories.sh
+++ b/bazel/repositories.sh
@@ -36,7 +36,7 @@ done
 
 set -o pipefail
 BUILD_LOG="${BASEDIR}"/build.log
-(time ./build_and_install_deps.sh ${DEPS}) 2>&1 | tee "${BUILD_LOG}"
+(time ./build_and_install_deps.sh ${DEPS}) 2>&1 | tee "${BUILD_LOG}" >&2
 
 ln -sf "$(realpath "${THIRDPARTY_SRC}")" thirdparty
 ln -sf "$(realpath "${THIRDPARTY_BUILD}")" thirdparty_build


### PR DESCRIPTION
The build error to stdout pollutes output of `bazel query`