### PR TITLE
admin: add /routes endpoint

### DIFF
--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -15,6 +15,8 @@
 namespace Envoy {
 namespace Router {
 
+static constexpr char route_config_provider_manager_singleton_name[] = "route_config_provider_manager_singleton_name";
+
 /**
  * The RouteConfigProviderManager exposes the ability to get a RouteConfigProvider. This interface
  * is exposed to the Server's FactoryContext in order to allow HttpConnectionManagers to get

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -33,10 +33,8 @@ static Registry::RegisterFactory<Singleton::RegistrationImpl<date_provider_singl
                                  Singleton::Registration>
     date_provider_singleton_registered_;
 
-static constexpr char route_config_provider_manager_singleton_name[] =
-    "route_config_provider_manager_singleton_name";
 static Registry::RegisterFactory<
-    Singleton::RegistrationImpl<route_config_provider_manager_singleton_name>,
+    Singleton::RegistrationImpl<Router::route_config_provider_manager_singleton_name>,
     Singleton::Registration>
     route_config_provider_manager_singleton_registered_;
 
@@ -52,7 +50,7 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactory(const Json::Object
 
   std::shared_ptr<Router::RouteConfigProviderManager> route_config_provider_manager =
       context.singletonManager().getTyped<Router::RouteConfigProviderManager>(
-          route_config_provider_manager_singleton_name, [&context] {
+          Router::route_config_provider_manager_singleton_name, [&context] {
             return std::make_shared<Router::RouteConfigProviderManagerImpl>(
                 context.runtime(), context.dispatcher(), context.random(), context.localInfo(),
                 context.threadLocal());

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:listen_socket_interface",
+        "//include/envoy/router:route_config_provider_manager_interface",
         "//include/envoy/server:admin_interface",
         "//include/envoy/server:hot_restart_interface",
         "//include/envoy/server:instance_interface",

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -127,6 +127,7 @@ private:
   Http::Code handlerStats(const std::string& url, Buffer::Instance& response);
   Http::Code handlerQuitQuitQuit(const std::string& url, Buffer::Instance& response);
   Http::Code handlerListenerInfo(const std::string& url, Buffer::Instance& response);
+  Http::Code handlerRoutes(const std::string& url, Buffer::Instance& response);
 
   Server::Instance& server_;
   std::list<Http::AccessLog::InstanceSharedPtr> access_logs_;


### PR DESCRIPTION
WIP - add a /routes endpoint to print out loaded dynamic route tables

TODO:
- [ ] add params (route_config_name, cluster) to only print selected route tables.
- [ ] save the json rds response in order to print.
- [ ] actually print in the http handler.