### PR TITLE
docs: typo in drain_timeout_ms

### DIFF
--- a/docs/configuration/http_conn_man/http_conn_man.rst
+++ b/docs/configuration/http_conn_man/http_conn_man.rst
@@ -171,7 +171,7 @@ idle_timeout_s
   manager. The idle timeout is defined as the period in which there are no active requests. If not
   set, there is no idle timeout. When the idle timeout is reached the connection will be closed. If
   the connection is an HTTP/2 connection a drain sequence will occur prior to closing the
-  connection. See :ref:`drain_timeout_s <config_http_conn_man_drain_timeout_ms>`.
+  connection. See :ref:`drain_timeout_ms <config_http_conn_man_drain_timeout_ms>`.
 
 .. _config_http_conn_man_drain_timeout_ms:
 


### PR DESCRIPTION
Fixing a small typo in the "HTTP Connection Manager" docs.