### PR TITLE
lds: migrate LDS to Subscription model.

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -11,6 +11,18 @@
 namespace Envoy {
 namespace Config {
 
+namespace {
+
+void translateApiConfigSource(const std::string& cluster, uint32_t refresh_delay_ms,
+                              envoy::api::v2::ApiConfigSource& api_config_source) {
+  api_config_source.set_api_type(envoy::api::v2::ApiConfigSource::REST_LEGACY);
+  api_config_source.add_cluster_name(cluster);
+  api_config_source.mutable_refresh_delay()->CopyFrom(
+      Protobuf::util::TimeUtil::MillisecondsToDuration(refresh_delay_ms));
+}
+
+} // namespace
+
 void Utility::checkCluster(const std::string& error_prefix, const std::string& cluster_name,
                            Upstream::ClusterManager& cm) {
   Upstream::ThreadLocalCluster* cluster = cm.get(cluster_name);
@@ -58,23 +70,25 @@ void Utility::sdsConfigToEdsConfig(const Upstream::SdsConfig& sds_config,
 
 void Utility::translateCdsConfig(const Json::Object& json_config,
                                  envoy::api::v2::ConfigSource& cds_config) {
-  auto* api_config_source = cds_config.mutable_api_config_source();
-  api_config_source->set_api_type(envoy::api::v2::ApiConfigSource::REST_LEGACY);
-  api_config_source->add_cluster_name(json_config.getObject("cluster")->getString("name"));
-  api_config_source->mutable_refresh_delay()->CopyFrom(
-      Protobuf::util::TimeUtil::MillisecondsToDuration(
-          json_config.getInteger("refresh_delay_ms", 30000)));
+  translateApiConfigSource(json_config.getObject("cluster")->getString("name"),
+                           json_config.getInteger("refresh_delay_ms", 30000),
+                           *cds_config.mutable_api_config_source());
 }
 
 void Utility::translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds) {
   json_rds.validateSchema(Json::Schema::RDS_CONFIGURATION_SCHEMA);
-  auto* api_config_source = rds.mutable_config_source()->mutable_api_config_source();
-  api_config_source->set_api_type(envoy::api::v2::ApiConfigSource::REST_LEGACY);
-  api_config_source->add_cluster_name(json_rds.getString("cluster"));
-  api_config_source->mutable_refresh_delay()->CopyFrom(
-      Protobuf::util::TimeUtil::MillisecondsToDuration(
-          json_rds.getInteger("refresh_delay_ms", 30000)));
+  translateApiConfigSource(json_rds.getString("cluster"),
+                           json_rds.getInteger("refresh_delay_ms", 30000),
+                           *rds.mutable_config_source()->mutable_api_config_source());
   JSON_UTIL_SET_STRING(json_rds, rds, route_config_name);
+}
+
+void Utility::translateLdsConfig(const Json::Object& json_lds,
+                                 envoy::api::v2::ConfigSource& lds_config) {
+  json_lds.validateSchema(Json::Schema::LDS_CONFIG_SCHEMA);
+  translateApiConfigSource(json_lds.getString("cluster"),
+                           json_lds.getInteger("refresh_delay_ms", 30000),
+                           *lds_config.mutable_api_config_source());
 }
 
 } // namespace Config

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -92,6 +92,14 @@ public:
   static void translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds);
 
   /**
+   * Convert a v1 LDS JSON config to v2 LDS envoy::api::v2::ConfigSource.
+   * @param json_lds source v1 LDS JSON config.
+   * @param lds_config destination v2 LDS envoy::api::v2::ConfigSource.
+   */
+  static void translateLdsConfig(const Json::Object& json_lds,
+                                 envoy::api::v2::ConfigSource& lds_config);
+
+  /**
    * Generate a SubscriptionStats object from stats scope.
    * @param scope for stats.
    * @return SubscriptionStats for scope.

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -25,8 +25,8 @@ RdsSubscription::RdsSubscription(Envoy::Config::SubscriptionStats stats,
   // TODO(htuch): Add support for multiple clusters, #1170.
   ASSERT(api_config_source.cluster_name().size() == 1);
   ASSERT(api_config_source.has_refresh_delay());
-  Envoy::Config::Utility::checkClusterAndLocalInfo(
-      "rds", rds.config_source().api_config_source().cluster_name()[0], cm, local_info);
+  Envoy::Config::Utility::checkClusterAndLocalInfo("rds", api_config_source.cluster_name()[0], cm,
+                                                   local_info);
 }
 
 void RdsSubscription::createRequest(Http::Message& request) {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -40,6 +40,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:lds_json_lib",
+        "//source/common/config:utility_lib",
         "//source/common/json:config_schemas_lib",
         "//source/common/network:utility_lib",
         "//source/common/ratelimit:ratelimit_lib",
@@ -154,9 +155,23 @@ envoy_cc_library(
     hdrs = ["lds_api.h"],
     external_deps = ["envoy_lds"],
     deps = [
+        ":lds_subscription_lib",
+        "//include/envoy/config:subscription_interface",
         "//include/envoy/init:init_interface",
         "//include/envoy/server:listener_manager_interface",
-        "//include/envoy/stats:stats_macros",
+        "//source/common/config:subscription_factory_lib",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "lds_subscription_lib",
+    srcs = ["lds_subscription.cc"],
+    hdrs = ["lds_subscription.h"],
+    external_deps = ["envoy_lds"],
+    deps = [
+        "//include/envoy/config:subscription_interface",
+        "//source/common/common:assert_lib",
         "//source/common/config:lds_json_lib",
         "//source/common/config:utility_lib",
         "//source/common/http:rest_api_fetcher_lib",

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -15,6 +15,7 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/config/lds_json.h"
+#include "common/config/utility.h"
 #include "common/json/config_schemas.h"
 #include "common/ratelimit/ratelimit_impl.h"
 #include "common/tracing/http_tracer_impl.h"
@@ -52,9 +53,11 @@ void MainImpl::initialize(const Json::Object& json, const envoy::api::v2::Bootst
   }
 
   if (json.hasObject("lds")) {
-    lds_api_.reset(new LdsApi(*json.getObject("lds"), *cluster_manager_, server.dispatcher(),
-                              server.random(), server.initManager(), server.localInfo(),
-                              server.stats(), server.listenerManager()));
+    envoy::api::v2::ConfigSource lds_config;
+    Config::Utility::translateLdsConfig(*json.getObject("lds"), lds_config);
+    lds_api_.reset(new LdsApi(lds_config, *cluster_manager_, server.dispatcher(), server.random(),
+                              server.initManager(), server.localInfo(), server.stats(),
+                              server.listenerManager()));
   }
 
   if (json.hasObject("statsd_local_udp_port") && json.hasObject("statsd_udp_ip_address")) {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -1,62 +1,47 @@
 #include "server/lds_api.h"
 
-#include <functional>
-
-#include "common/config/lds_json.h"
+#include "common/config/subscription_factory.h"
 #include "common/config/utility.h"
-#include "common/http/headers.h"
-#include "common/json/config_schemas.h"
-#include "common/json/json_loader.h"
 
-#include "api/lds.pb.h"
+#include "server/lds_subscription.h"
 
 namespace Envoy {
 namespace Server {
 
-LdsApi::LdsApi(const Json::Object& config, Upstream::ClusterManager& cm,
+LdsApi::LdsApi(const envoy::api::v2::ConfigSource& lds_config, Upstream::ClusterManager& cm,
                Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                Init::Manager& init_manager, const LocalInfo::LocalInfo& local_info,
                Stats::Scope& scope, ListenerManager& lm)
-    : Json::Validator(config, Json::Schema::LDS_CONFIG_SCHEMA),
-      RestApiFetcher(cm, config.getString("cluster"), dispatcher, random,
-                     std::chrono::milliseconds(config.getInteger("refresh_delay_ms", 30000))),
-      local_info_(local_info), listener_manager_(lm),
-      stats_({ALL_LDS_STATS(POOL_COUNTER_PREFIX(scope, "listener_manager.lds."))}) {
-
-  Config::Utility::checkClusterAndLocalInfo("lds", remote_cluster_name_, cm, local_info);
+    : listener_manager_(lm), scope_(scope.createScope("listener_manager.lds.")) {
+  subscription_ =
+      Envoy::Config::SubscriptionFactory::subscriptionFromConfigSource<envoy::api::v2::Listener>(
+          lds_config, local_info.node(), dispatcher, cm, random, *scope_,
+          [this, &lds_config, &cm, &dispatcher, &random,
+           &local_info]() -> Config::Subscription<envoy::api::v2::Listener>* {
+            return new LdsSubscription(Config::Utility::generateStats(*scope_), lds_config, cm,
+                                       dispatcher, random, local_info);
+          },
+          "envoy.api.v2.ListenerDiscoveryService.FetchListeners",
+          "envoy.api.v2.ListenerDiscoveryService.StreamListeners");
+  Config::Utility::checkLocalInfo("lds", local_info);
   init_manager.registerTarget(*this);
 }
 
 void LdsApi::initialize(std::function<void()> callback) {
   initialize_callback_ = callback;
-  RestApiFetcher::initialize();
+  subscription_->start({}, *this);
 }
 
-void LdsApi::createRequest(Http::Message& request) {
-  ENVOY_LOG(debug, "lds: starting request");
-  stats_.update_attempt_.inc();
-  request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
-  request.headers().insertPath().value(
-      fmt::format("/v1/listeners/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
-}
-
-void LdsApi::parseResponse(const Http::Message& response) {
-  ENVOY_LOG(debug, "lds: parsing response");
-  Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
-  response_json->validateSchema(Json::Schema::LDS_SCHEMA);
-  std::vector<Json::ObjectSharedPtr> json_listeners = response_json->getObjectArray("listeners");
-
+void LdsApi::onConfigUpdate(const ResourceVector& resources) {
   // We need to keep track of which listeners we might need to remove.
   std::unordered_map<std::string, std::reference_wrapper<Listener>> listeners_to_remove;
   for (const auto& listener : listener_manager_.listeners()) {
     listeners_to_remove.emplace(listener.get().name(), listener);
   }
 
-  for (const auto& json_listener : json_listeners) {
-    const std::string listener_name = json_listener->getString("name");
+  for (const auto& listener : resources) {
+    const std::string listener_name = listener.name();
     listeners_to_remove.erase(listener_name);
-    envoy::api::v2::Listener listener;
-    Config::LdsJson::translateListener(*json_listener, listener);
     if (listener_manager_.addOrUpdateListener(listener)) {
       ENVOY_LOG(info, "lds: add/update listener '{}'", listener_name);
     } else {
@@ -70,22 +55,19 @@ void LdsApi::parseResponse(const Http::Message& response) {
     }
   }
 
-  stats_.update_success_.inc();
+  runInitializeCallbackIfAny();
 }
 
-void LdsApi::onFetchComplete() {
+void LdsApi::onConfigUpdateFailed(const EnvoyException*) {
+  // We need to allow server startup to continue, even if we have a bad
+  // config.
+  runInitializeCallbackIfAny();
+}
+
+void LdsApi::runInitializeCallbackIfAny() {
   if (initialize_callback_) {
     initialize_callback_();
     initialize_callback_ = nullptr;
-  }
-}
-
-void LdsApi::onFetchFailure(const EnvoyException* e) {
-  stats_.update_failure_.inc();
-  if (e) {
-    ENVOY_LOG(warn, "lds: fetch failure: {}", e->what());
-  } else {
-    ENVOY_LOG(info, "lds: fetch failure: network error");
   }
 }
 

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -1,0 +1,69 @@
+#include "server/lds_subscription.h"
+
+#include "common/config/lds_json.h"
+#include "common/config/utility.h"
+#include "common/http/headers.h"
+#include "common/json/config_schemas.h"
+#include "common/json/json_loader.h"
+
+#include "api/lds.pb.h"
+
+namespace Envoy {
+namespace Server {
+
+LdsSubscription::LdsSubscription(Config::SubscriptionStats stats,
+                                 const envoy::api::v2::ConfigSource& lds_config,
+                                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+                                 Runtime::RandomGenerator& random,
+                                 const LocalInfo::LocalInfo& local_info)
+    : RestApiFetcher(cm, lds_config.api_config_source().cluster_name()[0], dispatcher, random,
+                     Config::Utility::apiConfigSourceRefreshDelay(lds_config.api_config_source())),
+      local_info_(local_info), stats_(stats) {
+  const auto& api_config_source = lds_config.api_config_source();
+  UNREFERENCED_PARAMETER(lds_config);
+  // If we are building an LdsSubscription, the ConfigSource should be REST_LEGACY.
+  ASSERT(api_config_source.api_type() == envoy::api::v2::ApiConfigSource::REST_LEGACY);
+  // TODO(htuch): Add support for multiple clusters, #1170.
+  ASSERT(api_config_source.cluster_name().size() == 1);
+  ASSERT(api_config_source.has_refresh_delay());
+  Envoy::Config::Utility::checkClusterAndLocalInfo("lds", api_config_source.cluster_name()[0], cm,
+                                                   local_info);
+}
+
+void LdsSubscription::createRequest(Http::Message& request) {
+  ENVOY_LOG(debug, "lds: starting request");
+  stats_.update_attempt_.inc();
+  request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
+  request.headers().insertPath().value(
+      fmt::format("/v1/listeners/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
+}
+
+void LdsSubscription::parseResponse(const Http::Message& response) {
+  ENVOY_LOG(debug, "lds: parsing response");
+  Json::ObjectSharedPtr response_json = Json::Factory::loadFromString(response.bodyAsString());
+  response_json->validateSchema(Json::Schema::LDS_SCHEMA);
+  std::vector<Json::ObjectSharedPtr> json_listeners = response_json->getObjectArray("listeners");
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::Listener> resources;
+  for (const Json::ObjectSharedPtr& json_listener : json_listeners) {
+    Config::LdsJson::translateListener(*json_listener, *resources.Add());
+  }
+
+  callbacks_->onConfigUpdate(resources);
+  stats_.update_success_.inc();
+}
+
+void LdsSubscription::onFetchComplete() {}
+
+void LdsSubscription::onFetchFailure(const EnvoyException* e) {
+  callbacks_->onConfigUpdateFailed(e);
+  stats_.update_failure_.inc();
+  if (e) {
+    ENVOY_LOG(warn, "lds: fetch failure: {}", e->what());
+  } else {
+    ENVOY_LOG(info, "lds: fetch failure: network error");
+  }
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/lds_subscription.h
+++ b/source/server/lds_subscription.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "envoy/config/subscription.h"
+
+#include "common/common/assert.h"
+#include "common/common/logger.h"
+#include "common/http/rest_api_fetcher.h"
+#include "common/json/json_validator.h"
+
+#include "api/lds.pb.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * Subscription implementation that reads listener information from the v1 REST Listener Discovery
+ * Service.
+ */
+class LdsSubscription : public Http::RestApiFetcher,
+                        public Config::Subscription<envoy::api::v2::Listener>,
+                        Logger::Loggable<Logger::Id::upstream> {
+public:
+  LdsSubscription(Config::SubscriptionStats stats, const envoy::api::v2::ConfigSource& lds_config,
+                  Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+                  Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
+
+private:
+  // Config::Subscription
+  void start(const std::vector<std::string>& resources,
+             Config::SubscriptionCallbacks<envoy::api::v2::Listener>& callbacks) override {
+    // LDS subscribes to all clusters.
+    ASSERT(resources.empty());
+    UNREFERENCED_PARAMETER(resources);
+    callbacks_ = &callbacks;
+    RestApiFetcher::initialize();
+  }
+
+  void updateResources(const std::vector<std::string>& resources) override {
+    // We should never hit this at runtime, since this legacy adapter is only used by CdsApiImpl
+    // that doesn't do dynamic modification of resources.
+    UNREFERENCED_PARAMETER(resources);
+    NOT_IMPLEMENTED;
+  }
+
+  // Http::RestApiFetcher
+  void createRequest(Http::Message& request) override;
+  void parseResponse(const Http::Message& response) override;
+  void onFetchComplete() override;
+  void onFetchFailure(const EnvoyException* e) override;
+
+  const LocalInfo::LocalInfo& local_info_;
+  Config::SubscriptionCallbacks<envoy::api::v2::Listener>* callbacks_;
+  Config::SubscriptionStats stats_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -89,6 +89,7 @@ envoy_cc_test(
     name = "lds_api_test",
     srcs = ["lds_api_test.cc"],
     deps = [
+        "//source/common/config:utility_lib",
         "//source/server:lds_api_lib",
         "//test/mocks/server:server_mocks",
         "//test/test_common:utility_lib",

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -1,3 +1,4 @@
+#include "common/config/utility.h"
 #include "common/http/message_impl.h"
 
 #include "server/lds_api.h"
@@ -29,8 +30,10 @@ public:
     )EOF";
 
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+    envoy::api::v2::ConfigSource lds_config;
+    Config::Utility::translateLdsConfig(*config, lds_config);
     EXPECT_CALL(init_, registerTarget(_));
-    lds_.reset(new LdsApi(*config, cluster_manager_, dispatcher_, random_, init_, local_info_,
+    lds_.reset(new LdsApi(lds_config, cluster_manager_, dispatcher_, random_, init_, local_info_,
                           store_, listener_manager_));
 
     expectRequest();
@@ -96,8 +99,10 @@ TEST_F(LdsApiTest, UnknownCluster) {
   )EOF";
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+  envoy::api::v2::ConfigSource lds_config;
+  Config::Utility::translateLdsConfig(*config, lds_config);
   ON_CALL(cluster_manager_, get("foo_cluster")).WillByDefault(Return(nullptr));
-  EXPECT_THROW_WITH_MESSAGE(LdsApi(*config, cluster_manager_, dispatcher_, random_, init_,
+  EXPECT_THROW_WITH_MESSAGE(LdsApi(lds_config, cluster_manager_, dispatcher_, random_, init_,
                                    local_info_, store_, listener_manager_),
                             EnvoyException, "lds: unknown cluster 'foo_cluster'");
 }
@@ -111,8 +116,10 @@ TEST_F(LdsApiTest, BadLocalInfo) {
   )EOF";
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+  envoy::api::v2::ConfigSource lds_config;
+  Config::Utility::translateLdsConfig(*config, lds_config);
   ON_CALL(local_info_, clusterName()).WillByDefault(ReturnRefOfCopy(std::string()));
-  EXPECT_THROW_WITH_MESSAGE(LdsApi(*config, cluster_manager_, dispatcher_, random_, init_,
+  EXPECT_THROW_WITH_MESSAGE(LdsApi(lds_config, cluster_manager_, dispatcher_, random_, init_,
                                    local_info_, store_, listener_manager_),
                             EnvoyException,
                             "lds: setting --service-cluster and --service-node is required");


### PR DESCRIPTION
Legacy REST adapter translates REST JSON API fetches to a v2 Subscription, similar to RDS/CDS/SDS/EDS.