### PR TITLE
admin: add the ability to remove handlers

### DIFF
--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -31,15 +31,18 @@ public:
    * @param prefix supplies the URL prefix to handle.
    * @param help_text supplies the help text for the handler.
    * @param callback supplies the callback to invoke when the prefix matches.
+   * @param if true allows the handler to be removed via removeHandler.
+   * @return bool true if the handler was added, false if it was not added.
    */
-  virtual void addHandler(const std::string& prefix, const std::string& help_text,
-                          HandlerCb callback) PURE;
+  virtual bool addHandler(const std::string& prefix, const std::string& help_text,
+                          HandlerCb callback, const bool removable) PURE;
 
   /**
-   * Remove an admin handler.
+   * Remove an admin handler if it is removable.
    * @param prefix supplies the URL prefix of the handler to delete.
+   * @return bool true if the handler was removed, false if it was not removed.
    */
-  virtual void removeHandler(const std::string& prefix) PURE;
+  virtual bool removeHandler(const std::string& prefix) PURE;
 
   /**
    * Obtain socket the admin endpoint is bound to.

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -31,7 +31,7 @@ public:
    * @param prefix supplies the URL prefix to handle.
    * @param help_text supplies the help text for the handler.
    * @param callback supplies the callback to invoke when the prefix matches.
-   * @param if true allows the handler to be removed via removeHandler.
+   * @param removable if true allows the handler to be removed via removeHandler.
    * @return bool true if the handler was added, false if it was not added.
    */
   virtual bool addHandler(const std::string& prefix, const std::string& help_text,

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -35,7 +35,7 @@ public:
    * @return bool true if the handler was added, false if it was not added.
    */
   virtual bool addHandler(const std::string& prefix, const std::string& help_text,
-                          HandlerCb callback, const bool removable) PURE;
+                          HandlerCb callback, bool removable) PURE;
 
   /**
    * Remove an admin handler if it is removable.

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -36,6 +36,12 @@ public:
                           HandlerCb callback) PURE;
 
   /**
+   * Remove an admin handler.
+   * @param prefix supplies the URL prefix of the handler to delete.
+   */
+  virtual void removeHandler(const std::string& prefix) PURE;
+
+  /**
    * Obtain socket the admin endpoint is bound to.
    * @return Network::ListenSocket& socket reference.
    */

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -428,9 +428,9 @@ const Network::Address::Instance& AdminImpl::localAddress() {
 }
 
 bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_text,
-                           HandlerCb callback, const bool removable) {
+                           HandlerCb callback, bool removable) {
   auto it = std::find_if(handlers_.begin(), handlers_.end(),
-                         [prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
+                         [&prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
   if (it == handlers_.end()) {
     handlers_.push_back({prefix, help_text, callback, removable});
     return true;
@@ -439,11 +439,10 @@ bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_te
 }
 
 bool AdminImpl::removeHandler(const std::string& prefix) {
-  auto it = std::find_if(handlers_.begin(), handlers_.end(), [prefix](const UrlHandler& entry) {
-    return prefix == entry.prefix_ && entry.removable_;
-  });
-  if (it != handlers_.end()) {
-    handlers_.erase(it);
+  uint size_before_removal = handlers_.size();
+  handlers_.remove_if(
+      [&prefix](const UrlHandler& entry) { return prefix == entry.prefix_ && entry.removable_; });
+  if (handlers_.size() == --size_before_removal) {
     return true;
   }
   return false;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -342,22 +342,24 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
                                                                        server_.stats())),
       handlers_{
-          {"/certs", "print certs on machine", MAKE_HANDLER(handlerCerts)},
-          {"/clusters", "upstream cluster status", MAKE_HANDLER(handlerClusters)},
-          {"/cpuprofiler", "enable/disable the CPU profiler", MAKE_HANDLER(handlerCpuProfiler)},
+          {"/certs", "print certs on machine", MAKE_HANDLER(handlerCerts), false},
+          {"/clusters", "upstream cluster status", MAKE_HANDLER(handlerClusters), false},
+          {"/cpuprofiler", "enable/disable the CPU profiler", MAKE_HANDLER(handlerCpuProfiler),
+           false},
           {"/healthcheck/fail", "cause the server to fail health checks",
-           MAKE_HANDLER(handlerHealthcheckFail)},
+           MAKE_HANDLER(handlerHealthcheckFail), false},
           {"/healthcheck/ok", "cause the server to pass health checks",
-           MAKE_HANDLER(handlerHealthcheckOk)},
+           MAKE_HANDLER(handlerHealthcheckOk), false},
           {"/hot_restart_version", "print the hot restart compatability version",
-           MAKE_HANDLER(handlerHotRestartVersion)},
-          {"/logging", "query/change logging levels", MAKE_HANDLER(handlerLogging)},
-          {"/quitquitquit", "exit the server", MAKE_HANDLER(handlerQuitQuitQuit)},
-          {"/reset_counters", "reset all counters to zero", MAKE_HANDLER(handlerResetCounters)},
+           MAKE_HANDLER(handlerHotRestartVersion), false},
+          {"/logging", "query/change logging levels", MAKE_HANDLER(handlerLogging), false},
+          {"/quitquitquit", "exit the server", MAKE_HANDLER(handlerQuitQuitQuit), false},
+          {"/reset_counters", "reset all counters to zero", MAKE_HANDLER(handlerResetCounters),
+           false},
           {"/server_info", "print server version/status information",
-           MAKE_HANDLER(handlerServerInfo)},
-          {"/stats", "print server stats", MAKE_HANDLER(handlerStats)},
-          {"/listeners", "print listener addresses", MAKE_HANDLER(handlerListenerInfo)}} {
+           MAKE_HANDLER(handlerServerInfo), false},
+          {"/stats", "print server stats", MAKE_HANDLER(handlerStats), false},
+          {"/listeners", "print listener addresses", MAKE_HANDLER(handlerListenerInfo), false}} {
 
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
@@ -425,12 +427,26 @@ const Network::Address::Instance& AdminImpl::localAddress() {
   return *server_.localInfo().address();
 }
 
-void AdminImpl::removeHandler(const std::string& prefix) {
+bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_text,
+                           HandlerCb callback, const bool removable) {
   auto it = std::find_if(handlers_.begin(), handlers_.end(),
                          [prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
+  if (it == handlers_.end()) {
+    handlers_.push_back({prefix, help_text, callback, removable});
+    return true;
+  }
+  return false;
+}
+
+bool AdminImpl::removeHandler(const std::string& prefix) {
+  auto it = std::find_if(handlers_.begin(), handlers_.end(), [prefix](const UrlHandler& entry) {
+    return prefix == entry.prefix_ && entry.removable_;
+  });
   if (it != handlers_.end()) {
     handlers_.erase(it);
+    return true;
   }
+  return false;
 }
 
 } // Server

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -439,10 +439,10 @@ bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_te
 }
 
 bool AdminImpl::removeHandler(const std::string& prefix) {
-  uint size_before_removal = handlers_.size();
+  const uint size_before_removal = handlers_.size();
   handlers_.remove_if(
       [&prefix](const UrlHandler& entry) { return prefix == entry.prefix_ && entry.removable_; });
-  if (handlers_.size() == --size_before_removal) {
+  if (handlers_.size() != size_before_removal) {
     return true;
   }
   return false;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -425,5 +425,13 @@ const Network::Address::Instance& AdminImpl::localAddress() {
   return *server_.localInfo().address();
 }
 
+void AdminImpl::removeHandler(const std::string& prefix) {
+  auto it = std::find_if(handlers_.begin(), handlers_.end(),
+                         [prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
+  if (it != handlers_.end()) {
+    handlers_.erase(it);
+  }
+}
+
 } // Server
 } // namespace Envoy

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -429,7 +429,7 @@ const Network::Address::Instance& AdminImpl::localAddress() {
 
 bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_text,
                            HandlerCb callback, bool removable) {
-  auto it = std::find_if(handlers_.begin(), handlers_.end(),
+  auto it = std::find_if(handlers_.cbegin(), handlers_.cend(),
                          [&prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
   if (it == handlers_.end()) {
     handlers_.push_back({prefix, help_text, callback, removable});

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -38,11 +38,9 @@ public:
   Network::ListenSocket& mutable_socket() { return *socket_; }
 
   // Server::Admin
-  void addHandler(const std::string& prefix, const std::string& help_text,
-                  HandlerCb callback) override {
-    handlers_.push_back({prefix, help_text, callback});
-  }
-  void removeHandler(const std::string& prefix) override;
+  bool addHandler(const std::string& prefix, const std::string& help_text, HandlerCb callback,
+                  const bool removable) override;
+  bool removeHandler(const std::string& prefix) override;
 
   // Network::FilterChainFactory
   bool createFilterChain(Network::Connection& connection) override;
@@ -87,6 +85,7 @@ private:
     const std::string prefix_;
     const std::string help_text_;
     const HandlerCb handler_;
+    const bool removable_;
   };
 
   /**
@@ -141,7 +140,7 @@ private:
   Optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
-};
+}; // namespace Server
 
 /**
  * A terminal HTTP filter that implements server admin functionality.

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -39,7 +39,7 @@ public:
 
   // Server::Admin
   bool addHandler(const std::string& prefix, const std::string& help_text, HandlerCb callback,
-                  const bool removable) override;
+                  bool removable) override;
   bool removeHandler(const std::string& prefix) override;
 
   // Network::FilterChainFactory

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -140,7 +140,7 @@ private:
   Optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
-}; // namespace Server
+};
 
 /**
  * A terminal HTTP filter that implements server admin functionality.

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -42,6 +42,7 @@ public:
                   HandlerCb callback) override {
     handlers_.push_back({prefix, help_text, callback});
   }
+  void removeHandler(const std::string& prefix) override;
 
   // Network::FilterChainFactory
   bool createFilterChain(Network::Connection& connection) override;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -75,7 +75,7 @@ public:
 
   // Server::Admin
   MOCK_METHOD4(addHandler, bool(const std::string& prefix, const std::string& help_text,
-                                HandlerCb callback, const bool removable));
+                                HandlerCb callback, bool removable));
   MOCK_METHOD1(removeHandler, bool(const std::string& prefix));
   MOCK_METHOD0(socket, Network::ListenSocket&());
 };

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -74,9 +74,9 @@ public:
   ~MockAdmin();
 
   // Server::Admin
-  MOCK_METHOD3(addHandler,
-               void(const std::string& prefix, const std::string& help_text, HandlerCb callback));
-  MOCK_METHOD1(removeHandler, void(const std::string& prefix));
+  MOCK_METHOD4(addHandler, bool(const std::string& prefix, const std::string& help_text,
+                                HandlerCb callback, const bool removable));
+  MOCK_METHOD1(removeHandler, bool(const std::string& prefix));
   MOCK_METHOD0(socket, Network::ListenSocket&());
 };
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -76,6 +76,7 @@ public:
   // Server::Admin
   MOCK_METHOD3(addHandler,
                void(const std::string& prefix, const std::string& help_text, HandlerCb callback));
+  MOCK_METHOD1(removeHandler, void(const std::string& prefix));
   MOCK_METHOD0(socket, Network::ListenSocket&());
 };
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -124,12 +124,26 @@ TEST_P(AdminInstanceTest, CustomHandler) {
     return Http::Code::Accepted;
   };
 
-  admin_.addHandler("/foo/bar", "hello", callback);
+  // Test removable handler.
+  EXPECT_TRUE(admin_.addHandler("/foo/bar", "hello", callback, true));
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::Accepted, admin_.runCallback("/foo/bar", response));
 
-  admin_.removeHandler("/foo/bar");
+  // Test that removable handler gets removed.
+  EXPECT_TRUE(admin_.removeHandler("/foo/bar"));
   EXPECT_EQ(Http::Code::NotFound, admin_.runCallback("/foo/bar", response));
+  EXPECT_FALSE(admin_.removeHandler("/foo/bar"));
+
+  // Add non removable handler.
+  EXPECT_TRUE(admin_.addHandler("/foo/bar", "hello", callback, false));
+  EXPECT_EQ(Http::Code::Accepted, admin_.runCallback("/foo/bar", response));
+
+  // Add again and make sure it is not there twice.
+  EXPECT_FALSE(admin_.addHandler("/foo/bar", "hello", callback, false));
+
+  // Try to remove non removable handler, and make sure it is not removed.
+  EXPECT_FALSE(admin_.removeHandler("/foo/bar"));
+  EXPECT_EQ(Http::Code::Accepted, admin_.runCallback("/foo/bar", response));
 }
 
 } // namespace Server

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -127,6 +127,9 @@ TEST_P(AdminInstanceTest, CustomHandler) {
   admin_.addHandler("/foo/bar", "hello", callback);
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::Accepted, admin_.runCallback("/foo/bar", response));
+
+  admin_.removeHandler("/foo/bar");
+  EXPECT_EQ(Http::Code::NotFound, admin_.runCallback("/foo/bar", response));
 }
 
 } // namespace Server


### PR DESCRIPTION
@lyft/network-team adding the ability to remove UrlHandlers from the Admin. This is needed to allow the /routes handler to exist only when there is a RouteConfigProviderManager.

@mattklein123 I am adding this first so that the /routes PR stands on its own.