### PR TITLE
Include port in authority computed from absolute-uri

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -142,6 +142,14 @@ TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath2) {
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
 }
 
+TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePathWithPort) {
+  TestHeaderMapImpl expected_headers{
+      {":authority", "www.somewhere.com:4532"}, {":path", "/foo/bar"}, {":method", "GET"}};
+  Buffer::OwnedImpl buffer(
+      "GET http://www.somewhere.com:4532/foo/bar HTTP/1.1\r\nHost: bah\r\n\r\n");
+  expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
+}
+
 TEST_F(Http1ServerConnectionImplTest, Http11AbsoluteEnabledNoOp) {
   TestHeaderMapImpl expected_headers{
       {":authority", "bah"}, {":path", "/foo/bar"}, {":method", "GET"}};

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -149,6 +149,17 @@
               ]
             },
             {
+              "name": "redirect",
+              "domains": [ "www.namewithport.com:1234" ],
+              "require_ssl": "all",
+              "routes": [
+                {
+                  "prefix": "/",
+                  "cluster": "cluster_1"
+                }
+              ]
+            },
+            {
               "name": "integration",
               "domains": [ "*" ],
               "routes": [

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -967,6 +967,36 @@ void BaseIntegrationTest::testAbsolutePath() {
   EXPECT_FALSE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
 }
 
+void BaseIntegrationTest::testAbsolutePathWithPort() {
+  Buffer::OwnedImpl buffer("GET http://www.namewithport.com:1234 HTTP/1.1\r\nHost: host\r\n\r\n");
+  std::string response;
+  RawConnectionDriver connection(
+      lookupPort("http_forward"), buffer,
+      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        client.close(Network::ConnectionCloseType::NoFlush);
+      },
+      version_);
+
+  connection.run();
+  EXPECT_FALSE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
+}
+
+void BaseIntegrationTest::testAbsolutePathWithoutPort() {
+  Buffer::OwnedImpl buffer("GET http://www.namewithport.com HTTP/1.1\r\nHost: host\r\n\r\n");
+  std::string response;
+  RawConnectionDriver connection(
+      lookupPort("http_forward"), buffer,
+      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        client.close(Network::ConnectionCloseType::NoFlush);
+      },
+      version_);
+
+  connection.run();
+  EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
+}
+
 void BaseIntegrationTest::testAllowAbsoluteSameRelative() {
   // Ensure that relative urls behave the same with allow_absolute_url enabled and without
   testEquivalent("GET /foo/bar HTTP/1.1\r\nHost: host\r\n\r\n");

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -224,6 +224,8 @@ protected:
   void testUpstreamProtocolError();
   void testBadPath();
   void testAbsolutePath();
+  void testAbsolutePathWithPort();
+  void testAbsolutePathWithoutPort();
   void testConnect();
   void testAllowAbsoluteSameRelative();
   // Test that a request returns the same content with both allow_absolute_urls enabled and

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -131,6 +131,10 @@ TEST_P(IntegrationTest, BadPath) { testBadPath(); }
 
 TEST_P(IntegrationTest, AbsolutePath) { testAbsolutePath(); }
 
+TEST_P(IntegrationTest, AbsolutePathWithPort) { testAbsolutePathWithPort(); }
+
+TEST_P(IntegrationTest, AbsolutePathWithoutPort) { testAbsolutePathWithoutPort(); }
+
 TEST_P(IntegrationTest, Connect) { testConnect(); }
 
 TEST_P(IntegrationTest, ValidZeroLengthContent) {


### PR DESCRIPTION
Fix the misuse of the UF_* bitfields correctly.