### PR TITLE
Clean up test/coverage/BUILD after coverage run.

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -67,6 +67,11 @@ time "${GCOVR}" --gcov-exclude="${GCOVR_EXCLUDE_REGEX}" \
   --html --html-details --exclude-unreachable-branches --print-summary \
   -o "${COVERAGE_DIR}"/coverage.html > "${COVERAGE_SUMMARY}"
 
+# Clean up the generated test/coverage/BUILD file: subsequent bazel invocations
+# can choke on it if it references things that changed since the last coverage
+# run.
+rm ${SRCDIR}/test/coverage/BUILD
+
 COVERAGE_VALUE=$(grep -Po 'lines: \K(\d|\.)*' "${COVERAGE_SUMMARY}")
 COVERAGE_THRESHOLD=98.0
 COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -70,7 +70,7 @@ time "${GCOVR}" --gcov-exclude="${GCOVR_EXCLUDE_REGEX}" \
 # Clean up the generated test/coverage/BUILD file: subsequent bazel invocations
 # can choke on it if it references things that changed since the last coverage
 # run.
-rm ${SRCDIR}/test/coverage/BUILD
+rm "${SRCDIR}"/test/coverage/BUILD
 
 COVERAGE_VALUE=$(grep -Po 'lines: \K(\d|\.)*' "${COVERAGE_SUMMARY}")
 COVERAGE_THRESHOLD=98.0


### PR DESCRIPTION
This file is autogenerated. If you do a coverage build, then change
other BUILD files to remove something referenced in the autogenerated
file, Bazel breaks in a confusing manner that is NOT resolved by "bazel
clean" and the presence of this file isn't obvious due to .gitignore.

It can be safely removed after the coverage build executes.