### PR TITLE
Tracing: Define OpenTracing standard tags for http method and status …

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -29,10 +29,8 @@ static std::string buildUrl(const Http::HeaderMap& request_headers) {
   std::string path = request_headers.EnvoyOriginalPath()
                          ? request_headers.EnvoyOriginalPath()->value().c_str()
                          : request_headers.Path()->value().c_str();
-  std::string url = fmt::format("{}://{}{}",
-                     "http",
-                     valueOrDefault(request_headers.Host(), ""),
-                     path);
+  std::string url =
+      fmt::format("{}://{}{}", "http", valueOrDefault(request_headers.Host(), ""), path);
   static const size_t max_path_length = 128;
   if (url.length() > max_path_length) {
     return url.substr(0, max_path_length);
@@ -129,7 +127,6 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
     span.setTag("guid:x-request-id", std::string(request_headers_->RequestId()->value().c_str()));
     span.setTag("http.url", buildUrl(*request_headers_));
     span.setTag("http.method", request_headers_->Method()->value().c_str());
-    span.setTag("host_header", valueOrDefault(request_headers_->Host(), "-"));
     span.setTag("downstream_cluster",
                 valueOrDefault(request_headers_->EnvoyDownstreamServiceCluster(), "-"));
     span.setTag("user_agent", valueOrDefault(request_headers_->UserAgent(), "-"));

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -17,6 +17,7 @@
 namespace Envoy {
 namespace Tracing {
 
+// TODO(mattklein123) PERF: Avoid string creations/copies in this entire file.
 static std::string buildResponseCode(const Http::AccessLog::RequestInfo& info) {
   return info.responseCode().valid() ? std::to_string(info.responseCode().value()) : "0";
 }
@@ -129,7 +130,7 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
     span.setTag("downstream_cluster",
                 valueOrDefault(request_headers_->EnvoyDownstreamServiceCluster(), "-"));
     span.setTag("user_agent", valueOrDefault(request_headers_->UserAgent(), "-"));
-    span.setTag("protocol",
+    span.setTag("http.protocol",
                 Http::AccessLog::AccessLogFormatUtils::protocolToString(request_info_.protocol()));
 
     if (request_headers_->ClientTraceId()) {

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -26,18 +26,16 @@ static std::string valueOrDefault(const Http::HeaderEntry* header, const char* d
 }
 
 static std::string buildUrl(const Http::HeaderMap& request_headers) {
-  const std::string path = request_headers.EnvoyOriginalPath()
-                               ? request_headers.EnvoyOriginalPath()->value().c_str()
-                               : request_headers.Path()->value().c_str();
-  const std::string url =
-      fmt::format("{}://{}{}", valueOrDefault(request_headers.ForwardedProto(), ""),
-                  valueOrDefault(request_headers.Host(), ""), path);
+  std::string path = request_headers.EnvoyOriginalPath()
+                         ? request_headers.EnvoyOriginalPath()->value().c_str()
+                         : request_headers.Path()->value().c_str();
   static const size_t max_path_length = 128;
-  if (url.length() > max_path_length) {
-    return url.substr(0, max_path_length);
+  if (path.length() > max_path_length) {
+    path = path.substr(0, max_path_length);
   }
 
-  return url;
+  return fmt::format("{}://{}{}", valueOrDefault(request_headers.ForwardedProto(), ""),
+                     valueOrDefault(request_headers.Host(), ""), path);
 }
 
 void HttpTracerUtility::mutateHeaders(Http::HeaderMap& request_headers, Runtime::Loader& runtime) {

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -132,6 +132,8 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
                 valueOrDefault(request_headers_->EnvoyDownstreamServiceCluster(), "-"));
     span.setTag("user_agent", valueOrDefault(request_headers_->UserAgent(), "-"));
 
+    span.setTag("http.method", request_headers_->Method()->value().c_str());
+
     if (request_headers_->ClientTraceId()) {
       span.setTag("guid:x-client-trace-id",
                   std::string(request_headers_->ClientTraceId()->value().c_str()));
@@ -152,7 +154,9 @@ void HttpConnManFinalizerImpl::finalize(Span& span) {
   }
 
   // Post response data.
-  span.setTag("response_code", buildResponseCode(request_info_));
+  std::string responseCode = buildResponseCode(request_info_);
+  span.setTag("http.status_code", responseCode);
+  span.setTag("response_code", responseCode);
   span.setTag("response_size", std::to_string(request_info_.bytesSent()));
   span.setTag("response_flags", Http::AccessLog::ResponseFlagUtils::toShortString(request_info_));
 

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -29,8 +29,8 @@ static std::string buildUrl(const Http::HeaderMap& request_headers) {
   std::string path = request_headers.EnvoyOriginalPath()
                          ? request_headers.EnvoyOriginalPath()->value().c_str()
                          : request_headers.Path()->value().c_str();
-  std::string url =
-      fmt::format("{}://{}{}", "http", valueOrDefault(request_headers.Host(), ""), path);
+  std::string url = fmt::format("{}://{}{}", valueOrDefault(request_headers.Scheme(), ""),
+                                valueOrDefault(request_headers.Host(), ""), path);
   static const size_t max_path_length = 128;
   if (url.length() > max_path_length) {
     return url.substr(0, max_path_length);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -240,8 +240,10 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   const std::string expected_path(128 - path_prefix.length(), 'a');
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
 
-  Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {"x-envoy-original-path", path}, {":method", "GET"}, {":scheme", "http"}};
+  Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
+                                          {"x-envoy-original-path", path},
+                                          {":method", "GET"},
+                                          {":scheme", "http"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -252,6 +252,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
 
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag("request_line", "GET " + expected_path + " HTTP/2"));
+  EXPECT_CALL(*span, setTag("http.method", "GET"));
   NiceMock<MockConfig> config;
 
   HttpConnManFinalizerImpl finalizer(&request_headers, request_info, config);
@@ -269,6 +270,7 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
 
   EXPECT_CALL(*span, setTag("response_code", "0"));
+  EXPECT_CALL(*span, setTag("http.status_code", "0"));
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "11"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
@@ -293,6 +295,7 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
 
   EXPECT_CALL(*span, setTag("upstream_cluster", "my_upstream_cluster"));
   EXPECT_CALL(*span, setTag("response_code", "0"));
+  EXPECT_CALL(*span, setTag("http.status_code", "0"));
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "11"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
@@ -322,6 +325,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(*span, setTag("user_agent", "-"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
+  EXPECT_CALL(*span, setTag("http.method", "GET"));
 
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
@@ -329,6 +333,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
 
   EXPECT_CALL(*span, setTag("response_code", "0"));
+  EXPECT_CALL(*span, setTag("http.status_code", "0"));
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_size", "100"));
   EXPECT_CALL(*span, setTag("response_flags", "-"));
@@ -364,6 +369,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(*span, setTag("downstream_cluster", "downstream_cluster"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
   EXPECT_CALL(*span, setTag("guid:x-client-trace-id", "client_trace_id"));
+  EXPECT_CALL(*span, setTag("http.method", "GET"));
 
   // Check that span has tags from custom headers.
   request_headers.addCopy(Http::LowerCaseString("aa"), "a");
@@ -386,6 +392,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
 
   EXPECT_CALL(*span, setTag("error", "true"));
   EXPECT_CALL(*span, setTag("response_code", "503"));
+  EXPECT_CALL(*span, setTag("http.status_code", "503"));
   EXPECT_CALL(*span, setTag("response_size", "100"));
   EXPECT_CALL(*span, setTag("response_flags", "UT"));
   EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -317,7 +317,6 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(*span, setTag("guid:x-request-id", "id"));
   EXPECT_CALL(*span, setTag("http.url", "http:///test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("host_header", "-"));
   EXPECT_CALL(*span, setTag("user_agent", "-"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
@@ -357,7 +356,6 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(*span, setTag("guid:x-request-id", "id"));
   EXPECT_CALL(*span, setTag("http.url", "http://api/test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("host_header", "api"));
   EXPECT_CALL(*span, setTag("user_agent", "agent"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "downstream_cluster"));
   EXPECT_CALL(*span, setTag("request_size", "10"));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -241,7 +241,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
 
   Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {"x-envoy-original-path", path}, {":method", "GET"}};
+      {"x-request-id", "id"}, {"x-envoy-original-path", path}, {":method", "GET"}, {":scheme", "http"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
@@ -307,7 +307,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
 
   Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}};
+      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}, {":scheme", "https"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
@@ -315,7 +315,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
 
   // Check that span is populated correctly.
   EXPECT_CALL(*span, setTag("guid:x-request-id", "id"));
-  EXPECT_CALL(*span, setTag("http.url", "http:///test"));
+  EXPECT_CALL(*span, setTag("http.url", "https:///test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
   EXPECT_CALL(*span, setTag("user_agent", "-"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
@@ -341,7 +341,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
 TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
   Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}};
+      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}, {":scheme", "http"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
   request_headers.insertHost().value(std::string("api"));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -243,17 +243,20 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
                                           {"x-envoy-original-path", path},
                                           {":method", "GET"},
-                                          {":scheme", "http"}};
+                                          {"x-forwarded-proto", "http"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
+  Http::Protocol protocol = Http::Protocol::Http2;
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(11));
+  EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
 
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag("http.url", path_prefix + expected_path));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
+  EXPECT_CALL(*span, setTag("protocol", "HTTP/2"));
   NiceMock<MockConfig> config;
 
   HttpConnManFinalizerImpl finalizer(&request_headers, request_info, config);
@@ -308,11 +311,15 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
 TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
 
-  Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}, {":scheme", "https"}};
+  Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
+                                          {":path", "/test"},
+                                          {":method", "GET"},
+                                          {"x-forwarded-proto", "https"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
+  Http::Protocol protocol = Http::Protocol::Http10;
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
+  EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
@@ -320,6 +327,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(*span, setTag("http.url", "https:///test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
   EXPECT_CALL(*span, setTag("user_agent", "-"));
+  EXPECT_CALL(*span, setTag("protocol", "HTTP/1.0"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
 
@@ -342,8 +350,10 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
 
 TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
-  Http::TestHeaderMapImpl request_headers{
-      {"x-request-id", "id"}, {":path", "/test"}, {":method", "GET"}, {":scheme", "http"}};
+  Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
+                                          {":path", "/test"},
+                                          {":method", "GET"},
+                                          {"x-forwarded-proto", "http"}};
   NiceMock<Http::AccessLog::MockRequestInfo> request_info;
 
   request_headers.insertHost().value(std::string("api"));
@@ -351,6 +361,8 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   request_headers.insertEnvoyDownstreamServiceCluster().value(std::string("downstream_cluster"));
   request_headers.insertClientTraceId().value(std::string("client_trace_id"));
 
+  Http::Protocol protocol = Http::Protocol::Http10;
+  EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
   EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(10));
   const std::string service_node = "i-453";
 
@@ -359,6 +371,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(*span, setTag("http.url", "http://api/test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
   EXPECT_CALL(*span, setTag("user_agent", "agent"));
+  EXPECT_CALL(*span, setTag("protocol", "HTTP/1.0"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "downstream_cluster"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
   EXPECT_CALL(*span, setTag("guid:x-client-trace-id", "client_trace_id"));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -237,7 +237,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   const std::string path(300, 'a');
   const std::string path_prefix = "http://";
-  const std::string expected_path(128 - path_prefix.length(), 'a');
+  const std::string expected_path(128, 'a');
   std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -256,7 +256,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag("http.url", path_prefix + expected_path));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("protocol", "HTTP/2"));
+  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/2"));
   NiceMock<MockConfig> config;
 
   HttpConnManFinalizerImpl finalizer(&request_headers, request_info, config);
@@ -327,7 +327,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(*span, setTag("http.url", "https:///test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
   EXPECT_CALL(*span, setTag("user_agent", "-"));
-  EXPECT_CALL(*span, setTag("protocol", "HTTP/1.0"));
+  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/1.0"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
 
@@ -371,7 +371,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   EXPECT_CALL(*span, setTag("http.url", "http://api/test"));
   EXPECT_CALL(*span, setTag("http.method", "GET"));
   EXPECT_CALL(*span, setTag("user_agent", "agent"));
-  EXPECT_CALL(*span, setTag("protocol", "HTTP/1.0"));
+  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/1.0"));
   EXPECT_CALL(*span, setTag("downstream_cluster", "downstream_cluster"));
   EXPECT_CALL(*span, setTag("request_size", "10"));
   EXPECT_CALL(*span, setTag("guid:x-client-trace-id", "client_trace_id"));


### PR DESCRIPTION
…code

OpenTracing defines a standard set of tags to be used when reporting tracing data (spans): https://github.com/opentracing/specification/blob/master/semantic_conventions.md

This PR adds the `http.method` and `http.status_code` tags.

The `http.status_code` tag is a duplication of the current `response_code` tag - wondering whether this should be deprecated?

These tags are also supported by Zipkin: https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/TraceKeys.java#L51 and https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/TraceKeys.java#L86.
