### PR TITLE
outlier: fix consecutive 5xx without interleaved success

### DIFF
--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -248,17 +248,15 @@ void DetectorImpl::onConsecutive5xxWorker(HostSharedPtr host) {
     return;
   }
 
-  // There are two outcomes here. The ejection will be enforced,
-  // or it won't. Either way the host won't trigger the check in the sink's putHttpResponseCode
-  // call if the host keeps been
-  // charged with only 5xx ResponseCodes without an intervening non-5xx code. Therefore,
-  // the sink's consecutive_5xx_ counter should be reset to allow the sink to detect another bout
-  // of 5xx from this host. The reset is done here instead of the sink's putHttpResponseCode
-  // call to prevent thread thrashing.
-  host_sinks_[host]->resetConsecutive5xx();
-
   stats_.ejections_consecutive_5xx_.inc();
   ejectHost(host, EjectionType::Consecutive5xx);
+
+  // Reset the DetectorHostSink's consecutive_5xx_. This counter needs to be reset
+  // in order to allow the Sink to detect a bout of consecutive 5xx responses even
+  // if the sink is not charged with an interleaved non-5xx code.
+  // The reset is done here instead of the Sink's putHttpResponseCode call to prevent
+  // thread thrashing.
+  host_sinks_[host]->resetConsecutive5xx();
 }
 
 Utility::EjectionPair Utility::successRateEjectionThreshold(

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -249,10 +249,12 @@ void DetectorImpl::onConsecutive5xxWorker(HostSharedPtr host) {
   }
 
   // There are two outcomes here. The ejection will be enforced,
-  // or it won't. Either way the host won't trigger the check above if it keeps been
+  // or it won't. Either way the host won't trigger the check in the sink's putHttpResponseCode
+  // call if the host keeps been
   // charged with only 5xx ResponseCodes without an intervening non-5xx code. Therefore,
-  // the consecutive_5xx_ counter should be reset to allow the Sink to detect another bout
-  // of 5xx from this host.
+  // the sink's consecutive_5xx_ counter should be reset to allow the sink to detect another bout
+  // of 5xx from this host. The reset is done here instead of the sink's putHttpResponseCode
+  // call to prevent thread thrashing.
   host_sinks_[host]->resetConsecutive5xx();
 
   stats_.ejections_consecutive_5xx_.inc();

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -251,11 +251,10 @@ void DetectorImpl::onConsecutive5xxWorker(HostSharedPtr host) {
   stats_.ejections_consecutive_5xx_.inc();
   ejectHost(host, EjectionType::Consecutive5xx);
 
-  // Reset the DetectorHostSink's consecutive_5xx_. This counter needs to be reset
-  // in order to allow the Sink to detect a bout of consecutive 5xx responses even
-  // if the sink is not charged with an interleaved non-5xx code.
-  // The reset is done here instead of the Sink's putHttpResponseCode call to prevent
-  // thread thrashing.
+  // Reset the DetectorHostSink's consecutive_5xx_ counter. The reset is performed here
+  // on the onConsecutive5xxWorker call to prevent thread thrashing. The consecutive_5xx_
+  // counter needs to be reset in order to allow the Sink to detect a bout of consecutive
+  // 5xx responses even if the sink is not charged with an interleaved non-5xx code.
   host_sinks_[host]->resetConsecutive5xx();
 }
 

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -60,7 +60,8 @@ void DetectorHostSinkImpl::putHttpResponseCode(uint64_t response_code) {
       // There are two outcomes here. The ejection will be enforced,
       // or it won't. Either way the host won't trigger the check above if it keeps been
       // charged with only 5xx ResponseCodes without an intervening non-5xx code. Therefore,
-      // the consecutive5xx counter should be reset to allow the host to be ejected again.
+      // the consecutive_5xx_ counter should be reset to allow the Sink to detect another bout
+      // of 5xx from this host.
       consecutive_5xx_ = 0;
       detector->onConsecutive5xx(host_.lock());
     }

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -57,6 +57,11 @@ void DetectorHostSinkImpl::putHttpResponseCode(uint64_t response_code) {
     if (++consecutive_5xx_ ==
         detector->runtime().snapshot().getInteger("outlier_detection.consecutive_5xx",
                                                   detector->config().consecutive5xx())) {
+      // There are two outcomes here. The ejection will be enforced,
+      // or it won't. Either way the host won't trigger the check above if it keeps been
+      // charged with only 5xx ResponseCodes without an intervening non-5xx code. Therefore,
+      // the consecutive5xx counter should be reset to allow the host to be ejected again.
+      consecutive_5xx_ = 0;
       detector->onConsecutive5xx(host_.lock());
     }
   } else {

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -114,6 +114,7 @@ public:
   void updateCurrentSuccessRateBucket();
   SuccessRateAccumulator& successRateAccumulator() { return success_rate_accumulator_; }
   void successRate(double new_success_rate) { success_rate_ = new_success_rate; }
+  void resetConsecutive5xx() { consecutive_5xx_ = 0; }
 
   // Upstream::Outlier::DetectorHostSink
   uint32_t numEjections() override { return num_ejections_; }


### PR DESCRIPTION
Fixes #1491.

The DetectorHostSink has a consecutive_5xx_ counter that gets incremented every time a 5xx response gets charged to the sink, and reset every time a non-5xx does. Previously if a Sink reached the consecutive 5xx limit, and the host was charged with a consecutive 5xx ejection, the consecutive_5xx_ counter was not been reset. This meant that the Sink would not trigger another consecutive 5xx ejection until a non-5xx code was charged and the counter was reset, and then subsequently increased to the limit. This PR fixes the issue by resetting the counter after the host has been charged with an ejection (whether the ejection is enforced or not).