### PR TITLE
config: Any opaque filter proto config support, LDS/RDS integration test.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -108,7 +108,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "32b1173cce4d49e9f26026f503d39a1192b98428",
+        commit = "d1608a1dcbef1a8acfdb1655f28772687ac6763e",
     )
     api_bind_targets = [
         "address",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPO_LOCATIONS = {
     "jinja2": "https://github.com/pallets/jinja.git",
     "grpc_transcoding": "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git",
-    "envoy_api": "https://github.com/lyft/envoy-api.git",
+    "envoy_api": "https://github.com/htuch/envoy-api.git",
     "protobuf" :"https://github.com/htuch/protobuf.git",
     "markupsafe": "https://github.com/pallets/markupsafe.git",
 }

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -111,6 +111,8 @@ envoy_cc_library(
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/common:macros",
+        "//source/common/protobuf",
     ],
 )
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -15,6 +15,9 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/common/macros.h"
+#include "common/protobuf/protobuf.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -151,6 +154,17 @@ public:
                                                      FactoryContext& context) PURE;
 
   /**
+   * v2 variant of createFilterFactory(..), where filter configs are specified as proto. This may be
+   * optionally implemented today, but will in the future become compulsory once v1 is deprecated.
+   */
+  virtual NetworkFilterFactoryCb createFilterFactoryFromProto(const ProtobufWkt::Any& config,
+                                                              FactoryContext& context) {
+    UNREFERENCED_PARAMETER(config);
+    UNREFERENCED_PARAMETER(context);
+    return NetworkFilterFactoryCb();
+  }
+
+  /**
    * @return std::string the identifying name for a particular implementation of a network filter
    * produced by the factory.
    */
@@ -196,6 +210,20 @@ public:
   virtual HttpFilterFactoryCb createFilterFactory(const Json::Object& config,
                                                   const std::string& stat_prefix,
                                                   FactoryContext& context) PURE;
+
+  /**
+   * v2 API variant of createFilterFactory(..), where filter configs are specified as proto. This
+   * may be optionally implemented today, but will in the future become compulsory once v1 is
+   * deprecated.
+   */
+  virtual HttpFilterFactoryCb createFilterFactoryFromProto(const ProtobufWkt::Any& config,
+                                                           const std::string& stat_prefix,
+                                                           FactoryContext& context) {
+    UNREFERENCED_PARAMETER(config);
+    UNREFERENCED_PARAMETER(stat_prefix);
+    UNREFERENCED_PARAMETER(context);
+    return HttpFilterFactoryCb();
+  }
 
   /**
    * @return std::string the identifying name for a particular implementation of an http filter

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -125,8 +125,11 @@ void FilterJson::translateHttpConnectionManager(
     JSON_UTIL_SET_STRING(*json_filter, *filter, name);
     JSON_UTIL_SET_STRING(*json_filter, *filter->mutable_deprecated_v1(), type);
 
-    const auto status = Protobuf::util::JsonStringToMessage(
-        json_filter->getObject("config")->asJsonString(), filter->mutable_config());
+    const std::string json_config =
+        "{\"@type\": \"type.googleapis.com/google.protobuf.Struct\", \"value\": " +
+        json_filter->getObject("config")->asJsonString() + "}";
+
+    const auto status = Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config());
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
     UNREFERENCED_PARAMETER(status);

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -28,8 +28,11 @@ void LdsJson::translateListener(const Json::Object& json_listener,
     JSON_UTIL_SET_STRING(*json_filter, *filter, name);
     JSON_UTIL_SET_STRING(*json_filter, *filter->mutable_deprecated_v1(), type);
 
-    const auto status = Protobuf::util::JsonStringToMessage(
-        json_filter->getObject("config")->asJsonString(), filter->mutable_config());
+    const std::string json_config =
+        "{\"@type\": \"type.googleapis.com/google.protobuf.Struct\", \"value\": " +
+        json_filter->getObject("config")->asJsonString() + "}";
+
+    const auto status = Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config());
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
     UNREFERENCED_PARAMETER(status);

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -21,7 +21,9 @@ envoy_cc_library(
     external_deps = ["protobuf"],
     deps = [
         ":protobuf",
+        "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
         "//source/common/filesystem:filesystem_lib",
+        "//source/common/json:json_loader_lib",
     ],
 )

--- a/source/common/protobuf/protobuf.h
+++ b/source/common/protobuf/protobuf.h
@@ -4,8 +4,10 @@
 #include <string>
 #include <vector>
 
+#include "google/protobuf/any.pb.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/descriptor.pb.h"
+#include "google/protobuf/empty.pb.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -1,6 +1,8 @@
 #include "common/protobuf/utility.h"
 
+#include "common/common/assert.h"
 #include "common/filesystem/filesystem_impl.h"
+#include "common/json/json_loader.h"
 
 #include "spdlog/spdlog.h"
 
@@ -11,12 +13,24 @@ MissingFieldException::MissingFieldException(const std::string& field_name,
     : EnvoyException(
           fmt::format("Field '{}' is missing in: {}", field_name, message.DebugString())) {}
 
-void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message) {
-  const std::string json = Filesystem::fileReadToEnd(path);
+void MessageUtil::loadFromJson(const std::string json, Protobuf::Message& message) {
   const auto status = Protobuf::util::JsonStringToMessage(json, &message);
   if (!status.ok()) {
-    throw EnvoyException("Unable to parse JSON as proto: " + json);
+    throw EnvoyException("Unable to parse JSON as proto (" + status.ToString() + "): " + json);
   }
+}
+
+void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message) {
+  loadFromJson(Filesystem::fileReadToEnd(path), message);
+}
+
+Json::ObjectSharedPtr WktUtil::getJsonObjectFromAny(const google::protobuf::Any& message) {
+  Protobuf::util::JsonOptions json_options;
+  ProtobufTypes::String json;
+  const auto status = Protobuf::util::MessageToJsonString(message, &json, json_options);
+  // This should always succeed unless something crash-worthy such as out-of-memory.
+  RELEASE_ASSERT(status.ok());
+  return Json::Factory::loadFromString(json);
 }
 
 } // namespace Envoy

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/exception.h"
+#include "envoy/json/json_object.h"
 
 #include "common/common/utility.h"
 #include "common/protobuf/protobuf.h"
@@ -51,7 +52,19 @@ public:
     return std::hash<std::string>{}(message.SerializeAsString());
   }
 
+  static void loadFromJson(const std::string json, Protobuf::Message& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message);
+};
+
+class WktUtil {
+public:
+  /**
+   * Extract JSON object from a google.protobuf.Any message of type
+   * type.googleapis.com/google.protobuf.Struct.
+   * @param message message of type type.googleapis.com/google.protobuf.Struct.
+   * @return Json::ObjectSharedPtr of embedded JSON object or nullptr if unable to extract.
+   */
+  static Json::ObjectSharedPtr getJsonObjectFromAny(const google::protobuf::Any& message);
 };
 
 } // namespace Envoy

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -27,6 +27,8 @@ public:
   // NamedNetworkFilterConfigFactory
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
                                              FactoryContext& context) override;
+  NetworkFilterFactoryCb createFilterFactoryFromProto(const ProtobufWkt::Any& config,
+                                                      FactoryContext& context) override;
 
   std::string name() override { return "http_connection_manager"; }
   NetworkFilterType type() override { return NetworkFilterType::Read; }

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -52,7 +52,11 @@ void MainImpl::initialize(const Json::Object& json, const envoy::api::v2::Bootst
     server.listenerManager().addOrUpdateListener(listener);
   }
 
-  if (json.hasObject("lds")) {
+  if (bootstrap.has_lds_config()) {
+    lds_api_.reset(new LdsApi(bootstrap.lds_config(), *cluster_manager_, server.dispatcher(),
+                              server.random(), server.initManager(), server.localInfo(),
+                              server.stats(), server.listenerManager()));
+  } else if (json.hasObject("lds")) {
     envoy::api::v2::ConfigSource lds_config;
     Config::Utility::translateLdsConfig(*json.getObject("lds"), lds_config);
     lds_api_.reset(new LdsApi(lds_config, *cluster_manager_, server.dispatcher(), server.random(),

--- a/test/config/integration/BUILD
+++ b/test/config/integration/BUILD
@@ -28,6 +28,8 @@ filegroup(
         "server_xds.cds.json",
         "server_xds.eds.json",
         "server_xds.json",
+        "server_xds.lds.json",
+        "server_xds.rds.json",
     ],
 )
 

--- a/test/config/integration/server_xds.bootstrap.json
+++ b/test/config/integration/server_xds.bootstrap.json
@@ -1,4 +1,7 @@
 {
+  "lds_config": {
+    "path": "{{ lds_json_path }}"
+  },
   "cds_config": {
     "path": "{{ cds_json_path }}"
   }

--- a/test/config/integration/server_xds.cds.json
+++ b/test/config/integration/server_xds.cds.json
@@ -1,18 +1,16 @@
 {
   "versionInfo": "0",
-  "resources": [
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "cluster_1",
-      "connectTimeout": { "seconds": 5 },
-      "type": "EDS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "path": "{{ eds_json_path }}"
-        }
-      },
-      "lbPolicy": "ROUND_ROBIN",
-      "http2ProtocolOptions": {}
-    }
-  ]
+  "resources": [{
+    "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+    "name": "cluster_1",
+    "connectTimeout": { "seconds": 5 },
+    "type": "EDS",
+    "edsClusterConfig": {
+      "edsConfig": {
+        "path": "{{ eds_json_path }}"
+      }
+    },
+    "lbPolicy": "ROUND_ROBIN",
+    "http2ProtocolOptions": {}
+  }]
 }

--- a/test/config/integration/server_xds.json
+++ b/test/config/integration/server_xds.json
@@ -1,39 +1,6 @@
 {
-  "listeners": [
-  {
-    "address": "tcp://{{ ip_loopback_address }}:0",
-    "filters": [
-    {
-      "type": "read",
-      "name": "http_connection_manager",
-      "config": {
-        "codec_type": "http2",
-        "drain_timeout_ms": 5000,
-        "stat_prefix": "router",
-        "route_config":
-        {
-          "virtual_hosts": [
-            {
-              "name": "integration",
-              "domains": [ "*" ],
-              "routes": [
-                {
-                  "prefix": "/test/long/url",
-                  "cluster": "cluster_1"
-                }
-              ]
-            }
-          ]
-        },
-        "filters": [
-          { "type": "decoder", "name": "router", "config": {}}
-        ]
-      }
-    }]
-  }],
-
+  "listeners": [],
   "admin": { "access_log_path": "/dev/null", "address": "tcp://{{ ip_loopback_address }}:0" },
-
   "cluster_manager": {
     "clusters": []
   }

--- a/test/config/integration/server_xds.lds.json
+++ b/test/config/integration/server_xds.lds.json
@@ -1,0 +1,29 @@
+{
+  "versionInfo": "0",
+  "resources": [{
+    "@type": "type.googleapis.com/envoy.api.v2.Listener",
+    "name": "listener_0",
+    "address": {
+      "socketAddress": {
+        "address": "{{ ntop_ip_loopback_address }}",
+        "portValue": 0
+      }
+    },
+    "filterChains": [{
+      "filters": [{
+        "name": "http_connection_manager",
+        "config": {
+          "@type": "type.googleapis.com/envoy.api.v2.filter.HttpConnectionManager",
+          "codecType": "HTTP2",
+          "drainTimeout": "5s",
+          "statPrefix": "router",
+          "rds": {
+            "routeConfigName": "route_config_0",
+            "configSource": { "path": "{{ rds_json_path }}" }
+          },
+          "httpFilters": [{ "name": "router", "config": { "@type": "type.googleapis.com/google.protobuf.Struct" }}]
+        }
+      }]
+    }]
+  }]
+}

--- a/test/config/integration/server_xds.rds.json
+++ b/test/config/integration/server_xds.rds.json
@@ -1,0 +1,15 @@
+{
+  "versionInfo": "0",
+  "resources": [{
+    "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+    "name": "route_config_0",
+    "virtual_hosts": [{
+      "name": "integration",
+      "domains": [ "*" ],
+      "routes": [{
+        "match": { "prefix": "/test/long/url" },
+        "route": { "cluster": "cluster_1" }
+      }]
+    }]
+  }]
+}

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -155,6 +155,8 @@ struct ApiFilesystemConfig {
   std::string bootstrap_path_;
   std::string cds_path_;
   std::string eds_path_;
+  std::string lds_path_;
+  std::string rds_path_;
 };
 
 /**

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -207,6 +207,13 @@ public:
   }
   void start(const Network::Address::IpVersion version);
   void start();
+
+  void waitForCounterGe(const std::string& name, uint64_t value) {
+    while (counter(name)->value() < value) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
   Stats::CounterSharedPtr counter(const std::string& name) {
     // When using the thread local store, only counters() is thread safe. This also allows us
     // to test if a counter exists at all versus just defaulting to zero.

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -20,6 +20,8 @@ public:
                             .bootstrap_path_ = "test/config/integration/server_xds.bootstrap.json",
                             .cds_path_ = "test/config/integration/server_xds.cds.json",
                             .eds_path_ = "test/config/integration/server_xds.eds.json",
+                            .lds_path_ = "test/config/integration/server_xds.lds.json",
+                            .rds_path_ = "test/config/integration/server_xds.rds.json",
                         },
                         {"http"});
   }


### PR DESCRIPTION
This PR provides an integration test demoing LDS/RDS/CDS/EDS. Along the way, needed to solve the
problem of plumbing in the new HTTP connection manager filter proto config, rather than the legacy
v1 JSON. The solution adopted in this PR is to use an Any field and the type_url to determine if
we're doing legacy config or v2 proto.