### PR TITLE
local info: workaround for protobuf string type mismatch.

### DIFF
--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -25,17 +25,17 @@ public:
   /**
    * Human readable zone name. E.g., "us-east-1a".
    */
-  virtual const std::string& zoneName() const PURE;
+  virtual const std::string zoneName() const PURE;
 
   /**
    * Human readable cluster name. E.g., "eta".
    */
-  virtual const std::string& clusterName() const PURE;
+  virtual const std::string clusterName() const PURE;
 
   /**
    * Human readable individual node name. E.g., "i-123456".
    */
-  virtual const std::string& nodeName() const PURE;
+  virtual const std::string nodeName() const PURE;
 
   /**
    * v2 API Node protobuf. This is the full node identity presented to management servers.

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -107,9 +107,7 @@ void ConnectionManagerUtility::mutateRequestHeaders(
     }
 
     if (!local_info.nodeName().empty()) {
-      // Following setReference() is safe because local info is constant for the life of the server.
-      request_headers.insertEnvoyDownstreamServiceNode().value().setReference(
-          local_info.nodeName());
+      request_headers.insertEnvoyDownstreamServiceNode().value(local_info.nodeName());
     }
   }
 

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -24,7 +24,8 @@ public:
     }
   }
 
-  // TODO: Revert https://github.com/lyft/envoy/pull/1500 once protobuf string types converge.
+  // TODO(PiotrSikora): Revert https://github.com/lyft/envoy/pull/1500 once protobuf string types
+  // converge.
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
   const std::string zoneName() const override { return node_.locality().zone(); }

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -25,9 +25,9 @@ public:
   }
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-  const std::string& zoneName() const override { return node_.locality().zone(); }
-  const std::string& clusterName() const override { return node_.cluster(); }
-  const std::string& nodeName() const override { return node_.id(); }
+  const std::string zoneName() const override { return node_.locality().zone(); }
+  const std::string clusterName() const override { return node_.cluster(); }
+  const std::string nodeName() const override { return node_.id(); }
   const envoy::api::v2::Node& node() const override { return node_; }
 
 private:

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -24,6 +24,8 @@ public:
     }
   }
 
+  // TODO: Revert https://github.com/lyft/envoy/pull/1500 once protobuf string types converge.
+
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
   const std::string zoneName() const override { return node_.locality().zone(); }
   const std::string clusterName() const override { return node_.cluster(); }

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -118,9 +118,7 @@ Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& head
           static_cast<Http::Code>(Http::Utility::getResponseStatus(headers)));
     }
 
-    // Following setReference() is safe because local info is constant for the life of the server.
-    headers.insertEnvoyUpstreamHealthCheckedCluster().value().setReference(
-        context_.localInfo().clusterName());
+    headers.insertEnvoyUpstreamHealthCheckedCluster().value(context_.localInfo().clusterName());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -27,6 +27,7 @@ using testing::NiceMock;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
+using testing::ReturnRefOfCopy;
 using testing::_;
 
 namespace Http {
@@ -40,7 +41,7 @@ public:
     message_->headers().insertMethod().value(std::string("GET"));
     message_->headers().insertHost().value(std::string("host"));
     message_->headers().insertPath().value(std::string("/"));
-    ON_CALL(*cm_.conn_pool_.host_, zone()).WillByDefault(ReturnRef(local_info_.zoneName()));
+    ON_CALL(*cm_.conn_pool_.host_, zone()).WillByDefault(ReturnRefOfCopy(local_info_.zoneName()));
   }
 
   void expectSuccess(uint64_t code) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -23,7 +23,6 @@ using testing::InSequence;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::_;
 
 namespace Http {
@@ -115,7 +114,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
-  EXPECT_CALL(local_info_, nodeName()).Times(2).WillRepeatedly(ReturnRef(canary_node_));
+  EXPECT_CALL(local_info_, nodeName()).Times(2).WillRepeatedly(Return(canary_node_));
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
                                                  route_config_, random_, runtime_, local_info_);
 
@@ -241,7 +240,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
-  EXPECT_CALL(local_info_, nodeName()).WillOnce(ReturnRef(empty_node_));
+  EXPECT_CALL(local_info_, nodeName()).WillOnce(Return(empty_node_));
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
                                                  route_config_, random_, runtime_, local_info_);
 

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -7,15 +7,16 @@
 
 namespace Envoy {
 using testing::Return;
+using testing::ReturnPointee;
 using testing::ReturnRef;
 
 namespace LocalInfo {
 
 MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("127.0.0.1")) {
   ON_CALL(*this, address()).WillByDefault(Return(address_));
-  ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(zone_name_));
-  ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
-  ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_name_));
+  ON_CALL(*this, zoneName()).WillByDefault(ReturnPointee(&zone_name_));
+  ON_CALL(*this, clusterName()).WillByDefault(ReturnPointee(&cluster_name_));
+  ON_CALL(*this, nodeName()).WillByDefault(ReturnPointee(&node_name_));
   ON_CALL(*this, node()).WillByDefault(ReturnRef(node_));
 }
 

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -15,9 +15,9 @@ public:
   ~MockLocalInfo();
 
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
-  MOCK_CONST_METHOD0(zoneName, std::string&());
-  MOCK_CONST_METHOD0(clusterName, std::string&());
-  MOCK_CONST_METHOD0(nodeName, std::string&());
+  MOCK_CONST_METHOD0(zoneName, const std::string());
+  MOCK_CONST_METHOD0(clusterName, const std::string());
+  MOCK_CONST_METHOD0(nodeName, const std::string());
   MOCK_CONST_METHOD0(node, envoy::api::v2::Node&());
 
   Network::Address::InstanceConstSharedPtr address_;

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -11,7 +11,6 @@
 using testing::InSequence;
 using testing::Invoke;
 using testing::Return;
-using testing::ReturnRefOfCopy;
 using testing::_;
 
 namespace Envoy {
@@ -118,7 +117,7 @@ TEST_F(LdsApiTest, BadLocalInfo) {
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
   envoy::api::v2::ConfigSource lds_config;
   Config::Utility::translateLdsConfig(*config, lds_config);
-  ON_CALL(local_info_, clusterName()).WillByDefault(ReturnRefOfCopy(std::string()));
+  ON_CALL(local_info_, clusterName()).WillByDefault(Return(std::string()));
   EXPECT_THROW_WITH_MESSAGE(LdsApi(lds_config, cluster_manager_, dispatcher_, random_, init_,
                                    local_info_, store_, listener_manager_),
                             EnvoyException,


### PR DESCRIPTION
This is helpful for Google import and shouldn't affect anybody else.