### PR TITLE
build: fix gperftools build on OS X

### DIFF
--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -11,7 +11,7 @@ cd gperftools-$VERSION
 if [[ `uname` == "Darwin" ]];
 then
   # enable ucontext(3) and syscall
-  export CPPFLAGS="-D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE"
+  export CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE"
 fi
 
 LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers --disable-libunwind

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -8,9 +8,9 @@ wget -O gperftools-$VERSION.tar.gz https://github.com/gperftools/gperftools/rele
 tar xf gperftools-$VERSION.tar.gz
 cd gperftools-$VERSION
 
+# TODO(zuercher): Remove this workaround for https://github.com/gperftools/gperftools/issues/910
 if [[ `uname` == "Darwin" ]];
 then
-  # enable ucontext(3) and syscall
   export CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE"
 fi
 

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -10,8 +10,8 @@ cd gperftools-$VERSION
 
 if [[ `uname` == "Darwin" ]];
 then
-  # enable ucontext(3)
-  export CPPFLAGS="-D_XOPEN_SOURCE=1"
+  # enable ucontext(3) and syscall
+  export CPPFLAGS="-D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE"
 fi
 
 LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers --disable-libunwind

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -7,5 +7,12 @@ VERSION=2.6.1
 wget -O gperftools-$VERSION.tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-$VERSION/gperftools-$VERSION.tar.gz
 tar xf gperftools-$VERSION.tar.gz
 cd gperftools-$VERSION
+
+if [[ `uname` == "Darwin" ]];
+then
+  # enable ucontext(3)
+  export CPPFLAGS="-D_XOPEN_SOURCE=1"
+fi
+
 LDFLAGS="-lpthread" ./configure --prefix=$THIRDPARTY_BUILD --enable-shared=no --enable-frame-pointers --disable-libunwind
 make V=1 install


### PR DESCRIPTION
gperftools-2.6.1 doesn't build on OS X without adding `-D_XOPEN_SOURCE=1` to enable some deprecated libc code.