### PR TITLE
build: circle-ci os x config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,40 @@
+version: 1
+machine:
+  xcode:
+    version: 8.3.3
+dependencies:
+  cache_directories:
+    # Cache homebrew and everything it installs.
+    - "/usr/local"
+  pre:
+    - brew ls --versions coreutils >/dev/null || brew install coreutils
+    - brew ls --versions wget >/dev/null || brew install wget
+    - brew ls --versions cmake >/dev/null || brew install cmake
+    - brew ls --versions libtool >/dev/null || brew install libtool
+    - brew ls --versions go >/dev/null || brew install go
+    - brew ls --versions bazel >/dev/null || brew install bazel
+    - |
+        if [ "${PULL_REQUEST}" = "true" -a -n "${PULL_REQUEST_REPO}" -a -n "${PULL_REQUEST_SHA}" ]; then
+          git remote add pr_repo "https://github.com/${PULL_REQUEST_REPO}.git"
+          git fetch pr_repo
+          git checkout -b ci-branch
+          git merge --no-edit "${PULL_REQUEST_SHA}"
+        fi
+compile:
+  override:
+    # set up bazelrc
+    - |
+        (echo "build --curses=no --show_task_finish" &&
+         echo "test --curses=no --show_task_finish") >~/.bazelrc
+
+    # bazel uses jgit internally and the default circle-ci .gitconfig says to
+    # convert https://github.com to ssh://git@github.com, which jgit does not support.
+    - mv ~/.gitconfig ~/.gitconfig_save
+    - bazel build --verbose_failures //source/...
+    - bazel build --verbose_failures //test/...
+test:
+  override:
+    - bazel test --test_output=all //test/...
+notify:
+  webhooks:
+    - url: "https://webhooks.turbinelabs.net/v1/build/webhook"


### PR DESCRIPTION
Circle CI configuration for a Mac OS X CI environment. Once this is on master, we can configure a webhook to trigger this build in my employer's Circle CI account and through the magic of some glue code should be a status check for Mac OS build/test. GitHub should automatically default to _not_ blocking merges based on this check, which is the desired configuration.

The shell code in the config that deals with PULL_REQUEST et al configures a remote in the build environment's git repository in order to fetch the git SHA referenced by the pull request and merge it into our fork's master. Our fork's master is kept in sync with lyft/envoy:master.