### PR TITLE
Improves error handling for gRPC-Web.

### DIFF
--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -90,7 +90,7 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
   const std::string decoded = Base64::decode(
       std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
                   decoding_buffer_.length()));
-  if (decoded == EMPTY_STRING) {
+  if (decoded.empty()) {
     // Error happened when decoding base64.
     Http::Utility::sendLocalReply(*decoder_callbacks_, stream_destroyed_, Http::Code::BadRequest,
                                   "Bad gRPC-web request, invalid base64 data.");

--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -3,10 +3,12 @@
 #include <arpa/inet.h>
 
 #include "common/common/base64.h"
+#include "common/common/empty_string.h"
 #include "common/common/utility.h"
 #include "common/grpc/common.h"
 #include "common/http/filter_utility.h"
 #include "common/http/headers.h"
+#include "common/http/utility.h"
 
 #include "spdlog/spdlog.h"
 
@@ -39,7 +41,8 @@ bool GrpcWebFilter::isGrpcWebRequest(const Http::HeaderMap& headers) {
 Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (!isGrpcWebRequest(headers)) {
-    // TODO(fengli): Return error response.
+    Http::Utility::sendLocalReply(*decoder_callbacks_, stream_destroyed_,
+                                  Http::Code::UnsupportedMediaType, EMPTY_STRING);
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -87,6 +90,13 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
   const std::string decoded = Base64::decode(
       std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
                   decoding_buffer_.length()));
+  if (decoded == EMPTY_STRING) {
+    // Error happened when decoding base64.
+    Http::Utility::sendLocalReply(*decoder_callbacks_, stream_destroyed_, Http::Code::BadRequest,
+                                  "Bad gRPC-web request, invalid base64 data.");
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
   decoding_buffer_.drain(decoding_buffer_.length());
   decoding_buffer_.move(data);
   data.add(decoded);

--- a/source/common/grpc/grpc_web_filter.h
+++ b/source/common/grpc/grpc_web_filter.h
@@ -21,7 +21,7 @@ public:
   virtual ~GrpcWebFilter(){};
 
   // Http::StreamFilterBase
-  void onDestroy() override{};
+  void onDestroy() override { stream_destroyed_ = true; };
 
   // Implements StreamDecoderFilter.
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override;
@@ -62,6 +62,7 @@ private:
   std::string grpc_service_;
   std::string grpc_method_;
   bool do_stat_tracking_{};
+  bool stream_destroyed_{};
 };
 
 } // namespace Grpc

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -1,6 +1,10 @@
+#include "envoy/http/filter.h"
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/base64.h"
+#include "common/common/utility.h"
 #include "common/grpc/grpc_web_filter.h"
+#include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 
@@ -28,6 +32,8 @@ const char TEXT_MESSAGE[] = "\x00\x00\x00\x00\x12grpc-web-text-data";
 const size_t TEXT_MESSAGE_SIZE = sizeof(TEXT_MESSAGE) - 1;
 const char B64_MESSAGE[] = "AAAAABJncnBjLXdlYi10ZXh0LWRhdGE=";
 const size_t B64_MESSAGE_SIZE = sizeof(B64_MESSAGE) - 1;
+const char INVALID_B64_MESSAGE[] = "****";
+const size_t INVALID_B64_MESSAGE_SIZE = 4;
 const char TRAILERS[] = "\x80\x00\x00\x00\x20grpc-status:0\r\ngrpc-message:ok\r\n";
 const size_t TRAILERS_SIZE = sizeof(TRAILERS) - 1;
 } // namespace
@@ -91,14 +97,54 @@ TEST_F(GrpcWebFilterTest, SupportedContentTypes) {
 TEST_F(GrpcWebFilterTest, UnsupportedContentType) {
   Http::TestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::Headers::get().ContentType, "unsupported");
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
+        uint64_t code;
+        StringUtil::atoul(headers.Status()->value().c_str(), code);
+        EXPECT_EQ(static_cast<uint64_t>(Http::Code::UnsupportedMediaType), code);
+      }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
 }
 
 TEST_F(GrpcWebFilterTest, NoContentType) {
   Http::TestHeaderMapImpl request_headers;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
+        uint64_t code;
+        StringUtil::atoul(headers.Status()->value().c_str(), code);
+        EXPECT_EQ(static_cast<uint64_t>(Http::Code::UnsupportedMediaType), code);
+      }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
+}
+
+TEST_F(GrpcWebFilterTest, InvalidBase64) {
+  Http::TestHeaderMapImpl request_headers;
+  request_headers.addCopy(Http::Headers::get().ContentType,
+                          Http::Headers::get().ContentTypeValues.GrpcWebText);
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
+        uint64_t code;
+        StringUtil::atoul(headers.Status()->value().c_str(), code);
+        EXPECT_EQ(static_cast<uint64_t>(Http::Code::BadRequest), code);
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, _))
+      .WillOnce(Invoke([](Buffer::Instance& data, bool) {
+        EXPECT_EQ("Bad gRPC-web request, invalid base64 data.", TestUtility::bufferToString(data));
+      }));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
+            request_headers.ContentType()->value().c_str());
+  EXPECT_EQ(Http::Headers::get().TEValues.Trailers, request_headers.TE()->value().c_str());
+  EXPECT_EQ(Http::Headers::get().GrpcAcceptEncodingValues.Default,
+            request_headers.GrpcAcceptEncoding()->value().c_str());
+
+  Buffer::OwnedImpl request_buffer;
+  Buffer::OwnedImpl decoded_buffer;
+  request_buffer.add(&INVALID_B64_MESSAGE, INVALID_B64_MESSAGE_SIZE);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_.decodeData(request_buffer, true));
 }
 
 TEST_P(GrpcWebFilterTest, StatsNoCluster) {

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -33,7 +33,7 @@ const size_t TEXT_MESSAGE_SIZE = sizeof(TEXT_MESSAGE) - 1;
 const char B64_MESSAGE[] = "AAAAABJncnBjLXdlYi10ZXh0LWRhdGE=";
 const size_t B64_MESSAGE_SIZE = sizeof(B64_MESSAGE) - 1;
 const char INVALID_B64_MESSAGE[] = "****";
-const size_t INVALID_B64_MESSAGE_SIZE = 4;
+const size_t INVALID_B64_MESSAGE_SIZE = sizeof(INVALID_B64_MESSAGE) - 1;
 const char TRAILERS[] = "\x80\x00\x00\x00\x20grpc-status:0\r\ngrpc-message:ok\r\n";
 const size_t TRAILERS_SIZE = sizeof(TRAILERS) - 1;
 } // namespace


### PR DESCRIPTION
Improves error handling for gRPC-web.
1. returns HTTP 415 if the requested content-type is not supported.
2. returns HTTP 400 if the request data contains invalid base64 chars when text format is in use.