### PR TITLE
Added request and response times to RequestInfo (#1464)

### DIFF
--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -66,6 +66,28 @@ public:
   virtual SystemTime startTime() const PURE;
 
   /**
+   * @return the time that the entire request was received from the downstream client.  Note: if
+   * unset, will return unix epoch.
+   */
+  virtual SystemTime requestReceivedTime() const PURE;
+
+  /**
+   * Set the time that the entire request was received from the downstream client.
+   */
+  virtual void requestReceivedTime(SystemTime time) PURE;
+
+  /**
+   * @return the time that the entire response was received from the upstream host.  Note: if unset,
+   * will return unix epoch.
+   */
+  virtual SystemTime responseReceivedTime() const PURE;
+
+  /**
+   * Set the time that the entire response was received from the upstream host.
+   */
+  virtual void responseReceivedTime(SystemTime time) PURE;
+
+  /**
    * @return the # of body bytes received in the request.
    */
   virtual uint64_t bytesReceived() const PURE;

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -67,9 +67,9 @@ public:
 
   /**
    * @return duration from request start to when the entire request was received from the
-   * downstream client.  Note: if unset, will return an empty optional.
+   * downstream client.  Note: if unset, will return 0 mircoseconds.
    */
-  virtual const Optional<std::chrono::milliseconds>& requestReceivedDuration() const PURE;
+  virtual std::chrono::microseconds requestReceivedDuration() const PURE;
 
   /**
    * Set the duration from request start to when the entire request was received from the
@@ -80,9 +80,9 @@ public:
 
   /**
    * @return the duration from request start to when the entire response was received from the
-   * upstream host.  Note: if unset, will return an empty optional.
+   * upstream host.  Note: if unset, will return 0 microseconds.
    */
-  virtual const Optional<std::chrono::milliseconds>& responseReceivedDuration() const PURE;
+  virtual std::chrono::microseconds responseReceivedDuration() const PURE;
 
   /**
    * Set the duration from request start to when the entire response was received from the
@@ -117,9 +117,9 @@ public:
   virtual uint64_t bytesSent() const PURE;
 
   /**
-   * @return the milliseconds duration of the first byte received to the last byte sent.
+   * @return the microseconds duration of the first byte received to the last byte sent.
    */
-  virtual std::chrono::milliseconds duration() const PURE;
+  virtual std::chrono::microseconds duration() const PURE;
 
   /**
    * @return whether response flag is set or not.

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -66,26 +66,30 @@ public:
   virtual SystemTime startTime() const PURE;
 
   /**
-   * @return the time that the entire request was received from the downstream client.  Note: if
-   * unset, will return unix epoch.
+   * @return duration from request start to when the entire request was received from the
+   * downstream client.  Note: if unset, will return an empty optional.
    */
-  virtual SystemTime requestReceivedTime() const PURE;
+  virtual const Optional<std::chrono::milliseconds>& requestReceivedDuration() const PURE;
 
   /**
-   * Set the time that the entire request was received from the downstream client.
+   * Set the duration from request start to when the entire request was received from the
+   * downstream client.
+   * @param time monotonic clock time when the response was received.
    */
-  virtual void requestReceivedTime(SystemTime time) PURE;
+  virtual void requestReceivedDuration(MonotonicTime time) PURE;
 
   /**
-   * @return the time that the entire response was received from the upstream host.  Note: if unset,
-   * will return unix epoch.
+   * @return the duration from request start to when the entire response was received from the
+   * upstream host.  Note: if unset, will return an empty optional.
    */
-  virtual SystemTime responseReceivedTime() const PURE;
+  virtual const Optional<std::chrono::milliseconds>& responseReceivedDuration() const PURE;
 
   /**
-   * Set the time that the entire response was received from the upstream host.
+   * Set the duration from request start to when the entire response was received from the
+   * upstream host.
+   * @param time monotonic clock time when the response was received.
    */
-  virtual void responseReceivedTime(SystemTime time) PURE;
+  virtual void responseReceivedDuration(MonotonicTime time) PURE;
 
   /**
    * @return the # of body bytes received in the request.

--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -67,7 +67,7 @@ public:
 
   /**
    * @return duration from request start to when the entire request was received from the
-   * downstream client.  Note: if unset, will return 0 mircoseconds.
+   * downstream client in microseconds. Note: if unset, will return 0 microseconds.
    */
   virtual std::chrono::microseconds requestReceivedDuration() const PURE;
 
@@ -80,7 +80,7 @@ public:
 
   /**
    * @return the duration from request start to when the entire response was received from the
-   * upstream host.  Note: if unset, will return 0 microseconds.
+   * upstream host in microseconds. Note: if unset, will return 0 microseconds.
    */
   virtual std::chrono::microseconds responseReceivedDuration() const PURE;
 

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -231,13 +231,17 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     field_extractor_ = [](const RequestInfo& request_info) {
       return AccessLogDateTimeFormatter::fromTime(request_info.startTime());
     };
-  } else if (field_name == "REQUEST_TIME") {
+  } else if (field_name == "REQUEST_DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return AccessLogDateTimeFormatter::fromTime(request_info.requestReceivedTime());
+      return request_info.requestReceivedDuration().valid()
+                 ? std::to_string(request_info.requestReceivedDuration().value().count())
+                 : "0";
     };
-  } else if (field_name == "RESPONSE_TIME") {
+  } else if (field_name == "RESPONSE_DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return AccessLogDateTimeFormatter::fromTime(request_info.responseReceivedTime());
+      return request_info.responseReceivedDuration().valid()
+                 ? std::to_string(request_info.responseReceivedDuration().value().count())
+                 : "0";
     };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const RequestInfo& request_info) {

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -233,15 +233,15 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "REQUEST_DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return request_info.requestReceivedDuration().valid()
-                 ? std::to_string(request_info.requestReceivedDuration().value().count())
-                 : "0";
+      return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                request_info.requestReceivedDuration())
+                                .count());
     };
   } else if (field_name == "RESPONSE_DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return request_info.responseReceivedDuration().valid()
-                 ? std::to_string(request_info.responseReceivedDuration().value().count())
-                 : "0";
+      return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                request_info.responseReceivedDuration())
+                                .count());
     };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const RequestInfo& request_info) {
@@ -263,7 +263,8 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return std::to_string(request_info.duration().count());
+      return std::to_string(
+          std::chrono::duration_cast<std::chrono::milliseconds>(request_info.duration()).count());
     };
   } else if (field_name == "RESPONSE_FLAGS") {
     field_extractor_ = [](const RequestInfo& request_info) {

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -231,6 +231,14 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     field_extractor_ = [](const RequestInfo& request_info) {
       return AccessLogDateTimeFormatter::fromTime(request_info.startTime());
     };
+  } else if (field_name == "REQUEST_TIME") {
+    field_extractor_ = [](const RequestInfo& request_info) {
+      return AccessLogDateTimeFormatter::fromTime(request_info.requestReceivedTime());
+    };
+  } else if (field_name == "RESPONSE_TIME") {
+    field_extractor_ = [](const RequestInfo& request_info) {
+      return AccessLogDateTimeFormatter::fromTime(request_info.responseReceivedTime());
+    };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const RequestInfo& request_info) {
       return std::to_string(request_info.bytesReceived());

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -17,20 +17,20 @@ struct RequestInfoImpl : public RequestInfo {
   // Http::AccessLog::RequestInfo
   SystemTime startTime() const override { return start_time_; }
 
-  const Optional<std::chrono::milliseconds>& requestReceivedDuration() const override {
+  std::chrono::microseconds requestReceivedDuration() const override {
     return request_received_duration_;
   }
   void requestReceivedDuration(MonotonicTime time) override {
     request_received_duration_ =
-        std::chrono::duration_cast<std::chrono::milliseconds>(time - start_time_monotonic_);
+        std::chrono::duration_cast<std::chrono::microseconds>(time - start_time_monotonic_);
   }
 
-  const Optional<std::chrono::milliseconds>& responseReceivedDuration() const override {
+  std::chrono::microseconds responseReceivedDuration() const override {
     return request_received_duration_;
   }
   void responseReceivedDuration(MonotonicTime time) override {
     request_received_duration_ =
-        std::chrono::duration_cast<std::chrono::milliseconds>(time - start_time_monotonic_);
+        std::chrono::duration_cast<std::chrono::microseconds>(time - start_time_monotonic_);
   }
 
   uint64_t bytesReceived() const override { return bytes_received_; }
@@ -42,9 +42,9 @@ struct RequestInfoImpl : public RequestInfo {
 
   uint64_t bytesSent() const override { return bytes_sent_; }
 
-  std::chrono::milliseconds duration() const override {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() -
-                                                                 start_time_);
+  std::chrono::microseconds duration() const override {
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() -
+                                                                 start_time_monotonic_);
   }
 
   void setResponseFlag(Http::AccessLog::ResponseFlag response_flag) override {
@@ -66,8 +66,8 @@ struct RequestInfoImpl : public RequestInfo {
   Protocol protocol_;
   const SystemTime start_time_;
   const MonotonicTime start_time_monotonic_;
-  Optional<std::chrono::milliseconds> request_received_duration_;
-  Optional<std::chrono::milliseconds> response_received_duration_;
+  std::chrono::microseconds request_received_duration_{};
+  std::chrono::microseconds response_received_duration_{};
   uint64_t bytes_received_{};
   Optional<uint32_t> response_code_;
   uint64_t bytes_sent_{};

--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -16,6 +16,12 @@ struct RequestInfoImpl : public RequestInfo {
   // Http::AccessLog::RequestInfo
   SystemTime startTime() const override { return start_time_; }
 
+  SystemTime requestReceivedTime() const override { return request_received_time_; }
+  void requestReceivedTime(SystemTime time) override { request_received_time_ = time; }
+
+  SystemTime responseReceivedTime() const override { return response_received_time_; }
+  void responseReceivedTime(SystemTime time) override { response_received_time_ = time; }
+
   uint64_t bytesReceived() const override { return bytes_received_; }
 
   Protocol protocol() const override { return protocol_; }
@@ -48,6 +54,8 @@ struct RequestInfoImpl : public RequestInfo {
 
   Protocol protocol_;
   const SystemTime start_time_;
+  SystemTime request_received_time_{};
+  SystemTime response_received_time_{};
   uint64_t bytes_received_{};
   Optional<uint32_t> response_code_;
   uint64_t bytes_sent_{};

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -334,7 +334,7 @@ void Filter::maybeDoShadowing() {
 void Filter::onRequestComplete() {
   downstream_end_stream_ = true;
   downstream_request_complete_time_ = std::chrono::steady_clock::now();
-  callbacks_->requestInfo().requestReceivedTime(std::chrono::system_clock::now());
+  callbacks_->requestInfo().requestReceivedDuration(downstream_request_complete_time_);
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
@@ -472,10 +472,11 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   // Only send upstream service time if we received the complete request and this is not a
   // premature response.
   if (DateUtil::timePointValid(downstream_request_complete_time_)) {
+    MonotonicTime response_received_time = std::chrono::steady_clock::now();
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - downstream_request_complete_time_);
+        response_received_time - downstream_request_complete_time_);
     headers->insertEnvoyUpstreamServiceTime().value(ms.count());
-    callbacks_->requestInfo().responseReceivedTime(std::chrono::system_clock::now());
+    callbacks_->requestInfo().responseReceivedDuration(response_received_time);
   }
 
   upstream_request_->upstream_canary_ =

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -334,6 +334,7 @@ void Filter::maybeDoShadowing() {
 void Filter::onRequestComplete() {
   downstream_end_stream_ = true;
   downstream_request_complete_time_ = std::chrono::steady_clock::now();
+  callbacks_->requestInfo().requestReceivedTime(std::chrono::system_clock::now());
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
@@ -474,6 +475,7 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - downstream_request_complete_time_);
     headers->insertEnvoyUpstreamServiceTime().value(ms.count());
+    callbacks_->requestInfo().responseReceivedTime(std::chrono::system_clock::now());
   }
 
   upstream_request_->upstream_canary_ =

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -93,6 +93,22 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
+    RequestInfoFormatter start_time_format("REQUEST_TIME");
+    SystemTime time;
+    EXPECT_CALL(request_info, requestReceivedTime()).WillOnce(Return(time));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              start_time_format.format(header, header, request_info));
+  }
+
+  {
+    RequestInfoFormatter start_time_format("RESPONSE_TIME");
+    SystemTime time;
+    EXPECT_CALL(request_info, responseReceivedTime()).WillOnce(Return(time));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              start_time_format.format(header, header, request_info));
+  }
+
+  {
     RequestInfoFormatter bytes_received_format("BYTES_RECEIVED");
     EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(1));
     EXPECT_EQ("1", bytes_received_format.format(header, header, request_info));

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -93,19 +93,17 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
-    RequestInfoFormatter start_time_format("REQUEST_TIME");
-    SystemTime time;
-    EXPECT_CALL(request_info, requestReceivedTime()).WillOnce(Return(time));
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
-              start_time_format.format(header, header, request_info));
+    RequestInfoFormatter request_duration_format("REQUEST_DURATION");
+    Optional<std::chrono::milliseconds> duration{std::chrono::milliseconds(5)};
+    EXPECT_CALL(request_info, requestReceivedDuration()).WillRepeatedly(ReturnRef(duration));
+    EXPECT_EQ("5", request_duration_format.format(header, header, request_info));
   }
 
   {
-    RequestInfoFormatter start_time_format("RESPONSE_TIME");
-    SystemTime time;
-    EXPECT_CALL(request_info, responseReceivedTime()).WillOnce(Return(time));
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
-              start_time_format.format(header, header, request_info));
+    RequestInfoFormatter response_duration_format("RESPONSE_DURATION");
+    Optional<std::chrono::milliseconds> duration{std::chrono::milliseconds(10)};
+    EXPECT_CALL(request_info, responseReceivedDuration()).WillRepeatedly(ReturnRef(duration));
+    EXPECT_EQ("10", response_duration_format.format(header, header, request_info));
   }
 
   {

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -94,15 +94,15 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter request_duration_format("REQUEST_DURATION");
-    Optional<std::chrono::milliseconds> duration{std::chrono::milliseconds(5)};
-    EXPECT_CALL(request_info, requestReceivedDuration()).WillRepeatedly(ReturnRef(duration));
+    std::chrono::microseconds duration{5000};
+    EXPECT_CALL(request_info, requestReceivedDuration()).WillOnce(Return(duration));
     EXPECT_EQ("5", request_duration_format.format(header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_duration_format("RESPONSE_DURATION");
-    Optional<std::chrono::milliseconds> duration{std::chrono::milliseconds(10)};
-    EXPECT_CALL(request_info, responseReceivedDuration()).WillRepeatedly(ReturnRef(duration));
+    std::chrono::microseconds duration{10000};
+    EXPECT_CALL(request_info, responseReceivedDuration()).WillRepeatedly(Return(duration));
     EXPECT_EQ("10", response_duration_format.format(header, header, request_info));
   }
 
@@ -140,7 +140,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter duration_format("DURATION");
-    std::chrono::milliseconds time{2};
+    std::chrono::microseconds time{2000};
     EXPECT_CALL(request_info, duration()).WillOnce(Return(time));
     EXPECT_EQ("2", duration_format.format(header, header, request_info));
   }

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -56,6 +56,10 @@ public:
   }
 
   SystemTime startTime() const override { return start_time_; }
+  SystemTime requestReceivedTime() const override { return request_received_time_; }
+  void requestReceivedTime(SystemTime time) override { request_received_time_ = time; }
+  SystemTime responseReceivedTime() const override { return response_received_time_; }
+  void responseReceivedTime(SystemTime time) override { response_received_time_ = time; }
   uint64_t bytesReceived() const override { return 1; }
   Protocol protocol() const override { return protocol_; }
   void protocol(Protocol protocol) override { protocol_ = protocol; }
@@ -76,6 +80,8 @@ public:
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
   SystemTime start_time_;
+  SystemTime request_received_time_{};
+  SystemTime response_received_time_{};
   Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;
   uint64_t response_flags_{};

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -56,10 +56,14 @@ public:
   }
 
   SystemTime startTime() const override { return start_time_; }
-  SystemTime requestReceivedTime() const override { return request_received_time_; }
-  void requestReceivedTime(SystemTime time) override { request_received_time_ = time; }
-  SystemTime responseReceivedTime() const override { return response_received_time_; }
-  void responseReceivedTime(SystemTime time) override { response_received_time_ = time; }
+  const Optional<std::chrono::milliseconds>& requestReceivedDuration() const override {
+    return request_received_duration_;
+  }
+  void requestReceivedDuration(MonotonicTime time) override { UNREFERENCED_PARAMETER(time); }
+  const Optional<std::chrono::milliseconds>& responseReceivedDuration() const override {
+    return request_received_duration_;
+  }
+  void responseReceivedDuration(MonotonicTime time) override { UNREFERENCED_PARAMETER(time); }
   uint64_t bytesReceived() const override { return 1; }
   Protocol protocol() const override { return protocol_; }
   void protocol(Protocol protocol) override { protocol_ = protocol; }
@@ -80,8 +84,8 @@ public:
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
   SystemTime start_time_;
-  SystemTime request_received_time_{};
-  SystemTime response_received_time_{};
+  Optional<std::chrono::milliseconds> request_received_duration_{std::chrono::milliseconds(4)};
+  Optional<std::chrono::milliseconds> response_received_duration_{std::chrono::milliseconds(5)};
   Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;
   uint64_t response_flags_{};

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -56,11 +56,11 @@ public:
   }
 
   SystemTime startTime() const override { return start_time_; }
-  const Optional<std::chrono::milliseconds>& requestReceivedDuration() const override {
+  std::chrono::microseconds requestReceivedDuration() const override {
     return request_received_duration_;
   }
   void requestReceivedDuration(MonotonicTime time) override { UNREFERENCED_PARAMETER(time); }
-  const Optional<std::chrono::milliseconds>& responseReceivedDuration() const override {
+  std::chrono::microseconds responseReceivedDuration() const override {
     return request_received_duration_;
   }
   void responseReceivedDuration(MonotonicTime time) override { UNREFERENCED_PARAMETER(time); }
@@ -69,8 +69,8 @@ public:
   void protocol(Protocol protocol) override { protocol_ = protocol; }
   const Optional<uint32_t>& responseCode() const override { return response_code_; }
   uint64_t bytesSent() const override { return 2; }
-  std::chrono::milliseconds duration() const override {
-    return std::chrono::milliseconds(duration_);
+  std::chrono::microseconds duration() const override {
+    return std::chrono::microseconds(duration_);
   }
   bool getResponseFlag(ResponseFlag response_flag) const override {
     return response_flags_ & response_flag;
@@ -84,12 +84,12 @@ public:
   void healthCheck(bool is_hc) override { hc_request_ = is_hc; }
 
   SystemTime start_time_;
-  Optional<std::chrono::milliseconds> request_received_duration_{std::chrono::milliseconds(4)};
-  Optional<std::chrono::milliseconds> response_received_duration_{std::chrono::milliseconds(5)};
+  std::chrono::microseconds request_received_duration_{1000};
+  std::chrono::microseconds response_received_duration_{2000};
   Protocol protocol_{Protocol::Http11};
   Optional<uint32_t> response_code_;
   uint64_t response_flags_{};
-  uint64_t duration_{3};
+  uint64_t duration_{3000};
   Upstream::HostDescriptionConstSharedPtr upstream_host_{};
   bool hc_request_{};
 };

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -173,8 +173,8 @@ MockInstance::~MockInstance() {}
 MockRequestInfo::MockRequestInfo() {
   ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_));
   ON_CALL(*this, startTime()).WillByDefault(Return(start_time_));
-  ON_CALL(*this, requestReceivedTime()).WillByDefault(Return(request_received_time_));
-  ON_CALL(*this, responseReceivedTime()).WillByDefault(Return(response_received_time_));
+  ON_CALL(*this, requestReceivedDuration()).WillByDefault(ReturnRef(request_received_duration_));
+  ON_CALL(*this, responseReceivedDuration()).WillByDefault(ReturnRef(response_received_duration_));
 }
 
 MockRequestInfo::~MockRequestInfo() {}

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -173,6 +173,8 @@ MockInstance::~MockInstance() {}
 MockRequestInfo::MockRequestInfo() {
   ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_));
   ON_CALL(*this, startTime()).WillByDefault(Return(start_time_));
+  ON_CALL(*this, requestReceivedTime()).WillByDefault(Return(request_received_time_));
+  ON_CALL(*this, responseReceivedTime()).WillByDefault(Return(response_received_time_));
 }
 
 MockRequestInfo::~MockRequestInfo() {}

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -173,8 +173,8 @@ MockInstance::~MockInstance() {}
 MockRequestInfo::MockRequestInfo() {
   ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_));
   ON_CALL(*this, startTime()).WillByDefault(Return(start_time_));
-  ON_CALL(*this, requestReceivedDuration()).WillByDefault(ReturnRef(request_received_duration_));
-  ON_CALL(*this, responseReceivedDuration()).WillByDefault(ReturnRef(response_received_duration_));
+  ON_CALL(*this, requestReceivedDuration()).WillByDefault(Return(request_received_duration_));
+  ON_CALL(*this, responseReceivedDuration()).WillByDefault(Return(response_received_duration_));
 }
 
 MockRequestInfo::~MockRequestInfo() {}

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -48,10 +48,10 @@ public:
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
-  MOCK_CONST_METHOD0(requestReceivedTime, SystemTime());
-  MOCK_METHOD1(requestReceivedTime, void(SystemTime time));
-  MOCK_CONST_METHOD0(responseReceivedTime, SystemTime());
-  MOCK_METHOD1(responseReceivedTime, void(SystemTime time));
+  MOCK_CONST_METHOD0(requestReceivedDuration, Optional<std::chrono::milliseconds>&());
+  MOCK_METHOD1(requestReceivedDuration, void(MonotonicTime time));
+  MOCK_CONST_METHOD0(responseReceivedDuration, Optional<std::chrono::milliseconds>&());
+  MOCK_METHOD1(responseReceivedDuration, void(MonotonicTime time));
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
   MOCK_CONST_METHOD0(protocol, Protocol());
   MOCK_METHOD1(protocol, void(Protocol protocol));
@@ -66,8 +66,8 @@ public:
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
   SystemTime start_time_;
-  SystemTime request_received_time_{};
-  SystemTime response_received_time_{};
+  Optional<std::chrono::milliseconds> request_received_duration_;
+  Optional<std::chrono::milliseconds> response_received_duration_;
 };
 
 } // namespace AccessLog

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -48,6 +48,10 @@ public:
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
+  MOCK_CONST_METHOD0(requestReceivedTime, SystemTime());
+  MOCK_METHOD1(requestReceivedTime, void(SystemTime time));
+  MOCK_CONST_METHOD0(responseReceivedTime, SystemTime());
+  MOCK_METHOD1(responseReceivedTime, void(SystemTime time));
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
   MOCK_CONST_METHOD0(protocol, Protocol());
   MOCK_METHOD1(protocol, void(Protocol protocol));
@@ -62,6 +66,8 @@ public:
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
   SystemTime start_time_;
+  SystemTime request_received_time_{};
+  SystemTime response_received_time_{};
 };
 
 } // namespace AccessLog

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -48,16 +48,16 @@ public:
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
-  MOCK_CONST_METHOD0(requestReceivedDuration, Optional<std::chrono::milliseconds>&());
+  MOCK_CONST_METHOD0(requestReceivedDuration, std::chrono::microseconds());
   MOCK_METHOD1(requestReceivedDuration, void(MonotonicTime time));
-  MOCK_CONST_METHOD0(responseReceivedDuration, Optional<std::chrono::milliseconds>&());
+  MOCK_CONST_METHOD0(responseReceivedDuration, std::chrono::microseconds());
   MOCK_METHOD1(responseReceivedDuration, void(MonotonicTime time));
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
   MOCK_CONST_METHOD0(protocol, Protocol());
   MOCK_METHOD1(protocol, void(Protocol protocol));
   MOCK_CONST_METHOD0(responseCode, Optional<uint32_t>&());
   MOCK_CONST_METHOD0(bytesSent, uint64_t());
-  MOCK_CONST_METHOD0(duration, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(duration, std::chrono::microseconds());
   MOCK_CONST_METHOD1(getResponseFlag, bool(Http::AccessLog::ResponseFlag));
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
@@ -66,8 +66,8 @@ public:
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
   SystemTime start_time_;
-  Optional<std::chrono::milliseconds> request_received_duration_;
-  Optional<std::chrono::milliseconds> response_received_duration_;
+  std::chrono::microseconds request_received_duration_;
+  std::chrono::microseconds response_received_duration_;
 };
 
 } // namespace AccessLog


### PR DESCRIPTION
This is a relatively straightforward addition to RequestInfo to add two new times:
- `requestReceivedTime` - the start point for `x-envoy-upstream-time`
- `responseReceivedTime` - the end point for `x-envoy-upstream-time`

However, this is not ready to be merged because of the way these two new timestamps are being set in the router.  `x-envoy-upstream-time` is only a duration, so it is measured using the `steady_clock`, which is monotonic, but not wall-clock time.  This means to get absolute times for the new timestamps, we need to measure the `system_clock` time at the same points where we're measuring the `steady_clock` time currently.  I just wanted to see what people thought about the following options:
- Measure the `x-envoy-upstream-time` using the `system_clock`.  This could create problems if the system clock goes backwards, or if we're expecting more accuracy from this measurement.
- Measure the new times as durations from when the `startTime` was measured.  This would require an additional `steady_clock` time to be recorded when the normal `startTime` is measured.
- What is currently in the PR: make two measurements (`steady_clock` and `system_clock`) at the beginning and end of `x-envoy-upstream-time`.