### PR TITLE
mac ci: clean up branch/repo before build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     - |
         if [ "${PULL_REQUEST}" = "true" -a -n "${PULL_REQUEST_REPO}" -a -n "${PULL_REQUEST_SHA}" ]; then
           git branch -D ci-branch || true
-          git remove remove pr_repo || true
+          git remote remove pr_repo || true
           git remote add pr_repo "https://github.com/${PULL_REQUEST_REPO}.git"
           git fetch pr_repo
           git checkout -b ci-branch

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,8 @@ dependencies:
     - brew ls --versions bazel >/dev/null || brew install bazel
     - |
         if [ "${PULL_REQUEST}" = "true" -a -n "${PULL_REQUEST_REPO}" -a -n "${PULL_REQUEST_SHA}" ]; then
+          git branch -D ci-branch || true
+          git remove remove pr_repo || true
           git remote add pr_repo "https://github.com/${PULL_REQUEST_REPO}.git"
           git fetch pr_repo
           git checkout -b ci-branch


### PR DESCRIPTION
For some reason I thought the results of these git commands would not be cached by Circle, but they are. Do some pre-cleanup (since there's no obvious way to cleanup at the end of a failed build).