### PR TITLE
Changed proto to json conversion to preserve proto field names

### DIFF
--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -63,7 +63,8 @@ public:
   void createRequest(Http::Message& request) override {
     ENVOY_LOG(debug, "Sending REST request for {}", path_);
     stats_.update_attempt_.inc();
-    Protobuf::util::JsonOptions json_options;
+    Protobuf::util::JsonPrintOptions json_options;
+    json_options.preserve_proto_field_names = true;
     ProtobufTypes::String request_json;
     const auto status = Protobuf::util::MessageToJsonString(request_, &request_json, json_options);
     // If the status isn't OK, we just send an empty body.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -32,6 +32,9 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
 
 Json::ObjectSharedPtr WktUtil::getJsonObjectFromStruct(const Protobuf::Struct& message) {
   Protobuf::util::JsonPrintOptions json_options;
+  // By default, proto field names are converted to camelCase when the message is converted to JSON.
+  // Setting this option makes debugging easier because it keeps field names consistent in JSON
+  // printouts.
   json_options.preserve_proto_field_names = true;
   ProtobufTypes::String json;
   const auto status = Protobuf::util::MessageToJsonString(message, &json, json_options);

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -31,7 +31,8 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
 }
 
 Json::ObjectSharedPtr WktUtil::getJsonObjectFromStruct(const Protobuf::Struct& message) {
-  Protobuf::util::JsonOptions json_options;
+  Protobuf::util::JsonPrintOptions json_options;
+  json_options.preserve_proto_field_names = true;
   ProtobufTypes::String json;
   const auto status = Protobuf::util::MessageToJsonString(message, &json, json_options);
   // This should always succeed unless something crash-worthy such as out-of-memory.

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -96,7 +96,7 @@ public:
     std::string response_json = "{\"version_info\":\"" + version + "\",\"resources\":[";
     for (const auto& cluster : cluster_names) {
       response_json += "{\"@type\":\"type.googleapis.com/"
-                       "envoy.api.v2.ClusterLoadAssignment\",\"clusterName\":\"" +
+                       "envoy.api.v2.ClusterLoadAssignment\",\"cluster_name\":\"" +
                        cluster + "\"},";
     }
     response_json.pop_back();

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -64,12 +64,12 @@ public:
                     std::string(request->headers().Path()->value().c_str()));
           std::string expected_request = "{";
           if (!version_.empty()) {
-            expected_request += "\"versionInfo\":\"" + version + "\",";
+            expected_request += "\"version_info\":\"" + version + "\",";
           }
           expected_request += "\"node\":{\"id\":\"fo0\"},";
           if (!cluster_names.empty()) {
             expected_request +=
-                "\"resourceNames\":[\"" + StringUtil::join(cluster_names, "\",\"") + "\"]";
+                "\"resource_names\":[\"" + StringUtil::join(cluster_names, "\",\"") + "\"]";
           }
           expected_request += "}";
           EXPECT_EQ(expected_request, request->bodyAsString());
@@ -93,7 +93,7 @@ public:
 
   void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
                            bool accept) override {
-    std::string response_json = "{\"versionInfo\":\"" + version + "\",\"resources\":[";
+    std::string response_json = "{\"version_info\":\"" + version + "\",\"resources\":[";
     for (const auto& cluster : cluster_names) {
       response_json += "{\"@type\":\"type.googleapis.com/"
                        "envoy.api.v2.ClusterLoadAssignment\",\"clusterName\":\"" +


### PR DESCRIPTION
@htuch and I found a new-ish feature in the proto json conversion API that allows the proto field names to be preserved during the conversion.