### PR TITLE
TLS NPN support

### DIFF
--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -379,13 +379,12 @@ ServerContextImpl::ServerContextImpl(ContextManagerImpl& parent, Stats::Scope& s
                                      out, outlen, in, inlen);
                                },
                                this);
-    SSL_CTX_set_next_protos_advertised_cb(ctx_.get(),
-                               [](SSL*, const uint8_t** out, unsigned int* outlen,
-                                   void* arg) -> int {
-                                 return static_cast<ServerContextImpl*>(arg)
-                                     ->npnListCallback(out, outlen);
-                               },
-                               this);
+    SSL_CTX_set_next_protos_advertised_cb(
+        ctx_.get(),
+        [](SSL*, const uint8_t** out, unsigned int* outlen, void* arg) -> int {
+          return static_cast<ServerContextImpl*>(arg)->npnListCallback(out, outlen);
+        },
+        this);
   }
 }
 

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -139,6 +139,8 @@ private:
   int alpnSelectCallback(const unsigned char** out, unsigned char* outlen, const unsigned char* in,
                          unsigned int inlen);
 
+  int npnListCallback(const uint8_t** out, unsigned int* outlen);
+
   Runtime::Loader& runtime_;
   std::vector<uint8_t> parsed_alt_alpn_protocols_;
 };


### PR DESCRIPTION
On my production system found that clients with TLS NPN can not connect to envoy. This patch fixes that, tested on my production system.