### PR TITLE
Making watermark callbacks safe to remove in-loop

### DIFF
--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -141,8 +141,6 @@ void TcpProxy::readDisableUpstream(bool disable) {
 void TcpProxy::readDisableDownstream(bool disable) {
   read_callbacks_->connection().readDisable(disable);
   // The WsHandlerImpl class uses TCP Proxy code with a null config.
-  // TODO (alyssawilk) make sure that HTTP conn man tracks the same
-  // flow control stuff, so that we get these stats for WebSockets/HTTP.
   if (!config_) {
     return;
   }

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -13,9 +13,10 @@ public:
     }
     ASSERT(high_watermark_callbacks_ > 0);
     --high_watermark_callbacks_;
-    // TODO(alyssawilk) see if we can make this safe for disconnects mid-loop
     for (StreamCallbacks* callbacks : callbacks_) {
-      callbacks->onBelowWriteBufferLowWatermark();
+      if (callbacks) {
+        callbacks->onBelowWriteBufferLowWatermark();
+      }
     }
   }
 
@@ -25,7 +26,9 @@ public:
     }
     ++high_watermark_callbacks_;
     for (StreamCallbacks* callbacks : callbacks_) {
-      callbacks->onAboveWriteBufferHighWatermark();
+      if (callbacks) {
+        callbacks->onAboveWriteBufferHighWatermark();
+      }
     }
   }
 

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -67,6 +67,8 @@ protected:
     // For performance reasons we just clear the callback and do not resize the vector.
     // Reset callbacks scale with the number of filters per request and do not get added and
     // removed multiple times.
+    // The vector may not be safely resized without making sure the run.*Callbacks() helper
+    // functions above still handle removeCallbacks_() calls mid-loop.
     for (size_t i = 0; i < callbacks_.size(); i++) {
       if (callbacks_[i] == &callbacks) {
         callbacks_[i] = nullptr;


### PR DESCRIPTION
Minor fix for #150.  Easier than expected - I hadn't noticed they were just nulled out.

Also removing a spurious TODO: 
source/common/http/conn_manager_impl.cc already increments:
parent_.connection_manager_.stats_.named_.downstream_flow_control_paused_reading_total_.inc();

