### PR TITLE
config: Tweaks to protobuf type aliases.

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -231,7 +231,7 @@ public:
    * may be optionally implemented today, but will in the future become compulsory once v1 is
    * deprecated.
    */
-  virtual HttpFilterFactoryCb createFilterFactoryFromProto(const ProtobufWkt::Message& config,
+  virtual HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                            const std::string& stat_prefix,
                                                            FactoryContext& context) {
     UNREFERENCED_PARAMETER(config);

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -52,7 +52,7 @@ public:
   static std::size_t hash(const Protobuf::Message& message) {
     // Use Protobuf::io::CodedOutputStream to force deterministic serialization, so that the same
     // message doesn't hash to different values.
-    std::string text;
+    ProtobufTypes::String text;
     Protobuf::io::StringOutputStream string_stream(&text);
     Protobuf::io::CodedOutputStream coded_stream(&string_stream);
     coded_stream.SetSerializationDeterministic(true);


### PR DESCRIPTION
This is a workaround for Google import issues and a no-op for everyone
else.