### PR TITLE
Added request and response durations to RequestInfo

### DIFF
--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -66,6 +66,32 @@ public:
   virtual SystemTime startTime() const PURE;
 
   /**
+   * @return duration from request start to when the entire request was received from the
+   * downstream client in microseconds. Note: if unset, will return 0 microseconds.
+   */
+  virtual std::chrono::microseconds requestReceivedDuration() const PURE;
+
+  /**
+   * Set the duration from request start to when the entire request was received from the
+   * downstream client.
+   * @param time monotonic clock time when the response was received.
+   */
+  virtual void requestReceivedDuration(MonotonicTime time) PURE;
+
+  /**
+   * @return the duration from request start to when the entire response was received from the
+   * upstream host in microseconds. Note: if unset, will return 0 microseconds.
+   */
+  virtual std::chrono::microseconds responseReceivedDuration() const PURE;
+
+  /**
+   * Set the duration from request start to when the entire response was received from the
+   * upstream host.
+   * @param time monotonic clock time when the response was received.
+   */
+  virtual void responseReceivedDuration(MonotonicTime time) PURE;
+
+  /**
    * @return the # of body bytes received in the request.
    */
   virtual uint64_t bytesReceived() const PURE;
@@ -91,9 +117,9 @@ public:
   virtual uint64_t bytesSent() const PURE;
 
   /**
-   * @return the milliseconds duration of the first byte received to the last byte sent.
+   * @return the microseconds duration of the first byte received to the last byte sent.
    */
-  virtual std::chrono::milliseconds duration() const PURE;
+  virtual std::chrono::microseconds duration() const PURE;
 
   /**
    * @return whether response flag is set or not.

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -231,6 +231,18 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     field_extractor_ = [](const RequestInfo& request_info) {
       return AccessLogDateTimeFormatter::fromTime(request_info.startTime());
     };
+  } else if (field_name == "REQUEST_DURATION") {
+    field_extractor_ = [](const RequestInfo& request_info) {
+      return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                request_info.requestReceivedDuration())
+                                .count());
+    };
+  } else if (field_name == "RESPONSE_DURATION") {
+    field_extractor_ = [](const RequestInfo& request_info) {
+      return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                request_info.responseReceivedDuration())
+                                .count());
+    };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const RequestInfo& request_info) {
       return std::to_string(request_info.bytesReceived());
@@ -251,7 +263,8 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "DURATION") {
     field_extractor_ = [](const RequestInfo& request_info) {
-      return std::to_string(request_info.duration().count());
+      return std::to_string(
+          std::chrono::duration_cast<std::chrono::milliseconds>(request_info.duration()).count());
     };
   } else if (field_name == "RESPONSE_FLAGS") {
     field_extractor_ = [](const RequestInfo& request_info) {

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -79,7 +79,8 @@ bool StatusCodeFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
 }
 
 bool DurationFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
-  return compareAgainstValue(info.duration().count());
+  return compareAgainstValue(
+      std::chrono::duration_cast<std::chrono::milliseconds>(info.duration()).count());
 }
 
 RuntimeFilter::RuntimeFilter(const envoy::api::v2::filter::RuntimeFilter& config,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -334,6 +334,7 @@ void Filter::maybeDoShadowing() {
 void Filter::onRequestComplete() {
   downstream_end_stream_ = true;
   downstream_request_complete_time_ = std::chrono::steady_clock::now();
+  callbacks_->requestInfo().requestReceivedDuration(downstream_request_complete_time_);
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
@@ -471,9 +472,11 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   // Only send upstream service time if we received the complete request and this is not a
   // premature response.
   if (DateUtil::timePointValid(downstream_request_complete_time_)) {
+    MonotonicTime response_received_time = std::chrono::steady_clock::now();
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - downstream_request_complete_time_);
+        response_received_time - downstream_request_complete_time_);
     headers->insertEnvoyUpstreamServiceTime().value(ms.count());
+    callbacks_->requestInfo().responseReceivedDuration(response_received_time);
   }
 
   upstream_request_->upstream_canary_ =

--- a/test/common/http/access_log/access_log_formatter_test.cc
+++ b/test/common/http/access_log/access_log_formatter_test.cc
@@ -93,6 +93,20 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
+    RequestInfoFormatter request_duration_format("REQUEST_DURATION");
+    std::chrono::microseconds duration{5000};
+    EXPECT_CALL(request_info, requestReceivedDuration()).WillOnce(Return(duration));
+    EXPECT_EQ("5", request_duration_format.format(header, header, request_info));
+  }
+
+  {
+    RequestInfoFormatter response_duration_format("RESPONSE_DURATION");
+    std::chrono::microseconds duration{10000};
+    EXPECT_CALL(request_info, responseReceivedDuration()).WillRepeatedly(Return(duration));
+    EXPECT_EQ("10", response_duration_format.format(header, header, request_info));
+  }
+
+  {
     RequestInfoFormatter bytes_received_format("BYTES_RECEIVED");
     EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(1));
     EXPECT_EQ("1", bytes_received_format.format(header, header, request_info));
@@ -126,7 +140,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter duration_format("DURATION");
-    std::chrono::milliseconds time{2};
+    std::chrono::microseconds time{2000};
     EXPECT_CALL(request_info, duration()).WillOnce(Return(time));
     EXPECT_EQ("2", duration_format.format(header, header, request_info));
   }

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -173,6 +173,8 @@ MockInstance::~MockInstance() {}
 MockRequestInfo::MockRequestInfo() {
   ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_));
   ON_CALL(*this, startTime()).WillByDefault(Return(start_time_));
+  ON_CALL(*this, requestReceivedDuration()).WillByDefault(Return(request_received_duration_));
+  ON_CALL(*this, responseReceivedDuration()).WillByDefault(Return(response_received_duration_));
 }
 
 MockRequestInfo::~MockRequestInfo() {}

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -48,12 +48,16 @@ public:
   MOCK_METHOD1(setResponseFlag, void(ResponseFlag response_flag));
   MOCK_METHOD1(onUpstreamHostSelected, void(Upstream::HostDescriptionConstSharedPtr host));
   MOCK_CONST_METHOD0(startTime, SystemTime());
+  MOCK_CONST_METHOD0(requestReceivedDuration, std::chrono::microseconds());
+  MOCK_METHOD1(requestReceivedDuration, void(MonotonicTime time));
+  MOCK_CONST_METHOD0(responseReceivedDuration, std::chrono::microseconds());
+  MOCK_METHOD1(responseReceivedDuration, void(MonotonicTime time));
   MOCK_CONST_METHOD0(bytesReceived, uint64_t());
   MOCK_CONST_METHOD0(protocol, Protocol());
   MOCK_METHOD1(protocol, void(Protocol protocol));
   MOCK_CONST_METHOD0(responseCode, Optional<uint32_t>&());
   MOCK_CONST_METHOD0(bytesSent, uint64_t());
-  MOCK_CONST_METHOD0(duration, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(duration, std::chrono::microseconds());
   MOCK_CONST_METHOD1(getResponseFlag, bool(Http::AccessLog::ResponseFlag));
   MOCK_CONST_METHOD0(upstreamHost, Upstream::HostDescriptionConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheck, bool());
@@ -62,6 +66,8 @@ public:
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
   SystemTime start_time_;
+  std::chrono::microseconds request_received_duration_;
+  std::chrono::microseconds response_received_duration_;
 };
 
 } // namespace AccessLog


### PR DESCRIPTION
This corrects the reason for the revert in #1541 .  

There was an additional callsite for the updated `duration()` signature.  It has been updated, and the tests involving that callsite have also been updated to reflect that the return value of `duration()` is in microseconds and are expected to be casted to milliseconds by the caller in that case.

@mattklein123 I verified that this is the only other callsite for `duration()`.