### PR TITLE
Change grpc-web filter to pass through if content-type is unsupported

### DIFF
--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -41,10 +41,9 @@ bool GrpcWebFilter::isGrpcWebRequest(const Http::HeaderMap& headers) {
 Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   const Http::HeaderEntry* content_type = headers.ContentType();
   if (!isGrpcWebRequest(headers)) {
-    is_grpc_web_req_ = false;
     return Http::FilterHeadersStatus::Continue;
   }
-  is_grpc_web_req_ = true;
+  is_grpc_web_request_ = true;
 
   setupStatTracking(headers);
 
@@ -73,7 +72,7 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
 }
 
 Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
-  if (!is_grpc_web_req_) {
+  if (!is_grpc_web_request_) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -109,7 +108,7 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool) {
 
 // Implements StreamEncoderFilter.
 Http::FilterHeadersStatus GrpcWebFilter::encodeHeaders(Http::HeaderMap& headers, bool) {
-  if (!is_grpc_web_req_) {
+  if (!is_grpc_web_request_) {
     return Http::FilterHeadersStatus::Continue;
   }
 
@@ -127,7 +126,7 @@ Http::FilterHeadersStatus GrpcWebFilter::encodeHeaders(Http::HeaderMap& headers,
 }
 
 Http::FilterDataStatus GrpcWebFilter::encodeData(Buffer::Instance& data, bool) {
-  if (!is_grpc_web_req_) {
+  if (!is_grpc_web_request_) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -161,7 +160,7 @@ Http::FilterDataStatus GrpcWebFilter::encodeData(Buffer::Instance& data, bool) {
 }
 
 Http::FilterTrailersStatus GrpcWebFilter::encodeTrailers(Http::HeaderMap& trailers) {
-  if (!is_grpc_web_req_) {
+  if (!is_grpc_web_request_) {
     return Http::FilterTrailersStatus::Continue;
   }
 

--- a/source/common/grpc/grpc_web_filter.h
+++ b/source/common/grpc/grpc_web_filter.h
@@ -63,6 +63,7 @@ private:
   std::string grpc_method_;
   bool do_stat_tracking_{};
   bool stream_destroyed_{};
+  bool is_grpc_web_req_{};
 };
 
 } // namespace Grpc

--- a/source/common/grpc/grpc_web_filter.h
+++ b/source/common/grpc/grpc_web_filter.h
@@ -63,7 +63,7 @@ private:
   std::string grpc_method_;
   bool do_stat_tracking_{};
   bool stream_destroyed_{};
-  bool is_grpc_web_req_{};
+  bool is_grpc_web_request_{};
 };
 
 } // namespace Grpc

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -95,14 +95,28 @@ TEST_F(GrpcWebFilterTest, SupportedContentTypes) {
 }
 
 TEST_F(GrpcWebFilterTest, UnsupportedContentType) {
+  Buffer::OwnedImpl data;
   Http::TestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::Headers::get().ContentType, "unsupported");
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(request_headers));
 }
 
 TEST_F(GrpcWebFilterTest, NoContentType) {
+  Buffer::OwnedImpl data;
   Http::TestHeaderMapImpl request_headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(request_headers));
 }
 
 TEST_F(GrpcWebFilterTest, InvalidBase64) {

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -97,26 +97,12 @@ TEST_F(GrpcWebFilterTest, SupportedContentTypes) {
 TEST_F(GrpcWebFilterTest, UnsupportedContentType) {
   Http::TestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::Headers::get().ContentType, "unsupported");
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
-      .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
-        uint64_t code;
-        StringUtil::atoul(headers.Status()->value().c_str(), code);
-        EXPECT_EQ(static_cast<uint64_t>(Http::Code::UnsupportedMediaType), code);
-      }));
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
 }
 
 TEST_F(GrpcWebFilterTest, NoContentType) {
   Http::TestHeaderMapImpl request_headers;
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
-      .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
-        uint64_t code;
-        StringUtil::atoul(headers.Status()->value().c_str(), code);
-        EXPECT_EQ(static_cast<uint64_t>(Http::Code::UnsupportedMediaType), code);
-      }));
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
 }
 
 TEST_F(GrpcWebFilterTest, InvalidBase64) {


### PR DESCRIPTION
I propose to change this filter so it will pass through requests that are not in its scope.
When I send a normal gRPC request to a listener that has this filter it will get blocked, which means I would need a separate listener. 
For me that seems like an unneeded hurdle. 