### PR TITLE
cleanup: Consistent arg names in Envoy::Grpc::Common.

### DIFF
--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -27,20 +27,20 @@ public:
 class Common {
 public:
   /**
-   * Returns the GrpcStatus code from a given set of headers, if present.
-   * @param headers the headers to parse.
+   * Returns the GrpcStatus code from a given set of trailers, if present.
+   * @param trailers the trailers to parse.
    * @return Optional<Status::GrpcStatus> the parsed status code or InvalidCode if no valid status
    *         is found.
    */
-  static Optional<Status::GrpcStatus> getGrpcStatus(const Http::HeaderMap& headers);
+  static Optional<Status::GrpcStatus> getGrpcStatus(const Http::HeaderMap& trailers);
 
   /**
-   * Returns the grpc-message from a given set of headers, if present.
-   * @param headers the headers to parse.
+   * Returns the grpc-message from a given set of trailers, if present.
+   * @param trailers the trailers to parse.
    * @return std::string the gRPC status message or empty string if grpc-message is not present in
-   *         headers.
+   *         trailers.
    */
-  static std::string getGrpcMessage(const Http::HeaderMap& headers);
+  static std::string getGrpcMessage(const Http::HeaderMap& trailers);
 
   /**
    * Returns the gRPC status code from a given HTTP response status code. Ordinarily, it is expected


### PR DESCRIPTION
getGrpc{Status,Message} had a parameter named `headers` in common.h but
`trailers` in common.cc. I confirmed with @lizan that `trailers` was
correct.