### PR TITLE
log: Avoid name conflicts in Loggable

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -159,7 +159,7 @@ protected:
 #define ENVOY_LOGGER() __log_do_not_use_read_comment()
 
 /**
- * Convenience
+ * Convenience macro to flush logger.
  */
 #define ENVOY_FLUSH_LOG() ENVOY_LOGGER().flush()
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -114,9 +114,10 @@ private:
 template <Id id> class Loggable {
 protected:
   /**
+   * Do not use this directly, use macros defined below.
    * @return spdlog::logger& the static log instance to use for class local logging.
    */
-  static spdlog::logger& logger() {
+  static spdlog::logger& __log_do_not_use_read_comment() {
     static spdlog::logger& instance = Registry::getLog(id);
     return instance;
   }
@@ -153,9 +154,19 @@ protected:
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
 
 /**
+ * Convenience macro to get logger.
+ */
+#define ENVOY_LOGGER() __log_do_not_use_read_comment()
+
+/**
+ * Convenience
+ */
+#define ENVOY_FLUSH_LOG() ENVOY_LOGGER().flush()
+
+/**
  * Convenience macro to log to the class' logger.
  */
-#define ENVOY_LOG(LEVEL, ...) ENVOY_LOG_TO_LOGGER(logger(), LEVEL, ##__VA_ARGS__)
+#define ENVOY_LOG(LEVEL, ...) ENVOY_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macro to log to the misc logger, which allows for logging without of direct access to
@@ -171,7 +182,7 @@ protected:
   ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, "[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
 
 #define ENVOY_CONN_LOG(LEVEL, FORMAT, CONNECTION, ...)                                             \
-  ENVOY_CONN_LOG_TO_LOGGER(logger(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
+  ENVOY_CONN_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with a stream ID and a connection ID.
@@ -182,6 +193,6 @@ protected:
                       (STREAM).streamId(), ##__VA_ARGS__)
 
 #define ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ...)                                               \
-  ENVOY_STREAM_LOG_TO_LOGGER(logger(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
+  ENVOY_STREAM_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
 } // namespace Envoy

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -116,7 +116,7 @@ protected:
   /**
    * @return spdlog::logger& the static log instance to use for class local logging.
    */
-  static spdlog::logger& log() {
+  static spdlog::logger& logger() {
     static spdlog::logger& instance = Registry::getLog(id);
     return instance;
   }
@@ -155,7 +155,7 @@ protected:
 /**
  * Convenience macro to log to the class' logger.
  */
-#define ENVOY_LOG(LEVEL, ...) ENVOY_LOG_TO_LOGGER(log(), LEVEL, ##__VA_ARGS__)
+#define ENVOY_LOG(LEVEL, ...) ENVOY_LOG_TO_LOGGER(logger(), LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macro to log to the misc logger, which allows for logging without of direct access to
@@ -171,7 +171,7 @@ protected:
   ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, "[C{}] " FORMAT, (CONNECTION).id(), ##__VA_ARGS__)
 
 #define ENVOY_CONN_LOG(LEVEL, FORMAT, CONNECTION, ...)                                             \
-  ENVOY_CONN_LOG_TO_LOGGER(log(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
+  ENVOY_CONN_LOG_TO_LOGGER(logger(), LEVEL, FORMAT, CONNECTION, ##__VA_ARGS__)
 
 /**
  * Convenience macros for logging with a stream ID and a connection ID.
@@ -182,6 +182,6 @@ protected:
                       (STREAM).streamId(), ##__VA_ARGS__)
 
 #define ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ...)                                               \
-  ENVOY_STREAM_LOG_TO_LOGGER(log(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
+  ENVOY_STREAM_LOG_TO_LOGGER(logger(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
 } // namespace Envoy

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -46,8 +46,8 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
                                POOL_GAUGE_PREFIX(stats_store_, "server."))},
       thread_local_(tls), api_(new Api::Impl(options.fileFlushIntervalMsec())),
       dispatcher_(api_->allocateDispatcher()), singleton_manager_(new Singleton::ManagerImpl()),
-      handler_(new ConnectionHandlerImpl(log(), *dispatcher_)), listener_component_factory_(*this),
-      worker_factory_(thread_local_, *api_, hooks),
+      handler_(new ConnectionHandlerImpl(logger(), *dispatcher_)),
+      listener_component_factory_(*this), worker_factory_(thread_local_, *api_, hooks),
       dns_resolver_(dispatcher_->createDnsResolver({})),
       access_log_manager_(*api_, *dispatcher_, access_log_lock, store) {
 
@@ -331,7 +331,7 @@ void InstanceImpl::run() {
   handler_.reset();
   thread_local_.shutdownThread();
   ENVOY_LOG(warn, "exiting");
-  log().flush();
+  logger().flush();
 }
 
 Runtime::Loader& InstanceImpl::runtime() { return *runtime_loader_; }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -46,7 +46,7 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
                                POOL_GAUGE_PREFIX(stats_store_, "server."))},
       thread_local_(tls), api_(new Api::Impl(options.fileFlushIntervalMsec())),
       dispatcher_(api_->allocateDispatcher()), singleton_manager_(new Singleton::ManagerImpl()),
-      handler_(new ConnectionHandlerImpl(logger(), *dispatcher_)),
+      handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
       listener_component_factory_(*this), worker_factory_(thread_local_, *api_, hooks),
       dns_resolver_(dispatcher_->createDnsResolver({})),
       access_log_manager_(*api_, *dispatcher_, access_log_lock, store) {
@@ -331,7 +331,7 @@ void InstanceImpl::run() {
   handler_.reset();
   thread_local_.shutdownThread();
   ENVOY_LOG(warn, "exiting");
-  logger().flush();
+  ENVOY_FLUSH_LOG();
 }
 
 Runtime::Loader& InstanceImpl::runtime() { return *runtime_loader_; }

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -16,9 +16,9 @@ namespace Server {
 
 WorkerPtr ProdWorkerFactory::createWorker() {
   Event::DispatcherPtr dispatcher(api_.allocateDispatcher());
-  return WorkerPtr{
-      new WorkerImpl(tls_, hooks_, std::move(dispatcher),
-                     Network::ConnectionHandlerPtr{new ConnectionHandlerImpl(log(), *dispatcher)})};
+  return WorkerPtr{new WorkerImpl(
+      tls_, hooks_, std::move(dispatcher),
+      Network::ConnectionHandlerPtr{new ConnectionHandlerImpl(logger(), *dispatcher)})};
 }
 
 WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, TestHooks& hooks,

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -18,7 +18,7 @@ WorkerPtr ProdWorkerFactory::createWorker() {
   Event::DispatcherPtr dispatcher(api_.allocateDispatcher());
   return WorkerPtr{new WorkerImpl(
       tls_, hooks_, std::move(dispatcher),
-      Network::ConnectionHandlerPtr{new ConnectionHandlerImpl(logger(), *dispatcher)})};
+      Network::ConnectionHandlerPtr{new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher)})};
 }
 
 WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, TestHooks& hooks,

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -235,7 +235,7 @@ FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr
     : ssl_ctx_(ssl_ctx), socket_(std::move(listen_socket)),
       api_(new Api::Impl(std::chrono::milliseconds(10000))),
       dispatcher_(api_->allocateDispatcher()),
-      handler_(new Server::ConnectionHandlerImpl(logger(), *dispatcher_)), http_type_(type) {
+      handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)), http_type_(type) {
   thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
   server_initialized_.waitReady();
 }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -235,7 +235,7 @@ FakeUpstream::FakeUpstream(Ssl::ServerContext* ssl_ctx, Network::ListenSocketPtr
     : ssl_ctx_(ssl_ctx), socket_(std::move(listen_socket)),
       api_(new Api::Impl(std::chrono::milliseconds(10000))),
       dispatcher_(api_->allocateDispatcher()),
-      handler_(new Server::ConnectionHandlerImpl(log(), *dispatcher_)), http_type_(type) {
+      handler_(new Server::ConnectionHandlerImpl(logger(), *dispatcher_)), http_type_(type) {
   thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
   server_initialized_.waitReady();
 }

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -22,7 +22,7 @@ namespace Server {
 
 class ConnectionHandlerTest : public testing::Test, protected Logger::Loggable<Logger::Id::main> {
 public:
-  ConnectionHandlerTest() : handler_(new ConnectionHandlerImpl(logger(), dispatcher_)) {}
+  ConnectionHandlerTest() : handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)) {}
 
   Stats::IsolatedStoreImpl stats_store_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -22,7 +22,7 @@ namespace Server {
 
 class ConnectionHandlerTest : public testing::Test, protected Logger::Loggable<Logger::Id::main> {
 public:
-  ConnectionHandlerTest() : handler_(new ConnectionHandlerImpl(log(), dispatcher_)) {}
+  ConnectionHandlerTest() : handler_(new ConnectionHandlerImpl(logger(), dispatcher_)) {}
 
   Stats::IsolatedStoreImpl stats_store_;
   NiceMock<Event::MockDispatcher> dispatcher_;


### PR DESCRIPTION
A class inherits `Http::AccessLog::Instance` cannot inherit `Loggable` and use `log()` due to the name confliction.

In istio/proxy we had workaround like this:
https://github.com/istio/proxy/blob/master/src/envoy/mixer/http_filter.cc#L334

it prevents us using `ENVOY_LOG` macro.