### PR TITLE
Added fmtlib/fmt as a direct dependency, and upgraded the spdlog depe…

### DIFF
--- a/bazel/target_recipes.bzl
+++ b/bazel/target_recipes.bzl
@@ -6,6 +6,7 @@ TARGET_RECIPES = {
     "backward": "backward",
     "event": "libevent",
     "event_pthreads": "libevent",
+    "fmtlib": "fmtlib",
     # TODO(htuch): This shouldn't be a build recipe, it's a tooling dependency
     # that is external to Bazel.
     "gcovr": "gcovr",

--- a/ci/build_container/build_recipes/fmtlib.sh
+++ b/ci/build_container/build_recipes/fmtlib.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+VERSION=4.0.0
+
+wget -O fmt-$VERSION.tar.gz https://github.com/fmtlib/fmt/archive/$VERSION.tar.gz
+tar xf fmt-$VERSION.tar.gz
+rsync -av fmt-$VERSION/* $THIRDPARTY_SRC/fmtlib

--- a/ci/build_container/build_recipes/spdlog.sh
+++ b/ci/build_container/build_recipes/spdlog.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=0.13.0
+VERSION=0.14.0
 
 wget -O spdlog-$VERSION.tar.gz https://github.com/gabime/spdlog/archive/v$VERSION.tar.gz
 tar xf spdlog-$VERSION.tar.gz

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -36,6 +36,18 @@ cc_library(
 )
 
 cc_library(
+    name = "fmtlib",
+    hdrs = glob([
+        "thirdparty/fmtlib/fmt/*.cc",
+        "thirdparty/fmtlib/fmt/*.h",
+    ]),
+    defines = ["FMT_HEADER_ONLY"],
+    include_prefix = "fmt",
+    includes = ["thirdparty/fmtlib/fmt"],
+    strip_include_prefix = "thirdparty/fmtlib/fmt/",
+)
+
+cc_library(
     name = "googletest",
     srcs = [
         "thirdparty_build/lib/libgmock.a",
@@ -100,7 +112,9 @@ cc_library(
         "thirdparty/spdlog/include/**/*.cc",
         "thirdparty/spdlog/include/**/*.h",
     ]),
+    defines = ["SPDLOG_FMT_EXTERNAL"],
     includes = ["thirdparty/spdlog/include"],
+    deps = ["fmtlib"],
 )
 
 cc_library(

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -10,7 +10,7 @@ Envoy has the following requirements:
 
 * GCC 4.9+ (for C++11 regex support)
 * `Bazel <https://github.com/bazelbuild/bazel>`_ (last tested with 0.5.3)
-* `spdlog <https://github.com/gabime/spdlog>`_ (last tested with 0.13.0)
+* `spdlog <https://github.com/gabime/spdlog>`_ (last tested with 0.14.0)
 * `http-parser <https://github.com/nodejs/http-parser>`_ (last tested with 2.7.1)
 * `nghttp2 <https://github.com/nghttp2/nghttp2>`_ (last tested with 1.23.1)
 * `libevent <http://libevent.org/>`_ (last tested with 2.1.8)
@@ -24,6 +24,7 @@ Envoy has the following requirements:
 * `backward <https://github.com/bombela/backward-cpp>`_ (last tested with 1.3)
 * `zlib <https://github.com/madler/zlib>`_ (last tested with 1.2.11)
 * `yaml-cpp <https://github.com/jbeder/yaml-cpp>`_ (last tested with sha e2818c423e5058a02f46ce2e519a82742a8ccac9).
+* `fmtlib <https://github.com/fmtlib/fmt/>`_ (last tested with 4.0.0)
 
 In order to compile and run the tests the following is required:
 

--- a/include/envoy/registry/BUILD
+++ b/include/envoy/registry/BUILD
@@ -11,4 +11,5 @@ envoy_package()
 envoy_cc_library(
     name = "registry",
     hdrs = ["registry.h"],
+    external_deps = ["fmtlib"],
 )

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -5,7 +5,7 @@
 
 #include "envoy/common/exception.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Registry {

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
     name = "hex_lib",
     srcs = ["hex.cc"],
     hdrs = ["hex.h"],
+    external_deps = ["fmtlib"],
     deps = [":utility_lib"],
 )
 
@@ -120,6 +121,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "version_lib",
     srcs = ["version.cc"],
+    external_deps = ["fmtlib"],
     linkstamp = "version_linkstamp.cc",
     deps = [
         ":version_includes",

--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -9,7 +9,7 @@
 
 #include "common/common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 std::string Hex::encode(const uint8_t* data, size_t length) {

--- a/source/common/common/version.cc
+++ b/source/common/common/version.cc
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 extern const char build_scm_revision[];
 extern const char build_scm_status[];

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -211,6 +211,7 @@ envoy_cc_library(
     external_deps = [
         "envoy_base",
         "envoy_filter_http_connection_manager",
+        "fmtlib",
     ],
     deps = [
         ":json_utility_lib",

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -6,7 +6,7 @@
 #include "common/json/config_schemas.h"
 #include "common/protobuf/protobuf.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Config {

--- a/source/common/dynamo/BUILD
+++ b/source/common/dynamo/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "dynamo_filter_lib",
     srcs = ["dynamo_filter.cc"],
     hdrs = ["dynamo_filter.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":dynamo_request_parser_lib",
         ":dynamo_utility_lib",

--- a/source/common/dynamo/dynamo_filter.cc
+++ b/source/common/dynamo/dynamo_filter.cc
@@ -13,7 +13,7 @@
 #include "common/http/utility.h"
 #include "common/json/json_loader.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Dynamo {

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "filesystem_lib",
     srcs = ["filesystem_impl.cc"],
     hdrs = ["filesystem_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/filesystem:filesystem_interface",
@@ -38,7 +39,10 @@ envoy_cc_library(
             "inotify/watcher_impl.h",
         ],
     }),
-    external_deps = ["event"],
+    external_deps = [
+        "event",
+        "fmtlib",
+    ],
     strip_include_prefix = select({
         "@bazel_tools//tools/osx:darwin": "kqueue",
         "//conditions:default": "inotify",

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -20,7 +20,7 @@
 #include "common/common/assert.h"
 #include "common/common/thread.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Filesystem {

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -11,7 +11,7 @@
 #include "common/common/utility.h"
 #include "common/filesystem/watcher_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Filesystem {

--- a/source/common/filesystem/kqueue/watcher_impl.cc
+++ b/source/common/filesystem/kqueue/watcher_impl.cc
@@ -11,6 +11,7 @@
 #include "common/filesystem/watcher_impl.h"
 
 #include "event2/event.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Filesystem {

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
     name = "ratelimit_lib",
     srcs = ["ratelimit.cc"],
     hdrs = ["ratelimit.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
@@ -41,6 +42,7 @@ envoy_cc_library(
     name = "tcp_proxy_lib",
     srcs = ["tcp_proxy.cc"],
     hdrs = ["tcp_proxy.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",

--- a/source/common/filter/auth/BUILD
+++ b/source/common/filter/auth/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "client_ssl_lib",
     srcs = ["client_ssl.cc"],
     hdrs = ["client_ssl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -14,7 +14,7 @@
 #include "common/json/config_schemas.h"
 #include "common/network/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Filter {

--- a/source/common/filter/ratelimit.cc
+++ b/source/common/filter/ratelimit.cc
@@ -6,7 +6,7 @@
 #include "common/common/empty_string.h"
 #include "common/json/config_schemas.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace RateLimit {

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -15,7 +15,7 @@
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Filter {

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     name = "common_lib",
     srcs = ["common.cc"],
     hdrs = ["common.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/common:optional",
         "//include/envoy/grpc:status",

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -16,7 +16,7 @@
 #include "common/http/utility.h"
 #include "common/protobuf/protobuf.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Grpc {

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
     name = "codes_lib",
     srcs = ["codes.cc"],
     hdrs = ["codes.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":headers_lib",
         ":utility_lib",
@@ -88,6 +89,7 @@ envoy_cc_library(
         "conn_manager_impl.h",
         "conn_manager_utility.h",
     ],
+    external_deps = ["fmtlib"],
     deps = [
         ":codes_lib",
         ":date_provider_lib",
@@ -223,7 +225,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["envoy_protocol"],
+    external_deps = [
+        "envoy_protocol",
+        "fmtlib",
+    ],
     deps = [
         ":exception_lib",
         ":header_map_lib",

--- a/source/common/http/access_log/BUILD
+++ b/source/common/http/access_log/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "access_log_formatter_lib",
     srcs = ["access_log_formatter.cc"],
     hdrs = ["access_log_formatter.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/http:access_log_interface",
         "//source/common/common:assert_lib",

--- a/source/common/http/access_log/access_log_formatter.cc
+++ b/source/common/http/access_log/access_log_formatter.cc
@@ -7,7 +7,7 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -11,7 +11,7 @@
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -29,7 +29,7 @@
 #include "common/http/utility.h"
 #include "common/network/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/filter/BUILD
+++ b/source/common/http/filter/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
     name = "fault_filter_lib",
     srcs = ["fault_filter.cc"],
     hdrs = ["fault_filter.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/event:timer_interface",
         "//include/envoy/http:codes_interface",
@@ -65,6 +66,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "ratelimit_lib",
     srcs = ["ratelimit.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         ":ratelimit_includes",
         "//include/envoy/http:codes_interface",

--- a/source/common/http/filter/fault_filter.cc
+++ b/source/common/http/filter/fault_filter.cc
@@ -18,6 +18,8 @@
 #include "common/json/config_schemas.h"
 #include "common/router/config_impl.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Http {
 

--- a/source/common/http/filter/ratelimit.cc
+++ b/source/common/http/filter/ratelimit.cc
@@ -11,7 +11,7 @@
 #include "common/http/codes.h"
 #include "common/router/config_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -12,7 +12,10 @@ envoy_cc_library(
     name = "codec_lib",
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
-    external_deps = ["http_parser"],
+    external_deps = [
+        "http_parser",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/http:codec_interface",

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -13,7 +13,7 @@
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -12,7 +12,10 @@ envoy_cc_library(
     name = "codec_lib",
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
-    external_deps = ["nghttp2"],
+    external_deps = [
+        "nghttp2",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/common:optional",
         "//include/envoy/event:deferred_deletable",

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -17,7 +17,7 @@
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -17,7 +17,7 @@
 #include "common/network/utility.h"
 #include "common/protobuf/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
     srcs = ["json_loader.cc"],
     hdrs = ["json_loader.h"],
     external_deps = [
+        "fmtlib",
         "rapidjson",
         "yaml_cpp",
     ],

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -13,7 +13,7 @@
 #include "common/common/utility.h"
 #include "common/filesystem/filesystem_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 // Do not let RapidJson leak outside of this file.
 #include "rapidjson/document.h"

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "bson_lib",
     srcs = ["bson_impl.cc"],
     hdrs = ["bson_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/mongo:bson_interface",
@@ -27,6 +28,7 @@ envoy_cc_library(
     name = "codec_lib",
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":bson_lib",
         "//include/envoy/buffer:buffer_interface",
@@ -40,6 +42,7 @@ envoy_cc_library(
     name = "proxy_lib",
     srcs = ["proxy.cc"],
     hdrs = ["proxy.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":codec_lib",
         ":utility_lib",

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -9,7 +9,7 @@
 #include "common/common/hex.h"
 #include "common/common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Bson {

--- a/source/common/mongo/codec_impl.cc
+++ b/source/common/mongo/codec_impl.cc
@@ -12,7 +12,7 @@
 #include "common/common/assert.h"
 #include "common/mongo/bson_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Mongo {

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -12,7 +12,7 @@
 #include "common/common/utility.h"
 #include "common/mongo/codec_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Mongo {

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "address_lib",
     srcs = ["address_impl.cc"],
     hdrs = ["address_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/network:address_interface",
         "//source/common/common:assert_lib",
@@ -23,6 +24,7 @@ envoy_cc_library(
     name = "cidr_range_lib",
     srcs = ["cidr_range.cc"],
     hdrs = ["cidr_range.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":address_lib",
         ":utility_lib",
@@ -93,6 +95,7 @@ envoy_cc_library(
     name = "listen_socket_lib",
     srcs = ["listen_socket_impl.cc"],
     hdrs = ["listen_socket_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":address_lib",
         ":utility_lib",
@@ -112,6 +115,7 @@ envoy_cc_library(
         "listener_impl.h",
         "proxy_protocol.h",
     ],
+    external_deps = ["fmtlib"],
     deps = [
         ":address_lib",
         ":connection_lib",
@@ -136,7 +140,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["envoy_base"],
+    external_deps = [
+        "envoy_base",
+        "fmtlib",
+    ],
     deps = [
         ":address_lib",
         "//include/envoy/network:connection_interface",

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -14,7 +14,7 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -16,7 +16,7 @@
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -11,7 +11,7 @@
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -14,7 +14,7 @@
 #include "common/ssl/connection_impl.h"
 
 #include "event2/listener.h"
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -25,7 +25,7 @@
 #include "common/network/address_impl.h"
 #include "common/protobuf/protobuf.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -18,7 +18,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["protobuf"],
+    external_deps = [
+        "protobuf",
+        "fmtlib",
+    ],
     deps = [
         ":protobuf",
         "//source/common/common:assert_lib",

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -5,7 +5,7 @@
 #include "common/json/json_loader.h"
 #include "common/protobuf/protobuf.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 

--- a/source/common/ratelimit/BUILD
+++ b/source/common/ratelimit/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     name = "ratelimit_lib",
     srcs = ["ratelimit_impl.cc"],
     hdrs = ["ratelimit_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":ratelimit_proto",
         "//include/envoy/grpc:async_client_interface",

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -12,7 +12,7 @@
 #include "common/grpc/async_client_impl.h"
 #include "common/http/headers.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace RateLimit {

--- a/source/common/redis/BUILD
+++ b/source/common/redis/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "codec_lib",
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/redis:codec_interface",
         "//source/common/common:assert_lib",
@@ -24,6 +25,7 @@ envoy_cc_library(
     name = "command_splitter_lib",
     srcs = ["command_splitter_impl.cc"],
     hdrs = ["command_splitter_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":supported_commands_lib",
         "//include/envoy/redis:command_splitter_interface",
@@ -57,6 +59,7 @@ envoy_cc_library(
     name = "proxy_filter_lib",
     srcs = ["proxy_filter.cc"],
     hdrs = ["proxy_filter.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/network:filter_interface",
         "//include/envoy/redis:codec_interface",

--- a/source/common/redis/codec_impl.cc
+++ b/source/common/redis/codec_impl.cc
@@ -7,7 +7,7 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Redis {

--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -8,7 +8,7 @@
 #include "common/common/assert.h"
 #include "common/redis/supported_commands.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Redis {

--- a/source/common/redis/proxy_filter.cc
+++ b/source/common/redis/proxy_filter.cc
@@ -7,7 +7,7 @@
 #include "common/config/utility.h"
 #include "common/json/config_schemas.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 // TODO(mattklein123): Graceful drain support.
 

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "config_lib",
     srcs = ["config_impl.cc"],
     hdrs = ["config_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":config_utility_lib",
         ":retry_state_lib",
@@ -55,6 +56,7 @@ envoy_cc_library(
     external_deps = [
         "envoy_filter_http_connection_manager",
         "envoy_rds",
+        "fmtlib",
     ],
     deps = [
         ":config_lib",
@@ -83,6 +85,7 @@ envoy_cc_library(
     hdrs = ["rds_subscription.h"],
     external_deps = [
         "envoy_filter_http_connection_manager",
+        "fmtlib",
     ],
     deps = [
         "//include/envoy/config:subscription_interface",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -23,7 +23,7 @@
 #include "common/protobuf/utility.h"
 #include "common/router/retry_state_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Router {

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -12,6 +12,8 @@
 #include "common/router/config_impl.h"
 #include "common/router/rds_subscription.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Router {
 

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -6,6 +6,8 @@
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Router {
 

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -12,7 +12,10 @@ envoy_cc_library(
     name = "runtime_lib",
     srcs = ["runtime_impl.cc"],
     hdrs = ["runtime_impl.h"],
-    external_deps = ["ssl"],
+    external_deps = [
+        "ssl",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/common:optional",
         "//include/envoy/event:dispatcher_interface",

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -15,8 +15,8 @@
 #include "common/common/utility.h"
 #include "common/filesystem/filesystem_impl.h"
 
+#include "fmt/format.h"
 #include "openssl/rand.h"
-#include "spdlog/spdlog.h"
 
 namespace Envoy {
 namespace Runtime {

--- a/source/common/singleton/BUILD
+++ b/source/common/singleton/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "manager_impl_lib",
     srcs = ["manager_impl.cc"],
     hdrs = ["manager_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/registry",
         "//include/envoy/singleton:manager_interface",

--- a/source/common/singleton/manager_impl.cc
+++ b/source/common/singleton/manager_impl.cc
@@ -4,6 +4,8 @@
 
 #include "common/common/assert.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Singleton {
 

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -47,7 +47,10 @@ envoy_cc_library(
         "context_impl.h",
         "context_manager_impl.h",
     ],
-    external_deps = ["ssl"],
+    external_deps = [
+        "ssl",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/ssl:context_config_interface",

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -11,8 +11,8 @@
 #include "common/common/assert.h"
 #include "common/common/hex.h"
 
+#include "fmt/format.h"
 #include "openssl/x509v3.h"
-#include "spdlog/spdlog.h"
 
 namespace Envoy {
 namespace Ssl {

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     name = "statsd_lib",
     srcs = ["statsd.cc"],
     hdrs = ["statsd.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/local_info:local_info_interface",

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -12,7 +12,7 @@
 #include "common/common/utility.h"
 #include "common/config/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Stats {

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     hdrs = [
         "http_tracer_impl.h",
     ],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
@@ -45,7 +46,10 @@ envoy_cc_library(
     hdrs = [
         "lightstep_tracer_impl.h",
     ],
-    external_deps = ["lightstep"],
+    external_deps = [
+        "lightstep",
+        "fmtlib",
+    ],
     deps = [
         ":http_tracer_lib",
     ],

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -12,7 +12,7 @@
 #include "common/http/utility.h"
 #include "common/runtime/uuid_util.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Tracing {

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -10,7 +10,7 @@
 #include "common/http/message_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Tracing {

--- a/source/common/tracing/zipkin/BUILD
+++ b/source/common/tracing/zipkin/BUILD
@@ -29,7 +29,10 @@ envoy_cc_library(
         "zipkin_json_field_names.h",
         "zipkin_tracer_impl.h",
     ],
-    external_deps = ["rapidjson"],
+    external_deps = [
+        "rapidjson",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/common:optional",
         "//include/envoy/common:time_interface",

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -7,7 +7,7 @@
 #include "common/tracing/http_tracer_impl.h"
 #include "common/tracing/zipkin/zipkin_core_constants.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Zipkin {

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -28,7 +28,10 @@ envoy_cc_library(
     name = "cds_subscription_lib",
     srcs = ["cds_subscription.cc"],
     hdrs = ["cds_subscription.h"],
-    external_deps = ["envoy_cds"],
+    external_deps = [
+        "envoy_cds",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/config:subscription_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -49,7 +52,10 @@ envoy_cc_library(
     name = "cluster_manager_lib",
     srcs = ["cluster_manager_impl.cc"],
     hdrs = ["cluster_manager_impl.h"],
-    external_deps = ["envoy_base"],
+    external_deps = [
+        "envoy_base",
+        "fmtlib",
+    ],
     deps = [
         ":cds_api_lib",
         ":load_balancer_lib",
@@ -134,6 +140,7 @@ envoy_cc_library(
     name = "logical_dns_cluster_lib",
     srcs = ["logical_dns_cluster.cc"],
     hdrs = ["logical_dns_cluster.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":upstream_includes",
         "//include/envoy/thread_local:thread_local_interface",
@@ -162,7 +169,10 @@ envoy_cc_library(
     name = "outlier_detection_lib",
     srcs = ["outlier_detection_impl.cc"],
     hdrs = ["outlier_detection_impl.h"],
-    external_deps = ["envoy_cds"],
+    external_deps = [
+        "envoy_cds",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -207,6 +217,7 @@ envoy_cc_library(
     external_deps = [
         "envoy_base",
         "envoy_eds",
+        "fmtlib",
     ],
     deps = [
         ":sds_subscription_lib",
@@ -245,7 +256,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "upstream_lib",
     srcs = ["upstream_impl.cc"],
-    external_deps = ["envoy_base"],
+    external_deps = [
+        "envoy_base",
+        "fmtlib",
+    ],
     deps = [
         ":eds_lib",
         ":health_checker_lib",

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -8,7 +8,7 @@
 #include "common/json/config_schemas.h"
 #include "common/json/json_loader.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -27,7 +27,7 @@
 #include "common/upstream/original_dst_cluster.h"
 #include "common/upstream/ring_hash_lb.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -9,6 +9,8 @@
 #include "common/network/utility.h"
 #include "common/upstream/sds_subscription.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Upstream {
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -11,7 +11,7 @@
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -13,7 +13,7 @@
 #include "common/http/codes.h"
 #include "common/protobuf/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -30,7 +30,7 @@
 #include "common/upstream/logical_dns_cluster.h"
 #include "common/upstream/original_dst_cluster.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     external_deps = [
         "envoy_bootstrap",
         "envoy_lds",
+        "fmtlib",
     ],
     deps = [
         ":lds_api_lib",
@@ -86,6 +87,7 @@ envoy_cc_library(
     name = "guarddog_lib",
     srcs = ["guarddog_impl.cc"],
     hdrs = ["guarddog_impl.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":watchdog_lib",
         "//include/envoy/common:optional",
@@ -105,6 +107,7 @@ envoy_cc_library(
     name = "hot_restart_lib",
     srcs = envoy_select_hot_restart(["hot_restart_impl.cc"]),
     hdrs = envoy_select_hot_restart(["hot_restart_impl.h"]),
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:file_event_interface",
@@ -140,7 +143,10 @@ envoy_cc_library(
     name = "options_lib",
     srcs = ["options_impl.cc"],
     hdrs = ["options_impl.h"],
-    external_deps = ["tclap"],
+    external_deps = [
+        "tclap",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",
@@ -168,7 +174,10 @@ envoy_cc_library(
     name = "lds_subscription_lib",
     srcs = ["lds_subscription.cc"],
     hdrs = ["lds_subscription.h"],
-    external_deps = ["envoy_lds"],
+    external_deps = [
+        "envoy_lds",
+        "fmtlib",
+    ],
     deps = [
         "//include/envoy/config:subscription_interface",
         "//source/common/common:assert_lib",
@@ -184,7 +193,10 @@ envoy_cc_library(
     name = "listener_manager_lib",
     srcs = ["listener_manager_impl.cc"],
     hdrs = ["listener_manager_impl.h"],
-    external_deps = ["envoy_lds"],
+    external_deps = [
+        "envoy_lds",
+        "fmtlib",
+    ],
     deps = [
         ":configuration_lib",
         ":drain_manager_lib",

--- a/source/server/config/network/BUILD
+++ b/source/server/config/network/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
     name = "http_connection_manager_lib",
     srcs = ["http_connection_manager.cc"],
     hdrs = ["http_connection_manager.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/http:filter_interface",

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -22,7 +22,7 @@
 #include "common/protobuf/utility.h"
 #include "common/router/rds_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -21,7 +21,7 @@
 #include "common/tracing/http_tracer_impl.h"
 
 #include "api/lds.pb.h"
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -7,7 +7,7 @@
 
 #include "server/watchdog_impl.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -18,7 +18,7 @@
 #include "common/common/utility.h"
 #include "common/network/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "admin_lib",
     srcs = ["admin.cc"],
     hdrs = ["admin.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/http:filter_interface",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -30,6 +30,7 @@
 #include "common/router/config_impl.h"
 #include "common/upstream/host_utility.h"
 
+#include "fmt/format.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -7,6 +7,7 @@
 #include "common/json/json_loader.h"
 
 #include "api/lds.pb.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -11,6 +11,8 @@
 #include "server/configuration_impl.h"
 #include "server/drain_manager_impl.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 namespace Server {
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -8,6 +8,7 @@
 #include "common/common/macros.h"
 #include "common/common/version.h"
 
+#include "fmt/format.h"
 #include "spdlog/spdlog.h"
 #include "tclap/CmdLine.h"
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -164,6 +164,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/config:protocol_json_lib",
         "//source/common/http:exception_lib",

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -10,8 +10,8 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 namespace Envoy {
 namespace Http {

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     data = [
         "//test/common/json/config_schemas_test_data:generate_test_data",
     ],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/json:config_schemas_lib",
         "//source/common/json:json_loader_lib",

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -7,9 +7,9 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 namespace Envoy {
 using testing::_;

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -11,6 +11,7 @@ envoy_package()
 envoy_cc_test(
     name = "address_impl_test",
     srcs = ["address_impl_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
@@ -23,6 +24,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "cidr_range_test",
     srcs = ["cidr_range_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/json:json_loader_lib",
         "//source/common/network:address_lib",
@@ -33,6 +35,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "connection_impl_test",
     srcs = ["connection_impl_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:empty_string",

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -17,6 +17,7 @@
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/common/network/cidr_range_test.cc
+++ b/test/common/network/cidr_range_test.cc
@@ -10,8 +10,8 @@
 #include "common/network/cidr_range.h"
 #include "common/network/utility.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 // We are adding things into the std namespace.
 // Note that this is technically undefined behavior!

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -21,6 +21,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/common/redis/BUILD
+++ b/test/common/redis/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "command_splitter_impl_test",
     srcs = ["command_splitter_impl_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/redis:command_splitter_lib",
         "//source/common/stats:stats_lib",

--- a/test/common/redis/command_splitter_impl_test.cc
+++ b/test/common/redis/command_splitter_impl_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/redis/mocks.h"
 #include "test/test_common/printers.h"
 
+#include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -113,6 +113,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_balancer_simulation_test",
     srcs = ["load_balancer_simulation_test.cc"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/network:utility_lib",
         "//source/common/runtime:runtime_lib",
@@ -253,6 +254,7 @@ envoy_cc_test(
 envoy_cc_test_library(
     name = "utility_lib",
     hdrs = ["utility.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/common/config:cds_json_lib",
         "//source/common/json:json_loader_lib",

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -10,9 +10,9 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 
+#include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 namespace Envoy {
 using testing::NiceMock;

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -4,6 +4,8 @@
 #include "common/config/cds_json.h"
 #include "common/json/json_loader.h"
 
+#include "fmt/printf.h"
+
 namespace Envoy {
 namespace Upstream {
 namespace {

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -31,6 +31,7 @@ envoy_cc_test_library(
     name = "config_test_lib",
     srcs = ["config_test.cc"],
     hdrs = ["config_test.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//source/server:configuration_lib",
         "//test/integration:integration_lib",

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -10,9 +10,9 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 using testing::Invoke;
 using testing::NiceMock;

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -91,6 +91,7 @@ envoy_cc_test(
         "//test/config/integration:server.json",
         "//test/config/integration:server_config_files",
     ],
+    external_deps = ["fmtlib"],
     deps = [
         ":integration_lib",
         "//include/envoy/http:header_map_interface",
@@ -114,6 +115,7 @@ envoy_cc_test_library(
         "utility.h",
     ],
     data = ["//test/common/runtime:filesystem_test_data"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/api:api_interface",
         "//include/envoy/buffer:buffer_interface",

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -21,6 +21,8 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
+
 namespace Envoy {
 FakeStream::FakeStream(FakeHttpConnection& parent, Http::StreamEncoder& encoder)
     : parent_(parent), encoder_(encoder) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -27,8 +27,8 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 using testing::AnyNumber;
 using testing::Invoke;

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/integration/utility.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -21,7 +21,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -35,6 +35,7 @@ envoy_cc_test_library(
     name = "network_utility_lib",
     srcs = ["network_utility.cc"],
     hdrs = ["network_utility.h"],
+    external_deps = ["fmtlib"],
     deps = [
         ":utility_lib",
         "//source/common/common:assert_lib",
@@ -59,6 +60,7 @@ envoy_cc_test_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
+    external_deps = ["fmtlib"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/http:codec_interface",

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -13,7 +13,7 @@
 
 #include "test/test_common/utility.h"
 
-#include "spdlog/spdlog.h"
+#include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -20,8 +20,8 @@
 
 #include "test/test_common/printers.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 using testing::GTEST_FLAG(random_seed);
 

--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -12,6 +12,7 @@ envoy_package()
 envoy_cc_test_library(
     name = "config_load_check_lib",
     srcs = ["config_load_check.cc"],
+    external_deps = ["fmtlib"],
     deps = ["//test/config_test:config_test_lib"],
 )
 

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -5,8 +5,8 @@
 
 #include "test/config_test/config_test.h"
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {


### PR DESCRIPTION
…ndency to version 0.14.0.

Notes:
- added fmtlib/fmt 4.0.0 as a new dependency
- upgraded spdlog dependency to 0.14.0
- spdlog now takes the version of fmt that we include, rather than spdlog's bundled version of fmt
- changed multiple source files to explicitly include fmt/format.h, rather than spdlog, when using fmt::format, and edited corresponding BUILD files to add fmtlib as an external dependency
- changed test/common/upstream/utility.h to include fmt/print.f instead of spdlog

#975 

@htuch 