### PR TITLE
tracing: Use 'operation_name' to determine whether client or server s…

### DIFF
--- a/examples/jaeger-tracing/front-envoy-jaeger.json
+++ b/examples/jaeger-tracing/front-envoy-jaeger.json
@@ -8,7 +8,7 @@
           "name": "http_connection_manager",
           "config": {
             "tracing": {
-              "operation_name": "ingress"
+              "operation_name": "egress"
             }, 
             "codec_type": "auto",
             "stat_prefix": "ingress_http",

--- a/examples/zipkin-tracing/front-envoy-zipkin.json
+++ b/examples/zipkin-tracing/front-envoy-zipkin.json
@@ -9,7 +9,7 @@
           "config": {
             "generate_request_id": true,
             "tracing": {
-              "operation_name": "ingress"
+              "operation_name": "egress"
             }, 
             "codec_type": "auto",
             "stat_prefix": "ingress_http",

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -79,9 +79,9 @@ public:
 
   /**
    * Create and start a child Span, with this Span as its parent in the trace.
+   * @param config the tracing configuration
    * @param name operation name captured by the spawned child
    * @param start_time initial start time for the operation captured by the child
-   * @param config the tracing configuration
    */
   virtual SpanPtr spawnChild(const Config& config, const std::string& name,
                              SystemTime start_time) PURE;

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -82,7 +82,8 @@ public:
    * @param name operation name captured by the spawned child
    * @param start_time initial start time for the operation captured by the child
    */
-  virtual SpanPtr spawnChild(const std::string& name, SystemTime start_time) PURE;
+  virtual SpanPtr spawnChild(const Config& config, const std::string& name,
+                             SystemTime start_time) PURE;
 };
 
 /**
@@ -95,8 +96,8 @@ public:
   /**
    * Start driver specific span.
    */
-  virtual SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string& operation_name,
-                            SystemTime start_time) PURE;
+  virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+                            const std::string& operation_name, SystemTime start_time) PURE;
 };
 
 typedef std::unique_ptr<Driver> DriverPtr;

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -81,6 +81,7 @@ public:
    * Create and start a child Span, with this Span as its parent in the trace.
    * @param name operation name captured by the spawned child
    * @param start_time initial start time for the operation captured by the child
+   * @param config the tracing configuration
    */
   virtual SpanPtr spawnChild(const Config& config, const std::string& name,
                              SystemTime start_time) PURE;

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -175,7 +175,8 @@ SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request
     span_name.append(request_headers.Host()->value().c_str());
   }
 
-  SpanPtr active_span = driver_->startSpan(request_headers, span_name, request_info.startTime());
+  SpanPtr active_span =
+      driver_->startSpan(config, request_headers, span_name, request_info.startTime());
   if (active_span) {
     active_span->setTag("node_id", local_info_.nodeName());
     active_span->setTag("zone", local_info_.zoneName());

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -68,7 +68,9 @@ public:
   void setTag(const std::string&, const std::string&) override {}
   void finishSpan(SpanFinalizer&) override {}
   void injectContext(Http::HeaderMap&) override {}
-  SpanPtr spawnChild(const std::string&, SystemTime) override { return SpanPtr{new NullSpan()}; }
+  SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
+    return SpanPtr{new NullSpan()};
+  }
 };
 
 class NullFinalizer : public SpanFinalizer {

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -36,7 +36,7 @@ void LightStepSpan::injectContext(Http::HeaderMap& request_headers) {
       Base64::encode(current_span_context.c_str(), current_span_context.length()));
 }
 
-SpanPtr LightStepSpan::spawnChild(const std::string& name, SystemTime start_time) {
+SpanPtr LightStepSpan::spawnChild(const Config&, const std::string& name, SystemTime start_time) {
   lightstep::Span ls_span = tracer_.StartSpan(
       name, {lightstep::ChildOf(span_.context()), lightstep::StartTimestamp(start_time)});
   return SpanPtr{new LightStepSpan(ls_span, tracer_)};
@@ -135,7 +135,7 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
   });
 }
 
-SpanPtr LightStepDriver::startSpan(Http::HeaderMap& request_headers,
+SpanPtr LightStepDriver::startSpan(const Config&, Http::HeaderMap& request_headers,
                                    const std::string& operation_name, SystemTime start_time) {
   lightstep::Tracer& tracer = *tls_->getTyped<TlsLightStepTracer>().tracer_;
   LightStepSpanPtr active_span;

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -35,7 +35,7 @@ public:
   void finishSpan(SpanFinalizer& finalizer) override;
   void setTag(const std::string& name, const std::string& value) override;
   void injectContext(Http::HeaderMap& request_headers) override;
-  SpanPtr spawnChild(const std::string& name, SystemTime start_time) override;
+  SpanPtr spawnChild(const Config& config, const std::string& name, SystemTime start_time) override;
 
   lightstep::SpanContext context() { return span_.context(); }
 
@@ -59,8 +59,8 @@ public:
                   std::unique_ptr<lightstep::TracerOptions> options);
 
   // Tracer::TracingDriver
-  SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string& operation_name,
-                    SystemTime start_time) override;
+  SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+                    const std::string& operation_name, SystemTime start_time) override;
 
   Upstream::ClusterManager& clusterManager() { return cm_; }
   Upstream::ClusterInfoConstSharedPtr cluster() { return cluster_; }

--- a/source/common/tracing/zipkin/span_context.cc
+++ b/source/common/tracing/zipkin/span_context.cc
@@ -75,22 +75,11 @@ SpanContext::SpanContext(const Span& span) {
   id_ = span.id();
   parent_id_ = span.isSetParentId() ? span.parentId() : 0;
 
-  for (const Annotation& annotation : span.annotations()) {
-    if (annotation.value() == ZipkinCoreConstants::get().CLIENT_RECV) {
-      annotation_values_.cr_ = true;
-    } else if (annotation.value() == ZipkinCoreConstants::get().CLIENT_SEND) {
-      annotation_values_.cs_ = true;
-    } else if (annotation.value() == ZipkinCoreConstants::get().SERVER_RECV) {
-      annotation_values_.sr_ = true;
-    } else if (annotation.value() == ZipkinCoreConstants::get().SERVER_SEND) {
-      annotation_values_.ss_ = true;
-    }
-  }
-
   is_initialized_ = true;
 }
 
 const std::string SpanContext::serializeToString() {
+
   if (!is_initialized_) {
     return unitializedSpanContext();
   }
@@ -99,19 +88,6 @@ const std::string SpanContext::serializeToString() {
   result = traceIdAsHexString() + fieldSeparator() + idAsHexString() + fieldSeparator() +
            parentIdAsHexString();
 
-  if (annotation_values_.cr_) {
-    result += fieldSeparator() + ZipkinCoreConstants::get().CLIENT_RECV;
-  }
-  if (annotation_values_.cs_) {
-    result += fieldSeparator() + ZipkinCoreConstants::get().CLIENT_SEND;
-  }
-  if (annotation_values_.sr_) {
-    result += fieldSeparator() + ZipkinCoreConstants::get().SERVER_RECV;
-  }
-  if (annotation_values_.ss_) {
-    result += fieldSeparator() + ZipkinCoreConstants::get().SERVER_SEND;
-  }
-
   return result;
 }
 
@@ -119,31 +95,12 @@ void SpanContext::populateFromString(const std::string& span_context_str) {
   std::smatch match;
 
   trace_id_ = parent_id_ = id_ = 0;
-  annotation_values_.cs_ = annotation_values_.cr_ = annotation_values_.ss_ =
-      annotation_values_.sr_ = false;
 
   if (std::regex_search(span_context_str, match, spanContextRegex())) {
     // This is a valid string encoding of the context
     trace_id_ = std::stoull(match.str(1), nullptr, 16);
     id_ = std::stoull(match.str(2), nullptr, 16);
     parent_id_ = std::stoull(match.str(3), nullptr, 16);
-
-    std::string matched_annotations = match.str(4);
-    if (matched_annotations.size() > 0) {
-      std::vector<std::string> annotation_value_strings =
-          StringUtil::split(matched_annotations, fieldSeparator());
-      for (const std::string& annotation_value : annotation_value_strings) {
-        if (annotation_value == ZipkinCoreConstants::get().CLIENT_RECV) {
-          annotation_values_.cr_ = true;
-        } else if (annotation_value == ZipkinCoreConstants::get().CLIENT_SEND) {
-          annotation_values_.cs_ = true;
-        } else if (annotation_value == ZipkinCoreConstants::get().SERVER_RECV) {
-          annotation_values_.sr_ = true;
-        } else if (annotation_value == ZipkinCoreConstants::get().SERVER_SEND) {
-          annotation_values_.ss_ = true;
-        }
-      }
-    }
 
     is_initialized_ = true;
   } else {

--- a/source/common/tracing/zipkin/span_context.cc
+++ b/source/common/tracing/zipkin/span_context.cc
@@ -79,7 +79,6 @@ SpanContext::SpanContext(const Span& span) {
 }
 
 const std::string SpanContext::serializeToString() {
-
   if (!is_initialized_) {
     return unitializedSpanContext();
   }

--- a/source/common/tracing/zipkin/span_context.h
+++ b/source/common/tracing/zipkin/span_context.h
@@ -9,26 +9,6 @@ namespace Envoy {
 namespace Zipkin {
 
 /**
- * This struct identifies which Zipkin annotations are present in the
- * span context (see SpanContext)
- * Each member is a one-bit boolean indicating whether or not the
- * corresponding annotation is present.
- *
- * In particular, the following annotations are tracked by this struct:
- * CS: "Client Send"
- * CR: "Client Receive"
- * SS: "Server Send"
- * SR: "Server Receive"
- */
-struct AnnotationSet {
-  AnnotationSet() : cs_(false), cr_(false), ss_(false), sr_(false) {}
-  bool cs_ : 1;
-  bool cr_ : 1;
-  bool ss_ : 1;
-  bool sr_ : 1;
-};
-
-/**
  * This class represents the context of a Zipkin span. It embodies the following
  * span characteristics: trace id, span id, parent id, and basic annotations.
  */
@@ -105,16 +85,10 @@ public:
    */
   std::string traceIdAsHexString() const { return Hex::uint64ToHex(trace_id_); }
 
-  /**
-   * @return a struct indicating which annotations are present in the span.
-   */
-  AnnotationSet annotationSet() const { return annotation_values_; }
-
 private:
   uint64_t trace_id_;
   uint64_t id_;
   uint64_t parent_id_;
-  AnnotationSet annotation_values_;
   bool is_initialized_;
 };
 } // namespace Zipkin

--- a/source/common/tracing/zipkin/tracer.cc
+++ b/source/common/tracing/zipkin/tracer.cc
@@ -3,20 +3,26 @@
 #include <chrono>
 
 #include "common/common/utility.h"
+#include "common/tracing/http_tracer_impl.h"
 #include "common/tracing/zipkin/util.h"
 #include "common/tracing/zipkin/zipkin_core_constants.h"
 
 namespace Envoy {
 namespace Zipkin {
 
-SpanPtr Tracer::startSpan(const std::string& span_name, SystemTime timestamp) {
+SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span_name,
+                          SystemTime timestamp) {
   // Build the endpoint
   Endpoint ep(service_name_, address_);
 
   // Build the CS annotation
   Annotation cs;
   cs.setEndpoint(std::move(ep));
-  cs.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
+  if (config.operationName() == Tracing::OperationName::Egress) {
+    cs.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
+  } else {
+    cs.setValue(ZipkinCoreConstants::get().SERVER_SEND);
+  }
 
   // Create an all-new span, with no parent id
   SpanPtr span_ptr(new Span());
@@ -44,8 +50,8 @@ SpanPtr Tracer::startSpan(const std::string& span_name, SystemTime timestamp) {
   return span_ptr;
 }
 
-SpanPtr Tracer::startSpan(const std::string& span_name, SystemTime timestamp,
-                          SpanContext& previous_context) {
+SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span_name,
+                          SystemTime timestamp, SpanContext& previous_context) {
   SpanPtr span_ptr(new Span());
   Annotation annotation;
   uint64_t timestamp_micro;
@@ -53,7 +59,7 @@ SpanPtr Tracer::startSpan(const std::string& span_name, SystemTime timestamp,
   timestamp_micro =
       std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count();
 
-  if (previous_context.annotationSet().sr_ && !previous_context.annotationSet().cs_) {
+  if (config.operationName() == Tracing::OperationName::Egress) {
     // We need to create a new span that is a child of the previous span; no shared context
 
     // Create a new span id
@@ -70,7 +76,7 @@ SpanPtr Tracer::startSpan(const std::string& span_name, SystemTime timestamp,
 
     // Set the timestamp globally for the span
     span_ptr->setTimestamp(timestamp_micro);
-  } else if (previous_context.annotationSet().cs_ && !previous_context.annotationSet().sr_) {
+  } else if (config.operationName() == Tracing::OperationName::Ingress) {
     // We need to create a new span that will share context with the previous span
 
     // Initialize the shared context for the new span

--- a/source/common/tracing/zipkin/tracer.cc
+++ b/source/common/tracing/zipkin/tracer.cc
@@ -21,7 +21,7 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
   if (config.operationName() == Tracing::OperationName::Egress) {
     cs.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
   } else {
-    cs.setValue(ZipkinCoreConstants::get().SERVER_SEND);
+    cs.setValue(ZipkinCoreConstants::get().SERVER_RECV);
   }
 
   // Create an all-new span, with no parent id

--- a/source/common/tracing/zipkin/tracer.h
+++ b/source/common/tracing/zipkin/tracer.h
@@ -62,6 +62,7 @@ public:
   /**
    * Creates a "root" Zipkin span.
    *
+   * @param config The tracing configuration
    * @param span_name Name of the new span.
    * @param start_time The time indicating the beginning of the span.
    */
@@ -70,6 +71,7 @@ public:
   /**
    * Depending on the given context, creates either a "child" or a "shared-context" Zipkin span.
    *
+   * @param config The tracing configuration
    * @param span_name Name of the new span.
    * @param start_time The time indicating the beginning of the span.
    * @param previous_context The context of the span preceding the one to be created.

--- a/source/common/tracing/zipkin/tracer.h
+++ b/source/common/tracing/zipkin/tracer.h
@@ -3,6 +3,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/tracing/http_tracer.h"
 
 #include "common/tracing/zipkin/span_context.h"
 #include "common/tracing/zipkin/tracer_interface.h"
@@ -64,7 +65,7 @@ public:
    * @param span_name Name of the new span.
    * @param start_time The time indicating the beginning of the span.
    */
-  SpanPtr startSpan(const std::string& span_name, SystemTime timestamp);
+  SpanPtr startSpan(const Tracing::Config&, const std::string& span_name, SystemTime timestamp);
 
   /**
    * Depending on the given context, creates either a "child" or a "shared-context" Zipkin span.
@@ -73,7 +74,7 @@ public:
    * @param start_time The time indicating the beginning of the span.
    * @param previous_context The context of the span preceding the one to be created.
    */
-  SpanPtr startSpan(const std::string& span_name, SystemTime timestamp,
+  SpanPtr startSpan(const Tracing::Config&, const std::string& span_name, SystemTime timestamp,
                     SpanContext& previous_context);
 
   /**

--- a/source/common/tracing/zipkin/zipkin_core_types.cc
+++ b/source/common/tracing/zipkin/zipkin_core_types.cc
@@ -220,7 +220,7 @@ const std::string Span::toJson() {
 void Span::finish() {
   // Assumption: Span will have only one annotation when this method is called
   SpanContext context(*this);
-  if (context.annotationSet().sr_ && !context.annotationSet().ss_) {
+  if (annotations_[0].value() == ZipkinCoreConstants::get().SERVER_RECV) {
     // Need to set the SS annotation
     Annotation ss;
     ss.setEndpoint(annotations_[0].endpoint());
@@ -229,7 +229,7 @@ void Span::finish() {
                         .count());
     ss.setValue(ZipkinCoreConstants::get().SERVER_SEND);
     annotations_.push_back(std::move(ss));
-  } else if (context.annotationSet().cs_ && !context.annotationSet().cr_) {
+  } else if (annotations_[0].value() == ZipkinCoreConstants::get().CLIENT_SEND) {
     // Need to set the CR annotation
     Annotation cr;
     const uint64_t stop_timestamp =

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -41,9 +41,11 @@ void ZipkinSpan::injectContext(Http::HeaderMap& request_headers) {
   request_headers.insertOtSpanContext().value(context.serializeToString());
 }
 
-Tracing::SpanPtr ZipkinSpan::spawnChild(const std::string& name, SystemTime start_time) {
+Tracing::SpanPtr ZipkinSpan::spawnChild(const Tracing::Config& config, const std::string& name,
+                                        SystemTime start_time) {
   SpanContext context(span_);
-  return Tracing::SpanPtr{new ZipkinSpan(*tracer_.startSpan(name, start_time, context), tracer_)};
+  return Tracing::SpanPtr{
+      new ZipkinSpan(*tracer_.startSpan(config, name, start_time, context), tracer_)};
 }
 
 Driver::TlsTracer::TlsTracer(TracerPtr&& tracer, Driver& driver)
@@ -76,8 +78,8 @@ Driver::Driver(const Json::Object& config, Upstream::ClusterManager& cluster_man
   });
 }
 
-Tracing::SpanPtr Driver::startSpan(Http::HeaderMap& request_headers, const std::string&,
-                                   SystemTime start_time) {
+Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
+                                   const std::string&, SystemTime start_time) {
   Tracer& tracer = *tls_->getTyped<TlsTracer>().tracer_;
   SpanPtr new_zipkin_span;
 
@@ -102,10 +104,10 @@ Tracing::SpanPtr Driver::startSpan(Http::HeaderMap& request_headers, const std::
     // being at the receiving end, will add the SR annotation to the shared span context.
 
     new_zipkin_span =
-        tracer.startSpan(request_headers.Host()->value().c_str(), start_time, context);
+        tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time, context);
   } else {
     // Create a root Zipkin span. No context was found in the headers.
-    new_zipkin_span = tracer.startSpan(request_headers.Host()->value().c_str(), start_time);
+    new_zipkin_span = tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time);
   }
 
   ZipkinSpanPtr active_span(new ZipkinSpan(*new_zipkin_span, tracer));

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.h
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.h
@@ -90,7 +90,7 @@ public:
    * It starts a new Zipkin span. Depending on the request headers, it can create a root span,
    * a child span, or a shared-context span.
    *
-   * The second parameter (operation_name) does not actually make sense for Zipkin.
+   * The third parameter (operation_name) does not actually make sense for Zipkin.
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.h
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.h
@@ -56,7 +56,8 @@ public:
   void setTag(const std::string& name, const std::string& value) override;
 
   void injectContext(Http::HeaderMap& request_headers) override;
-  Tracing::SpanPtr spawnChild(const std::string& name, SystemTime start_time) override;
+  Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
+                              SystemTime start_time) override;
 
   /**
    * @return a reference to the Zipkin::Span object.
@@ -93,8 +94,8 @@ public:
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */
-  Tracing::SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string&,
-                             SystemTime start_time) override;
+  Tracing::SpanPtr startSpan(const Tracing::Config&, Http::HeaderMap& request_headers,
+                             const std::string&, SystemTime start_time) override;
 
   // Getters to return the ZipkinDriver's key members.
   Upstream::ClusterManager& clusterManager() { return cm_; }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -421,7 +421,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
 
   span_ptr->setTag("foo", "bar");
   span_ptr->injectContext(request_headers);
-  EXPECT_NE(nullptr, span_ptr->spawnChild("foo", std::chrono::system_clock::now()));
+  EXPECT_NE(nullptr, span_ptr->spawnChild(config, "foo", std::chrono::system_clock::now()));
 }
 
 class HttpTracerImplTest : public Test {
@@ -445,7 +445,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNullSpan) {
   EXPECT_CALL(config_, operationName()).Times(2);
   EXPECT_CALL(request_info_, startTime());
   const std::string operation_name = "ingress";
-  EXPECT_CALL(*driver_, startSpan_(_, operation_name, request_info_.start_time_))
+  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_))
       .WillOnce(Return(nullptr));
 
   tracer_->startSpan(config_, request_headers_, request_info_);
@@ -458,7 +458,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
 
   NiceMock<MockSpan>* span = new NiceMock<MockSpan>();
   const std::string operation_name = "egress test";
-  EXPECT_CALL(*driver_, startSpan_(_, operation_name, request_info_.start_time_))
+  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_))
       .WillOnce(Return(span));
 
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());

--- a/test/common/tracing/zipkin/span_context_test.cc
+++ b/test/common/tracing/zipkin/span_context_test.cc
@@ -16,13 +16,9 @@ TEST(ZipkinSpanContextTest, populateFromString) {
   EXPECT_EQ("0000000000000000", span_context.idAsHexString());
   EXPECT_EQ(0ULL, span_context.parent_id());
   EXPECT_EQ("0000000000000000", span_context.parentIdAsHexString());
-  EXPECT_FALSE(span_context.annotationSet().cr_);
-  EXPECT_FALSE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
   EXPECT_EQ("0000000000000000;0000000000000000;0000000000000000", span_context.serializeToString());
 
-  // Span context populated with trace id, id, parent id, and no annotations
+  // Span context populated with trace id, id and parent id
   span_context.populateFromString("25c6f38dd0600e79;56707c7b3e1092af;c49193ea42335d1c");
   EXPECT_EQ(2722130815203937913ULL, span_context.trace_id());
   EXPECT_EQ("25c6f38dd0600e79", span_context.traceIdAsHexString());
@@ -30,71 +26,7 @@ TEST(ZipkinSpanContextTest, populateFromString) {
   EXPECT_EQ("56707c7b3e1092af", span_context.idAsHexString());
   EXPECT_EQ(14164264937399213340ULL, span_context.parent_id());
   EXPECT_EQ("c49193ea42335d1c", span_context.parentIdAsHexString());
-  EXPECT_FALSE(span_context.annotationSet().cr_);
-  EXPECT_FALSE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
   EXPECT_EQ("25c6f38dd0600e79;56707c7b3e1092af;c49193ea42335d1c", span_context.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and one annotation
-  span_context.populateFromString("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs");
-  EXPECT_EQ(2722130815203937912ULL, span_context.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context.parentIdAsHexString());
-  EXPECT_FALSE(span_context.annotationSet().cr_);
-  EXPECT_TRUE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs",
-            span_context.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and two annotations
-  span_context.populateFromString("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs;cr");
-  EXPECT_EQ(2722130815203937912ULL, span_context.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context.parentIdAsHexString());
-  EXPECT_TRUE(span_context.annotationSet().cr_);
-  EXPECT_TRUE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cr;cs",
-            span_context.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and three annotations
-  span_context.populateFromString("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs;cr;ss");
-  EXPECT_EQ(2722130815203937912ULL, span_context.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context.parentIdAsHexString());
-  EXPECT_TRUE(span_context.annotationSet().cr_);
-  EXPECT_TRUE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_TRUE(span_context.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cr;cs;ss",
-            span_context.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and four annotations
-  span_context.populateFromString("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs;cr;ss;sr");
-  EXPECT_EQ(2722130815203937912ULL, span_context.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context.parentIdAsHexString());
-  EXPECT_TRUE(span_context.annotationSet().cr_);
-  EXPECT_TRUE(span_context.annotationSet().cs_);
-  EXPECT_TRUE(span_context.annotationSet().sr_);
-  EXPECT_TRUE(span_context.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cr;cs;sr;ss",
-            span_context.serializeToString());
 
   // Span context populated with invalid string: it gets reset to its non-initialized state
   span_context.populateFromString("invalid string");
@@ -104,10 +36,6 @@ TEST(ZipkinSpanContextTest, populateFromString) {
   EXPECT_EQ("0000000000000000", span_context.idAsHexString());
   EXPECT_EQ(0ULL, span_context.parent_id());
   EXPECT_EQ("0000000000000000", span_context.parentIdAsHexString());
-  EXPECT_FALSE(span_context.annotationSet().cr_);
-  EXPECT_FALSE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
   EXPECT_EQ("0000000000000000;0000000000000000;0000000000000000", span_context.serializeToString());
 }
 
@@ -122,13 +50,9 @@ TEST(ZipkinSpanContextTest, populateFromSpan) {
   EXPECT_EQ("0000000000000000", span_context.idAsHexString());
   EXPECT_EQ(0ULL, span_context.parent_id());
   EXPECT_EQ("0000000000000000", span_context.parentIdAsHexString());
-  EXPECT_FALSE(span_context.annotationSet().cr_);
-  EXPECT_FALSE(span_context.annotationSet().cs_);
-  EXPECT_FALSE(span_context.annotationSet().sr_);
-  EXPECT_FALSE(span_context.annotationSet().ss_);
   EXPECT_EQ("0000000000000000;0000000000000000;0000000000000000", span_context.serializeToString());
 
-  // Span context populated with trace id, id, parent id, and no annotations
+  // Span context populated with trace id, id and parent id
   span.setTraceId(2722130815203937912ULL);
   span.setId(6228615153417491119ULL);
   span.setParentId(14164264937399213340ULL);
@@ -139,10 +63,6 @@ TEST(ZipkinSpanContextTest, populateFromSpan) {
   EXPECT_EQ("56707c7b3e1092af", span_context_2.idAsHexString());
   EXPECT_EQ(14164264937399213340ULL, span_context_2.parent_id());
   EXPECT_EQ("c49193ea42335d1c", span_context_2.parentIdAsHexString());
-  EXPECT_FALSE(span_context_2.annotationSet().cr_);
-  EXPECT_FALSE(span_context_2.annotationSet().cs_);
-  EXPECT_FALSE(span_context_2.annotationSet().sr_);
-  EXPECT_FALSE(span_context_2.annotationSet().ss_);
   EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c",
             span_context_2.serializeToString());
 
@@ -154,84 +74,6 @@ TEST(ZipkinSpanContextTest, populateFromSpan) {
   // We currently drop the high bits. So, we expect the same context as above
   EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c",
             span_context_high_id.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and one annotation
-  Annotation ann;
-  ann.setValue(ZipkinCoreConstants::get().SERVER_RECV);
-  span.addAnnotation(ann);
-  SpanContext span_context_3(span);
-  EXPECT_EQ(2722130815203937912ULL, span_context_3.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context_3.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context_3.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context_3.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context_3.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context_3.parentIdAsHexString());
-  EXPECT_FALSE(span_context_3.annotationSet().cr_);
-  EXPECT_FALSE(span_context_3.annotationSet().cs_);
-  EXPECT_TRUE(span_context_3.annotationSet().sr_);
-  EXPECT_FALSE(span_context_3.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;sr",
-            span_context_3.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and two annotations
-  ann.setValue(ZipkinCoreConstants::get().SERVER_SEND);
-  span.addAnnotation(ann);
-  SpanContext span_context_4(span);
-  EXPECT_EQ(2722130815203937912ULL, span_context_4.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context_4.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context_4.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context_4.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context_4.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context_4.parentIdAsHexString());
-  EXPECT_FALSE(span_context_4.annotationSet().cr_);
-  EXPECT_FALSE(span_context_4.annotationSet().cs_);
-  EXPECT_TRUE(span_context_4.annotationSet().sr_);
-  EXPECT_TRUE(span_context_4.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;sr;ss",
-            span_context_4.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and three annotations
-  ann.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
-  span.addAnnotation(ann);
-  SpanContext span_context_5(span);
-  EXPECT_EQ(2722130815203937912ULL, span_context_5.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context_5.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context_5.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context_5.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context_5.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context_5.parentIdAsHexString());
-  EXPECT_FALSE(span_context_5.annotationSet().cr_);
-  EXPECT_TRUE(span_context_5.annotationSet().cs_);
-  EXPECT_TRUE(span_context_5.annotationSet().sr_);
-  EXPECT_TRUE(span_context_5.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cs;sr;ss",
-            span_context_5.serializeToString());
-
-  // Span context populated with trace id, id, parent id, and four annotations
-  std::vector<Annotation> annotations;
-  annotations.push_back(ann);
-  ann.setValue(ZipkinCoreConstants::get().SERVER_SEND);
-  annotations.push_back(ann);
-  ann.setValue(ZipkinCoreConstants::get().SERVER_RECV);
-  annotations.push_back(ann);
-  ann.setValue(ZipkinCoreConstants::get().CLIENT_RECV);
-  annotations.push_back(ann);
-  ann.setValue(ZipkinCoreConstants::get().CLIENT_SEND);
-  annotations.push_back(ann);
-  span.setAnnotations(annotations);
-  SpanContext span_context_6(span);
-  EXPECT_EQ(2722130815203937912ULL, span_context_6.trace_id());
-  EXPECT_EQ("25c6f38dd0600e78", span_context_6.traceIdAsHexString());
-  EXPECT_EQ(6228615153417491119ULL, span_context_6.id());
-  EXPECT_EQ("56707c7b3e1092af", span_context_6.idAsHexString());
-  EXPECT_EQ(14164264937399213340ULL, span_context_6.parent_id());
-  EXPECT_EQ("c49193ea42335d1c", span_context_6.parentIdAsHexString());
-  EXPECT_TRUE(span_context_6.annotationSet().cr_);
-  EXPECT_TRUE(span_context_6.annotationSet().cs_);
-  EXPECT_TRUE(span_context_6.annotationSet().sr_);
-  EXPECT_TRUE(span_context_6.annotationSet().ss_);
-  EXPECT_EQ("25c6f38dd0600e78;56707c7b3e1092af;c49193ea42335d1c;cr;cs;sr;ss",
-            span_context_6.serializeToString());
 }
 } // namespace Zipkin
 } // namespace Envoy

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -36,11 +36,13 @@ public:
   MOCK_METHOD1(finishSpan, void(SpanFinalizer& finalizer));
   MOCK_METHOD1(injectContext, void(Http::HeaderMap& request_headers));
 
-  SpanPtr spawnChild(const std::string& name, SystemTime start_time) override {
-    return SpanPtr{spawnChild_(name, start_time)};
+  SpanPtr spawnChild(const Config& config, const std::string& name,
+                     SystemTime start_time) override {
+    return SpanPtr{spawnChild_(config, name, start_time)};
   }
 
-  MOCK_METHOD2(spawnChild_, Span*(const std::string& name, SystemTime start_time));
+  MOCK_METHOD3(spawnChild_,
+               Span*(const Config& config, const std::string& name, SystemTime start_time));
 };
 
 class MockFinalizer : public SpanFinalizer {
@@ -70,12 +72,12 @@ public:
   MockDriver();
   ~MockDriver();
 
-  SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string& operation_name,
-                    SystemTime start_time) override {
-    return SpanPtr{startSpan_(request_headers, operation_name, start_time)};
+  SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
+                    const std::string& operation_name, SystemTime start_time) override {
+    return SpanPtr{startSpan_(config, request_headers, operation_name, start_time)};
   }
 
-  MOCK_METHOD3(startSpan_, Span*(Http::HeaderMap& request_headers,
+  MOCK_METHOD4(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
                                  const std::string& operation_name, SystemTime start_time));
 };
 


### PR DESCRIPTION
…pan and remove annotations from propagated OtSpanContext

This is a purely internal change that should not affect any users. It is primarily to localise the decision regarding whether a client or server span should be created based on the tracing configuration associated with the filter - i.e. ingress = server span, egress = client span.

Currently this decision is based on what annotations have previously been set and passed with the OtSpanContext header.