### PR TITLE
ci: small docker changes for local dev

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -6,7 +6,7 @@ set -e
 
 export PPROF_PATH=/thirdparty_build/bin/pprof
 
-NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
+[ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 
 export ENVOY_SRCDIR=/source
 

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -20,5 +20,5 @@ fi
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
-  -v "$PWD":/source lyft/envoy-build:"${IMAGE_ID}" /bin/bash -c "cd source && $*"
+docker run --rm -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
+  -v "$PWD":/source -e NUM_CPUS lyft/envoy-build:"${IMAGE_ID}" /bin/bash -c "cd source && $*"


### PR DESCRIPTION
1) Pass --rm to run_envoy_docker() to clean up container when finished.
2) Allow NUM_CPUS to be overridden.