### PR TITLE
docs: add automake to OS X build instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -41,6 +41,7 @@ brew install cmake
 brew install libtool
 brew install go
 brew install bazel
+brew install automake
 ```
 
 Envoy compiles and passes tests with the version of clang installed by XCode 8.3.3:


### PR DESCRIPTION
When trying to run the build on OS X (10.12.6) following the build instructions in `bazel/README.md` I encountered a failure when running `bazel fetch //source/...` to fetch and build all external dependencies.

The output contained the following logs:

```
++ 1504041217.N ./buildconf
buildconf: running libtoolize
buildconf: converting all mv to mv -f in local m4/libtool.m4
buildconf: running aclocal
./buildconf: line 217: aclocal: command not found
buildconf: aclocal command failed
```

As `aclocal` is part of `automake`, running the following command fixed the failure:

```
brew install automake
```

This PR adds this command to the build instructions.