### PR TITLE
add x-envoy-immediate-health-check-fail header support

### DIFF
--- a/docs/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/configuration/cluster_manager/cluster_stats.rst
@@ -78,6 +78,7 @@ If health check is configured, the cluster has an additional statistics tree roo
   attempt, Counter, Number of health checks
   success, Counter, Number of successful health checks
   failure, Counter, Number of immediately failed health checks (e.g. HTTP 503) as well as network failures
+  passive_failure, Counter, Number of health check failures due to passive events (e.g. x-envoy-immediate-health-check-fail)
   network_failure, Counter, Number of health check failures due to network error
   verify_cluster, Counter, Number of health checks that attempted cluster name verification
   healthy, Gauge, Number of healthy members

--- a/docs/configuration/http_filters/health_check_filter.rst
+++ b/docs/configuration/http_filters/health_check_filter.rst
@@ -17,6 +17,11 @@ Health check filter :ref:`architecture overview <arch_overview_health_checking_f
      }
   }
 
+Note that the filter will automatically set the :ref:`x-envoy-immediate-health-check-fail
+<config_http_filters_router_x-envoy-immediate-health-check-fail>` header if the
+:ref:`/healthcheck/fail <operations_admin_interface_healthcheck_fail>` admin endpoint has been
+called.
+
 pass_through_mode
   *(required, boolean)* Specifies whether the filter operates in pass through mode or not.
 

--- a/docs/configuration/http_filters/health_check_filter.rst
+++ b/docs/configuration/http_filters/health_check_filter.rst
@@ -17,10 +17,12 @@ Health check filter :ref:`architecture overview <arch_overview_health_checking_f
      }
   }
 
-Note that the filter will automatically set the :ref:`x-envoy-immediate-health-check-fail
+Note that the filter will automatically fail health checks and set the
+:ref:`x-envoy-immediate-health-check-fail
 <config_http_filters_router_x-envoy-immediate-health-check-fail>` header if the
 :ref:`/healthcheck/fail <operations_admin_interface_healthcheck_fail>` admin endpoint has been
-called.
+called. (The :ref:`/healthcheck/ok <operations_admin_interface_healthcheck_ok>` admin endpoint
+reverses this behavior).
 
 pass_through_mode
   *(required, boolean)* Specifies whether the filter operates in pass through mode or not.

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -209,6 +209,18 @@ If the route utilizes :ref:`prefix_rewrite <config_http_conn_man_route_table_rou
 Envoy will put the original path header in this header. This can be useful for logging and
 debugging.
 
+.. _config_http_filters_router_x-envoy-immediate-health-check-fail:
+
+x-envoy-immediate-health-check-fail
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the upstream host returns this header (set to any value), Envoy will immediately assume the
+upstream host has failed :ref:`active health checking <arch_overview_health_checking>` (if the
+cluster has been :ref:`configured <config_cluster_manager_cluster_hc>` for active health checking).
+This can be used to fast fail an upstream host via standard data plane processing without waiting
+for the next health check interval. See the :ref:`health checking overview
+<arch_overview_health_checking>` for more information.
+
 .. _config_http_filters_router_stats:
 
 Statistics

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -218,8 +218,9 @@ If the upstream host returns this header (set to any value), Envoy will immediat
 upstream host has failed :ref:`active health checking <arch_overview_health_checking>` (if the
 cluster has been :ref:`configured <config_cluster_manager_cluster_hc>` for active health checking).
 This can be used to fast fail an upstream host via standard data plane processing without waiting
-for the next health check interval. See the :ref:`health checking overview
-<arch_overview_health_checking>` for more information.
+for the next health check interval. The host can become healthy again via standard active health
+checks. See the :ref:`health checking overview <arch_overview_health_checking>` for more
+information.
 
 .. _config_http_filters_router_stats:
 

--- a/docs/intro/arch_overview/health_checking.rst
+++ b/docs/intro/arch_overview/health_checking.rst
@@ -21,7 +21,10 @@ unhealthy, successes required before marking a host healthy, etc.):
   server can respond with anything other than PONG to cause an immediate active health check
   failure.
 
-Note that Envoy also supports passive health checking via :ref:`outlier detection
+Passive health checking
+-----------------------
+
+Envoy also supports passive health checking via :ref:`outlier detection
 <arch_overview_outlier_detection>`.
 
 .. _arch_overview_health_checking_filter:
@@ -47,7 +50,11 @@ operation:
   eventually consistent view of the health state of each upstream host without overwhelming the
   local service with a large number of health check requests.
 
-Health check filter :ref:`configuration <config_http_filters_health_check>`.
+Further reading:
+
+* Health check filter :ref:`configuration <config_http_filters_health_check>`.
+* :ref:`/healthcheck/fail <operations_admin_interface_healthcheck_fail>` admin endpoint.
+* :ref:`/healthcheck/ok <operations_admin_interface_healthcheck_ok>` admin endpoint.
 
 Active health checking fast failure
 -----------------------------------

--- a/docs/intro/arch_overview/health_checking.rst
+++ b/docs/intro/arch_overview/health_checking.rst
@@ -49,6 +49,23 @@ operation:
 
 Health check filter :ref:`configuration <config_http_filters_health_check>`.
 
+Active health checking fast failure
+-----------------------------------
+
+When using active health checking along with passive health checking (:ref:`outlier detection
+<arch_overview_outlier_detection>`), it is common to use a long health checking interval to avoid a
+large amount of active health checking traffic. In this case, it is still useful to be able to
+quickly drain an upstream host when using the :ref:`/healthcheck/fail
+<operations_admin_interface_healthcheck_fail>` admin endpoint. To support this, the :ref:`router
+filter <config_http_filters_router>` will respond to the :ref:`x-envoy-immediate-health-check-fail
+<config_http_filters_router_x-envoy-immediate-health-check-fail>` header. If this header is set by
+an upstream host, Envoy will immediately mark the host as being failed for active health check. Note
+that this only occurs if the host's cluster has active health checking :ref:`configured
+<config_cluster_manager_cluster_hc>`. The :ref:`health checking filter
+<config_http_filters_health_check>` will automatically set this header if Envoy has been marked as
+failed via the :ref:`/healthcheck/fail <operations_admin_interface_healthcheck_fail>` admin
+endpoint.
+
 .. _arch_overview_health_checking_identity:
 
 Health check identity

--- a/docs/operations/admin.rst
+++ b/docs/operations/admin.rst
@@ -66,6 +66,8 @@ modify different aspects of the server.
 
   Enable or disable the CPU profiler. Requires compiling with gperftools.
 
+.. _operations_admin_interface_healthcheck_fail:
+
 .. http:get:: /healthcheck/fail
 
   Fail inbound health checks. This requires the use of the HTTP :ref:`health check filter

--- a/docs/operations/admin.rst
+++ b/docs/operations/admin.rst
@@ -75,6 +75,8 @@ modify different aspects of the server.
   down or doing a full restart. Invoking this command will universally fail health check requests
   regardless of how the filter is configured (pass through, etc.).
 
+.. _operations_admin_interface_healthcheck_ok:
+
 .. http:get:: /healthcheck/ok
 
   Negate the effect of :http:get:`/healthcheck/fail`. This requires the use of the HTTP

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -212,6 +212,7 @@ private:
   HEADER_FUNC(EnvoyExpectedRequestTimeoutMs)                                                       \
   HEADER_FUNC(EnvoyExternalAddress)                                                                \
   HEADER_FUNC(EnvoyForceTrace)                                                                     \
+  HEADER_FUNC(EnvoyImmediateHealthCheckFail)                                                       \
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -35,9 +35,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "health_checker_sink_interface",
+    hdrs = ["health_checker_sink.h"],
+)
+
+envoy_cc_library(
     name = "host_description_interface",
     hdrs = ["host_description.h"],
     deps = [
+        ":health_checker_sink_interface",
         ":outlier_detection_interface",
         "//include/envoy/network:address_interface",
         "//include/envoy/stats:stats_macros",
@@ -78,6 +84,7 @@ envoy_cc_library(
     name = "upstream_interface",
     hdrs = ["upstream.h"],
     deps = [
+        ":health_checker_sink_interface",
         ":load_balancer_type_interface",
         ":resource_manager_interface",
         "//include/envoy/common:callback",

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -35,15 +35,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "health_checker_sink_interface",
-    hdrs = ["health_checker_sink.h"],
+    name = "health_check_host_monitor_interface",
+    hdrs = ["health_check_host_monitor.h"],
 )
 
 envoy_cc_library(
     name = "host_description_interface",
     hdrs = ["host_description.h"],
     deps = [
-        ":health_checker_sink_interface",
+        ":health_check_host_monitor_interface",
         ":outlier_detection_interface",
         "//include/envoy/network:address_interface",
         "//include/envoy/stats:stats_macros",
@@ -84,7 +84,7 @@ envoy_cc_library(
     name = "upstream_interface",
     hdrs = ["upstream.h"],
     deps = [
-        ":health_checker_sink_interface",
+        ":health_check_host_monitor_interface",
         ":load_balancer_type_interface",
         ":resource_manager_interface",
         "//include/envoy/common:callback",

--- a/include/envoy/upstream/health_check_host_monitor.h
+++ b/include/envoy/upstream/health_check_host_monitor.h
@@ -6,22 +6,22 @@ namespace Envoy {
 namespace Upstream {
 
 /**
- * A sink for "passive" health check events that might happen on every thread. For example, if a
+ * A monitor for "passive" health check events that might happen on every thread. For example, if a
  * special HTTP header is received, the data plane may decide to fast fail a host to avoid waiting
  * for the full HC interval to elapse before determining the host is active HC failed.
  */
-class HealthCheckerSink {
+class HealthCheckHostMonitor {
 public:
-  virtual ~HealthCheckerSink() {}
+  virtual ~HealthCheckHostMonitor() {}
 
   /**
-   * Mark the sink as unhealthy. Note that this may not be immediate as events may need to be
+   * Mark the host as unhealthy. Note that this may not be immediate as events may need to be
    * propagated between multiple threads.
    */
   virtual void setUnhealthy() PURE;
 };
 
-typedef std::unique_ptr<HealthCheckerSink> HealthCheckerSinkPtr;
+typedef std::unique_ptr<HealthCheckHostMonitor> HealthCheckHostMonitorPtr;
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -36,7 +36,7 @@ public:
   virtual void start() PURE;
 };
 
-typedef std::unique_ptr<HealthChecker> HealthCheckerPtr;
+typedef std::shared_ptr<HealthChecker> HealthCheckerSharedPtr;
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/health_checker_sink.h
+++ b/include/envoy/upstream/health_checker_sink.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * A sink for "passive" health check events that might happen on every thread. For example, if a
+ * special HTTP header is received, the data plane may decide to fast fail a host to avoid waiting
+ * for the full HC interval to elapse before determining the host is active HC failed.
+ */
+class HealthCheckerSink {
+public:
+  virtual ~HealthCheckerSink() {}
+
+  /**
+   * Mark the sink as unhealthy. Note that this may not be immediate as events may need to be
+   * propagated between multiple threads.
+   */
+  virtual void setUnhealthy() PURE;
+};
+
+typedef std::unique_ptr<HealthCheckerSink> HealthCheckerSinkPtr;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -5,6 +5,7 @@
 
 #include "envoy/network/address.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/upstream/health_checker_sink.h"
 #include "envoy/upstream/outlier_detection.h"
 
 namespace Envoy {
@@ -53,6 +54,11 @@ public:
    * @return the host's outlier detection sink.
    */
   virtual Outlier::DetectorHostSink& outlierDetector() const PURE;
+
+  /**
+   * @return the host's health checker sink.
+   */
+  virtual HealthCheckerSink& healthChecker() const PURE;
 
   /**
    * @return the hostname associated with the host if any.

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -5,7 +5,7 @@
 
 #include "envoy/network/address.h"
 #include "envoy/stats/stats_macros.h"
-#include "envoy/upstream/health_checker_sink.h"
+#include "envoy/upstream/health_check_host_monitor.h"
 #include "envoy/upstream/outlier_detection.h"
 
 namespace Envoy {
@@ -51,14 +51,14 @@ public:
   virtual const ClusterInfo& cluster() const PURE;
 
   /**
-   * @return the host's outlier detection sink.
+   * @return the host's outlier detection monitor.
    */
-  virtual Outlier::DetectorHostSink& outlierDetector() const PURE;
+  virtual Outlier::DetectorHostMonitor& outlierDetector() const PURE;
 
   /**
-   * @return the host's health checker sink.
+   * @return the host's health checker monitor.
    */
-  virtual HealthCheckerSink& healthChecker() const PURE;
+  virtual HealthCheckHostMonitor& healthChecker() const PURE;
 
   /**
    * @return the hostname associated with the host if any.

--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -21,11 +21,11 @@ typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;
 namespace Outlier {
 
 /**
- * Sink for per host data. Proxy filters should send pertinent data when available.
+ * Monitor for per host data. Proxy filters should send pertinent data when available.
  */
-class DetectorHostSink {
+class DetectorHostMonitor {
 public:
-  virtual ~DetectorHostSink() {}
+  virtual ~DetectorHostMonitor() {}
 
   /**
    * @return the number of times this host has been ejected.
@@ -63,7 +63,7 @@ public:
   virtual double successRate() const PURE;
 };
 
-typedef std::unique_ptr<DetectorHostSink> DetectorHostSinkPtr;
+typedef std::unique_ptr<DetectorHostMonitor> DetectorHostMonitorPtr;
 
 /**
  * Interface for an outlier detection engine. Uses per host data to determine which hosts in a

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -13,6 +13,7 @@
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
 #include "envoy/ssl/context.h"
+#include "envoy/upstream/health_checker_sink.h"
 #include "envoy/upstream/load_balancer_type.h"
 #include "envoy/upstream/outlier_detection.h"
 #include "envoy/upstream/resource_manager.h"
@@ -78,6 +79,13 @@ public:
    *         information may be considered.
    */
   virtual bool healthy() const PURE;
+
+  /**
+   * Set the host's health checker sink. Sinks are assumed to be thread safe, however
+   * a new sink must be installed before the host is used across threads. Thus,
+   * this routine should only be called on the main thread before the host is used across threads.
+   */
+  virtual void setHealthChecker(HealthCheckerSinkPtr&& health_checker) PURE;
 
   /**
    * Set the host's outlier detector. Outlier detectors are assumed to be thread safe, however

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -13,7 +13,7 @@
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
 #include "envoy/ssl/context.h"
-#include "envoy/upstream/health_checker_sink.h"
+#include "envoy/upstream/health_check_host_monitor.h"
 #include "envoy/upstream/load_balancer_type.h"
 #include "envoy/upstream/outlier_detection.h"
 #include "envoy/upstream/resource_manager.h"
@@ -81,18 +81,19 @@ public:
   virtual bool healthy() const PURE;
 
   /**
-   * Set the host's health checker sink. Sinks are assumed to be thread safe, however
-   * a new sink must be installed before the host is used across threads. Thus,
+   * Set the host's health checker monitor. Monitors are assumed to be thread safe, however
+   * a new monitor must be installed before the host is used across threads. Thus,
    * this routine should only be called on the main thread before the host is used across threads.
    */
-  virtual void setHealthChecker(HealthCheckerSinkPtr&& health_checker) PURE;
+  virtual void setHealthChecker(HealthCheckHostMonitorPtr&& health_checker) PURE;
 
   /**
-   * Set the host's outlier detector. Outlier detectors are assumed to be thread safe, however
-   * a new outlier detector must be installed before the host is used across threads. Thus,
-   * this routine should only be called on the main thread before the host is used across threads.
+   * Set the host's outlier detector monitor. Outlier detector monitors are assumed to be thread
+   * safe, however a new outlier detector monitor must be installed before the host is used across
+   * threads. Thus, this routine should only be called on the main thread before the host is used
+   * across threads.
    */
-  virtual void setOutlierDetector(Outlier::DetectorHostSinkPtr&& outlier_detector) PURE;
+  virtual void setOutlierDetector(Outlier::DetectorHostMonitorPtr&& outlier_detector) PURE;
 
   /**
    * @return the current load balancing weight of the host, in the range 1-100.

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -26,6 +26,7 @@ public:
   const LowerCaseString EnvoyDownstreamServiceNode{"x-envoy-downstream-service-node"};
   const LowerCaseString EnvoyExternalAddress{"x-envoy-external-address"};
   const LowerCaseString EnvoyForceTrace{"x-envoy-force-trace"};
+  const LowerCaseString EnvoyImmediateHealthCheckFail{"x-envoy-immediate-health-check-fail"};
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
@@ -88,6 +89,10 @@ public:
     const std::string GrpcWebTextProto{"application/grpc-web-text+proto"};
     const std::string Json{"application/json"};
   } ContentTypeValues;
+
+  struct {
+    const std::string True{"true"};
+  } EnvoyImmediateHealthCheckFailValues;
 
   struct {
     const std::string True{"true"};

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -455,6 +455,10 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(
       Http::Utility::getResponseStatus(*headers));
 
+  if (headers->EnvoyImmediateHealthCheckFail() != nullptr) {
+    upstream_request_->upstream_host_->healthChecker().setUnhealthy();
+  }
+
   if (retry_state_ &&
       retry_state_->shouldRetry(headers.get(), Optional<Http::StreamResetReason>(),
                                 [this]() -> void { doRetry(); }) &&

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -27,21 +27,20 @@
 namespace Envoy {
 namespace Upstream {
 
-HealthCheckerPtr HealthCheckerFactory::create(const envoy::api::v2::HealthCheck& hc_config,
-                                              Upstream::Cluster& cluster, Runtime::Loader& runtime,
-                                              Runtime::RandomGenerator& random,
-                                              Event::Dispatcher& dispatcher) {
+HealthCheckerSharedPtr HealthCheckerFactory::create(const envoy::api::v2::HealthCheck& hc_config,
+                                                    Upstream::Cluster& cluster,
+                                                    Runtime::Loader& runtime,
+                                                    Runtime::RandomGenerator& random,
+                                                    Event::Dispatcher& dispatcher) {
   switch (hc_config.health_checker_case()) {
   case envoy::api::v2::HealthCheck::HealthCheckerCase::kHttpHealthCheck:
-    return HealthCheckerPtr{
-        new ProdHttpHealthCheckerImpl(cluster, hc_config, dispatcher, runtime, random)};
+    return std::make_shared<ProdHttpHealthCheckerImpl>(cluster, hc_config, dispatcher, runtime,
+                                                       random);
   case envoy::api::v2::HealthCheck::HealthCheckerCase::kTcpHealthCheck:
-    return HealthCheckerPtr{
-        new TcpHealthCheckerImpl(cluster, hc_config, dispatcher, runtime, random)};
+    return std::make_shared<TcpHealthCheckerImpl>(cluster, hc_config, dispatcher, runtime, random);
   case envoy::api::v2::HealthCheck::HealthCheckerCase::kRedisHealthCheck:
-    return HealthCheckerPtr{
-        new RedisHealthCheckerImpl(cluster, hc_config, dispatcher, runtime, random,
-                                   Redis::ConnPool::ClientFactoryImpl::instance_)};
+    return std::make_shared<RedisHealthCheckerImpl>(cluster, hc_config, dispatcher, runtime, random,
+                                                    Redis::ConnPool::ClientFactoryImpl::instance_);
   default:
     // TODO(htuch): This should be subsumed eventually by the constraint checking in #1308.
     throw EnvoyException("Health checker type not set");
@@ -113,6 +112,8 @@ std::chrono::milliseconds HealthCheckerImplBase::interval() const {
 void HealthCheckerImplBase::addHosts(const std::vector<HostSharedPtr>& hosts) {
   for (const HostSharedPtr& host : hosts) {
     active_sessions_[host] = makeSession(host);
+    host->setHealthChecker(
+        HealthCheckerSinkPtr{new HealthCheckerSinkImpl(shared_from_this(), host)});
     active_sessions_[host]->start();
   }
 }
@@ -143,6 +144,35 @@ void HealthCheckerImplBase::runCallbacks(HostSharedPtr host, bool changed_state)
   for (const HostStatusCb& cb : callbacks_) {
     cb(host, changed_state);
   }
+}
+
+void HealthCheckerImplBase::HealthCheckerSinkImpl::setUnhealthy() {
+  // This is called cross thread. The cluster/health checker might already be gone.
+  std::shared_ptr<HealthCheckerImplBase> health_checker = health_checker_.lock();
+  if (health_checker) {
+    health_checker->setUnhealthyCrossThread(host_.lock());
+  }
+}
+
+void HealthCheckerImplBase::setUnhealthyCrossThread(const HostSharedPtr& host) {
+  // The threading here is complex. The cluster owns the only strong reference to the health
+  // checker. It might go away when we post to the main thread. We capture a weak reference and
+  // make sure it is still valid when we get to the other thread. Additionally, the host/session
+  // may also be gone by then so we check that also.
+  std::weak_ptr<HealthCheckerImplBase> weak_this = shared_from_this();
+  dispatcher_.post([weak_this, host]() -> void {
+    std::shared_ptr<HealthCheckerImplBase> shared_this = weak_this.lock();
+    if (shared_this == nullptr) {
+      return;
+    }
+
+    const auto session = shared_this->active_sessions_.find(host);
+    if (session == shared_this->active_sessions_.end()) {
+      return;
+    }
+
+    session->second->setUnhealthy(ActiveHealthCheckSession::FailureType::Passive);
+  });
 }
 
 void HealthCheckerImplBase::start() { addHosts(cluster_.hosts()); }
@@ -188,13 +218,13 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::handleSuccess() {
   interval_timer_->enableTimer(parent_.interval());
 }
 
-void HealthCheckerImplBase::ActiveHealthCheckSession::handleFailure(bool network_failure) {
+void HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(FailureType type) {
   // If we are unhealthy, reset the # of healthy to zero.
   num_healthy_ = 0;
 
   bool changed_state = false;
   if (!host_->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
-    if (!network_failure || ++num_unhealthy_ == parent_.unhealthy_threshold_) {
+    if (type != FailureType::Network || ++num_unhealthy_ == parent_.unhealthy_threshold_) {
       host_->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
       parent_.decHealthy();
       changed_state = true;
@@ -202,13 +232,18 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::handleFailure(bool network
   }
 
   parent_.stats_.failure_.inc();
-  if (network_failure) {
+  if (type == FailureType::Network) {
     parent_.stats_.network_failure_.inc();
+  } else if (type == FailureType::Passive) {
+    parent_.stats_.passive_failure_.inc();
   }
 
   first_check_ = false;
   parent_.runCallbacks(host_, changed_state);
+}
 
+void HealthCheckerImplBase::ActiveHealthCheckSession::handleFailure(FailureType type) {
+  setUnhealthy(type);
   timeout_timer_->disableTimer();
   interval_timer_->enableTimer(parent_.interval());
 }
@@ -221,7 +256,7 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::onIntervalBase() {
 
 void HealthCheckerImplBase::ActiveHealthCheckSession::onTimeoutBase() {
   onTimeout();
-  handleFailure(true);
+  handleFailure(FailureType::Network);
 }
 
 HttpHealthCheckerImpl::HttpHealthCheckerImpl(const Cluster& cluster,
@@ -295,7 +330,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResetStream(Http::St
 
   ENVOY_CONN_LOG(debug, "connection/stream error health_flags={}", *client_,
                  HostUtility::healthFlagsToString(*host_));
-  handleFailure(true);
+  handleFailure(FailureType::Network);
 }
 
 bool HttpHealthCheckerImpl::HttpActiveHealthCheckSession::isHealthCheckSucceeded() {
@@ -325,7 +360,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
   if (isHealthCheckSucceeded()) {
     handleSuccess();
   } else {
-    handleFailure(false);
+    handleFailure(FailureType::Active);
   }
 
   if (response_headers_->Connection() &&
@@ -408,7 +443,7 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onData(Buffer::Instance&
 
 void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose) {
-    handleFailure(true);
+    handleFailure(FailureType::Network);
   }
 
   if (event == Network::ConnectionEvent::RemoteClose ||
@@ -511,13 +546,13 @@ void RedisHealthCheckerImpl::RedisActiveHealthCheckSession::onResponse(
   if (value->type() == Redis::RespType::SimpleString && value->asString() == "PONG") {
     handleSuccess();
   } else {
-    handleFailure(false);
+    handleFailure(FailureType::Active);
   }
 }
 
 void RedisHealthCheckerImpl::RedisActiveHealthCheckSession::onFailure() {
   current_request_ = nullptr;
-  handleFailure(true);
+  handleFailure(FailureType::Network);
 }
 
 void RedisHealthCheckerImpl::RedisActiveHealthCheckSession::onTimeout() {

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -127,12 +127,12 @@ protected:
   Runtime::RandomGenerator& random_;
 
 private:
-  struct HealthCheckerSinkImpl : public HealthCheckerSink {
-    HealthCheckerSinkImpl(const std::shared_ptr<HealthCheckerImplBase>& health_checker,
-                          const HostSharedPtr& host)
+  struct HealthCheckHostMonitorImpl : public HealthCheckHostMonitor {
+    HealthCheckHostMonitorImpl(const std::shared_ptr<HealthCheckerImplBase>& health_checker,
+                               const HostSharedPtr& host)
         : health_checker_(health_checker), host_(host) {}
 
-    // Upstream::HealthCheckerSink
+    // Upstream::HealthCheckHostMonitor
     void setUnhealthy() override;
 
     std::weak_ptr<HealthCheckerImplBase> health_checker_;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -40,9 +40,10 @@ public:
    * @param dispatcher supplies the dispatcher.
    * @return a health checker.
    */
-  static HealthCheckerPtr create(const envoy::api::v2::HealthCheck& hc_config,
-                                 Upstream::Cluster& cluster, Runtime::Loader& runtime,
-                                 Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher);
+  static HealthCheckerSharedPtr create(const envoy::api::v2::HealthCheck& hc_config,
+                                       Upstream::Cluster& cluster, Runtime::Loader& runtime,
+                                       Runtime::RandomGenerator& random,
+                                       Event::Dispatcher& dispatcher);
 };
 
 /**
@@ -53,6 +54,7 @@ public:
   COUNTER(attempt)                                                                                 \
   COUNTER(success)                                                                                 \
   COUNTER(failure)                                                                                 \
+  COUNTER(passive_failure)                                                                         \
   COUNTER(network_failure)                                                                         \
   COUNTER(verify_cluster)                                                                          \
   GAUGE  (healthy)
@@ -68,7 +70,9 @@ struct HealthCheckerStats {
 /**
  * Base implementation for both the HTTP and TCP health checker.
  */
-class HealthCheckerImplBase : public HealthChecker, protected Logger::Loggable<Logger::Id::hc> {
+class HealthCheckerImplBase : public HealthChecker,
+                              protected Logger::Loggable<Logger::Id::hc>,
+                              public std::enable_shared_from_this<HealthCheckerImplBase> {
 public:
   // Upstream::HealthChecker
   void addHostCheckCompleteCb(HostStatusCb callback) override { callbacks_.push_back(callback); }
@@ -77,14 +81,17 @@ public:
 protected:
   class ActiveHealthCheckSession {
   public:
+    enum class FailureType { Active, Passive, Network };
+
     virtual ~ActiveHealthCheckSession();
+    void setUnhealthy(FailureType type);
     void start() { onIntervalBase(); }
 
   protected:
     ActiveHealthCheckSession(HealthCheckerImplBase& parent, HostSharedPtr host);
 
     void handleSuccess();
-    void handleFailure(bool network_failure);
+    void handleFailure(FailureType type);
 
     HostSharedPtr host_;
 
@@ -120,6 +127,18 @@ protected:
   Runtime::RandomGenerator& random_;
 
 private:
+  struct HealthCheckerSinkImpl : public HealthCheckerSink {
+    HealthCheckerSinkImpl(const std::shared_ptr<HealthCheckerImplBase>& health_checker,
+                          const HostSharedPtr& host)
+        : health_checker_(health_checker), host_(host) {}
+
+    // Upstream::HealthCheckerSink
+    void setUnhealthy() override;
+
+    std::weak_ptr<HealthCheckerImplBase> health_checker_;
+    std::weak_ptr<Host> host_;
+  };
+
   void addHosts(const std::vector<HostSharedPtr>& hosts);
   void decHealthy();
   HealthCheckerStats generateStats(Stats::Scope& scope);
@@ -129,6 +148,7 @@ private:
                              const std::vector<HostSharedPtr>& hosts_removed);
   void refreshHealthyStat();
   void runCallbacks(HostSharedPtr host, bool changed_state);
+  void setUnhealthyCrossThread(const HostSharedPtr& host);
 
   static const std::chrono::milliseconds NO_TRAFFIC_INTERVAL;
 

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -66,6 +66,7 @@ private:
     // Upstream:HostDescription
     bool canary() const override { return false; }
     const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
+    HealthCheckerSink& healthChecker() const override { return logical_host_->healthChecker(); }
     Outlier::DetectorHostSink& outlierDetector() const override {
       return logical_host_->outlierDetector();
     }

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -66,8 +66,10 @@ private:
     // Upstream:HostDescription
     bool canary() const override { return false; }
     const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
-    HealthCheckerSink& healthChecker() const override { return logical_host_->healthChecker(); }
-    Outlier::DetectorHostSink& outlierDetector() const override {
+    HealthCheckHostMonitor& healthChecker() const override {
+      return logical_host_->healthChecker();
+    }
+    Outlier::DetectorHostMonitor& outlierDetector() const override {
       return logical_host_->outlierDetector();
     }
     const HostStats& stats() const override { return logical_host_->stats(); }

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -30,22 +30,22 @@ DetectorSharedPtr DetectorImplFactory::createForCluster(
   }
 }
 
-void DetectorHostSinkImpl::eject(MonotonicTime ejection_time) {
+void DetectorHostMonitorImpl::eject(MonotonicTime ejection_time) {
   ASSERT(!host_.lock()->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
   host_.lock()->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   num_ejections_++;
   last_ejection_time_.value(ejection_time);
 }
 
-void DetectorHostSinkImpl::uneject(MonotonicTime unejection_time) {
+void DetectorHostMonitorImpl::uneject(MonotonicTime unejection_time) {
   last_unejection_time_.value(unejection_time);
 }
 
-void DetectorHostSinkImpl::updateCurrentSuccessRateBucket() {
+void DetectorHostMonitorImpl::updateCurrentSuccessRateBucket() {
   success_rate_accumulator_bucket_.store(success_rate_accumulator_.updateCurrentWriter());
 }
 
-void DetectorHostSinkImpl::putHttpResponseCode(uint64_t response_code) {
+void DetectorHostMonitorImpl::putHttpResponseCode(uint64_t response_code) {
   success_rate_accumulator_bucket_.load()->total_request_counter_++;
   if (Http::CodeUtility::is5xx(response_code)) {
     std::shared_ptr<DetectorImpl> detector = detector_.lock();
@@ -95,7 +95,7 @@ DetectorImpl::DetectorImpl(const Cluster& cluster,
 }
 
 DetectorImpl::~DetectorImpl() {
-  for (auto host : host_sinks_) {
+  for (auto host : host_monitors_) {
     if (host.first->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
       ASSERT(stats_.ejections_active_.value() > 0);
       stats_.ejections_active_.dec();
@@ -116,34 +116,34 @@ DetectorImpl::create(const Cluster& cluster,
 
 void DetectorImpl::initialize(const Cluster& cluster) {
   for (const HostSharedPtr& host : cluster.hosts()) {
-    addHostSink(host);
+    addHostMonitor(host);
   }
 
   cluster.addMemberUpdateCb([this](const std::vector<HostSharedPtr>& hosts_added,
                                    const std::vector<HostSharedPtr>& hosts_removed) -> void {
     for (const HostSharedPtr& host : hosts_added) {
-      addHostSink(host);
+      addHostMonitor(host);
     }
 
     for (const HostSharedPtr& host : hosts_removed) {
-      ASSERT(host_sinks_.count(host) == 1);
+      ASSERT(host_monitors_.count(host) == 1);
       if (host->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
         ASSERT(stats_.ejections_active_.value() > 0);
         stats_.ejections_active_.dec();
       }
 
-      host_sinks_.erase(host);
+      host_monitors_.erase(host);
     }
   });
 
   armIntervalTimer();
 }
 
-void DetectorImpl::addHostSink(HostSharedPtr host) {
-  ASSERT(host_sinks_.count(host) == 0);
-  DetectorHostSinkImpl* sink = new DetectorHostSinkImpl(shared_from_this(), host);
-  host_sinks_[host] = sink;
-  host->setOutlierDetector(DetectorHostSinkPtr{sink});
+void DetectorImpl::addHostMonitor(HostSharedPtr host) {
+  ASSERT(host_monitors_.count(host) == 0);
+  DetectorHostMonitorImpl* monitor = new DetectorHostMonitorImpl(shared_from_this(), host);
+  host_monitors_[host] = monitor;
+  host->setOutlierDetector(DetectorHostMonitorPtr{monitor});
 }
 
 void DetectorImpl::armIntervalTimer() {
@@ -151,7 +151,7 @@ void DetectorImpl::armIntervalTimer() {
       runtime_.snapshot().getInteger("outlier_detection.interval_ms", config_.intervalMs())));
 }
 
-void DetectorImpl::checkHostForUneject(HostSharedPtr host, DetectorHostSinkImpl* sink,
+void DetectorImpl::checkHostForUneject(HostSharedPtr host, DetectorHostMonitorImpl* monitor,
                                        MonotonicTime now) {
   if (!host->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
     return;
@@ -160,11 +160,11 @@ void DetectorImpl::checkHostForUneject(HostSharedPtr host, DetectorHostSinkImpl*
   std::chrono::milliseconds base_eject_time =
       std::chrono::milliseconds(runtime_.snapshot().getInteger(
           "outlier_detection.base_ejection_time_ms", config_.baseEjectionTimeMs()));
-  ASSERT(sink->numEjections() > 0)
-  if ((base_eject_time * sink->numEjections()) <= (now - sink->lastEjectionTime().value())) {
+  ASSERT(monitor->numEjections() > 0)
+  if ((base_eject_time * monitor->numEjections()) <= (now - monitor->lastEjectionTime().value())) {
     stats_.ejections_active_.dec();
     host->healthFlagClear(Host::HealthFlag::FAILED_OUTLIER_CHECK);
-    sink->uneject(now);
+    monitor->uneject(now);
     runCallbacks(host);
 
     if (event_logger_) {
@@ -190,12 +190,12 @@ void DetectorImpl::ejectHost(HostSharedPtr host, EjectionType type) {
   uint64_t max_ejection_percent = std::min<uint64_t>(
       100, runtime_.snapshot().getInteger("outlier_detection.max_ejection_percent",
                                           config_.maxEjectionPercent()));
-  double ejected_percent = 100.0 * stats_.ejections_active_.value() / host_sinks_.size();
+  double ejected_percent = 100.0 * stats_.ejections_active_.value() / host_monitors_.size();
   if (ejected_percent < max_ejection_percent) {
     stats_.ejections_total_.inc();
     if (enforceEjection(type)) {
       stats_.ejections_active_.inc();
-      host_sinks_[host]->eject(time_source_.currentTime());
+      host_monitors_[host]->eject(time_source_.currentTime());
       runCallbacks(host);
 
       if (event_logger_) {
@@ -240,7 +240,7 @@ void DetectorImpl::onConsecutive5xx(HostSharedPtr host) {
 void DetectorImpl::onConsecutive5xxWorker(HostSharedPtr host) {
   // This comes in cross thread. There is a chance that the host has already been removed from
   // the set. If so, just ignore it.
-  if (host_sinks_.count(host) == 0) {
+  if (host_monitors_.count(host) == 0) {
     return;
   }
 
@@ -251,11 +251,11 @@ void DetectorImpl::onConsecutive5xxWorker(HostSharedPtr host) {
   stats_.ejections_consecutive_5xx_.inc();
   ejectHost(host, EjectionType::Consecutive5xx);
 
-  // Reset the DetectorHostSink's consecutive_5xx_ counter. The reset is performed here
+  // Reset the DetectorHostMonitor's consecutive_5xx_ counter. The reset is performed here
   // on the onConsecutive5xxWorker call to prevent thread thrashing. The consecutive_5xx_
-  // counter needs to be reset in order to allow the Sink to detect a bout of consecutive
-  // 5xx responses even if the sink is not charged with an interleaved non-5xx code.
-  host_sinks_[host]->resetConsecutive5xx();
+  // counter needs to be reset in order to allow the monitor to detect a bout of consecutive
+  // 5xx responses even if the monitor is not charged with an interleaved non-5xx code.
+  host_monitors_[host]->resetConsecutive5xx();
 }
 
 Utility::EjectionPair Utility::successRateEjectionThreshold(
@@ -301,14 +301,14 @@ void DetectorImpl::processSuccessRateEjections() {
   success_rate_ejection_threshold_ = -1;
 
   // Exit early if there are not enough hosts.
-  if (host_sinks_.size() < success_rate_minimum_hosts) {
+  if (host_monitors_.size() < success_rate_minimum_hosts) {
     return;
   }
 
   // reserve upper bound of vector size to avoid reallocation.
-  valid_success_rate_hosts.reserve(host_sinks_.size());
+  valid_success_rate_hosts.reserve(host_monitors_.size());
 
-  for (const auto& host : host_sinks_) {
+  for (const auto& host : host_monitors_) {
     // Don't do work if the host is already ejected.
     if (!host.first->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {
       Optional<double> host_success_rate =
@@ -344,7 +344,7 @@ void DetectorImpl::processSuccessRateEjections() {
 void DetectorImpl::onIntervalTimer() {
   MonotonicTime now = time_source_.currentTime();
 
-  for (auto host : host_sinks_) {
+  for (auto host : host_monitors_) {
     checkHostForUneject(host.first, host.second, now);
 
     // Need to update the writer bucket to keep the data valid.

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -22,11 +22,11 @@ namespace Upstream {
 namespace Outlier {
 
 /**
- * Null host sink implementation.
+ * Null host monitor implementation.
  */
-class DetectorHostSinkNullImpl : public DetectorHostSink {
+class DetectorHostMonitorNullImpl : public DetectorHostMonitor {
 public:
-  // Upstream::Outlier::DetectorHostSink
+  // Upstream::Outlier::DetectorHostMonitor
   uint32_t numEjections() override { return 0; }
   void putHttpResponseCode(uint64_t) override {}
   void putResponseTime(std::chrono::milliseconds) override {}
@@ -99,11 +99,11 @@ private:
 class DetectorImpl;
 
 /**
- * Implementation of DetectorHostSink for the generic detector.
+ * Implementation of DetectorHostMonitor for the generic detector.
  */
-class DetectorHostSinkImpl : public DetectorHostSink {
+class DetectorHostMonitorImpl : public DetectorHostMonitor {
 public:
-  DetectorHostSinkImpl(std::shared_ptr<DetectorImpl> detector, HostSharedPtr host)
+  DetectorHostMonitorImpl(std::shared_ptr<DetectorImpl> detector, HostSharedPtr host)
       : detector_(detector), host_(host), success_rate_(-1) {
     // Point the success_rate_accumulator_bucket_ pointer to a bucket.
     updateCurrentSuccessRateBucket();
@@ -116,7 +116,7 @@ public:
   void successRate(double new_success_rate) { success_rate_ = new_success_rate; }
   void resetConsecutive5xx() { consecutive_5xx_ = 0; }
 
-  // Upstream::Outlier::DetectorHostSink
+  // Upstream::Outlier::DetectorHostMonitor
   uint32_t numEjections() override { return num_ejections_; }
   void putHttpResponseCode(uint64_t response_code) override;
   void putResponseTime(std::chrono::milliseconds) override {}
@@ -211,9 +211,9 @@ private:
                Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                MonotonicTimeSource& time_source, EventLoggerSharedPtr event_logger);
 
-  void addHostSink(HostSharedPtr host);
+  void addHostMonitor(HostSharedPtr host);
   void armIntervalTimer();
-  void checkHostForUneject(HostSharedPtr host, DetectorHostSinkImpl* sink, MonotonicTime now);
+  void checkHostForUneject(HostSharedPtr host, DetectorHostMonitorImpl* monitor, MonotonicTime now);
   void ejectHost(HostSharedPtr host, EjectionType type);
   static DetectionStats generateStats(Stats::Scope& scope);
   void initialize(const Cluster& cluster);
@@ -230,7 +230,7 @@ private:
   DetectionStats stats_;
   Event::TimerPtr interval_timer_;
   std::list<ChangeStateCb> callbacks_;
-  std::unordered_map<HostSharedPtr, DetectorHostSinkImpl*> host_sinks_;
+  std::unordered_map<HostSharedPtr, DetectorHostMonitorImpl*> host_monitors_;
   EventLoggerSharedPtr event_logger_;
   double success_rate_average_;
   double success_rate_ejection_threshold_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -49,8 +49,6 @@ getSourceAddress(const envoy::api::v2::Cluster& cluster,
 }
 } // namespace
 
-Outlier::DetectorHostSinkNullImpl HostDescriptionImpl::null_outlier_detector_;
-
 Host::CreateConnectionData HostImpl::createConnection(Event::Dispatcher& dispatcher) const {
   return {createConnection(dispatcher, *cluster_, address_), shared_from_this()};
 }
@@ -263,9 +261,9 @@ void ClusterImplBase::runUpdateCallbacks(const std::vector<HostSharedPtr>& hosts
   HostSetImpl::runUpdateCallbacks(hosts_added, hosts_removed);
 }
 
-void ClusterImplBase::setHealthChecker(HealthCheckerPtr&& health_checker) {
+void ClusterImplBase::setHealthChecker(const HealthCheckerSharedPtr& health_checker) {
   ASSERT(!health_checker_);
-  health_checker_ = std::move(health_checker);
+  health_checker_ = health_checker;
   health_checker_->start();
   health_checker_->addHostCheckCompleteCb([this](HostSharedPtr, bool changed_state) -> void {
     // If we get a health check completion that resulted in a state change, signal to
@@ -276,12 +274,12 @@ void ClusterImplBase::setHealthChecker(HealthCheckerPtr&& health_checker) {
   });
 }
 
-void ClusterImplBase::setOutlierDetector(Outlier::DetectorSharedPtr outlier_detector) {
+void ClusterImplBase::setOutlierDetector(const Outlier::DetectorSharedPtr& outlier_detector) {
   if (!outlier_detector) {
     return;
   }
 
-  outlier_detector_ = std::move(outlier_detector);
+  outlier_detector_ = outlier_detector;
   outlier_detector_->addChangedStateCb([this](HostSharedPtr) -> void { reloadHealthyHosts(); });
 }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -34,11 +34,11 @@ namespace Envoy {
 namespace Upstream {
 
 /**
- * Null implementation of HealthCheckerSink.
+ * Null implementation of HealthCheckHostMonitor.
  */
-class HealthCheckerSinkNullImpl : public HealthCheckerSink {
+class HealthCheckHostMonitorNullImpl : public HealthCheckHostMonitor {
 public:
-  // Upstream::HealthCheckerSink
+  // Upstream::HealthCheckHostMonitor
   void setUnhealthy() override {}
 };
 
@@ -56,20 +56,21 @@ public:
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
   const ClusterInfo& cluster() const override { return *cluster_; }
-  HealthCheckerSink& healthChecker() const override {
+  HealthCheckHostMonitor& healthChecker() const override {
     if (health_checker_) {
       return *health_checker_;
     } else {
-      static HealthCheckerSinkNullImpl* null_health_checker = new HealthCheckerSinkNullImpl();
+      static HealthCheckHostMonitorNullImpl* null_health_checker =
+          new HealthCheckHostMonitorNullImpl();
       return *null_health_checker;
     }
   }
-  Outlier::DetectorHostSink& outlierDetector() const override {
+  Outlier::DetectorHostMonitor& outlierDetector() const override {
     if (outlier_detector_) {
       return *outlier_detector_;
     } else {
-      static Outlier::DetectorHostSinkNullImpl* null_outlier_detector =
-          new Outlier::DetectorHostSinkNullImpl();
+      static Outlier::DetectorHostMonitorNullImpl* null_outlier_detector =
+          new Outlier::DetectorHostMonitorNullImpl();
       return *null_outlier_detector;
     }
   }
@@ -86,8 +87,8 @@ protected:
   const std::string zone_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_;
-  Outlier::DetectorHostSinkPtr outlier_detector_;
-  HealthCheckerSinkPtr health_checker_;
+  Outlier::DetectorHostMonitorPtr outlier_detector_;
+  HealthCheckHostMonitorPtr health_checker_;
 };
 
 /**
@@ -111,10 +112,10 @@ public:
   void healthFlagClear(HealthFlag flag) override { health_flags_ &= ~enumToInt(flag); }
   bool healthFlagGet(HealthFlag flag) const override { return health_flags_ & enumToInt(flag); }
   void healthFlagSet(HealthFlag flag) override { health_flags_ |= enumToInt(flag); }
-  void setHealthChecker(HealthCheckerSinkPtr&& health_checker) override {
+  void setHealthChecker(HealthCheckHostMonitorPtr&& health_checker) override {
     health_checker_ = std::move(health_checker);
   }
-  void setOutlierDetector(Outlier::DetectorHostSinkPtr&& outlier_detector) override {
+  void setOutlierDetector(Outlier::DetectorHostMonitorPtr&& outlier_detector) override {
     outlier_detector_ = std::move(outlier_detector);
   }
   bool healthy() const override { return !health_flags_; }

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -18,6 +18,11 @@ DrainManagerImpl::DrainManagerImpl(Instance& server) : server_(server) {}
 
 bool DrainManagerImpl::drainClose() const {
   // If we are actively HC failed, always drain close.
+  //
+  // TODO(mattklein123): In relation to x-envoy-immediate-health-check-fail, it would be better
+  // if even in that case we had some period of drain ramp up. This would allow the other side
+  // to fail health check for the host which will require some thread jumps versus immediately
+  // start GOAWAY/connection thrashing.
   if (server_.healthCheckFailed()) {
     return true;
   }

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -20,9 +20,9 @@ bool DrainManagerImpl::drainClose() const {
   // If we are actively HC failed, always drain close.
   //
   // TODO(mattklein123): In relation to x-envoy-immediate-health-check-fail, it would be better
-  // if even in that case we had some period of drain ramp up. This would allow the other side
-  // to fail health check for the host which will require some thread jumps versus immediately
-  // start GOAWAY/connection thrashing.
+  // if even in the case of server health check failure we had some period of drain ramp up. This
+  // would allow the other side to fail health check for the host which will require some thread
+  // jumps versus immediately start GOAWAY/connection thrashing.
   if (server_.healthCheckFailed()) {
     return true;
   }

--- a/source/server/http/health_check.cc
+++ b/source/server/http/health_check.cc
@@ -119,6 +119,9 @@ Http::FilterHeadersStatus HealthCheckFilter::encodeHeaders(Http::HeaderMap& head
     }
 
     headers.insertEnvoyUpstreamHealthCheckedCluster().value(context_.localInfo().clusterName());
+  } else if (context_.healthCheckFailed()) {
+    headers.insertEnvoyImmediateHealthCheckFail().value(
+        Http::Headers::get().EnvoyImmediateHealthCheckFailValues.True);
   }
 
   return Http::FilterHeadersStatus::Continue;
@@ -149,4 +152,5 @@ void HealthCheckFilter::onComplete() {
 
   callbacks_->encodeHeaders(std::move(headers), true);
 }
+
 } // namespace Envoy

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -30,7 +30,7 @@ class LogicalDnsClusterTest : public testing::Test {
 public:
   void setup(const std::string& json) {
     resolve_timer_ = new Event::MockTimer(&dispatcher_);
-    MockClusterManager cm;
+    NiceMock<MockClusterManager> cm;
     cluster_.reset(new LogicalDnsCluster(parseClusterFromJson(json), runtime_, stats_store_,
                                          ssl_context_manager_, dns_resolver_, tls_, cm, dispatcher_,
                                          false));
@@ -130,6 +130,7 @@ TEST_P(LogicalDnsParamTest, ImmediateResolve) {
   EXPECT_EQ(1UL, cluster_->hosts().size());
   EXPECT_EQ(1UL, cluster_->healthyHosts().size());
   EXPECT_EQ("foo.bar.com", cluster_->hosts()[0]->hostname());
+  cluster_->hosts()[0]->healthChecker().setUnhealthy();
   tls_.shutdownThread();
 }
 

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -516,8 +516,8 @@ TEST_F(OutlierDetectorImplTest, Consecutive5xxAlreadyEjected) {
   loadRq(cluster_.hosts_[0], 5, 503);
 }
 
-TEST(DetectorHostSinkNullImplTest, All) {
-  DetectorHostSinkNullImpl null_sink;
+TEST(DetectorHostMonitorNullImplTest, All) {
+  DetectorHostMonitorNullImpl null_sink;
 
   EXPECT_EQ(0UL, null_sink.numEjections());
   EXPECT_FALSE(null_sink.lastEjectionTime().valid());

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -218,10 +218,10 @@ TEST_F(SdsTest, NoHealthChecker) {
 
 TEST_F(SdsTest, HealthChecker) {
   InSequence s;
-  MockHealthChecker* health_checker = new MockHealthChecker();
+  std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
   EXPECT_CALL(*health_checker, start());
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
-  cluster_->setHealthChecker(HealthCheckerPtr{health_checker});
+  cluster_->setHealthChecker(health_checker);
   cluster_->setInitializedCb([&]() -> void { membership_updated_.ready(); });
 
   setupRequest();

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -412,8 +412,8 @@ TEST(StaticClusterImplTest, HealthyStat) {
   Outlier::MockDetector* outlier_detector = new NiceMock<Outlier::MockDetector>();
   cluster.setOutlierDetector(Outlier::DetectorSharedPtr{outlier_detector});
 
-  MockHealthChecker* health_checker = new NiceMock<MockHealthChecker>();
-  cluster.setHealthChecker(HealthCheckerPtr{health_checker});
+  std::shared_ptr<MockHealthChecker> health_checker(new NiceMock<MockHealthChecker>());
+  cluster.setHealthChecker(health_checker);
 
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
   EXPECT_EQ(2UL, cluster.info()->stats().membership_healthy_.value());
@@ -485,6 +485,7 @@ TEST(StaticClusterImplTest, UrlConfig) {
   EXPECT_EQ(2UL, cluster.healthyHosts().size());
   EXPECT_EQ(0UL, cluster.hostsPerZone().size());
   EXPECT_EQ(0UL, cluster.healthyHostsPerZone().size());
+  cluster.hosts()[0]->healthChecker().setUnhealthy();
 }
 
 TEST(StaticClusterImplTest, UnsupportedLBType) {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -61,6 +61,14 @@ public:
 
 } // namespace Outlier
 
+class MockHealthCheckerSink : public HealthCheckerSink {
+public:
+  MockHealthCheckerSink();
+  ~MockHealthCheckerSink();
+
+  MOCK_METHOD0(setUnhealthy, void());
+};
+
 class MockHostDescription : public HostDescription {
 public:
   MockHostDescription();
@@ -70,6 +78,7 @@ public:
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
+  MOCK_CONST_METHOD0(healthChecker, HealthCheckerSink&());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());
@@ -77,6 +86,7 @@ public:
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
   testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
+  testing::NiceMock<MockHealthCheckerSink> health_checker_;
   testing::NiceMock<MockClusterInfo> cluster_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))};
@@ -97,6 +107,10 @@ public:
     return {Network::ClientConnectionPtr{data.connection_}, data.host_description_};
   }
 
+  void setHealthChecker(HealthCheckerSinkPtr&& health_checker) override {
+    setHealthChecker_(health_checker);
+  }
+
   void setOutlierDetector(Outlier::DetectorHostSinkPtr&& outlier_detector) override {
     setOutlierDetector_(outlier_detector);
   }
@@ -107,12 +121,14 @@ public:
   MOCK_CONST_METHOD0(counters, std::list<Stats::CounterSharedPtr>());
   MOCK_CONST_METHOD1(createConnection_, MockCreateConnectionData(Event::Dispatcher& dispatcher));
   MOCK_CONST_METHOD0(gauges, std::list<Stats::GaugeSharedPtr>());
+  MOCK_CONST_METHOD0(healthChecker, HealthCheckerSink&());
   MOCK_METHOD1(healthFlagClear, void(HealthFlag flag));
   MOCK_CONST_METHOD1(healthFlagGet, bool(HealthFlag flag));
   MOCK_METHOD1(healthFlagSet, void(HealthFlag flag));
   MOCK_CONST_METHOD0(healthy, bool());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
+  MOCK_METHOD1(setHealthChecker_, void(HealthCheckerSinkPtr& health_checker));
   MOCK_METHOD1(setOutlierDetector_, void(Outlier::DetectorHostSinkPtr& outlier_detector));
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(weight, uint32_t());

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -17,10 +17,10 @@ namespace Envoy {
 namespace Upstream {
 namespace Outlier {
 
-class MockDetectorHostSink : public DetectorHostSink {
+class MockDetectorHostMonitor : public DetectorHostMonitor {
 public:
-  MockDetectorHostSink();
-  ~MockDetectorHostSink();
+  MockDetectorHostMonitor();
+  ~MockDetectorHostMonitor();
 
   MOCK_METHOD0(numEjections, uint32_t());
   MOCK_METHOD1(putHttpResponseCode, void(uint64_t code));
@@ -61,10 +61,10 @@ public:
 
 } // namespace Outlier
 
-class MockHealthCheckerSink : public HealthCheckerSink {
+class MockHealthCheckHostMonitor : public HealthCheckHostMonitor {
 public:
-  MockHealthCheckerSink();
-  ~MockHealthCheckerSink();
+  MockHealthCheckHostMonitor();
+  ~MockHealthCheckHostMonitor();
 
   MOCK_METHOD0(setUnhealthy, void());
 };
@@ -77,16 +77,16 @@ public:
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
-  MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
-  MOCK_CONST_METHOD0(healthChecker, HealthCheckerSink&());
+  MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
+  MOCK_CONST_METHOD0(healthChecker, HealthCheckHostMonitor&());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(zone, const std::string&());
 
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
-  testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
-  testing::NiceMock<MockHealthCheckerSink> health_checker_;
+  testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;
+  testing::NiceMock<MockHealthCheckHostMonitor> health_checker_;
   testing::NiceMock<MockClusterInfo> cluster_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))};
@@ -107,11 +107,11 @@ public:
     return {Network::ClientConnectionPtr{data.connection_}, data.host_description_};
   }
 
-  void setHealthChecker(HealthCheckerSinkPtr&& health_checker) override {
+  void setHealthChecker(HealthCheckHostMonitorPtr&& health_checker) override {
     setHealthChecker_(health_checker);
   }
 
-  void setOutlierDetector(Outlier::DetectorHostSinkPtr&& outlier_detector) override {
+  void setOutlierDetector(Outlier::DetectorHostMonitorPtr&& outlier_detector) override {
     setOutlierDetector_(outlier_detector);
   }
 
@@ -121,15 +121,15 @@ public:
   MOCK_CONST_METHOD0(counters, std::list<Stats::CounterSharedPtr>());
   MOCK_CONST_METHOD1(createConnection_, MockCreateConnectionData(Event::Dispatcher& dispatcher));
   MOCK_CONST_METHOD0(gauges, std::list<Stats::GaugeSharedPtr>());
-  MOCK_CONST_METHOD0(healthChecker, HealthCheckerSink&());
+  MOCK_CONST_METHOD0(healthChecker, HealthCheckHostMonitor&());
   MOCK_METHOD1(healthFlagClear, void(HealthFlag flag));
   MOCK_CONST_METHOD1(healthFlagGet, bool(HealthFlag flag));
   MOCK_METHOD1(healthFlagSet, void(HealthFlag flag));
   MOCK_CONST_METHOD0(healthy, bool());
   MOCK_CONST_METHOD0(hostname, const std::string&());
-  MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostSink&());
-  MOCK_METHOD1(setHealthChecker_, void(HealthCheckerSinkPtr& health_checker));
-  MOCK_METHOD1(setOutlierDetector_, void(Outlier::DetectorHostSinkPtr& outlier_detector));
+  MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
+  MOCK_METHOD1(setHealthChecker_, void(HealthCheckHostMonitorPtr& health_checker));
+  MOCK_METHOD1(setOutlierDetector_, void(Outlier::DetectorHostMonitorPtr& outlier_detector));
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(weight, uint32_t());
   MOCK_METHOD1(weight, void(uint32_t new_weight));
@@ -138,7 +138,7 @@ public:
   MOCK_CONST_METHOD0(zone, const std::string&());
 
   testing::NiceMock<MockClusterInfo> cluster_;
-  testing::NiceMock<Outlier::MockDetectorHostSink> outlier_detector_;
+  testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))};
 };

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -38,6 +38,9 @@ MockDetector::~MockDetector() {}
 
 } // namespace Outlier
 
+MockHealthCheckerSink::MockHealthCheckerSink() {}
+MockHealthCheckerSink::~MockHealthCheckerSink() {}
+
 MockHostDescription::MockHostDescription()
     : address_(Network::Utility::resolveUrl("tcp://10.0.0.1:443")) {
   ON_CALL(*this, hostname()).WillByDefault(ReturnRef(hostname_));
@@ -45,6 +48,7 @@ MockHostDescription::MockHostDescription()
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   ON_CALL(*this, cluster()).WillByDefault(ReturnRef(cluster_));
+  ON_CALL(*this, healthChecker()).WillByDefault(ReturnRef(health_checker_));
 }
 
 MockHostDescription::~MockHostDescription() {}

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -22,8 +22,8 @@ using testing::_;
 namespace Upstream {
 namespace Outlier {
 
-MockDetectorHostSink::MockDetectorHostSink() {}
-MockDetectorHostSink::~MockDetectorHostSink() {}
+MockDetectorHostMonitor::MockDetectorHostMonitor() {}
+MockDetectorHostMonitor::~MockDetectorHostMonitor() {}
 
 MockEventLogger::MockEventLogger() {}
 MockEventLogger::~MockEventLogger() {}
@@ -38,8 +38,8 @@ MockDetector::~MockDetector() {}
 
 } // namespace Outlier
 
-MockHealthCheckerSink::MockHealthCheckerSink() {}
-MockHealthCheckerSink::~MockHealthCheckerSink() {}
+MockHealthCheckHostMonitor::MockHealthCheckHostMonitor() {}
+MockHealthCheckHostMonitor::~MockHealthCheckHostMonitor() {}
 
 MockHostDescription::MockHostDescription()
     : address_(Network::Utility::resolveUrl("tcp://10.0.0.1:443")) {

--- a/test/server/http/health_check_test.cc
+++ b/test/server/http/health_check_test.cc
@@ -73,10 +73,14 @@ TEST_F(HealthCheckFilterNoPassThroughTest, OkOrFailed) {
 }
 
 TEST_F(HealthCheckFilterNoPassThroughTest, NotHcRequest) {
-  EXPECT_CALL(context_, healthCheckFailed()).Times(0);
   EXPECT_CALL(callbacks_.request_info_, healthCheck(_)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(request_headers_no_hc_, true));
+
+  Http::TestHeaderMapImpl service_response{{":status", "200"}};
+  EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(service_response, true));
+  EXPECT_STREQ("true", service_response.EnvoyImmediateHealthCheckFail()->value().c_str());
 }
 
 TEST_F(HealthCheckFilterNoPassThroughTest, HealthCheckFailedCallbackCalled) {
@@ -88,6 +92,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, HealthCheckFailedCallbackCalled) {
       .WillRepeatedly(Invoke([&](Http::HeaderMap& headers, bool end_stream) {
         filter_->encodeHeaders(headers, end_stream);
         EXPECT_STREQ("cluster_name", headers.EnvoyUpstreamHealthCheckedCluster()->value().c_str());
+        EXPECT_EQ(nullptr, headers.EnvoyImmediateHealthCheckFail());
       }));
 
   EXPECT_CALL(callbacks_.request_info_,


### PR DESCRIPTION
This feature adds the ability for data plane processing to cause a host
to be considered active health check failed. This is currently only used
by the router filter and the health check filter, but could be extended
to other protocols later.

Fixes https://github.com/lyft/envoy/issues/1423