### PR TITLE
Wrap static all_loggers in a function.

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -21,7 +21,8 @@ Logger::Logger(const std::string& name) {
 }
 
 std::vector<Logger>& Registry::allLoggers() {
-  static std::vector<Logger>* all_loggers = new std::vector<Logger>({ALL_LOGGER_IDS(GENERATE_LOGGER)});
+  static std::vector<Logger>* all_loggers =
+      new std::vector<Logger>({ALL_LOGGER_IDS(GENERATE_LOGGER)});
   return *all_loggers;
 }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -14,12 +14,15 @@ namespace Logger {
 
 #define GENERATE_LOGGER(X) Logger(#X),
 
-std::vector<Logger> Registry::all_loggers_ = {ALL_LOGGER_IDS(GENERATE_LOGGER)};
-
 Logger::Logger(const std::string& name) {
   logger_ = std::make_shared<spdlog::logger>(name, Registry::getSink());
   logger_->set_pattern("[%Y-%m-%d %T.%e][%t][%l][%n] %v");
   logger_->set_level(spdlog::level::trace);
+}
+
+std::vector<Logger>& Registry::allLoggers() {
+  static std::vector<Logger> all_loggers = {ALL_LOGGER_IDS(GENERATE_LOGGER)};
+  return all_loggers;
 }
 
 void LockingStderrSink::log(const spdlog::details::log_msg& msg) {
@@ -32,11 +35,11 @@ void LockingStderrSink::flush() {
   std::cerr << std::flush;
 }
 
-spdlog::logger& Registry::getLog(Id id) { return *all_loggers_[static_cast<int>(id)].logger_; }
+spdlog::logger& Registry::getLog(Id id) { return *allLoggers()[static_cast<int>(id)].logger_; }
 
 void Registry::initialize(uint64_t log_level, Thread::BasicLockable& lock) {
   getSink()->setLock(lock);
-  for (Logger& logger : all_loggers_) {
+  for (Logger& logger : allLoggers()) {
     logger.logger_->set_level(static_cast<spdlog::level::level_enum>(log_level));
   }
 }

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -21,8 +21,8 @@ Logger::Logger(const std::string& name) {
 }
 
 std::vector<Logger>& Registry::allLoggers() {
-  static std::vector<Logger> all_loggers = {ALL_LOGGER_IDS(GENERATE_LOGGER)};
-  return all_loggers;
+  static std::vector<Logger>* all_loggers = new std::vector<Logger>({ALL_LOGGER_IDS(GENERATE_LOGGER)});
+  return *all_loggers;
 }
 
 void LockingStderrSink::log(const spdlog::details::log_msg& msg) {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -100,12 +100,15 @@ public:
   static void initialize(uint64_t log_level, Thread::BasicLockable& lock);
 
   /**
-   * @return const std::vector<Logger>& the installed loggers.
+   * @return const std::vector<Logger>& return a const reference to the installed loggers.
    */
-  static const std::vector<Logger>& loggers() { return all_loggers_; }
+  static const std::vector<Logger>& loggers() { return allLoggers(); }
 
 private:
-  static std::vector<Logger> all_loggers_;
+  /*
+   * @return std::vector<Logger>& return the installed loggers.
+   */
+  static std::vector<Logger>& allLoggers();
 };
 
 /**

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -100,7 +100,7 @@ public:
   static void initialize(uint64_t log_level, Thread::BasicLockable& lock);
 
   /**
-   * @return const std::vector<Logger>& return a const reference to the installed loggers.
+   * @return const std::vector<Logger>& the installed loggers.
    */
   static const std::vector<Logger>& loggers() { return allLoggers(); }
 

--- a/test/tools/router_check/BUILD
+++ b/test/tools/router_check/BUILD
@@ -12,6 +12,7 @@ envoy_package()
 envoy_cc_binary(
     name = "router_check_tool",
     testonly = 1,
+    srcs = ["router_check.cc"],
     deps = [":router_check_main_lib"],
 )
 
@@ -20,7 +21,6 @@ envoy_cc_test_library(
     srcs = [
         "router.cc",
         "router.h",
-        "router_check.cc",
     ],
     deps = [
         "//source/common/config:rds_json_lib",


### PR DESCRIPTION
Wrap the static Logger variable all_loggers into a function to avoid the static initialization fiasco. 

This caused the router tool test to fail with a rate of ~1%.

Fixes #1526.