### PR TITLE
config: remove network/HTTP filter type from interfaces.

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -23,4 +23,5 @@ The following features have been DEPRECATED and will be removed in the specified
   RPC stubs. `Grpc::AsyncClientImpl` supports streaming, in addition to the previous unary, RPCs.
 * The direction of network and HTTP filters in the configuration will be ignored from 1.4.0 and
   later removed from the configuration in the v2 APIs. Filter direction is now implied at the C++ type
-  level.
+  level. The `type()` methods on the `NamedNetworkFilterConfigFactory` and
+  `NamedHttpFilterConfigFactory` intefaces have been removed to reflect this.

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -77,7 +77,7 @@ then
 fi
 
 # This is the hash on https://github.com/lyft/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 77fdf641a61b5a8f20e2568c4e7eb6a3644fe7c9)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout b904b8ce9cabafb485e6b6fae1d0fd9e33ddfcc1)
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -118,8 +118,6 @@ public:
   virtual Server::Admin& admin() PURE;
 };
 
-enum class NetworkFilterType { Read, Write, Both };
-
 /**
  * This function is used to wrap the creation of a network filter chain for new connections as
  * they come in. Filter factories create the lambda at configuration initialization time, and then
@@ -174,14 +172,7 @@ public:
    * produced by the factory.
    */
   virtual std::string name() PURE;
-
-  /**
-   * @return NetworkFilterType the type of filter.
-   */
-  virtual NetworkFilterType type() PURE;
 };
-
-enum class HttpFilterType { Decoder, Encoder, Both };
 
 /**
  * This function is used to wrap the creation of an HTTP filter chain for new streams as they
@@ -243,11 +234,6 @@ public:
    * produced by the factory.
    */
   virtual std::string name() PURE;
-
-  /**
-   * @return HttpFilterType the type of filter.
-   */
-  virtual HttpFilterType type() PURE;
 };
 
 } // namespace Configuration

--- a/source/server/config/http/buffer.h
+++ b/source/server/config/http/buffer.h
@@ -17,7 +17,6 @@ public:
                                           const std::string& stats_prefix,
                                           FactoryContext& context) override;
   std::string name() override { return "buffer"; }
-  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/dynamo.h
+++ b/source/server/config/http/dynamo.h
@@ -16,7 +16,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string& stat_prefix,
                                           FactoryContext& context) override;
   std::string name() override { return "http_dynamo_filter"; }
-  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/fault.h
+++ b/source/server/config/http/fault.h
@@ -17,7 +17,6 @@ public:
                                           const std::string& stats_prefix,
                                           FactoryContext& context) override;
   std::string name() override { return "fault"; }
-  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/grpc_http1_bridge.h
+++ b/source/server/config/http/grpc_http1_bridge.h
@@ -16,7 +16,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
                                           FactoryContext& context) override;
   std::string name() override { return "grpc_http1_bridge"; }
-  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/grpc_json_transcoder.h
+++ b/source/server/config/http/grpc_json_transcoder.h
@@ -18,7 +18,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
                                           FactoryContext& context) override;
   std::string name() override { return "grpc_json_transcoder"; };
-  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/grpc_web.h
+++ b/source/server/config/http/grpc_web.h
@@ -11,7 +11,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
                                           FactoryContext&) override;
   std::string name() override { return "grpc_web"; }
-  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/ip_tagging.h
+++ b/source/server/config/http/ip_tagging.h
@@ -17,7 +17,6 @@ public:
                                           const std::string& stat_prefix,
                                           FactoryContext& context) override;
   std::string name() override { return "ip_tagging"; }
-  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/ratelimit.h
+++ b/source/server/config/http/ratelimit.h
@@ -16,7 +16,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object& config, const std::string&,
                                           FactoryContext& context) override;
   std::string name() override { return "rate_limit"; }
-  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // namespace Configuration

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -17,7 +17,6 @@ public:
                                           const std::string& stat_prefix,
                                           FactoryContext& context) override;
   std::string name() override { return "router"; }
-  HttpFilterType type() override { return HttpFilterType::Decoder; }
 };
 
 } // namespace Configuration

--- a/source/server/config/network/client_ssl_auth.h
+++ b/source/server/config/network/client_ssl_auth.h
@@ -17,7 +17,6 @@ public:
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                              FactoryContext& context) override;
   std::string name() override { return "client_ssl_auth"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // namespace Configuration

--- a/source/server/config/network/echo.cc
+++ b/source/server/config/network/echo.cc
@@ -22,7 +22,6 @@ public:
   }
 
   std::string name() override { return "echo"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 /**

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -284,17 +284,6 @@ void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainFactoryCall
   }
 }
 
-HttpFilterType HttpConnectionManagerConfig::stringToType(const std::string& type) {
-  if (type == "decoder") {
-    return HttpFilterType::Decoder;
-  } else if (type == "encoder") {
-    return HttpFilterType::Encoder;
-  } else {
-    ASSERT(type == "both" || type.empty());
-    return HttpFilterType::Both;
-  }
-}
-
 const Network::Address::Instance& HttpConnectionManagerConfig::localAddress() {
   return *context_.localInfo().address();
 }

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -35,7 +35,6 @@ public:
         new envoy::api::v2::filter::HttpConnectionManager());
   }
   std::string name() override { return "http_connection_manager"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 /**
@@ -97,8 +96,6 @@ public:
 
 private:
   enum class CodecType { HTTP1, HTTP2, AUTO };
-
-  HttpFilterType stringToType(const std::string& type);
 
   FactoryContext& context_;
   std::list<HttpFilterFactoryCb> filter_factories_;

--- a/source/server/config/network/mongo_proxy.h
+++ b/source/server/config/network/mongo_proxy.h
@@ -18,7 +18,6 @@ public:
                                              FactoryContext& context) override;
 
   std::string name() override { return "mongo_proxy"; }
-  NetworkFilterType type() override { return NetworkFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/source/server/config/network/ratelimit.h
+++ b/source/server/config/network/ratelimit.h
@@ -17,7 +17,6 @@ public:
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                              FactoryContext& context) override;
   std::string name() override { return "ratelimit"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // namespace Configuration

--- a/source/server/config/network/redis_proxy.h
+++ b/source/server/config/network/redis_proxy.h
@@ -17,7 +17,6 @@ public:
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
                                              FactoryContext& context) override;
   std::string name() override { return "redis_proxy"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // namespace Configuration

--- a/source/server/config/network/tcp_proxy.h
+++ b/source/server/config/network/tcp_proxy.h
@@ -17,7 +17,6 @@ public:
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
                                              FactoryContext& context) override;
   std::string name() override { return "tcp_proxy"; }
-  NetworkFilterType type() override { return NetworkFilterType::Read; }
 };
 
 } // namespace Configuration

--- a/source/server/http/health_check.h
+++ b/source/server/http/health_check.h
@@ -18,7 +18,6 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object& config, const std::string&,
                                           FactoryContext& context) override;
   std::string name() override { return "health_check"; }
-  HttpFilterType type() override { return HttpFilterType::Both; }
 };
 
 } // namespace Configuration

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -39,7 +39,6 @@ TEST(HttpFilterConfigTest, BufferFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   BufferFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
@@ -71,7 +70,6 @@ TEST(HttpFilterConfigTest, RateLimitFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   RateLimitFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
@@ -101,7 +99,6 @@ TEST(HttpFilterConfigTest, DynamoFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   DynamoFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Both, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
@@ -122,7 +119,6 @@ TEST(HttpFilterConfigTest, FaultFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   FaultFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
@@ -138,7 +134,6 @@ TEST(HttpFilterConfigTest, GrpcHttp1BridgeFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   GrpcHttp1BridgeFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Both, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
@@ -154,7 +149,6 @@ TEST(HttpFilterConfigTest, GrpcWebFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   GrpcWebFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Both, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
@@ -172,7 +166,6 @@ TEST(HttpFilterConfigTest, HealthCheckFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   HealthCheckFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Both, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
@@ -204,7 +197,6 @@ TEST(HttpFilterConfigTest, RouterFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   RouterFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
@@ -240,7 +232,6 @@ TEST(HttpFilterConfigTest, IpTaggingFilter) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   IpTaggingFilterConfig factory;
-  EXPECT_EQ(HttpFilterType::Decoder, factory.type());
   HttpFilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -37,7 +37,6 @@ TEST(NetworkFilterConfigTest, RedisProxy) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Read, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
@@ -88,7 +87,6 @@ TEST_P(RouteIpListConfigTest, TcpProxy) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   TcpProxyConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Read, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
@@ -116,7 +114,6 @@ TEST_P(IpWhiteListConfigTest, ClientSslAuth) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   ClientSslAuthConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Read, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
@@ -136,7 +133,6 @@ TEST(NetworkFilterConfigTest, Ratelimit) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   RateLimitConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Read, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));

--- a/test/server/config/network/mongo_proxy_test.cc
+++ b/test/server/config/network/mongo_proxy_test.cc
@@ -26,7 +26,6 @@ TEST(MongoFilterConfigTest, CorrectConfigurationNoFaults) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   MongoProxyFilterConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Both, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addFilter(_));
@@ -212,7 +211,6 @@ TEST(MongoFilterConfigTest, CorrectFaultConfiguration) {
   Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   NiceMock<MockFactoryContext> context;
   MongoProxyFilterConfigFactory factory;
-  EXPECT_EQ(NetworkFilterType::Both, factory.type());
   NetworkFilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
   Network::MockConnection connection;
   EXPECT_CALL(connection, addFilter(_));

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -221,9 +221,6 @@ public:
     return [](Network::FilterManager&) -> void {};
   }
   std::string name() override { return "stats_test"; }
-  Configuration::NetworkFilterType type() override {
-    return Configuration::NetworkFilterType::Read;
-  }
 };
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {


### PR DESCRIPTION
This has been removed from the v2 config already, is ignored in v1 and is vestigial in the code
base.

Partial fix for #1535.