### PR TITLE
Fixed coverage for RequestInfoImpl

### DIFF
--- a/test/common/http/access_log/BUILD
+++ b/test/common/http/access_log/BUILD
@@ -46,3 +46,14 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "request_info_impl_test",
+    srcs = ["request_info_impl_test.cc"],
+    deps = [
+        "//include/envoy/http:protocol_interface",
+        "//include/envoy/upstream:host_description_interface",
+        "//source/common/http/access_log:request_info_lib",
+        "//test/mocks/upstream:upstream_mocks",
+    ],
+)

--- a/test/common/http/access_log/request_info_impl_test.cc
+++ b/test/common/http/access_log/request_info_impl_test.cc
@@ -19,19 +19,26 @@ namespace {
 
 class RequestInfoTimingWrapper {
 public:
-  RequestInfoTimingWrapper() : pre_start_(std::chrono::steady_clock::now()), request_info_(Protocol::Http2), post_start_(std::chrono::steady_clock::now()) {
-  }
+  RequestInfoTimingWrapper()
+      : pre_start_(std::chrono::steady_clock::now()), request_info_(Protocol::Http2),
+        post_start_(std::chrono::steady_clock::now()) {}
 
-  void checkTimingBounds(const std::function<std::chrono::microseconds(RequestInfoImpl&)> &measure_duration, const std::string &duration_name) {
+  void checkTimingBounds(
+      const std::function<std::chrono::microseconds(RequestInfoImpl&)>& measure_duration,
+      const std::string& duration_name) {
     MonotonicTime pre_measurement = std::chrono::steady_clock::now();
     std::chrono::microseconds duration = measure_duration(request_info_);
     MonotonicTime post_measurement = std::chrono::steady_clock::now();
 
-    std::chrono::microseconds lower_bound = std::chrono::duration_cast<std::chrono::microseconds>(pre_measurement - post_start_);
-    EXPECT_LE(lower_bound, duration) << fmt::format("Duration {} was lower than expected", duration_name);
+    std::chrono::microseconds lower_bound =
+        std::chrono::duration_cast<std::chrono::microseconds>(pre_measurement - post_start_);
+    EXPECT_LE(lower_bound, duration)
+        << fmt::format("Duration {} was lower than expected", duration_name);
 
-    std::chrono::microseconds upper_bound = std::chrono::duration_cast<std::chrono::microseconds>(post_measurement - pre_start_);
-    EXPECT_GE(upper_bound, duration) << fmt::format("Duration: {} was higher than expected", duration_name);
+    std::chrono::microseconds upper_bound =
+        std::chrono::duration_cast<std::chrono::microseconds>(post_measurement - pre_start_);
+    EXPECT_GE(upper_bound, duration)
+        << fmt::format("Duration: {} was higher than expected", duration_name);
   }
 
 private:
@@ -44,19 +51,22 @@ TEST(RequestInfoImplTest, TimingTest) {
 
   RequestInfoTimingWrapper wrapper;
 
-  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
-    request_info.requestReceivedDuration(std::chrono::steady_clock::now());
-    return request_info.requestReceivedDuration();
-  }, "request received");
+  wrapper.checkTimingBounds(
+      [](RequestInfoImpl& request_info) {
+        request_info.requestReceivedDuration(std::chrono::steady_clock::now());
+        return request_info.requestReceivedDuration();
+      },
+      "request received");
 
-  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
-    request_info.responseReceivedDuration(std::chrono::steady_clock::now());
-    return request_info.responseReceivedDuration();
-  }, "response received");
+  wrapper.checkTimingBounds(
+      [](RequestInfoImpl& request_info) {
+        request_info.responseReceivedDuration(std::chrono::steady_clock::now());
+        return request_info.responseReceivedDuration();
+      },
+      "response received");
 
-  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
-    return request_info.duration();
-  }, "stream duration");
+  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) { return request_info.duration(); },
+                            "stream duration");
 }
 
 TEST(RequestInfoImplTest, BytesTest) {
@@ -72,16 +82,28 @@ TEST(RequestInfoImplTest, BytesTest) {
 }
 
 TEST(RequestInfoImplTest, ResponseFlagTest) {
-  std::vector<ResponseFlag> responseFlags = {FailedLocalHealthCheck, NoHealthyUpstream, UpstreamRequestTimeout, LocalReset, UpstreamRemoteReset, UpstreamConnectionFailure, UpstreamConnectionTermination, UpstreamOverflow, NoRouteFound, DelayInjected, FaultInjected, RateLimited };
+  std::vector<ResponseFlag> responseFlags = {FailedLocalHealthCheck,
+                                             NoHealthyUpstream,
+                                             UpstreamRequestTimeout,
+                                             LocalReset,
+                                             UpstreamRemoteReset,
+                                             UpstreamConnectionFailure,
+                                             UpstreamConnectionTermination,
+                                             UpstreamOverflow,
+                                             NoRouteFound,
+                                             DelayInjected,
+                                             FaultInjected,
+                                             RateLimited};
 
   RequestInfoImpl request_info(Protocol::Http2);
   for (ResponseFlag flag : responseFlags) {
     // Test cumulative setting of response flags.
-    EXPECT_FALSE(request_info.getResponseFlag(flag)) << fmt::format("Flag: {} was already set", flag);
+    EXPECT_FALSE(request_info.getResponseFlag(flag))
+        << fmt::format("Flag: {} was already set", flag);
     request_info.setResponseFlag(flag);
-    EXPECT_TRUE(request_info.getResponseFlag(flag)) << fmt::format("Flag: {} was expected to be set", flag);
+    EXPECT_TRUE(request_info.getResponseFlag(flag))
+        << fmt::format("Flag: {} was expected to be set", flag);
   }
-
 }
 
 TEST(RequestInfoImplTest, MiscSettersAndGetters) {
@@ -105,9 +127,6 @@ TEST(RequestInfoImplTest, MiscSettersAndGetters) {
   request_info.healthCheck(true);
   EXPECT_TRUE(request_info.healthCheck());
 }
-
-
-
 
 } // namespace
 } // namespace AccessLog

--- a/test/common/http/access_log/request_info_impl_test.cc
+++ b/test/common/http/access_log/request_info_impl_test.cc
@@ -1,0 +1,115 @@
+#include <chrono>
+#include <functional>
+
+#include "envoy/http/protocol.h"
+#include "envoy/upstream/host_description.h"
+
+#include "common/http/access_log/request_info_impl.h"
+
+#include "test/mocks/upstream/mocks.h"
+
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Http {
+namespace AccessLog {
+namespace {
+
+class RequestInfoTimingWrapper {
+public:
+  RequestInfoTimingWrapper() : pre_start_(std::chrono::steady_clock::now()), request_info_(Protocol::Http2), post_start_(std::chrono::steady_clock::now()) {
+  }
+
+  void checkTimingBounds(const std::function<std::chrono::microseconds(RequestInfoImpl&)> &measure_duration, const std::string &duration_name) {
+    MonotonicTime pre_measurement = std::chrono::steady_clock::now();
+    std::chrono::microseconds duration = measure_duration(request_info_);
+    MonotonicTime post_measurement = std::chrono::steady_clock::now();
+
+    std::chrono::microseconds lower_bound = std::chrono::duration_cast<std::chrono::microseconds>(pre_measurement - post_start_);
+    EXPECT_LE(lower_bound, duration) << fmt::format("Duration {} was lower than expected", duration_name);
+
+    std::chrono::microseconds upper_bound = std::chrono::duration_cast<std::chrono::microseconds>(post_measurement - pre_start_);
+    EXPECT_GE(upper_bound, duration) << fmt::format("Duration: {} was higher than expected", duration_name);
+  }
+
+private:
+  const MonotonicTime pre_start_;
+  RequestInfoImpl request_info_;
+  const MonotonicTime post_start_;
+};
+
+TEST(RequestInfoImplTest, TimingTest) {
+
+  RequestInfoTimingWrapper wrapper;
+
+  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
+    request_info.requestReceivedDuration(std::chrono::steady_clock::now());
+    return request_info.requestReceivedDuration();
+  }, "request received");
+
+  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
+    request_info.responseReceivedDuration(std::chrono::steady_clock::now());
+    return request_info.responseReceivedDuration();
+  }, "response received");
+
+  wrapper.checkTimingBounds([](RequestInfoImpl& request_info) {
+    return request_info.duration();
+  }, "stream duration");
+}
+
+TEST(RequestInfoImplTest, BytesTest) {
+  RequestInfoImpl request_info(Protocol::Http2);
+  const uint64_t bytes_sent = 7;
+  const uint64_t bytes_received = 12;
+
+  request_info.bytes_sent_ = bytes_sent;
+  request_info.bytes_received_ = bytes_received;
+
+  EXPECT_EQ(bytes_sent, request_info.bytesSent());
+  EXPECT_EQ(bytes_received, request_info.bytesReceived());
+}
+
+TEST(RequestInfoImplTest, ResponseFlagTest) {
+  std::vector<ResponseFlag> responseFlags = {FailedLocalHealthCheck, NoHealthyUpstream, UpstreamRequestTimeout, LocalReset, UpstreamRemoteReset, UpstreamConnectionFailure, UpstreamConnectionTermination, UpstreamOverflow, NoRouteFound, DelayInjected, FaultInjected, RateLimited };
+
+  RequestInfoImpl request_info(Protocol::Http2);
+  for (ResponseFlag flag : responseFlags) {
+    // Test cumulative setting of response flags.
+    EXPECT_FALSE(request_info.getResponseFlag(flag)) << fmt::format("Flag: {} was already set", flag);
+    request_info.setResponseFlag(flag);
+    EXPECT_TRUE(request_info.getResponseFlag(flag)) << fmt::format("Flag: {} was expected to be set", flag);
+  }
+
+}
+
+TEST(RequestInfoImplTest, MiscSettersAndGetters) {
+  RequestInfoImpl request_info(Protocol::Http2);
+  EXPECT_EQ(Protocol::Http2, request_info.protocol());
+
+  request_info.protocol(Protocol::Http10);
+  EXPECT_EQ(Protocol::Http10, request_info.protocol());
+
+  EXPECT_FALSE(request_info.responseCode().valid());
+  request_info.response_code_ = 200;
+  ASSERT_TRUE(request_info.responseCode().valid());
+  EXPECT_EQ(200, request_info.responseCode().value());
+
+  EXPECT_EQ(nullptr, request_info.upstreamHost());
+  Upstream::HostDescriptionConstSharedPtr host(new NiceMock<Upstream::MockHostDescription>());
+  request_info.onUpstreamHostSelected(host);
+  EXPECT_EQ(host, request_info.upstreamHost());
+
+  EXPECT_FALSE(request_info.healthCheck());
+  request_info.healthCheck(true);
+  EXPECT_TRUE(request_info.healthCheck());
+}
+
+
+
+
+} // namespace
+} // namespace AccessLog
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/access_log/request_info_impl_test.cc
+++ b/test/common/http/access_log/request_info_impl_test.cc
@@ -48,7 +48,6 @@ private:
 };
 
 TEST(RequestInfoImplTest, TimingTest) {
-
   RequestInfoTimingWrapper wrapper;
 
   wrapper.checkTimingBounds(
@@ -82,18 +81,18 @@ TEST(RequestInfoImplTest, BytesTest) {
 }
 
 TEST(RequestInfoImplTest, ResponseFlagTest) {
-  std::vector<ResponseFlag> responseFlags = {FailedLocalHealthCheck,
-                                             NoHealthyUpstream,
-                                             UpstreamRequestTimeout,
-                                             LocalReset,
-                                             UpstreamRemoteReset,
-                                             UpstreamConnectionFailure,
-                                             UpstreamConnectionTermination,
-                                             UpstreamOverflow,
-                                             NoRouteFound,
-                                             DelayInjected,
-                                             FaultInjected,
-                                             RateLimited};
+  const std::vector<ResponseFlag> responseFlags = {FailedLocalHealthCheck,
+                                                   NoHealthyUpstream,
+                                                   UpstreamRequestTimeout,
+                                                   LocalReset,
+                                                   UpstreamRemoteReset,
+                                                   UpstreamConnectionFailure,
+                                                   UpstreamConnectionTermination,
+                                                   UpstreamOverflow,
+                                                   NoRouteFound,
+                                                   DelayInjected,
+                                                   FaultInjected,
+                                                   RateLimited};
 
   RequestInfoImpl request_info(Protocol::Http2);
   for (ResponseFlag flag : responseFlags) {

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -12,6 +12,7 @@
         "access_log": [
         {
           "path": "/dev/null",
+          "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" \"%REQUEST_DURATION%\" \"%RESPONSE_DURATION%\"\n",
           "filter" : {
             "type": "logical_or",
             "filters": [
@@ -114,6 +115,7 @@
         "access_log": [
         {
           "path": "/dev/null",
+          "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" \"%REQUEST_DURATION%\" \"%RESPONSE_DURATION%\"\n",
           "filter" : {
             "type": "logical_or",
             "filters": [
@@ -224,6 +226,7 @@
         "access_log": [
         {
           "path": "/dev/null",
+          "format": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" \"%REQUEST_DURATION%\" \"%RESPONSE_DURATION%\"\n",
           "filter" : {
             "type": "logical_or",
             "filters": [


### PR DESCRIPTION
Did so by expanding the access log format used in the server integration test.