### PR TITLE
Bug Fix: Record `UO` response flag on `retry overflow` circuit breaker.

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -91,8 +91,8 @@ public:
    *                 This is used to add timed backoff, etc. The callback will never be called
    *                 inline.
    * @return RetryStatus if a retry should take place. @param callback will be called at some point
-   * in the future. Otherwise a retry should not take place and the callback will never be called.
-   *         Calling code should proceed with error handling.
+   *         in the future. Otherwise a retry should not take place and the callback will never be
+   *         called. Calling code should proceed with error handling.
    */
   virtual RetryStatus shouldRetry(const Http::HeaderMap* response_headers,
                                   const Optional<Http::StreamResetReason>& reset_reason,

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -65,6 +65,11 @@ public:
 };
 
 /**
+ * RetryStatus whether request should be retried or not.
+ */
+enum class RetryStatus { No, NoOverflow, Yes };
+
+/**
  * Wraps retry state for an active routed request.
  */
 class RetryState {
@@ -85,13 +90,13 @@ public:
    * @param callback supplies the callback that will be invoked when the retry should take place.
    *                 This is used to add timed backoff, etc. The callback will never be called
    *                 inline.
-   * @return TRUE if a retry should take place. @param callback will be called at some point in the
-   *         future. Otherwise a retry should not take place and the callback will never be called.
+   * @return RetryStatus if a retry should take place. @param callback will be called at some point
+   * in the future. Otherwise a retry should not take place and the callback will never be called.
    *         Calling code should proceed with error handling.
    */
-  virtual bool shouldRetry(const Http::HeaderMap* response_headers,
-                           const Optional<Http::StreamResetReason>& reset_reason,
-                           DoRetryCallback callback) PURE;
+  virtual RetryStatus shouldRetry(const Http::HeaderMap* response_headers,
+                                  const Optional<Http::StreamResetReason>& reset_reason,
+                                  DoRetryCallback callback) PURE;
 };
 
 typedef std::unique_ptr<RetryState> RetryStatePtr;

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -127,9 +127,9 @@ void RetryStateImpl::resetRetry() {
   }
 }
 
-bool RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
-                                 const Optional<Http::StreamResetReason>& reset_reason,
-                                 DoRetryCallback callback) {
+RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
+                                        const Optional<Http::StreamResetReason>& reset_reason,
+                                        DoRetryCallback callback) {
   ASSERT((response_headers != nullptr) ^ reset_reason.valid());
 
   if (callback_ && !wouldRetry(response_headers, reset_reason)) {
@@ -139,21 +139,21 @@ bool RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
   resetRetry();
 
   if (retries_remaining_ == 0) {
-    return false;
+    return RetryStatus::No;
   }
 
   if (!runtime_.snapshot().featureEnabled("upstream.use_retry", 100)) {
-    return false;
+    return RetryStatus::No;
   }
 
   retries_remaining_--;
   if (!wouldRetry(response_headers, reset_reason)) {
-    return false;
+    return RetryStatus::No;
   }
 
   if (!cluster_.resourceManager(priority_).retries().canCreate()) {
     cluster_.stats().upstream_rq_retry_overflow_.inc();
-    return false;
+    return RetryStatus::NoOverflow;
   }
 
   ASSERT(!callback_);
@@ -161,7 +161,7 @@ bool RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
   cluster_.resourceManager(priority_).retries().inc();
   cluster_.stats().upstream_rq_retry_.inc();
   enableBackoffTimer();
-  return true;
+  return RetryStatus::Yes;
 }
 
 bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -32,9 +32,9 @@ public:
 
   // Router::RetryState
   bool enabled() override { return retry_on_ != 0; }
-  bool shouldRetry(const Http::HeaderMap* response_headers,
-                   const Optional<Http::StreamResetReason>& reset_reason,
-                   DoRetryCallback callback) override;
+  RetryStatus shouldRetry(const Http::HeaderMap* response_headers,
+                          const Optional<Http::StreamResetReason>& reset_reason,
+                          DoRetryCallback callback) override;
 
 private:
   RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap& request_headers,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -396,10 +396,10 @@ void Filter::onUpstreamReset(UpstreamResetType type,
   if (type != UpstreamResetType::GlobalTimeout && !downstream_response_started_ && retry_state_) {
     RetryStatus retry_status =
         retry_state_->shouldRetry(nullptr, reset_reason, [this]() -> void { doRetry(); });
-    if (retry_status == RetryStatus::NoOverflow) {
-      callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::UpstreamOverflow);
-    } else if (retry_status == RetryStatus::Yes && setupRetry(true)) {
+    if (retry_status == RetryStatus::Yes && setupRetry(true)) {
       return;
+    } else if (retry_status == RetryStatus::NoOverflow) {
+      callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::UpstreamOverflow);
     }
   }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -475,8 +475,6 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
       callbacks_->requestInfo().setResponseFlag(Http::AccessLog::ResponseFlag::UpstreamOverflow);
     }
 
-    retry_state_.reset();
-  } else {
     // Make sure any retry timers are destroyed since we may not call cleanup() if end_stream is
     // false.
     retry_state_.reset();

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -81,11 +81,11 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemoteReset) {
   EXPECT_TRUE(state_->enabled());
 
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(nullptr, remote_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_FALSE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
@@ -95,11 +95,11 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "503"}};
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
@@ -109,11 +109,11 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
@@ -123,11 +123,11 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcDeadlineExceeded) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "4"}};
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
@@ -137,11 +137,11 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "8"}};
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
@@ -150,8 +150,8 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
-  EXPECT_FALSE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, RuntimeGuard) {
@@ -161,14 +161,14 @@ TEST_F(RouterRetryStateImplTest, RuntimeGuard) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
-  EXPECT_FALSE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyConnectFailureOtherReset) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"}};
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
-  EXPECT_FALSE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyConnectFailureResetConnectFailure) {
@@ -177,7 +177,7 @@ TEST_F(RouterRetryStateImplTest, PolicyConnectFailureResetConnectFailure) {
   EXPECT_TRUE(state_->enabled());
 
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(nullptr, connect_failure_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(nullptr, connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 }
@@ -189,7 +189,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxRetry) {
 
   Http::TestHeaderMapImpl response_headers{{":status", "409"}};
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 }
@@ -200,7 +200,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxNoRetry) {
   EXPECT_TRUE(state_->enabled());
 
   Http::TestHeaderMapImpl response_headers{{":status", "400"}};
-  EXPECT_FALSE(state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxReset) {
@@ -208,7 +208,7 @@ TEST_F(RouterRetryStateImplTest, PolicyRetriable4xxReset) {
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
 
-  EXPECT_FALSE(state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 
 TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
@@ -219,7 +219,7 @@ TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
   EXPECT_TRUE(state_->enabled());
 
   expectTimerCreateAndEnable();
-  EXPECT_TRUE(state_->shouldRetry(nullptr, connect_failure_, callback_));
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(nullptr, connect_failure_, callback_));
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 }
@@ -227,6 +227,7 @@ TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
 TEST_F(RouterRetryStateImplTest, NoAvailableRetries) {
   cluster_.resource_manager_.reset(
       new Upstream::ResourceManagerImpl(runtime_, "fake_key", 0, 0, 0, 0));
+
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"}};
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
@@ -258,7 +259,7 @@ TEST_F(RouterRetryStateImplTest, MaxRetriesHeader) {
   EXPECT_CALL(callback_ready_, ready());
   retry_timer_->callback_();
 
-  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(nullptr, connect_failure_, callback_));
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, connect_failure_, callback_));
 
   EXPECT_EQ(3UL, cluster_.stats().upstream_rq_retry_.value());
   EXPECT_EQ(0UL, cluster_.stats().upstream_rq_retry_success_.value());

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -512,7 +512,7 @@ TEST_F(RouterTest, RetryUpstreamReset) {
   router_.retry_state_->callback_();
 
   // Normal response.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
   response_decoder->decodeHeaders(std::move(response_headers), true);
@@ -554,7 +554,7 @@ TEST_F(RouterTest, RetryUpstreamPerTryTimeout) {
   router_.retry_state_->callback_();
 
   // Normal response.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
   response_decoder->decodeHeaders(std::move(response_headers), true);
@@ -577,7 +577,7 @@ TEST_F(RouterTest, RetryUpstreamResetResponseStarted) {
   router_.decodeHeaders(headers, true);
 
   // Since the response is already started we don't retry.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
@@ -621,7 +621,7 @@ TEST_F(RouterTest, RetryUpstream5xx) {
   router_.retry_state_->callback_();
 
   // Normal response.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   EXPECT_CALL(cm_.conn_pool_.host_->health_checker_, setUnhealthy()).Times(0);
   Http::HeaderMapPtr response_headers2(new Http::TestHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
@@ -752,7 +752,7 @@ TEST_F(RouterTest, RetryUpstream5xxNotComplete) {
   router_.retry_state_->callback_();
 
   // Normal response.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putResponseTime(_));
   EXPECT_CALL(cm_.conn_pool_.host_->health_checker_, setUnhealthy());
@@ -811,7 +811,7 @@ TEST_F(RouterTest, RetryUpstreamGrpcCancelled) {
   router_.retry_state_->callback_();
 
   // Normal response.
-  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
   response_decoder->decodeHeaders(std::move(response_headers), true);

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -20,7 +20,8 @@ MockRedirectEntry::~MockRedirectEntry() {}
 MockRetryState::MockRetryState() {}
 
 void MockRetryState::expectRetry() {
-  EXPECT_CALL(*this, shouldRetry(_, _, _)).WillOnce(DoAll(SaveArg<2>(&callback_), Return(true)));
+  EXPECT_CALL(*this, shouldRetry(_, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&callback_), Return(RetryStatus::Yes)));
 }
 
 MockRetryState::~MockRetryState() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -56,9 +56,9 @@ public:
   void expectRetry();
 
   MOCK_METHOD0(enabled, bool());
-  MOCK_METHOD3(shouldRetry, bool(const Http::HeaderMap* response_headers,
-                                 const Optional<Http::StreamResetReason>& reset_reason,
-                                 DoRetryCallback callback));
+  MOCK_METHOD3(shouldRetry, RetryStatus(const Http::HeaderMap* response_headers,
+                                        const Optional<Http::StreamResetReason>& reset_reason,
+                                        DoRetryCallback callback));
 
   DoRetryCallback callback_;
 };


### PR DESCRIPTION
@lyft/network-team 