### PR TITLE
Unwinding read blocked state in the connection manager for HTTP/1

### DIFF
--- a/source/docs/flow_control.md
+++ b/source/docs/flow_control.md
@@ -92,11 +92,12 @@ the router filter only subscribes to notifications when it has an upstream
 connection, the connection manager tracks how many outstanding high watermark
 events have occurred and passes any on to the router filter when it subscribes.
 
-It is worth noting that the router does not unwind `readDisable(true)` calls on
-destruction.  The codecs are responsible for tracking that a given stream no
-longer contributes to the read blocked state and unwinding.  In the case of
-HTTP/2 the `Envoy::Http::Http2::ConnectionImpl` will consume any outstanding flow control
-window on stream deletion to avoid leaking the connection-level window.
+It is worth noting that the router does not unwind`readDisable(true)` calls on
+destruction.  Each codec must ensure that any necessary readDisable calls are
+unwound.  In the case of HTTP/2 the `Envoy::Http::Http2::ConnectionImpl` will consume
+any outstanding flow control window on stream deletion to avoid leaking the connection-level
+window.  In the case of HTTP, the Envoy::Http::ConnectionManagerImpl unwinds any readDisable()
+calls to ensure that pipelined requests will be read.
 
 ## HTTP/2 codec recv buffer
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1226,6 +1226,29 @@ TEST_F(HttpConnectionManagerImplTest, UpstreamWatermarkCallbacks) {
   ASSERT(decoder_filters_[0]->callbacks_ != nullptr);
   decoder_filters_[0]->callbacks_->onDecoderFilterBelowWriteBufferLowWatermark();
   EXPECT_EQ(1U, stats_.named_.downstream_flow_control_resumed_reading_total_.value());
+
+  // Backup upstream once again.
+  EXPECT_CALL(response_encoder_, getStream()).Times(1).WillOnce(ReturnRef(stream_));
+  EXPECT_CALL(stream_, readDisable(true));
+  ASSERT(decoder_filters_[0]->callbacks_ != nullptr);
+  decoder_filters_[0]->callbacks_->onDecoderFilterAboveWriteBufferHighWatermark();
+  EXPECT_EQ(2U, stats_.named_.downstream_flow_control_paused_reading_total_.value());
+
+  // Send a full response.
+  EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, true));
+  EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, true));
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, true));
+  // When the stream ends, the manager should check to see if the connection is
+  // read disabled, and keep calling readDisable(false) until readEnabled()
+  // returns true.
+  EXPECT_CALL(filter_callbacks_.connection_, readEnabled())
+      .Times(2)
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(filter_callbacks_.connection_, readDisable(false));
+  expectOnDestroy();
+  decoder_filters_[1]->callbacks_->encodeHeaders(
+      HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, true);
 }
 
 TEST_F(HttpConnectionManagerImplTest, DownstreamWatermarkCallbacks) {


### PR DESCRIPTION
We don't hit the unwind in newStream if the connection is blocked.