### PR TITLE
hot restart: fix hot restart test

### DIFF
--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -38,8 +38,9 @@ TEST_INDEX=0
 for HOT_RESTART_JSON in "${JSON_TEST_ARRAY[@]}"
 do
   # Test validation.
+  # TODO(jun03): instead of setting the base-id, the validate server should use the nop hot restart
   "${ENVOY_BIN}" -c "${HOT_RESTART_JSON}" --mode validate --service-cluster cluster \
-      --service-node node
+      --service-node node --base-id 1
 
   # Now start the real server, hot restart it twice, and shut it all down as a basic hot restart
   # sanity test.


### PR DESCRIPTION
Fix hot restart test which fails because the validation server uses real hot restart. This is a short term solution. The long term solution is to use the nop hot restarter for validation mode.