### PR TITLE
common/network: fix BindFailureTest on macOS

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -89,7 +89,6 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
       // Set a special error state to ensure asynchronous close to give the owner of the
       // ConnectionImpl a chance to add callbacks and detect the "disconnect"
       state_ |= InternalState::BindError;
-      state_ &= ~InternalState::Connecting;
       // Indicate this bind close should "flush", i.e. wait for a dispatcher callback cycle.
       close(ConnectionCloseType::FlushWrite);
     }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -89,8 +89,9 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
       // Set a special error state to ensure asynchronous close to give the owner of the
       // ConnectionImpl a chance to add callbacks and detect the "disconnect"
       state_ |= InternalState::BindError;
-      // Indicate this bind close should "flush", i.e. wait for a dispatcher callback cycle.
-      close(ConnectionCloseType::FlushWrite);
+
+      // Trigger a write event to close this connection out-of-band.
+      file_event_->activate(Event::FileReadyType::Write);
     }
   }
 }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -89,6 +89,7 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
       // Set a special error state to ensure asynchronous close to give the owner of the
       // ConnectionImpl a chance to add callbacks and detect the "disconnect"
       state_ |= InternalState::BindError;
+      state_ &= ~InternalState::Connecting;
       // Indicate this bind close should "flush", i.e. wait for a dispatcher callback cycle.
       close(ConnectionCloseType::FlushWrite);
     }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -125,8 +125,7 @@ void ConnectionImpl::close(ConnectionCloseType type) {
 
   uint64_t data_to_write = write_buffer_.length();
   ENVOY_CONN_LOG(debug, "closing data_to_write={} type={}", *this, data_to_write, enumToInt(type));
-  if ((data_to_write == 0 && !(state_ & InternalState::BindError)) ||
-      type == ConnectionCloseType::NoFlush) {
+  if (data_to_write == 0 || type == ConnectionCloseType::NoFlush) {
     if (data_to_write > 0) {
       // We aren't going to wait to flush, but try to write as much as we can if there is pending
       // data.

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -20,6 +20,7 @@ void FilterManagerImpl::addFilter(FilterSharedPtr filter) {
 }
 
 void FilterManagerImpl::addReadFilter(ReadFilterSharedPtr filter) {
+  ASSERT(connection_.state() == Connection::State::Open);
   ActiveReadFilterPtr new_filter(new ActiveReadFilter{*this, filter});
   filter->initializeReadFilterCallbacks(*new_filter);
   new_filter->moveIntoListBack(std::move(new_filter), upstream_filters_);

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -531,7 +531,6 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   client_connection_->addConnectionCallbacks(client_callbacks_);
   EXPECT_CALL(connection_stats.bind_errors_, inc());
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
-
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -524,44 +524,15 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
       dispatcher_->createListener(connection_handler_, socket_, listener_callbacks_, stats_store_,
                                   Network::ListenerOptions::listenerOptionsWithBindToPort());
 
-  int expected_callbacks = 2;
-  EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
-      .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        server_connection_ = std::move(conn);
-        server_connection_->addConnectionCallbacks(server_callbacks_);
-
-        expected_callbacks--;
-        if (expected_callbacks == 0) {
-          dispatcher_->exit();
-        }
-      }));
-
   client_connection_ = dispatcher_->createClientConnection(socket_.localAddress(), source_address_);
 
   MockConnectionStats connection_stats;
   client_connection_->setConnectionStats(connection_stats.toBufferStats());
   client_connection_->addConnectionCallbacks(client_callbacks_);
   EXPECT_CALL(connection_stats.bind_errors_, inc());
-  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose))
-      .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
-        expected_callbacks--;
-        if (expected_callbacks == 0) {
-          dispatcher_->exit();
-        }
-      }));;
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
 
-  // Make sure write event gets activated or else the callbacks may never happen.
-  client_connection_->connect();
-  Buffer::OwnedImpl buffer("data");
-  client_connection_->write(buffer);
-
-  dispatcher_->run(Event::Dispatcher::RunType::Block);
-
-  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::RemoteClose))
-      .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));
-
-  dispatcher_->run(Event::Dispatcher::RunType::Block);
-
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 
 class ReadBufferLimitTest : public ConnectionImplTest {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -531,6 +531,11 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   client_connection_->addConnectionCallbacks(client_callbacks_);
   EXPECT_CALL(connection_stats.bind_errors_, inc());
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
+
+  // Make sure write event gets activated or else the callbacks may never happen.
+  Buffer::OwnedImpl buffer("data");
+  client_connection_->write(buffer);
+
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 


### PR DESCRIPTION
On Linux, during BindFailureTest, an `Event::FileReadyType::Write` event is triggered, causing `ConnectionImpl::onFileEvent` to fire a `ConnectionEvent::LocalClose` callback and increment the bind error stat.

On macOS, the write event does not occur and the test fails. So, force activation of the write event and subsequent callback/stats code.