### PR TITLE
Fixing up waitForNewStream to wait for new streams

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -163,7 +163,10 @@ public:
 
   FakeHttpConnection(QueuedConnectionWrapperPtr connection_wrapper, Stats::Store& store, Type type);
   Network::Connection& connection() { return connection_; }
-  FakeStreamPtr waitForNewStream();
+  // By default waitForNewStream assumes the next event is a new stream and
+  // fails an assert if an unexpected event occurs.  If a caller truly wishes to
+  // wait for a new stream, set ignore_spurious_events = true.
+  FakeStreamPtr waitForNewStream(bool ignore_spurious_events = false);
 
   // Http::ServerConnectionCallbacks
   Http::StreamDecoder& newStream(Http::StreamEncoder& response_encoder) override;

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -338,7 +338,9 @@ void Http2UpstreamIntegrationTest::manySimultaneousRequests(uint32_t port, uint3
        [&]() -> void {
          fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
          for (uint32_t i = 0; i < num_requests; ++i) {
-           upstream_requests.push_back(fake_upstream_connection_->waitForNewStream());
+           // As data and streams are interwoven, make sure waitForNewStream()
+           // ignores incoming data and waits for actual stream establishment.
+           upstream_requests.push_back(fake_upstream_connection_->waitForNewStream(true));
          }
        },
        [&]() -> void {


### PR DESCRIPTION
I believe this will fix the flake I noticed on the OSX build where waitForNewStream 
exited connection_event_.wait(lock); when there is no new stream.

 RUN      ] IpVersions/Http2UpstreamIntegrationTest.ManyLargeSimultaneousRequestWithBufferLimits/1
TestRandomGenerator running with seed 690114504
[2017-09-08 13:53:04.416][130871][critical][assert] test/integration/fake_upstream.cc:201] assert failure: !new_streams_.empty()
[2017-09-08 13:53:04.416][130871][critical][backtrace] bazel-out/darwin_x86_64-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:101] Caught Abort trap: 6, suspect faulting address 0x7fff99e89d42
[2017-09-08 13:53:04.416][130871][critical][backtrace] bazel-out/darwin_x86_64-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:76] Back trace attempt failed
================================================================================
[1,733 / 1,733] Testing //test/integration:http2_upstream_integration_test DONE