### PR TITLE
installs and uses python3 and pip3 on frontproxy service example

### DIFF
--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -2,8 +2,14 @@ FROM lyft/envoy:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl \
-    python-pip
-RUN pip install -q Flask==0.11.1
+    software-properties-common \
+    python-software-properties
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get -q install -y \
+    python3 \
+    python3-pip
+RUN python3 --version && pip3 --version
+RUN pip3 install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/examples/front-proxy/start_service.sh
+++ b/examples/front-proxy/start_service.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-python /code/service.py &
+python3 /code/service.py &
 envoy -c /etc/service-envoy.json --service-cluster service${SERVICE_NAME}


### PR DESCRIPTION
Fixes #1597

- installs and uses python3 and pip3 to address Issue #1597
- uses [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)
- [fork build passed](https://circleci.com/gh/marcosrmendezthd/envoy/tree/frontproxy_python3)

Could also incorporate the instructions on https://github.com/docker-library/python/blob/master/3.5/jessie/Dockerfile, though this might be overkill. 😄 