### PR TITLE
add xxHash library

### DIFF
--- a/bazel/target_recipes.bzl
+++ b/bazel/target_recipes.bzl
@@ -21,6 +21,7 @@ TARGET_RECIPES = {
     "spdlog": "spdlog",
     "ssl": "boringssl",
     "tclap": "tclap",
+    "xxhash": "xxhash",
     "yaml_cpp": "yaml-cpp",
     "zlib": "zlib",
 }

--- a/ci/build_container/build_recipes/xxhash.sh
+++ b/ci/build_container/build_recipes/xxhash.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+VERSION=0.6.3
+
+wget -O xxHash-v"$VERSION".tar.gz https://github.com/Cyan4973/xxHash/archive/v"$VERSION".tar.gz
+tar xf xxHash-v"$VERSION".tar.gz
+cd xxHash-"$VERSION"
+"$CC" $CFLAGS "$CPPFLAGS" -c xxhash.c -o xxhash.o
+ar rcs xxhash.a xxhash.o
+cp xxhash.a "$THIRDPARTY_BUILD"/lib
+cp xxhash.h "$THIRDPARTY_BUILD"/include

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -135,6 +135,13 @@ cc_library(
 )
 
 cc_library(
+    name = "xxhash",
+    srcs = ["thirdparty_build/lib/xxhash.a"],
+    hdrs = ["thirdparty_build/include/xxhash.h"],
+    includes = ["thirdparty_build/include"],
+)
+
+cc_library(
     name = "yaml_cpp",
     srcs = ["thirdparty_build/lib/libyaml-cpp.a"],
     hdrs = glob(["thirdparty_build/include/yaml-cpp/**/*.h"]),

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -25,6 +25,7 @@ Envoy has the following requirements:
 * `zlib <https://github.com/madler/zlib>`_ (last tested with 1.2.11)
 * `yaml-cpp <https://github.com/jbeder/yaml-cpp>`_ (last tested with sha e2818c423e5058a02f46ce2e519a82742a8ccac9).
 * `fmtlib <https://github.com/fmtlib/fmt/>`_ (last tested with 4.0.0)
+* `xxHash <https://github.com/Cyan4973/xxHash>`_ (last tested with 0.6.3)
 
 In order to compile and run the tests the following is required:
 


### PR DESCRIPTION
Currently we use `std::hash` for hashing which is not consistent across platforms. This introduces xxHash which is portable, fast, and used by many other open-source projects.

After this PR is merged, I will followup with a change to update `ENVOY_BUILD_SHA` and convert usages of `std::hash`.