### PR TITLE
Add integration tests for .json config

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -12,6 +12,33 @@ load(
 envoy_package()
 
 envoy_cc_test(
+    name = "legacy_json_integration_test",
+    srcs = ["legacy_json_integration_test.cc"],
+    data = [
+        "//test/config/integration:echo_server.json",
+        "//test/config/integration:server.json",
+        "//test/config/integration:server_grpc_json_transcoder.json",
+        "//test/config/integration:server_http2.json",
+        "//test/config/integration:server_http2_upstream.json",
+        "//test/config/integration:server_proxy_proto.json",
+        "//test/config/integration:server_ratelimit.json",
+        "//test/config/integration:server_ssl.json",
+        "//test/config/integration:server_uds.json",
+        "//test/config/integration:server_xfcc.json",
+        "//test/config/integration:tcp_proxy.json",
+        "//test/config/integration/certs",
+        "//test/proto:bookstore_proto_descriptor",
+    ],
+    deps = [
+        ":integration_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/protobuf:utility_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "proto_integration_test",
     srcs = ["proto_integration_test.cc"],
     deps = [

--- a/test/integration/legacy_json_integration_test.cc
+++ b/test/integration/legacy_json_integration_test.cc
@@ -1,0 +1,78 @@
+#include "test/integration/integration.h"
+#include "test/mocks/runtime/mocks.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+// This test loops through all of the json config files submitted as of
+// 11/10/2017 and verifies Envoy continues to load the json version of their
+// configuration.
+class LegacyJsonIntegrationTest : public BaseIntegrationTest,
+                                  public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  LegacyJsonIntegrationTest() : BaseIntegrationTest(GetParam()) {}
+
+  void SetUp() override {
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+    registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+    registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+    registerPort("cluster_with_buffer_limits",
+                 fake_upstreams_.back()->localAddress()->ip()->port());
+  }
+};
+
+TEST_P(LegacyJsonIntegrationTest, TestServer) {
+  createTestServer("test/config/integration/server.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerHttp2) {
+  createTestServer("test/config/integration/server_http2.json", {"echo"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerHttp2Upstream) {
+  createTestServer("test/config/integration/server_http2_upstream.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerProxyProto) {
+  createTestServer("test/config/integration/server_proxy_proto.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerSsl) {
+  createTestServer("test/config/integration/server_ssl.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestTcpProxy) {
+  createTestServer("test/config/integration/tcp_proxy.json", {"tcp_proxy"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerUds) {
+  createTestServer("test/config/integration/server_uds.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerXfc) {
+  TestEnvironment::ParamMap param_map;
+  param_map["forward_client_cert"] = "forward_only";
+  param_map["set_current_client_cert_details"] = "";
+  std::string config = TestEnvironment::temporaryFileSubstitute(
+      "test/config/integration/server_xfcc.json", param_map, port_map_, version_);
+  IntegrationTestServer::create(config, version_);
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestEchoServer) {
+  createTestServer("test/config/integration/echo_server.json", {"echo"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerGrpcJsonTranscoder) {
+  createTestServer("test/config/integration/server_grpc_json_transcoder.json", {"http"});
+}
+
+TEST_P(LegacyJsonIntegrationTest, TestServerRatelimit) {
+  createTestServer("test/config/integration/server_ratelimit.json", {"http"});
+}
+
+INSTANTIATE_TEST_CASE_P(IpVersions, LegacyJsonIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+} // namespace Envoy


### PR DESCRIPTION
precursor to #1162 and migrating all the integration tests to proto, so we don't lose json coverage

It turns out the config tests didn't use "external" files, and were pretty hard-wired to treat each file as a config file.  Rather than do a bunch of work to get that working with certs and protos, as well as rewriting the configs to get rid of the {{}} stuff I just figured we'd keep one legacy integration test which launched each config.  I'll then add all the utilities to do easy proto config extension, then finally move all the logic to read and edit json files to the legacy json test so no other tests can continue using them.  Developers are welcome to keep using json fles until the proto utils exist because I dislike "deprecated" and "not ready yet" and besides, it will put most of the merge pain on me, not on them.

The one area I noticed we're losing config coverage is that xfcc_integration_test does a bunch of rewrites
"always_forwarded_only" "sanitize" "sanitize_set" etc.   We could leave that test as a json test, port over one test case per config option or just leave the one option I stuck in legacy_json_integration_test per your preference.

