### PR TITLE
Parameterize IP version used in stats config test.

### DIFF
--- a/test/server/config/stats/BUILD
+++ b/test/server/config/stats/BUILD
@@ -21,6 +21,8 @@ envoy_cc_test(
         "//source/common/stats:statsd_lib",
         "//source/server/config/stats:statsd_lib",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )


### PR DESCRIPTION
The //test/server/config/stats:config_test used a hardcoded IPv4
loopback IP. This causes problems for IPv6 only test running environments.
Use the same IP version parametization approach we use elsewhere
instead.