### PR TITLE
Switch to return-by-value for versionInfo string.

### DIFF
--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -62,6 +62,11 @@ public:
 
   /**
    * @return std::string version info from last accepted onConfigUpdate.
+   *
+   * TODO(dnoe): This would ideally return by reference, but this causes a
+   *             problem due to incompatible string implementations returned by
+   *             protobuf generated code. Revisit when string implementations
+   *             are converged.
    */
   virtual const std::string versionInfo() const PURE;
 };

--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -61,9 +61,9 @@ public:
   virtual void updateResources(const std::vector<std::string>& resources) PURE;
 
   /**
-   * @return version info from last accepted onConfigUpdate.
+   * @return std::string version info from last accepted onConfigUpdate.
    */
-  virtual const std::string& versionInfo() const PURE;
+  virtual const std::string versionInfo() const PURE;
 };
 
 /**

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -24,6 +24,11 @@ public:
 
   /**
    * @return const std::string version info from last accepted config.
+   *
+   * TODO(dnoe): This would ideally return by reference, but this causes a
+   *             problem due to incompatible string implementations returned by
+   *             protobuf generated code. Revisit when string implementations
+   *             are converged.
    */
   virtual const std::string versionInfo() const PURE;
 };

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -23,9 +23,9 @@ public:
   virtual Router::ConfigConstSharedPtr config() PURE;
 
   /**
-   * @return const std::string& version info from last accepted config.
+   * @return const std::string version info from last accepted config.
    */
-  virtual const std::string& versionInfo() const PURE;
+  virtual const std::string versionInfo() const PURE;
 };
 
 /**

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -150,6 +150,11 @@ public:
 
   /**
    * @return std::string last accepted version from fetch.
+   *
+   * TODO(dnoe): This would ideally return by reference, but this causes a
+   *             problem due to incompatible string implementations returned by
+   *             protobuf generated code. Revisit when string implementations
+   *             are converged.
    */
   virtual const std::string versionInfo() const PURE;
 };

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -149,9 +149,9 @@ public:
   virtual void setInitializedCb(std::function<void()> callback) PURE;
 
   /**
-   * @return last accepted version from fetch.
+   * @return std::string last accepted version from fetch.
    */
-  virtual const std::string& versionInfo() const PURE;
+  virtual const std::string versionInfo() const PURE;
 };
 
 typedef std::unique_ptr<CdsApi> CdsApiPtr;

--- a/source/common/config/ads_subscription_impl.h
+++ b/source/common/config/ads_subscription_impl.h
@@ -40,7 +40,7 @@ public:
     watch_ = ads_api_.subscribe(type_url_, resources, *this);
   }
 
-  const std::string& versionInfo() const override { NOT_IMPLEMENTED; }
+  const std::string versionInfo() const override { NOT_IMPLEMENTED; }
 
   // Config::AdsCallbacks
   void onConfigUpdate(const Protobuf::RepeatedPtrField<ProtobufWkt::Any>& resources) override {

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -47,7 +47,7 @@ public:
     UNREFERENCED_PARAMETER(resources);
   }
 
-  const std::string& versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return version_info_; }
 
 private:
   void refresh() {

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -81,7 +81,7 @@ public:
     sendDiscoveryRequest();
   }
 
-  const std::string& versionInfo() const override { return request_.version_info(); }
+  const std::string versionInfo() const override { return request_.version_info(); }
 
   // Grpc::AsyncStreamCallbacks
   void onCreateInitialMetadata(Http::HeaderMap& metadata) override {

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -60,7 +60,7 @@ public:
     request_.mutable_resource_names()->Swap(&resources_vector);
   }
 
-  const std::string& versionInfo() const override { return request_.version_info(); }
+  const std::string versionInfo() const override { return request_.version_info(); }
 
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -49,7 +49,7 @@ public:
 
   // Router::RouteConfigProvider
   Router::ConfigConstSharedPtr config() override { return config_; }
-  const std::string& versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, "static"); }
+  const std::string versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, "static"); }
 
 private:
   ConfigConstSharedPtr config_;
@@ -100,7 +100,7 @@ public:
   }
   const std::string& routeConfigName() const override { return route_config_name_; }
   const std::string& clusterName() const override { return cluster_name_; }
-  const std::string& versionInfo() const override { return subscription_->versionInfo(); }
+  const std::string versionInfo() const override { return subscription_->versionInfo(); }
 
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const ResourceVector& resources) override;

--- a/source/common/router/rds_subscription.h
+++ b/source/common/router/rds_subscription.h
@@ -45,7 +45,7 @@ private:
     NOT_IMPLEMENTED;
   }
 
-  const std::string& versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return version_info_; }
 
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override;

--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -32,7 +32,7 @@ public:
   void setInitializedCb(std::function<void()> callback) override {
     initialize_callback_ = callback;
   }
-  const std::string& versionInfo() const override { return subscription_->versionInfo(); }
+  const std::string versionInfo() const override { return subscription_->versionInfo(); }
 
 private:
   CdsApiImpl(const envoy::api::v2::ConfigSource& cds_config,

--- a/source/common/upstream/cds_subscription.h
+++ b/source/common/upstream/cds_subscription.h
@@ -46,7 +46,7 @@ private:
     NOT_IMPLEMENTED;
   }
 
-  const std::string& versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return version_info_; }
 
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override;

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -23,7 +23,7 @@ public:
                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                  bool added_via_api);
 
-  const std::string& versionInfo() const { return subscription_->versionInfo(); }
+  const std::string versionInfo() const { return subscription_->versionInfo(); }
 
   // Upstream::Cluster
   void initialize() override;

--- a/source/common/upstream/sds_subscription.h
+++ b/source/common/upstream/sds_subscription.h
@@ -27,7 +27,7 @@ public:
                   Runtime::RandomGenerator& random);
 
   // Config::Subscription
-  const std::string& versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return version_info_; }
 
 private:
   // Config::Subscription

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -98,7 +98,7 @@ private:
 
     // Router::RouteConfigProvider
     Router::ConfigConstSharedPtr config() override { return config_; }
-    const std::string& versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, ""); }
+    const std::string versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, ""); }
 
     Router::ConfigConstSharedPtr config_;
   };

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -25,7 +25,7 @@ public:
          Init::Manager& init_manager, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
          ListenerManager& lm);
 
-  const std::string& versionInfo() const { return subscription_->versionInfo(); }
+  const std::string versionInfo() const { return subscription_->versionInfo(); }
 
   // Init::Target
   void initialize(std::function<void()> callback) override;

--- a/source/server/lds_subscription.h
+++ b/source/server/lds_subscription.h
@@ -42,7 +42,7 @@ private:
     NOT_IMPLEMENTED;
   }
 
-  const std::string& versionInfo() const override { return version_info_; }
+  const std::string versionInfo() const override { return version_info_; }
 
   // Http::RestApiFetcher
   void createRequest(Http::Message& request) override;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -59,7 +59,7 @@ public:
   struct RouteConfigProvider : public Router::RouteConfigProvider {
     // Router::RouteConfigProvider
     Router::ConfigConstSharedPtr config() override { return route_config_; }
-    const std::string& versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, ""); }
+    const std::string versionInfo() const override { CONSTRUCT_ON_FIRST_USE(std::string, ""); }
 
     std::shared_ptr<Router::MockConfig> route_config_{new NiceMock<Router::MockConfig>()};
   };

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -23,7 +23,7 @@ public:
                              SubscriptionCallbacks<ResourceType>& callbacks));
   MOCK_METHOD1_T(updateResources, void(const std::vector<std::string>& resources));
 
-  MOCK_CONST_METHOD0_T(versionInfo, const std::string&());
+  MOCK_CONST_METHOD0_T(versionInfo, const std::string());
 };
 
 class MockAdsWatch : public AdsWatch {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -146,7 +146,7 @@ public:
 
   MOCK_METHOD0(initialize, void());
   MOCK_METHOD1(setInitializedCb, void(std::function<void()> callback));
-  MOCK_CONST_METHOD0(versionInfo, const std::string&());
+  MOCK_CONST_METHOD0(versionInfo, const std::string());
 
   std::function<void()> initialized_callback_;
 };


### PR DESCRIPTION
Returning the versionInfo by reference creates problems for the Google
import due to the protobuf generated code returning a string variant
convertible to std::string rather than std::string itself. This results
in the creation of a temporary std::string in grpc_subscription_impl.h
and http_subscription_impl.h, which cannot be returned by reference.

Switch to return-by-value for the versionInfo string.