### PR TITLE
cluster_manager: fix use-after-free bug in drainConnPools().  

### DIFF
--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -48,7 +48,7 @@ void RdsSubscription::parseResponse(const Http::Message& response) {
   Envoy::Config::RdsJson::translateRouteConfiguration(*response_json, *resources.Add());
   resources[0].set_name(route_config_name_);
   callbacks_->onConfigUpdate(resources);
-  version_info_ = Config::Utility::computeHashedVersion(response_body);
+  version_info_ = Envoy::Config::Utility::computeHashedVersion(response_body);
   stats_.update_success_.inc();
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -483,6 +483,13 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
         host_http_conn_pool_map_.erase(old_host);
       }
     });
+
+    // The above addDrainedCallback() drain completion callback might execute immediately. This can
+    // then effectively nuke 'container', which means we can't continue to loop on its contents
+    // (we're done here).
+    if (host_http_conn_pool_map_.count(old_host) == 0) {
+      break;
+    }
   }
 }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -747,6 +747,8 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
   // drain callbacks, etc.
   dns_timer_->callback_();
   dns_callback(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.3"}));
+  dns_timer_->callback_();
+  dns_callback(TestUtility::makeDnsResponse({"127.0.0.2"}));
 
   factory_.tls_.shutdownThread();
 }


### PR DESCRIPTION
   This showed up in the ASAN/TSAN presubmits for #1621.

Bonus namespace cleanup in rds_subscription.cc that I hit with local clang-asan run.