### PR TITLE
server: fix SIGTERM during init crashes

### DIFF
--- a/source/server/server.h
+++ b/source/server/server.h
@@ -88,6 +88,23 @@ public:
 };
 
 /**
+ * This is a helper used by InstanceImpl::run() on the stack. It's broken out to make testing
+ * easier.
+ */
+class RunHelper : Logger::Loggable<Logger::Id::main> {
+public:
+  RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm, HotRestart& hot_restart,
+            AccessLog::AccessLogManager& access_log_manager, InitManagerImpl& init_manager,
+            std::function<void()> workers_start_cb);
+
+private:
+  Event::SignalEventPtr sigterm_;
+  Event::SignalEventPtr sig_usr_1_;
+  Event::SignalEventPtr sig_hup_;
+  bool shutdown_{};
+};
+
+/**
  * This is the actual full standalone server which stiches together various common components.
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>, public Instance {
@@ -162,9 +179,6 @@ private:
   std::unique_ptr<ListenerManager> listener_manager_;
   std::unique_ptr<Configuration::Main> config_;
   Stats::ScopePtr admin_scope_;
-  Event::SignalEventPtr sigterm_;
-  Event::SignalEventPtr sig_usr_1_;
-  Event::SignalEventPtr sig_hup_;
   Network::DnsResolverSharedPtr dns_resolver_;
   Event::TimerPtr stat_flush_timer_;
   LocalInfo::LocalInfoPtr local_info_;

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -36,6 +36,14 @@ MockTimer::MockTimer(MockDispatcher* dispatcher) {
 
 MockTimer::~MockTimer() {}
 
+MockSignalEvent::MockSignalEvent(MockDispatcher* dispatcher) {
+  EXPECT_CALL(*dispatcher, listenForSignal_(_, _))
+      .WillOnce(DoAll(SaveArg<1>(&callback_), Return(this)))
+      .RetiresOnSaturation();
+}
+
+MockSignalEvent::~MockSignalEvent() {}
+
 MockFileEvent::MockFileEvent() {}
 MockFileEvent::~MockFileEvent() {}
 

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -129,6 +129,14 @@ public:
   TimerCb callback_;
 };
 
+class MockSignalEvent : public SignalEvent {
+public:
+  MockSignalEvent(MockDispatcher* dispatcher);
+  ~MockSignalEvent();
+
+  SignalCb callback_;
+};
+
 class MockFileEvent : public FileEvent {
 public:
   MockFileEvent();


### PR DESCRIPTION
Fixes https://github.com/lyft/envoy/issues/1610

If we receive SIGTERM during initialize we can attempt to start
workers while shutting down. This fixes that. A small amount of
code was broken out to ease testing. I'm not crazy about that, but
I could not find a better way to test this case without a bunch
more effort which did not seem worth it.