### PR TITLE
docs: remove real world deployments page

### DIFF
--- a/docs/intro/intro.rst
+++ b/docs/intro/intro.rst
@@ -9,7 +9,6 @@ Introduction
   what_is_envoy
   arch_overview/arch_overview
   deployment_types/deployment_types
-  real_world_deployments
   comparison
   getting_help
   version_history

--- a/docs/intro/real_world_deployments.rst
+++ b/docs/intro/real_world_deployments.rst
@@ -1,9 +1,0 @@
-Real world deployments
-----------------------
-
-If you have an Envoy deployment open a PR to add yourself or :ref:`let us know <getting_help>`!
-
-Lyft
-  Envoy was initially developed for use at Lyft as the primary edge and service to service
-  networking layer. Lyft's deployment is currently across thousands of hosts and processes over
-  2 million requests per second at peak.


### PR DESCRIPTION
No one updates this page and it is not representative of the large number
of people using Envoy. We will try to figure out a better way of tracking
users.