### PR TITLE
docs: remove filter "type"

### DIFF
--- a/docs/configuration/http_conn_man/filters.rst
+++ b/docs/configuration/http_conn_man/filters.rst
@@ -8,15 +8,9 @@ HTTP filter :ref:`architecture overview <arch_overview_http_filters>`.
 .. code-block:: json
 
   {
-    "type": "...",
     "name": "...",
     "config": "{...}"
   }
-
-type
-  *(required, string)* The type of filter to instantiate. Most filters implement a specific type,
-  though it is theoretically possible for a filter to be written such that it can operate in
-  multiple modes. Supported types are *decoder*, *encoder*, and *both*.
 
 name
   *(required, string)* The name of the filter to instantiate. The name must match a :ref:`supported

--- a/docs/configuration/http_conn_man/http_conn_man.rst
+++ b/docs/configuration/http_conn_man/http_conn_man.rst
@@ -9,7 +9,6 @@ HTTP connection manager
 .. code-block:: json
 
   {
-    "type": "read",
     "name": "http_connection_manager",
     "config": {
       "codec_type": "...",

--- a/docs/configuration/http_filters/buffer_filter.rst
+++ b/docs/configuration/http_filters/buffer_filter.rst
@@ -10,7 +10,6 @@ with partial requests and high network latency.
 .. code-block:: json
 
   {
-    "type": "decoder",
     "name": "buffer",
     "config": {
       "max_request_bytes": "...",

--- a/docs/configuration/http_filters/dynamodb_filter.rst
+++ b/docs/configuration/http_filters/dynamodb_filter.rst
@@ -8,13 +8,9 @@ DynamoDB :ref:`architecture overview <arch_overview_dynamo>`.
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "http_dynamo_filter",
     "config": {}
   }
-
-type
-  *(required, string)* Filter type. The only supported value is `both`.
 
 name
   *(required, string)* Filter name. The only supported value is `http_dynamo_filter`.

--- a/docs/configuration/http_filters/fault_filter.rst
+++ b/docs/configuration/http_filters/fault_filter.rst
@@ -34,7 +34,6 @@ including the router filter.*
 .. code-block:: json
 
   {
-    "type" : "decoder",
     "name" : "fault",
     "config" : {
       "abort" : "{...}",

--- a/docs/configuration/http_filters/grpc_http1_bridge_filter.rst
+++ b/docs/configuration/http_filters/grpc_http1_bridge_filter.rst
@@ -37,7 +37,6 @@ normal gRPC requests over HTTP/2.
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "grpc_http1_bridge",
     "config": {}
   }

--- a/docs/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -12,13 +12,12 @@ and get proxied to a gRPC service. The HTTP mapping for the gRPC service has to 
 Configure gRPC-JSON transcoder
 ------------------------------
 
-The filter config for the filter requires the descriptor file as well as a list of the gRPC 
+The filter config for the filter requires the descriptor file as well as a list of the gRPC
 services to be transcoded.
 
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "grpc_json_transcoder",
     "config": {
       "proto_descriptor": "proto.pb",
@@ -34,7 +33,7 @@ services to be transcoded.
 
 proto_descriptor
   *(required, string)* Supplies the binary protobuf descriptor set for the gRPC services.
-  The descriptor set has to include all of the types that are used in the services. Make sure 
+  The descriptor set has to include all of the types that are used in the services. Make sure
   to use the ``--include_import`` option for ``protoc``.
 
   To generate a protobuf descriptor set for the gRPC service, you'll also need to clone the

--- a/docs/configuration/http_filters/grpc_web_filter.rst
+++ b/docs/configuration/http_filters/grpc_web_filter.rst
@@ -11,7 +11,6 @@ following https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md.
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "grpc_web",
     "config": {}
   }

--- a/docs/configuration/http_filters/health_check_filter.rst
+++ b/docs/configuration/http_filters/health_check_filter.rst
@@ -8,7 +8,6 @@ Health check filter :ref:`architecture overview <arch_overview_health_checking_f
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "health_check",
     "config": {
       "pass_through_mode": "...",

--- a/docs/configuration/http_filters/ip_tagging_filter.rst
+++ b/docs/configuration/http_filters/ip_tagging_filter.rst
@@ -12,7 +12,6 @@ words, installing this filter is a no-op in the filter chain.
 .. code-block:: json
 
   {
-    "type": "decoder",
     "name": "ip_tagging",
     "config": {
       "request_type": "...",

--- a/docs/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/configuration/http_filters/rate_limit_filter.rst
@@ -17,7 +17,6 @@ If the rate limit service is called, and the response for any of the descriptors
 .. code-block:: json
 
   {
-    "type": "decoder",
     "name": "rate_limit",
     "config": {
       "domain": "...",

--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -11,7 +11,6 @@ redirection, the filter also handles retry, statistics, etc.
 .. code-block:: json
 
   {
-    "type": "decoder",
     "name": "router",
     "config": {
       "dynamic_stats": "..."

--- a/docs/configuration/listeners/filters.rst
+++ b/docs/configuration/listeners/filters.rst
@@ -8,15 +8,9 @@ Network filter :ref:`architecture overview <arch_overview_network_filters>`.
 .. code-block:: json
 
   {
-    "type": "...",
     "name": "...",
     "config": "{...}"
   }
-
-type
-  *(required, string)* The type of filter to instantiate. Most filters implement a specific type,
-  though it is theoretically possible for a filter to be written such that it can operate in
-  multiple modes. Supported types are *read*, *write*, and *both*.
 
 name
   *(required, string)* The name of the filter to instantiate. The name must match a :ref:`supported

--- a/docs/configuration/network_filters/client_ssl_auth_filter.rst
+++ b/docs/configuration/network_filters/client_ssl_auth_filter.rst
@@ -8,7 +8,6 @@ Client TLS authentication filter :ref:`architecture overview <arch_overview_ssl_
 .. code-block:: json
 
   {
-    "type": "read",
     "name": "client_ssl_auth",
     "config": {
       "auth_api_cluster": "...",

--- a/docs/configuration/network_filters/echo_filter.rst
+++ b/docs/configuration/network_filters/echo_filter.rst
@@ -7,7 +7,6 @@ installed it will echo (write) all received data back to the connected downstrea
 .. code-block:: json
 
   {
-    "type": "read",
     "name": "echo",
     "config": {}
   }

--- a/docs/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/configuration/network_filters/mongo_proxy_filter.rst
@@ -8,7 +8,6 @@ MongoDB :ref:`architecture overview <arch_overview_mongo>`.
 .. code-block:: json
 
   {
-    "type": "both",
     "name": "mongo_proxy",
     "config": {
       "stat_prefix": "...",
@@ -30,7 +29,7 @@ fault
   *(optional, object)* If specified, the filter will inject faults based on the values in the object.
 
 Fault configuration
--------------------  
+-------------------
 
 Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB operations: Query, Insert,
 GetMore, and KillCursors. Once an active delay is in progress, all incoming data up until the timer event fires
@@ -186,7 +185,7 @@ mongo.fault.fixed_delay.percent
 
 mongo.fault.fixed_delay.duration_ms
   The delay duration in milliseconds. Defaults to the *duration_ms* specified in the config.
-  
+
 Access log format
 -----------------
 

--- a/docs/configuration/network_filters/rate_limit_filter.rst
+++ b/docs/configuration/network_filters/rate_limit_filter.rst
@@ -8,7 +8,6 @@ Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`.
 .. code-block:: json
 
   {
-    "type": "read",
     "name": "ratelimit",
     "config": {
       "stat_prefix": "...",

--- a/docs/configuration/network_filters/tcp_proxy_filter.rst
+++ b/docs/configuration/network_filters/tcp_proxy_filter.rst
@@ -8,7 +8,6 @@ TCP proxy :ref:`architecture overview <arch_overview_tcp_proxy>`.
 .. code-block:: json
 
   {
-    "type": "read",
     "name": "tcp_proxy",
     "config": {
       "stat_prefix": "...",
@@ -140,4 +139,3 @@ statistics are rooted at *tcp.<stat_prefix>.* with the following statistics:
   downstream_cx_tx_bytes_buffered, Gauge, Total bytes currently buffered to the downstream connection.
   downstream_flow_control_paused_reading_total, Counter, Total number of times flow control paused reading from downstream.
   downstream_flow_control_resumed_reading_total, Counter, Total number of times flow control resumed reading from downstream.
-

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -38,7 +38,7 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
           },
           "config": {"type" : "object"}
         },
-        "required": ["type", "name", "config"],
+        "required": ["name", "config"],
         "additionalProperties": false
       }
     },
@@ -244,7 +244,7 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
           "name" : {"type": "string"},
           "config": {"type" : "object"}
         },
-        "required": ["type", "name", "config"],
+        "required": ["name", "config"],
         "additionalProperties" : false
       }
     },


### PR DESCRIPTION
This is no longer used by code. This change removes it from the docs
and also makes the field optional in the schema so that we don't
break existing configs.